### PR TITLE
fix: bound 403 retry by a 2-minute IAM propagation timeout

### DIFF
--- a/internal/services/cockpit/alert_manager_test.go
+++ b/internal/services/cockpit/alert_manager_test.go
@@ -1,6 +1,7 @@
 package cockpit_test
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strconv"
@@ -15,6 +16,7 @@ import (
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/httperrors"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/meta"
 	accounttestfuncs "github.com/scaleway/terraform-provider-scaleway/v2/internal/services/account/testfuncs"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/transport"
 )
 
 func TestAccCockpitAlertManager_CreateWithSingleContact(t *testing.T) {
@@ -275,8 +277,16 @@ func testAccCheckCockpitContactPointExists(tt *acctest.TestTools, resourceName s
 		api := cockpit.NewRegionalAPI(meta.ExtractScwClient(tt.Meta))
 		projectID := rs.Primary.Attributes["project_id"]
 
-		contactPoints, err := api.ListContactPoints(&cockpit.RegionalAPIListContactPointsRequest{
-			ProjectID: projectID,
+		var contactPoints *cockpit.ListContactPointsResponse
+
+		err := transport.RetryOn403(context.Background(), func() error {
+			var err error
+
+			contactPoints, err = api.ListContactPoints(&cockpit.RegionalAPIListContactPointsRequest{
+				ProjectID: projectID,
+			})
+
+			return err
 		})
 		if err != nil {
 			return err
@@ -532,11 +542,19 @@ func testAccCheckPreconfiguredAlertsCount(tt *acctest.TestTools, resourceName st
 			}
 		}
 
-		alerts, err := api.ListAlerts(&cockpit.RegionalAPIListAlertsRequest{
-			Region:          region,
-			ProjectID:       projectID,
-			IsPreconfigured: new(true),
-		}, scw.WithAllPages())
+		var alerts *cockpit.ListAlertsResponse
+
+		err = transport.RetryOn403(context.Background(), func() error {
+			var err error
+
+			alerts, err = api.ListAlerts(&cockpit.RegionalAPIListAlertsRequest{
+				Region:          region,
+				ProjectID:       projectID,
+				IsPreconfigured: new(true),
+			}, scw.WithAllPages())
+
+			return err
+		})
 		if err != nil {
 			return fmt.Errorf("failed to list alerts: %w", err)
 		}
@@ -573,9 +591,17 @@ func testAccCheckManagedAlertsEnabled(tt *acctest.TestTools, resourceName string
 		projectID := rs.Primary.Attributes["project_id"]
 		region := scw.Region(rs.Primary.Attributes["region"])
 
-		alertManager, err := api.GetAlertManager(&cockpit.RegionalAPIGetAlertManagerRequest{
-			Region:    region,
-			ProjectID: projectID,
+		var alertManager *cockpit.AlertManager
+
+		err := transport.RetryOn403(context.Background(), func() error {
+			var err error
+
+			alertManager, err = api.GetAlertManager(&cockpit.RegionalAPIGetAlertManagerRequest{
+				Region:    region,
+				ProjectID: projectID,
+			})
+
+			return err
 		})
 		if err != nil {
 			return err

--- a/internal/services/cockpit/exporter_test.go
+++ b/internal/services/cockpit/exporter_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/acctest"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/httperrors"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/services/cockpit"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/transport"
 )
 
 const defaultOrgIDPlaceholder = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
@@ -287,9 +288,13 @@ func isExporterPresent(tt *acctest.TestTools, n string) resource.TestCheckFunc {
 			return err
 		}
 
-		_, err = api.GetExporter(&cockpitSDK.RegionalAPIGetExporterRequest{
-			Region:     region,
-			ExporterID: id,
+		err = transport.RetryOn403(context.Background(), func() error {
+			_, err := api.GetExporter(&cockpitSDK.RegionalAPIGetExporterRequest{
+				Region:     region,
+				ExporterID: id,
+			})
+
+			return err
 		})
 		if err != nil {
 			return err

--- a/internal/services/cockpit/grafana_user_test.go
+++ b/internal/services/cockpit/grafana_user_test.go
@@ -1,6 +1,7 @@
 package cockpit_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/acctest"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/httperrors"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/services/cockpit"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/transport"
 )
 
 func TestAccGrafanaUser_Basic(t *testing.T) {
@@ -132,9 +134,17 @@ func isGrafanaUserPresent(tt *acctest.TestTools, n string) resource.TestCheckFun
 			return err
 		}
 
-		res, err := api.ListGrafanaUsers(&cockpitSDK.GlobalAPIListGrafanaUsersRequest{ //nolint:staticcheck // legacy Grafana user resource uses deprecated API
-			ProjectID: projectID,
-		}, scw.WithAllPages())
+		var res *cockpitSDK.ListGrafanaUsersResponse
+
+		err = transport.RetryOn403(context.Background(), func() error {
+			var err error
+
+			res, err = api.ListGrafanaUsers(&cockpitSDK.GlobalAPIListGrafanaUsersRequest{ //nolint:staticcheck // legacy Grafana user resource uses deprecated API
+				ProjectID: projectID,
+			}, scw.WithAllPages())
+
+			return err
+		})
 		if err != nil {
 			return err
 		}

--- a/internal/services/cockpit/source_test.go
+++ b/internal/services/cockpit/source_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/acctest"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/httperrors"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/services/cockpit"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/transport"
 )
 
 var DestroyWaitTimeout = 3 * time.Minute
@@ -218,9 +219,13 @@ func isSourcePresent(tt *acctest.TestTools, n string) resource.TestCheckFunc {
 			return err
 		}
 
-		_, err = api.GetDataSource(&cockpitSDK.RegionalAPIGetDataSourceRequest{
-			Region:       region,
-			DataSourceID: ID,
+		err = transport.RetryOn403(context.Background(), func() error {
+			_, err := api.GetDataSource(&cockpitSDK.RegionalAPIGetDataSourceRequest{
+				Region:       region,
+				DataSourceID: ID,
+			})
+
+			return err
 		})
 		if err != nil {
 			return err

--- a/internal/services/cockpit/token_test.go
+++ b/internal/services/cockpit/token_test.go
@@ -1,6 +1,7 @@
 package cockpit_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/acctest"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/httperrors"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/services/cockpit"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/transport"
 )
 
 func TestAccToken_Basic(t *testing.T) {
@@ -185,9 +187,13 @@ func isTokenPresent(tt *acctest.TestTools, n string) resource.TestCheckFunc {
 			return err
 		}
 
-		_, err = api.GetToken(&cockpitSDK.RegionalAPIGetTokenRequest{
-			TokenID: ID,
-			Region:  region,
+		err = transport.RetryOn403(context.Background(), func() error {
+			_, err := api.GetToken(&cockpitSDK.RegionalAPIGetTokenRequest{
+				TokenID: ID,
+				Region:  region,
+			})
+
+			return err
 		})
 		if err != nil {
 			return err

--- a/internal/services/rdb/database_backup_test.go
+++ b/internal/services/rdb/database_backup_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/logging"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/services/rdb"
 	rdbchecks "github.com/scaleway/terraform-provider-scaleway/v2/internal/services/rdb/testfuncs"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/transport"
 )
 
 func init() {
@@ -171,9 +172,13 @@ func isBackupPresent(tt *acctest.TestTools, databaseBackup string) resource.Test
 			return err
 		}
 
-		_, err = rdbAPI.GetDatabaseBackup(&rdbSDK.GetDatabaseBackupRequest{
-			Region:           region,
-			DatabaseBackupID: id,
+		err = transport.RetryOn403(context.Background(), func() error {
+			_, err := rdbAPI.GetDatabaseBackup(&rdbSDK.GetDatabaseBackupRequest{
+				Region:           region,
+				DatabaseBackupID: id,
+			})
+
+			return err
 		})
 		if err != nil {
 			return fmt.Errorf("failed to get database backup: %w", err)

--- a/internal/services/rdb/database_export_backup_action_test.go
+++ b/internal/services/rdb/database_export_backup_action_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/scaleway/scaleway-sdk-go/scw"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/acctest"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/locality/regional"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/transport"
 )
 
 func TestAccActionRDBDatabaseBackupExport_Basic(t *testing.T) {
@@ -86,10 +87,18 @@ func isBackupExported(tt *acctest.TestTools, resourceName string) resource.TestC
 
 		api := rdbSDK.NewAPI(tt.Meta.ScwClient())
 
-		backup, err := api.GetDatabaseBackup(&rdbSDK.GetDatabaseBackupRequest{
-			Region:           region,
-			DatabaseBackupID: id,
-		}, scw.WithContext(context.Background()))
+		var backup *rdbSDK.DatabaseBackup
+
+		err = transport.RetryOn403(context.Background(), func() error {
+			var err error
+
+			backup, err = api.GetDatabaseBackup(&rdbSDK.GetDatabaseBackupRequest{
+				Region:           region,
+				DatabaseBackupID: id,
+			}, scw.WithContext(context.Background()))
+
+			return err
+		})
 		if err != nil {
 			return fmt.Errorf("failed to get backup: %w", err)
 		}

--- a/internal/services/rdb/database_restore_backup_action_test.go
+++ b/internal/services/rdb/database_restore_backup_action_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/scaleway/scaleway-sdk-go/scw"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/acctest"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/locality/regional"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/transport"
 )
 
 func TestAccActionRDBDatabaseBackupRestore_Basic(t *testing.T) {
@@ -100,11 +101,19 @@ func isDatabaseRestored(tt *acctest.TestTools, instanceResourceName, databaseNam
 
 		api := rdbSDK.NewAPI(tt.Meta.ScwClient())
 
-		databases, err := api.ListDatabases(&rdbSDK.ListDatabasesRequest{
-			Region:     region,
-			InstanceID: id,
-			Name:       new(databaseName),
-		}, scw.WithContext(context.Background()))
+		var databases *rdbSDK.ListDatabasesResponse
+
+		err = transport.RetryOn403(context.Background(), func() error {
+			var err error
+
+			databases, err = api.ListDatabases(&rdbSDK.ListDatabasesRequest{
+				Region:     region,
+				InstanceID: id,
+				Name:       new(databaseName),
+			}, scw.WithContext(context.Background()))
+
+			return err
+		})
 		if err != nil {
 			return fmt.Errorf("failed to list databases: %w", err)
 		}

--- a/internal/services/rdb/database_test.go
+++ b/internal/services/rdb/database_test.go
@@ -1,6 +1,7 @@
 package rdb_test
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -12,6 +13,7 @@ import (
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/acctest"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/services/rdb"
 	rdbchecks "github.com/scaleway/terraform-provider-scaleway/v2/internal/services/rdb/testfuncs"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/transport"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -125,13 +127,21 @@ func isDatabasePresent(tt *acctest.TestTools, instance string, database string) 
 			return err
 		}
 
-		databases, err := rdbAPI.ListDatabases(&rdbSDK.ListDatabasesRequest{
-			Region:     region,
-			InstanceID: instanceID,
-			Name:       &databaseName,
-			Managed:    nil,
-			Owner:      nil,
-			OrderBy:    "",
+		var databases *rdbSDK.ListDatabasesResponse
+
+		err = transport.RetryOn403(context.Background(), func() error {
+			var err error
+
+			databases, err = rdbAPI.ListDatabases(&rdbSDK.ListDatabasesRequest{
+				Region:     region,
+				InstanceID: instanceID,
+				Name:       &databaseName,
+				Managed:    nil,
+				Owner:      nil,
+				OrderBy:    "",
+			})
+
+			return err
 		})
 		if err != nil {
 			return err

--- a/internal/services/rdb/instance_prepare_logs_action_test.go
+++ b/internal/services/rdb/instance_prepare_logs_action_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/scaleway/scaleway-sdk-go/scw"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/acctest"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/locality/regional"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/transport"
 )
 
 func TestAccActionRDBInstanceLogPrepare_Basic(t *testing.T) {
@@ -72,10 +73,18 @@ func isInstanceLogPrepared(tt *acctest.TestTools, instanceResourceName string) r
 
 		api := rdbSDK.NewAPI(tt.Meta.ScwClient())
 
-		instance, err := api.GetInstance(&rdbSDK.GetInstanceRequest{
-			Region:     region,
-			InstanceID: id,
-		}, scw.WithContext(context.Background()))
+		var instance *rdbSDK.Instance
+
+		err = transport.RetryOn403(context.Background(), func() error {
+			var err error
+
+			instance, err = api.GetInstance(&rdbSDK.GetInstanceRequest{
+				Region:     region,
+				InstanceID: id,
+			}, scw.WithContext(context.Background()))
+
+			return err
+		})
 		if err != nil {
 			return fmt.Errorf("failed to get instance: %w", err)
 		}

--- a/internal/services/rdb/instance_purge_logs_action_test.go
+++ b/internal/services/rdb/instance_purge_logs_action_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/scaleway/scaleway-sdk-go/scw"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/acctest"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/locality/regional"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/transport"
 )
 
 func TestAccActionRDBInstanceLogsPurge_Basic(t *testing.T) {
@@ -71,10 +72,18 @@ func isInstanceLogsPurged(tt *acctest.TestTools, instanceResourceName string) re
 
 		api := rdbSDK.NewAPI(tt.Meta.ScwClient())
 
-		instance, err := api.GetInstance(&rdbSDK.GetInstanceRequest{
-			Region:     region,
-			InstanceID: id,
-		}, scw.WithContext(context.Background()))
+		var instance *rdbSDK.Instance
+
+		err = transport.RetryOn403(context.Background(), func() error {
+			var err error
+
+			instance, err = api.GetInstance(&rdbSDK.GetInstanceRequest{
+				Region:     region,
+				InstanceID: id,
+			}, scw.WithContext(context.Background()))
+
+			return err
+		})
 		if err != nil {
 			return fmt.Errorf("failed to get instance: %w", err)
 		}

--- a/internal/services/rdb/instance_renew_certificate_action_test.go
+++ b/internal/services/rdb/instance_renew_certificate_action_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/scaleway/scaleway-sdk-go/scw"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/acctest"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/locality/regional"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/transport"
 )
 
 func TestAccActionRDBInstanceCertificateRenew_Basic(t *testing.T) {
@@ -72,10 +73,18 @@ func isInstanceCertificateRenewed(tt *acctest.TestTools, instanceResourceName st
 
 		api := rdbSDK.NewAPI(tt.Meta.ScwClient())
 
-		instance, err := api.GetInstance(&rdbSDK.GetInstanceRequest{
-			Region:     region,
-			InstanceID: id,
-		}, scw.WithContext(context.Background()))
+		var instance *rdbSDK.Instance
+
+		err = transport.RetryOn403(context.Background(), func() error {
+			var err error
+
+			instance, err = api.GetInstance(&rdbSDK.GetInstanceRequest{
+				Region:     region,
+				InstanceID: id,
+			}, scw.WithContext(context.Background()))
+
+			return err
+		})
 		if err != nil {
 			return fmt.Errorf("failed to get instance: %w", err)
 		}

--- a/internal/services/rdb/instance_restart_action_test.go
+++ b/internal/services/rdb/instance_restart_action_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/scaleway/scaleway-sdk-go/scw"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/acctest"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/locality/regional"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/transport"
 )
 
 func TestAccActionRDBInstanceRestart_Basic(t *testing.T) {
@@ -72,10 +73,18 @@ func isInstanceRestarted(tt *acctest.TestTools, instanceResourceName string) res
 
 		api := rdbSDK.NewAPI(tt.Meta.ScwClient())
 
-		instance, err := api.GetInstance(&rdbSDK.GetInstanceRequest{
-			Region:     region,
-			InstanceID: id,
-		}, scw.WithContext(context.Background()))
+		var instance *rdbSDK.Instance
+
+		err = transport.RetryOn403(context.Background(), func() error {
+			var err error
+
+			instance, err = api.GetInstance(&rdbSDK.GetInstanceRequest{
+				Region:     region,
+				InstanceID: id,
+			}, scw.WithContext(context.Background()))
+
+			return err
+		})
 		if err != nil {
 			return fmt.Errorf("failed to get instance: %w", err)
 		}

--- a/internal/services/rdb/instance_test.go
+++ b/internal/services/rdb/instance_test.go
@@ -1,6 +1,7 @@
 package rdb_test
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"regexp"
@@ -15,6 +16,7 @@ import (
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/services/rdb"
 	rdbchecks "github.com/scaleway/terraform-provider-scaleway/v2/internal/services/rdb/testfuncs"
 	vpcchecks "github.com/scaleway/terraform-provider-scaleway/v2/internal/services/vpc/testfuncs"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/transport"
 )
 
 const (
@@ -1797,9 +1799,13 @@ func TestAccInstance_EngineUpgrade(t *testing.T) {
 							return fmt.Errorf("expected new instance ID after upgrade, but got same ID: %s", newInstanceID)
 						}
 
-						_, err = rdbAPI.GetInstance(&rdbSDK.GetInstanceRequest{
-							Region:     region,
-							InstanceID: oldInstanceID,
+						err = transport.RetryOn403(context.Background(), func() error {
+							_, err := rdbAPI.GetInstance(&rdbSDK.GetInstanceRequest{
+								Region:     region,
+								InstanceID: oldInstanceID,
+							})
+
+							return err
 						})
 						if err == nil {
 							return fmt.Errorf("expected old instance %s to be destroyed, but it still exists", oldInstanceID)
@@ -1902,9 +1908,17 @@ func TestAccInstance_EngineUpgradeKeepsHA(t *testing.T) {
 							return fmt.Errorf("expected new instance ID after upgrade, but got same ID: %s", newInstanceID)
 						}
 
-						instance, err := rdbAPI.GetInstance(&rdbSDK.GetInstanceRequest{
-							Region:     region,
-							InstanceID: newInstanceID,
+						var instance *rdbSDK.Instance
+
+						err = transport.RetryOn403(context.Background(), func() error {
+							var err error
+
+							instance, err = rdbAPI.GetInstance(&rdbSDK.GetInstanceRequest{
+								Region:     region,
+								InstanceID: newInstanceID,
+							})
+
+							return err
 						})
 						if err != nil {
 							return err
@@ -1914,9 +1928,13 @@ func TestAccInstance_EngineUpgradeKeepsHA(t *testing.T) {
 							return fmt.Errorf("expected upgraded instance %s to keep HA enabled", newInstanceID)
 						}
 
-						_, err = rdbAPI.GetInstance(&rdbSDK.GetInstanceRequest{
-							Region:     region,
-							InstanceID: oldInstanceID,
+						err = transport.RetryOn403(context.Background(), func() error {
+							_, err := rdbAPI.GetInstance(&rdbSDK.GetInstanceRequest{
+								Region:     region,
+								InstanceID: oldInstanceID,
+							})
+
+							return err
 						})
 						if err == nil {
 							return fmt.Errorf("expected old instance %s to be destroyed, but it still exists", oldInstanceID)
@@ -2072,10 +2090,18 @@ func checkInstanceACLRules(tt *acctest.TestTools, instanceResource string, expec
 			return err
 		}
 
-		res, err := rdbAPI.ListInstanceACLRules(&rdbSDK.ListInstanceACLRulesRequest{
-			Region:     region,
-			InstanceID: instanceID,
-		}, scw.WithAllPages())
+		var res *rdbSDK.ListInstanceACLRulesResponse
+
+		err = transport.RetryOn403(context.Background(), func() error {
+			var err error
+
+			res, err = rdbAPI.ListInstanceACLRules(&rdbSDK.ListInstanceACLRulesRequest{
+				Region:     region,
+				InstanceID: instanceID,
+			}, scw.WithAllPages())
+
+			return err
+		})
 		if err != nil {
 			return fmt.Errorf("listing ACL rules: %w", err)
 		}
@@ -2107,9 +2133,13 @@ func isInstancePresent(tt *acctest.TestTools, n string) resource.TestCheckFunc {
 			return err
 		}
 
-		_, err = rdbAPI.GetInstance(&rdbSDK.GetInstanceRequest{
-			InstanceID: ID,
-			Region:     region,
+		err = transport.RetryOn403(context.Background(), func() error {
+			_, err := rdbAPI.GetInstance(&rdbSDK.GetInstanceRequest{
+				InstanceID: ID,
+				Region:     region,
+			})
+
+			return err
 		})
 		if err != nil {
 			return err

--- a/internal/services/rdb/privilege_test.go
+++ b/internal/services/rdb/privilege_test.go
@@ -1,6 +1,7 @@
 package rdb_test
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -11,6 +12,7 @@ import (
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/acctest"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/services/rdb"
 	rdbchecks "github.com/scaleway/terraform-provider-scaleway/v2/internal/services/rdb/testfuncs"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/transport"
 )
 
 func TestAccPrivilege_UpdatePermission(t *testing.T) {
@@ -283,11 +285,19 @@ func isPrivilegePresent(tt *acctest.TestTools, instance string, database string,
 			return err
 		}
 
-		databases, err := rdbAPI.ListPrivileges(&rdbSDK.ListPrivilegesRequest{
-			Region:       region,
-			InstanceID:   instanceID,
-			DatabaseName: &databaseName,
-			UserName:     &userName,
+		var databases *rdbSDK.ListPrivilegesResponse
+
+		err = transport.RetryOn403(context.Background(), func() error {
+			var err error
+
+			databases, err = rdbAPI.ListPrivileges(&rdbSDK.ListPrivilegesRequest{
+				Region:       region,
+				InstanceID:   instanceID,
+				DatabaseName: &databaseName,
+				UserName:     &userName,
+			})
+
+			return err
 		})
 		if err != nil {
 			return err

--- a/internal/services/rdb/read_replica_reset_action_test.go
+++ b/internal/services/rdb/read_replica_reset_action_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/scaleway/scaleway-sdk-go/scw"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/acctest"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/locality/regional"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/transport"
 )
 
 func TestAccActionRDBReadReplicaReset_Basic(t *testing.T) {
@@ -77,10 +78,18 @@ func isReadReplicaReset(tt *acctest.TestTools, readReplicaResourceName string) r
 
 		api := rdbSDK.NewAPI(tt.Meta.ScwClient())
 
-		readReplica, err := api.GetReadReplica(&rdbSDK.GetReadReplicaRequest{
-			Region:        region,
-			ReadReplicaID: id,
-		}, scw.WithContext(context.Background()))
+		var readReplica *rdbSDK.ReadReplica
+
+		err = transport.RetryOn403(context.Background(), func() error {
+			var err error
+
+			readReplica, err = api.GetReadReplica(&rdbSDK.GetReadReplicaRequest{
+				Region:        region,
+				ReadReplicaID: id,
+			}, scw.WithContext(context.Background()))
+
+			return err
+		})
 		if err != nil {
 			return fmt.Errorf("failed to get read replica: %w", err)
 		}

--- a/internal/services/rdb/read_replica_test.go
+++ b/internal/services/rdb/read_replica_test.go
@@ -1,6 +1,7 @@
 package rdb_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/services/rdb"
 	rdbchecks "github.com/scaleway/terraform-provider-scaleway/v2/internal/services/rdb/testfuncs"
 	vpcchecks "github.com/scaleway/terraform-provider-scaleway/v2/internal/services/vpc/testfuncs"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/transport"
 )
 
 func TestAccReadReplica_Basic(t *testing.T) {
@@ -598,9 +600,13 @@ func isReadReplicaPresent(tt *acctest.TestTools, readReplica string) resource.Te
 			return err
 		}
 
-		_, err = rdbAPI.GetReadReplica(&rdbSDK.GetReadReplicaRequest{
-			Region:        region,
-			ReadReplicaID: ID,
+		err = transport.RetryOn403(context.Background(), func() error {
+			_, err := rdbAPI.GetReadReplica(&rdbSDK.GetReadReplicaRequest{
+				Region:        region,
+				ReadReplicaID: ID,
+			})
+
+			return err
 		})
 		if err != nil {
 			return err

--- a/internal/services/rdb/snapshot_action_test.go
+++ b/internal/services/rdb/snapshot_action_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/scaleway/scaleway-sdk-go/scw"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/acctest"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/locality/regional"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/transport"
 )
 
 func TestAccActionRDBInstanceSnapshot_Basic(t *testing.T) {
@@ -75,11 +76,19 @@ func isSnapshotCreated(tt *acctest.TestTools, instanceResourceName, snapshotName
 
 		api := rdbSDK.NewAPI(tt.Meta.ScwClient())
 
-		snapshots, err := api.ListSnapshots(&rdbSDK.ListSnapshotsRequest{
-			Region:     region,
-			InstanceID: new(id),
-			Name:       new(snapshotName),
-		}, scw.WithContext(context.Background()))
+		var snapshots *rdbSDK.ListSnapshotsResponse
+
+		err = transport.RetryOn403(context.Background(), func() error {
+			var err error
+
+			snapshots, err = api.ListSnapshots(&rdbSDK.ListSnapshotsRequest{
+				Region:     region,
+				InstanceID: new(id),
+				Name:       new(snapshotName),
+			}, scw.WithContext(context.Background()))
+
+			return err
+		})
 		if err != nil {
 			return fmt.Errorf("failed to list snapshots: %w", err)
 		}

--- a/internal/services/rdb/user_test.go
+++ b/internal/services/rdb/user_test.go
@@ -1,6 +1,7 @@
 package rdb_test
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -11,6 +12,7 @@ import (
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/acctest"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/services/rdb"
 	rdbchecks "github.com/scaleway/terraform-provider-scaleway/v2/internal/services/rdb/testfuncs"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/transport"
 )
 
 func TestAccUser_Basic(t *testing.T) {
@@ -202,10 +204,18 @@ func isUserPresent(tt *acctest.TestTools, instance string, user string) resource
 			return err
 		}
 
-		users, err := rdbAPI.ListUsers(&rdbSDK.ListUsersRequest{
-			InstanceID: instanceID,
-			Region:     region,
-			Name:       &userName,
+		var users *rdbSDK.ListUsersResponse
+
+		err = transport.RetryOn403(context.Background(), func() error {
+			var err error
+
+			users, err = rdbAPI.ListUsers(&rdbSDK.ListUsersRequest{
+				InstanceID: instanceID,
+				Region:     region,
+				Name:       &userName,
+			})
+
+			return err
 		})
 		if err != nil {
 			return err

--- a/internal/services/rdb/waiters.go
+++ b/internal/services/rdb/waiters.go
@@ -2,46 +2,12 @@ package rdb
 
 import (
 	"context"
-	"errors"
-	"net/http"
 	"time"
 
 	"github.com/scaleway/scaleway-sdk-go/api/rdb/v1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/transport"
 )
-
-var (
-	maxRetriesOnForbidden = 3
-	waitTime              = 1 * time.Second
-)
-
-// Mitigate transient permission issue during provisioning,
-// caused by IAM permissions propagation delta.
-func retryOn403(ctx context.Context, fn func() error) error {
-	var lastErr error
-
-	for range maxRetriesOnForbidden {
-		lastErr = fn()
-		if lastErr == nil {
-			return nil
-		}
-
-		var respErr *scw.ResponseError
-		if errors.As(lastErr, &respErr) && respErr.StatusCode == http.StatusForbidden {
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case <-time.After(waitTime):
-				continue
-			}
-		}
-
-		return lastErr
-	}
-
-	return lastErr
-}
 
 func waitForRDBInstance(ctx context.Context, api *rdb.API, region scw.Region, id string, timeout time.Duration) (*rdb.Instance, error) {
 	retryInterval := defaultWaitRetryInterval
@@ -51,7 +17,7 @@ func waitForRDBInstance(ctx context.Context, api *rdb.API, region scw.Region, id
 
 	var instance *rdb.Instance
 
-	err := retryOn403(ctx, func() error {
+	err := transport.RetryOn403(ctx, func() error {
 		var err error
 
 		instance, err = api.WaitForInstance(&rdb.WaitForInstanceRequest{
@@ -75,7 +41,7 @@ func waitForRDBDatabaseBackup(ctx context.Context, api *rdb.API, region scw.Regi
 
 	var backup *rdb.DatabaseBackup
 
-	err := retryOn403(ctx, func() error {
+	err := transport.RetryOn403(ctx, func() error {
 		var err error
 
 		backup, err = api.WaitForDatabaseBackup(&rdb.WaitForDatabaseBackupRequest{
@@ -99,7 +65,7 @@ func waitForRDBReadReplica(ctx context.Context, api *rdb.API, region scw.Region,
 
 	var replica *rdb.ReadReplica
 
-	err := retryOn403(ctx, func() error {
+	err := transport.RetryOn403(ctx, func() error {
 		var err error
 
 		replica, err = api.WaitForReadReplica(&rdb.WaitForReadReplicaRequest{
@@ -123,7 +89,7 @@ func waitForRDBSnapshot(ctx context.Context, api *rdb.API, region scw.Region, sn
 
 	var snapshot *rdb.Snapshot
 
-	err := retryOn403(ctx, func() error {
+	err := transport.RetryOn403(ctx, func() error {
 		var err error
 
 		snapshot, err = api.WaitForSnapshot(&rdb.WaitForSnapshotRequest{

--- a/internal/transport/retry.go
+++ b/internal/transport/retry.go
@@ -15,8 +15,10 @@ import (
 )
 
 const (
-	// MaxRetriesOnForbidden is the number of retries when a request fails with HTTP 403.
-	MaxRetriesOnForbidden = 5
+	// IAMPropagationTimeout bounds how long RetryOn403 keeps retrying a transient HTTP 403 while IAM
+	// permissions propagate. IAM is eventually consistent and its cache is per-instance, so a freshly
+	// granted permission can intermittently 403 even after a prior 200.
+	IAMPropagationTimeout = 2 * time.Minute
 
 	// RetryOn403WaitTime is the delay between retries on HTTP 403.
 	RetryOn403WaitTime = 2 * time.Second
@@ -120,57 +122,49 @@ func (c *RetryableTransport) RoundTrip(r *http.Request) (*http.Response, error) 
 	return c.Do(req)
 }
 
-// RetryOn403 retries fn when it returns a transient HTTP 403 caused by IAM permission propagation.
+// RetryOn403 retries fn while it returns a transient HTTP 403 caused by IAM permission propagation,
+// up to IAMPropagationTimeout. Any non-403 error (including a legitimate, persistent 403 that
+// outlives the propagation window) is returned to the caller without further retries.
 func RetryOn403(ctx context.Context, fn func() error) error {
-	var lastErr error
+	_, err := RetryOn403Value(ctx, func() (struct{}, error) {
+		return struct{}{}, fn()
+	})
 
-	for range MaxRetriesOnForbidden {
-		lastErr = fn()
-		if lastErr == nil {
-			return nil
-		}
-
-		if httperrors.Is403(lastErr) {
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case <-time.After(RetryOn403WaitTime):
-				continue
-			}
-		}
-
-		return lastErr
-	}
-
-	return lastErr
+	return err
 }
 
-// RetryOn403Value retries fn when it returns a transient HTTP 403 caused by IAM permission propagation.
+// RetryOn403Value behaves like RetryOn403 for a function returning a value.
 func RetryOn403Value[T any](ctx context.Context, fn func() (T, error)) (T, error) {
 	var (
 		result  T
 		lastErr error
 	)
 
-	for range MaxRetriesOnForbidden {
+	wait := RetryOn403WaitTime
+	if DefaultWaitRetryInterval != nil {
+		wait = *DefaultWaitRetryInterval
+	}
+
+	deadline := time.Now().Add(IAMPropagationTimeout)
+
+	for {
 		result, lastErr = fn()
 		if lastErr == nil {
 			return result, nil
 		}
 
-		if httperrors.Is403(lastErr) {
-			select {
-			case <-ctx.Done():
-				return result, ctx.Err()
-			case <-time.After(RetryOn403WaitTime):
-				continue
-			}
+		// Stop on any non-403 error, or once the propagation window elapses: a 403 outliving
+		// IAMPropagationTimeout is treated as a real permission problem, not propagation lag.
+		if !httperrors.Is403(lastErr) || time.Now().After(deadline) {
+			return result, lastErr
 		}
 
-		return result, lastErr
+		select {
+		case <-ctx.Done():
+			return result, ctx.Err()
+		case <-time.After(wait):
+		}
 	}
-
-	return result, lastErr
 }
 
 func RetryOnTransientStateError[T any, U any](action func() (T, error), waiter func() (U, error)) (T, error) {


### PR DESCRIPTION
## Summary

IAM is eventually consistent: just after a resource is created, a granted permission can intermittently return 403 (even after a prior 200), causing flaky acceptance tests. This bounds the 403 retry by a 2-minute propagation window — a 403 that outlives it is treated as a real permission error.

## Changes

- `transport.RetryOn403` / `RetryOn403Value` are bounded by `IAMPropagationTimeout` (2 min) instead of a fixed retry count; they retry only on HTTP 403 and respect `ctx`. On VCR replay the wait collapses to 0.
- `rdb` `retryOn403` now delegates to `transport.RetryOn403`.
- Acceptance `Check` functions in cockpit & rdb call the API directly (outside provider CRUD) and were not guarded; their reads are now wrapped with `transport.RetryOn403`.