### PR TITLE
fix(secret/kms): add retries on eventually consistent calls

### DIFF
--- a/internal/services/keymanager/key_resource.go
+++ b/internal/services/keymanager/key_resource.go
@@ -14,6 +14,7 @@ import (
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/identity"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/locality/regional"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/services/account"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/transport"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/types"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/verify"
 )
@@ -168,7 +169,15 @@ func resourceKeyManagerKeyCreate(ctx context.Context, d *schema.ResourceData, m 
 
 	createReq.Usage = keyUsage
 
-	key, err := api.CreateKey(createReq)
+	var key *key_manager.Key
+
+	err = transport.RetryOn403(ctx, func() error {
+		var err error
+
+		key, err = api.CreateKey(createReq)
+
+		return err
+	})
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -187,9 +196,12 @@ func resourceKeyManagerKeyRead(ctx context.Context, d *schema.ResourceData, m an
 		return diag.FromErr(err)
 	}
 
-	key, err := client.GetKey(&key_manager.GetKeyRequest{
-		Region: region,
-		KeyID:  keyID,
+	// Retry on 404 to handle eventual consistency issues
+	key, err := transport.RetryOn404(ctx, func(ctx context.Context) (*key_manager.Key, error) {
+		return client.GetKey(&key_manager.GetKeyRequest{
+			Region: region,
+			KeyID:  keyID,
+		})
 	})
 	if err != nil {
 		return diag.FromErr(err)
@@ -253,9 +265,11 @@ func resourceKeyManagerKeyDelete(ctx context.Context, d *schema.ResourceData, m 
 		return diag.FromErr(err)
 	}
 
-	err = client.DeleteKey(&key_manager.DeleteKeyRequest{
-		Region: region,
-		KeyID:  keyID,
+	err = transport.RetryOn403(ctx, func() error {
+		return client.DeleteKey(&key_manager.DeleteKeyRequest{
+			Region: region,
+			KeyID:  keyID,
+		})
 	})
 	if err != nil {
 		return diag.FromErr(err)

--- a/internal/services/keymanager/testdata/action-rotate-key-basic.cassette.yaml
+++ b/internal/services/keymanager/testdata/action-rotate-key-basic.cassette.yaml
@@ -6,36 +6,36 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 232
+        content_length: 278
         host: api.scaleway.com
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation-action","usage":{"symmetric_encryption":"aes_256_gcm"},"description":"Test key","tags":["tf","test"],"unprotected":true,"origin":"unknown_origin"}'
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation-action","usage":{"symmetric_encryption":"aes_256_gcm"},"description":"Test key","tags":["tf","test"],"unprotected":true,"origin":"unknown_origin","protection_level":"unknown_protection_level"}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 541
-        body: '{"id":"3ea4b5ff-8c94-41ea-9e02-27e86053babc", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-kms-key-rotation-action", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-01-07T10:29:51.325530Z", "updated_at":"2026-01-07T10:29:51.329107Z", "protected":false, "locked":false, "description":"Test key", "tags":["tf", "test"], "rotated_at":"2026-01-07T10:29:51.329107Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 554
+        body: '{"id":"866337c1-b045-426a-91c8-6d3ab6194e9e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation-action","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:23.813688Z","updated_at":"2026-07-03T15:28:23.818427Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:23.818427Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "541"
+                - "554"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 07 Jan 2026 10:29:51 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 717680bb-517c-4628-af8d-d57283d82e0e
+                - f9187ec5-f51c-4c93-9340-a0cb36608421
         status: 200 OK
         code: 200
-        duration: 258.927849ms
+        duration: 95.780472ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -45,29 +45,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/3ea4b5ff-8c94-41ea-9e02-27e86053babc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/866337c1-b045-426a-91c8-6d3ab6194e9e
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 541
-        body: '{"id":"3ea4b5ff-8c94-41ea-9e02-27e86053babc", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-kms-key-rotation-action", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-01-07T10:29:51.325530Z", "updated_at":"2026-01-07T10:29:51.329107Z", "protected":false, "locked":false, "description":"Test key", "tags":["tf", "test"], "rotated_at":"2026-01-07T10:29:51.329107Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 554
+        body: '{"id":"866337c1-b045-426a-91c8-6d3ab6194e9e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation-action","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:23.813688Z","updated_at":"2026-07-03T15:28:23.818427Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:23.818427Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "541"
+                - "554"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 07 Jan 2026 10:29:51 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - fa59c3b0-fecf-4e77-9584-cb9e32b81283
+                - 8af8cc78-f618-4063-b205-f9c807a98701
         status: 200 OK
         code: 200
-        duration: 55.784717ms
+        duration: 52.104116ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -80,29 +80,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/3ea4b5ff-8c94-41ea-9e02-27e86053babc/rotate
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/866337c1-b045-426a-91c8-6d3ab6194e9e/rotate
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 541
-        body: '{"id":"3ea4b5ff-8c94-41ea-9e02-27e86053babc", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-kms-key-rotation-action", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":2, "created_at":"2026-01-07T10:29:51.325530Z", "updated_at":"2026-01-07T10:29:51.585437Z", "protected":false, "locked":false, "description":"Test key", "tags":["tf", "test"], "rotated_at":"2026-01-07T10:29:51.585437Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 554
+        body: '{"id":"866337c1-b045-426a-91c8-6d3ab6194e9e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation-action","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":2,"created_at":"2026-07-03T15:28:23.813688Z","updated_at":"2026-07-03T15:28:24.080715Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:24.080715Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "541"
+                - "554"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 07 Jan 2026 10:29:51 GMT
+                - Fri, 03 Jul 2026 15:28:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - d6a29a99-5a54-4fcd-859f-fe780b1a79a1
+                - 42cf769c-81b8-4482-8bc9-7d02a92ff24c
         status: 200 OK
         code: 200
-        duration: 290.017084ms
+        duration: 198.452669ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -112,29 +112,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/3ea4b5ff-8c94-41ea-9e02-27e86053babc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/866337c1-b045-426a-91c8-6d3ab6194e9e
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 541
-        body: '{"id":"3ea4b5ff-8c94-41ea-9e02-27e86053babc", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-kms-key-rotation-action", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":2, "created_at":"2026-01-07T10:29:51.325530Z", "updated_at":"2026-01-07T10:29:51.585437Z", "protected":false, "locked":false, "description":"Test key", "tags":["tf", "test"], "rotated_at":"2026-01-07T10:29:51.585437Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 554
+        body: '{"id":"866337c1-b045-426a-91c8-6d3ab6194e9e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation-action","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":2,"created_at":"2026-07-03T15:28:23.813688Z","updated_at":"2026-07-03T15:28:24.080715Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:24.080715Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "541"
+                - "554"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 07 Jan 2026 10:29:52 GMT
+                - Fri, 03 Jul 2026 15:28:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 1d1be396-35b7-4f2d-ab84-7068fdb2514e
+                - 1e451726-8985-4e39-9d8f-ef3dfbf3e914
         status: 200 OK
         code: 200
-        duration: 79.238221ms
+        duration: 47.925818ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -144,29 +144,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/3ea4b5ff-8c94-41ea-9e02-27e86053babc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/866337c1-b045-426a-91c8-6d3ab6194e9e
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 541
-        body: '{"id":"3ea4b5ff-8c94-41ea-9e02-27e86053babc", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-kms-key-rotation-action", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":2, "created_at":"2026-01-07T10:29:51.325530Z", "updated_at":"2026-01-07T10:29:51.585437Z", "protected":false, "locked":false, "description":"Test key", "tags":["tf", "test"], "rotated_at":"2026-01-07T10:29:51.585437Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 554
+        body: '{"id":"866337c1-b045-426a-91c8-6d3ab6194e9e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation-action","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":2,"created_at":"2026-07-03T15:28:23.813688Z","updated_at":"2026-07-03T15:28:24.080715Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:24.080715Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "541"
+                - "554"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 07 Jan 2026 10:29:52 GMT
+                - Fri, 03 Jul 2026 15:28:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 3ad41d97-e7ab-4978-93ac-2ba160d26260
+                - d9a8d5d7-111e-45fc-84cd-d9d02bd1b8a0
         status: 200 OK
         code: 200
-        duration: 50.533975ms
+        duration: 41.041067ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -176,29 +176,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/3ea4b5ff-8c94-41ea-9e02-27e86053babc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/866337c1-b045-426a-91c8-6d3ab6194e9e
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 541
-        body: '{"id":"3ea4b5ff-8c94-41ea-9e02-27e86053babc", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-kms-key-rotation-action", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":2, "created_at":"2026-01-07T10:29:51.325530Z", "updated_at":"2026-01-07T10:29:51.585437Z", "protected":false, "locked":false, "description":"Test key", "tags":["tf", "test"], "rotated_at":"2026-01-07T10:29:51.585437Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 554
+        body: '{"id":"866337c1-b045-426a-91c8-6d3ab6194e9e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation-action","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":2,"created_at":"2026-07-03T15:28:23.813688Z","updated_at":"2026-07-03T15:28:24.080715Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:24.080715Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "541"
+                - "554"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 07 Jan 2026 10:29:52 GMT
+                - Fri, 03 Jul 2026 15:28:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 4ee9f329-c265-42b2-9d78-8f67047d6d0a
+                - b8c402b5-6676-4258-9807-e1f31f7a554b
         status: 200 OK
         code: 200
-        duration: 51.894237ms
+        duration: 51.891096ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -208,29 +208,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/3ea4b5ff-8c94-41ea-9e02-27e86053babc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/866337c1-b045-426a-91c8-6d3ab6194e9e
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 541
-        body: '{"id":"3ea4b5ff-8c94-41ea-9e02-27e86053babc", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-kms-key-rotation-action", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":2, "created_at":"2026-01-07T10:29:51.325530Z", "updated_at":"2026-01-07T10:29:51.585437Z", "protected":false, "locked":false, "description":"Test key", "tags":["tf", "test"], "rotated_at":"2026-01-07T10:29:51.585437Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 554
+        body: '{"id":"866337c1-b045-426a-91c8-6d3ab6194e9e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation-action","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":2,"created_at":"2026-07-03T15:28:23.813688Z","updated_at":"2026-07-03T15:28:24.080715Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:24.080715Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "541"
+                - "554"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 07 Jan 2026 10:29:53 GMT
+                - Fri, 03 Jul 2026 15:28:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - de163591-f71b-4a04-9f26-609074de34ab
+                - 03f16cce-4f4b-45ec-83c7-f7004280e6d5
         status: 200 OK
         code: 200
-        duration: 63.014957ms
+        duration: 43.066721ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -240,29 +240,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/3ea4b5ff-8c94-41ea-9e02-27e86053babc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/866337c1-b045-426a-91c8-6d3ab6194e9e
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 541
-        body: '{"id":"3ea4b5ff-8c94-41ea-9e02-27e86053babc", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-kms-key-rotation-action", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":2, "created_at":"2026-01-07T10:29:51.325530Z", "updated_at":"2026-01-07T10:29:51.585437Z", "protected":false, "locked":false, "description":"Test key", "tags":["tf", "test"], "rotated_at":"2026-01-07T10:29:51.585437Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 554
+        body: '{"id":"866337c1-b045-426a-91c8-6d3ab6194e9e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation-action","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":2,"created_at":"2026-07-03T15:28:23.813688Z","updated_at":"2026-07-03T15:28:24.080715Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:24.080715Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "541"
+                - "554"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 07 Jan 2026 10:29:53 GMT
+                - Fri, 03 Jul 2026 15:28:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 4ed24abb-b4a1-4598-832b-fc9625c942df
+                - 16a4e346-cd4e-402e-a6f5-a62501969c17
         status: 200 OK
         code: 200
-        duration: 39.87429ms
+        duration: 44.835343ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -272,29 +272,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/3ea4b5ff-8c94-41ea-9e02-27e86053babc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/866337c1-b045-426a-91c8-6d3ab6194e9e
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 541
-        body: '{"id":"3ea4b5ff-8c94-41ea-9e02-27e86053babc", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-kms-key-rotation-action", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":2, "created_at":"2026-01-07T10:29:51.325530Z", "updated_at":"2026-01-07T10:29:51.585437Z", "protected":false, "locked":false, "description":"Test key", "tags":["tf", "test"], "rotated_at":"2026-01-07T10:29:51.585437Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 554
+        body: '{"id":"866337c1-b045-426a-91c8-6d3ab6194e9e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation-action","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":2,"created_at":"2026-07-03T15:28:23.813688Z","updated_at":"2026-07-03T15:28:24.080715Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:24.080715Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "541"
+                - "554"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 07 Jan 2026 10:29:53 GMT
+                - Fri, 03 Jul 2026 15:28:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 816406e7-219e-4a61-915c-dbcec0a16058
+                - ab1ef72d-a0f0-4ade-9925-a6c5331c0dbe
         status: 200 OK
         code: 200
-        duration: 27.263578ms
+        duration: 46.461808ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -304,8 +304,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/3ea4b5ff-8c94-41ea-9e02-27e86053babc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/866337c1-b045-426a-91c8-6d3ab6194e9e
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -317,14 +317,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 07 Jan 2026 10:29:53 GMT
+                - Fri, 03 Jul 2026 15:28:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - d272528e-847a-449c-9ee3-f54a7d9c8e25
+                - 240a32e9-1435-4ccf-9034-9c61a7ae2b56
         status: 204 No Content
         code: 204
-        duration: 115.417923ms
+        duration: 70.866317ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -334,29 +334,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/3ea4b5ff-8c94-41ea-9e02-27e86053babc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/866337c1-b045-426a-91c8-6d3ab6194e9e
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 581
-        body: '{"id":"3ea4b5ff-8c94-41ea-9e02-27e86053babc", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-kms-key-rotation-action", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"scheduled_for_deletion", "rotation_count":2, "created_at":"2026-01-07T10:29:51.325530Z", "updated_at":"2026-01-07T10:29:51.585437Z", "protected":false, "locked":false, "description":"Test key", "tags":["tf", "test"], "rotated_at":"2026-01-07T10:29:51.585437Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":"2026-01-07T10:29:53.829847Z", "region":"fr-par"}'
+        content_length: 594
+        body: '{"id":"866337c1-b045-426a-91c8-6d3ab6194e9e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation-action","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":2,"created_at":"2026-07-03T15:28:23.813688Z","updated_at":"2026-07-03T15:28:26.130567Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:24.080715Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-03T15:28:26.130566Z","protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "581"
+                - "594"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 07 Jan 2026 10:29:53 GMT
+                - Fri, 03 Jul 2026 15:28:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 5a693db0-bcb6-42c6-a8c2-42ea29e52c5a
+                - 1122f6b0-fb72-41a6-8e32-67b73326cd43
         status: 200 OK
         code: 200
-        duration: 88.686387ms
+        duration: 48.180887ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -366,26 +366,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/3ea4b5ff-8c94-41ea-9e02-27e86053babc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/866337c1-b045-426a-91c8-6d3ab6194e9e
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 581
-        body: '{"id":"3ea4b5ff-8c94-41ea-9e02-27e86053babc", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-kms-key-rotation-action", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"scheduled_for_deletion", "rotation_count":2, "created_at":"2026-01-07T10:29:51.325530Z", "updated_at":"2026-01-07T10:29:51.585437Z", "protected":false, "locked":false, "description":"Test key", "tags":["tf", "test"], "rotated_at":"2026-01-07T10:29:51.585437Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":"2026-01-07T10:29:53.829847Z", "region":"fr-par"}'
+        content_length: 594
+        body: '{"id":"866337c1-b045-426a-91c8-6d3ab6194e9e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation-action","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":2,"created_at":"2026-07-03T15:28:23.813688Z","updated_at":"2026-07-03T15:28:26.130567Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:24.080715Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-03T15:28:26.130566Z","protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "581"
+                - "594"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 07 Jan 2026 10:29:54 GMT
+                - Fri, 03 Jul 2026 15:28:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 355843b3-6683-4a47-8c03-81dc77ebbdfa
+                - 015da37b-89b0-41a9-be97-5a934ec5c30c
         status: 200 OK
         code: 200
-        duration: 72.817766ms
+        duration: 35.355016ms

--- a/internal/services/keymanager/testdata/data-source-key-basic.cassette.yaml
+++ b/internal/services/keymanager/testdata/data-source-key-basic.cassette.yaml
@@ -6,36 +6,36 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 219
+        content_length: 265
         host: api.scaleway.com
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-ds","usage":{"symmetric_encryption":"aes_256_gcm"},"description":"Test key","tags":["tf","test"],"unprotected":true,"origin":"unknown_origin"}'
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-ds","usage":{"symmetric_encryption":"aes_256_gcm"},"description":"Test key","tags":["tf","test"],"unprotected":true,"origin":"unknown_origin","protection_level":"unknown_protection_level"}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 511
-        body: '{"id":"910dc2f0-caff-4ed9-bd92-f8ebe25ddaf5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-ds","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-06-05T16:02:20.888879Z","updated_at":"2026-06-05T16:02:20.891268Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-06-05T16:02:20.891268Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 541
+        body: '{"id":"3ce11279-c8b9-4f12-aaaf-e26766a2967c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-ds","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:21.508255Z","updated_at":"2026-07-03T15:28:21.511698Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:21.511698Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "511"
+                - "541"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Jun 2026 16:02:20 GMT
+                - Fri, 03 Jul 2026 15:28:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 0d44a92d-7fc7-4dd2-9eca-1bf32c528aa6
+                - fa215b5d-104d-4a47-be2d-f2cb3bf9d59c
         status: 200 OK
         code: 200
-        duration: 283.003359ms
+        duration: 266.596542ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -45,29 +45,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/910dc2f0-caff-4ed9-bd92-f8ebe25ddaf5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/3ce11279-c8b9-4f12-aaaf-e26766a2967c
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 511
-        body: '{"id":"910dc2f0-caff-4ed9-bd92-f8ebe25ddaf5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-ds","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-06-05T16:02:20.888879Z","updated_at":"2026-06-05T16:02:20.891268Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-06-05T16:02:20.891268Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 541
+        body: '{"id":"3ce11279-c8b9-4f12-aaaf-e26766a2967c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-ds","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:21.508255Z","updated_at":"2026-07-03T15:28:21.511698Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:21.511698Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "511"
+                - "541"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Jun 2026 16:02:20 GMT
+                - Fri, 03 Jul 2026 15:28:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - d54cebf8-f138-46a7-859b-b7e79d6bac8b
+                - fb97c1c0-925b-40b3-9769-fdbb072b1ea7
         status: 200 OK
         code: 200
-        duration: 40.122629ms
+        duration: 47.061705ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -77,29 +77,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/910dc2f0-caff-4ed9-bd92-f8ebe25ddaf5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/3ce11279-c8b9-4f12-aaaf-e26766a2967c
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 511
-        body: '{"id":"910dc2f0-caff-4ed9-bd92-f8ebe25ddaf5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-ds","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-06-05T16:02:20.888879Z","updated_at":"2026-06-05T16:02:20.891268Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-06-05T16:02:20.891268Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 541
+        body: '{"id":"3ce11279-c8b9-4f12-aaaf-e26766a2967c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-ds","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:21.508255Z","updated_at":"2026-07-03T15:28:21.511698Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:21.511698Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "511"
+                - "541"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Jun 2026 16:02:20 GMT
+                - Fri, 03 Jul 2026 15:28:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 286739c6-a4bc-4f95-a19f-4ec529a99a0e
+                - 5e1126e5-f3ee-44a3-b9f4-8247de777059
         status: 200 OK
         code: 200
-        duration: 28.810263ms
+        duration: 51.001575ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -109,29 +109,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/910dc2f0-caff-4ed9-bd92-f8ebe25ddaf5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/3ce11279-c8b9-4f12-aaaf-e26766a2967c
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 511
-        body: '{"id":"910dc2f0-caff-4ed9-bd92-f8ebe25ddaf5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-ds","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-06-05T16:02:20.888879Z","updated_at":"2026-06-05T16:02:20.891268Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-06-05T16:02:20.891268Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 541
+        body: '{"id":"3ce11279-c8b9-4f12-aaaf-e26766a2967c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-ds","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:21.508255Z","updated_at":"2026-07-03T15:28:21.511698Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:21.511698Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "511"
+                - "541"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Jun 2026 16:02:21 GMT
+                - Fri, 03 Jul 2026 15:28:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 78ff9199-b9a7-4ebb-bdb5-2c4481b019aa
+                - 5ae63f97-04e5-46cb-a2f0-3fb724a48748
         status: 200 OK
         code: 200
-        duration: 31.04393ms
+        duration: 34.258436ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -141,29 +141,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/910dc2f0-caff-4ed9-bd92-f8ebe25ddaf5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/3ce11279-c8b9-4f12-aaaf-e26766a2967c
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 511
-        body: '{"id":"910dc2f0-caff-4ed9-bd92-f8ebe25ddaf5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-ds","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-06-05T16:02:20.888879Z","updated_at":"2026-06-05T16:02:20.891268Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-06-05T16:02:20.891268Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 541
+        body: '{"id":"3ce11279-c8b9-4f12-aaaf-e26766a2967c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-ds","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:21.508255Z","updated_at":"2026-07-03T15:28:21.511698Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:21.511698Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "511"
+                - "541"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Jun 2026 16:02:21 GMT
+                - Fri, 03 Jul 2026 15:28:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 2a1fcf6d-f630-4349-80f8-0a11f2ceb5c2
+                - 8ded4ea3-88ff-46aa-8b18-771470ea9588
         status: 200 OK
         code: 200
-        duration: 38.869904ms
+        duration: 45.031823ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -173,29 +173,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/910dc2f0-caff-4ed9-bd92-f8ebe25ddaf5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/3ce11279-c8b9-4f12-aaaf-e26766a2967c
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 511
-        body: '{"id":"910dc2f0-caff-4ed9-bd92-f8ebe25ddaf5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-ds","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-06-05T16:02:20.888879Z","updated_at":"2026-06-05T16:02:20.891268Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-06-05T16:02:20.891268Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 541
+        body: '{"id":"3ce11279-c8b9-4f12-aaaf-e26766a2967c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-ds","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:21.508255Z","updated_at":"2026-07-03T15:28:21.511698Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:21.511698Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "511"
+                - "541"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Jun 2026 16:02:21 GMT
+                - Fri, 03 Jul 2026 15:28:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 566af168-e690-4923-8cf6-13d481f5be11
+                - eaedcbab-d617-466d-881f-ec8b5232a2de
         status: 200 OK
         code: 200
-        duration: 42.437828ms
+        duration: 49.704358ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -205,8 +205,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/910dc2f0-caff-4ed9-bd92-f8ebe25ddaf5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/3ce11279-c8b9-4f12-aaaf-e26766a2967c
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -218,14 +218,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Jun 2026 16:02:21 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - a49659d3-4903-4c81-a40a-2d7ccfd9bd97
+                - 50768a69-04a0-4c97-9988-e6ab41b949ff
         status: 204 No Content
         code: 204
-        duration: 114.385384ms
+        duration: 150.215626ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -235,29 +235,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/910dc2f0-caff-4ed9-bd92-f8ebe25ddaf5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/3ce11279-c8b9-4f12-aaaf-e26766a2967c
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 551
-        body: '{"id":"910dc2f0-caff-4ed9-bd92-f8ebe25ddaf5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-ds","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-06-05T16:02:20.888879Z","updated_at":"2026-06-05T16:02:20.891268Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-06-05T16:02:20.891268Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-06-05T16:02:21.898531Z","region":"fr-par"}'
+        content_length: 581
+        body: '{"id":"3ce11279-c8b9-4f12-aaaf-e26766a2967c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-ds","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-03T15:28:21.508255Z","updated_at":"2026-07-03T15:28:23.104417Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:21.511698Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-03T15:28:23.104417Z","protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "551"
+                - "581"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Jun 2026 16:02:21 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 4a446f0e-e478-46f6-aa07-54dc80dd9536
+                - 99ba9850-c01a-449c-b511-d6d4367779a0
         status: 200 OK
         code: 200
-        duration: 42.176858ms
+        duration: 41.837182ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -267,26 +267,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/910dc2f0-caff-4ed9-bd92-f8ebe25ddaf5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/3ce11279-c8b9-4f12-aaaf-e26766a2967c
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 551
-        body: '{"id":"910dc2f0-caff-4ed9-bd92-f8ebe25ddaf5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-ds","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-06-05T16:02:20.888879Z","updated_at":"2026-06-05T16:02:20.891268Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-06-05T16:02:20.891268Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-06-05T16:02:21.898531Z","region":"fr-par"}'
+        content_length: 581
+        body: '{"id":"3ce11279-c8b9-4f12-aaaf-e26766a2967c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-ds","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-03T15:28:21.508255Z","updated_at":"2026-07-03T15:28:23.104417Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:21.511698Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-03T15:28:23.104417Z","protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "551"
+                - "581"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Jun 2026 16:02:22 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - e0233e60-ac68-46fe-bfb6-bbb581c0b712
+                - 3882cb86-e3d5-4b7e-873f-a01b96eea161
         status: 200 OK
         code: 200
-        duration: 34.878795ms
+        duration: 34.513827ms

--- a/internal/services/keymanager/testdata/data-source-verify-basic.cassette.yaml
+++ b/internal/services/keymanager/testdata/data-source-verify-basic.cassette.yaml
@@ -13,29 +13,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 449
-        body: '{"id":"5f1e5c6b-c6ed-4737-8cec-ade7b6b92b63", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"test-verify-secret", "status":"ready", "created_at":"2026-01-23T17:30:33.795583Z", "updated_at":"2026-01-23T17:30:33.795583Z", "tags":[], "version_count":0, "description":"", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}'
+        content_length: 432
+        body: '{"id":"fd998353-a9be-444d-afec-f8546785aac4","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-verify-secret","status":"ready","created_at":"2026-07-03T15:28:18.803210Z","updated_at":"2026-07-03T15:28:18.803210Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "449"
+                - "432"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:33 GMT
+                - Fri, 03 Jul 2026 15:28:18 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 13d4bbe2-6e76-406c-b06d-7e4dab1879e9
+                - df4b2d91-a7ca-4b2b-a47d-06079d1fa781
         status: 200 OK
         code: 200
-        duration: 255.611141ms
+        duration: 185.190779ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -45,65 +45,30 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5f1e5c6b-c6ed-4737-8cec-ade7b6b92b63
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/fd998353-a9be-444d-afec-f8546785aac4
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 449
-        body: '{"id":"5f1e5c6b-c6ed-4737-8cec-ade7b6b92b63", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"test-verify-secret", "status":"ready", "created_at":"2026-01-23T17:30:33.795583Z", "updated_at":"2026-01-23T17:30:33.795583Z", "tags":[], "version_count":0, "description":"", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}'
+        content_length: 432
+        body: '{"id":"fd998353-a9be-444d-afec-f8546785aac4","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-verify-secret","status":"ready","created_at":"2026-07-03T15:28:18.803210Z","updated_at":"2026-07-03T15:28:18.803210Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "449"
+                - "432"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:33 GMT
+                - Fri, 03 Jul 2026 15:28:18 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - cd59699a-1d43-4ae6-84eb-a44c0f02a4ab
+                - 0441e972-feaf-4223-a8cf-c544e6991577
         status: 200 OK
         code: 200
-        duration: 81.995954ms
+        duration: 45.750392ms
     - id: 2
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 191
-        host: api.scaleway.com
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"tags":null,"unprotected":true,"origin":"unknown_origin"}'
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 516
-        body: '{"id":"9e624e94-4092-426e-acdf-a51f748c0247", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-verify-key", "usage":{"asymmetric_signing":"rsa_pss_2048_sha256"}, "state":"enabled", "rotation_count":1, "created_at":"2026-01-23T17:30:33.812404Z", "updated_at":"2026-01-23T17:30:33.898520Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-01-23T17:30:33.898520Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "516"
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 17:30:33 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            X-Request-Id:
-                - c118ab4c-b61b-43a8-be66-fd0dd4565107
-        status: 200 OK
-        code: 200
-        duration: 374.344511ms
-    - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -115,29 +80,64 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5f1e5c6b-c6ed-4737-8cec-ade7b6b92b63/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/fd998353-a9be-444d-afec-f8546785aac4/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 32
-        body: '{"versions":[], "total_count":0}'
+        content_length: 31
+        body: '{"versions":[],"total_count":0}'
         headers:
             Content-Length:
-                - "32"
+                - "31"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:33 GMT
+                - Fri, 03 Jul 2026 15:28:18 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 1806b1cf-b388-4416-92d8-38d788eab461
+                - 91f23282-e4c9-48b9-836f-12d6142b3e5a
         status: 200 OK
         code: 200
-        duration: 75.458599ms
+        duration: 44.152991ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 237
+        host: api.scaleway.com
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"tags":null,"unprotected":true,"origin":"unknown_origin","protection_level":"unknown_protection_level"}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 530
+        body: '{"id":"7e6da60c-5bfa-475c-851d-c7cf98923041","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.283852Z","updated_at":"2026-07-03T15:28:19.368507Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.368507Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "530"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:19 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - df1184e2-6c60-4e52-9dd5-b7eaf4c63971
+        status: 200 OK
+        code: 200
+        duration: 755.031225ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -147,29 +147,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/9e624e94-4092-426e-acdf-a51f748c0247
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/7e6da60c-5bfa-475c-851d-c7cf98923041
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 516
-        body: '{"id":"9e624e94-4092-426e-acdf-a51f748c0247", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-verify-key", "usage":{"asymmetric_signing":"rsa_pss_2048_sha256"}, "state":"enabled", "rotation_count":1, "created_at":"2026-01-23T17:30:33.812404Z", "updated_at":"2026-01-23T17:30:33.898520Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-01-23T17:30:33.898520Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 530
+        body: '{"id":"7e6da60c-5bfa-475c-851d-c7cf98923041","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.283852Z","updated_at":"2026-07-03T15:28:19.368507Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.368507Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "516"
+                - "530"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:34 GMT
+                - Fri, 03 Jul 2026 15:28:19 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 7b6cc9b7-6357-4243-84f3-2eae2d98777a
+                - 836781c0-e21c-4c8a-97e6-f57653c04b92
         status: 200 OK
         code: 200
-        duration: 87.397269ms
+        duration: 145.915629ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -182,29 +182,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/9e624e94-4092-426e-acdf-a51f748c0247/sign
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/7e6da60c-5bfa-475c-851d-c7cf98923041/sign
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 409
-        body: '{"key_id":"9e624e94-4092-426e-acdf-a51f748c0247", "signature":"Uj2O31pSiPmHnKazOnD9i3OnuE15O6jMTwjLylg5UfhQ/KZEnIdxTqkle10oDAjKavmJevSTi7VXXXzFrNUo7x/5bWVe+sR6vDh0DaJd0dr+94h110Z71ONM/bGZtC9RfBPeXaDrs7JKHRk5PnnmPqQwbDYjLSU7Dv7rj1ikLHHGEXcDGAZZiQBmzYuEaf0fNik16fzRYXToJTMWfTZrBx6GPmBh9v79Dz/EGcX6hLspGKP4VySt72pvuMqJ0Rp37ZdhN9yCTOE0sOSfbUKODGZvNEZkcm7J+NK1eCyNzlVQKlaSB+IROlPRXnHcEg+hLM5EhJpnj2ctHD5qv2em6g=="}'
+        content_length: 408
+        body: '{"key_id":"7e6da60c-5bfa-475c-851d-c7cf98923041","signature":"Dub3a7I4vAHU2uTpV/sZ1Zt1m2qrq2I1xzseAU9uTXwMTk5nsy/NHKxW1RP4TmRiVE1lJLXmO8E2R8lJlCn+JGWWCWSyFj9RZviiAFdFwXRlrhAclpo5ntDDbATk9WOA3DFmJ8KUkZAUXlDYyOc4Mf1uBhAC6hqUlNoBzcCmsmG8JJuJLqAODSZqhZWFqcMZTncdyPPXHuB/NeWsQA1IXi/4UBsexNmMku9AuzvWQMnMmBR9hd0NsUckuLqtWYWsCeDhuTSrx2eFphX4O4ewdp0Bepj5WdDYvx+kvv98+FwDklSotx68pIT8E2sl7+W16qtlRDqsmzLlf46/9lAG1A=="}'
         headers:
             Content-Length:
-                - "409"
+                - "408"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:34 GMT
+                - Fri, 03 Jul 2026 15:28:19 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 71882f0d-6cd0-4a9f-bab2-85fb768c3e2f
+                - 42472701-4303-4c78-b9e7-e6013dd0def6
         status: 200 OK
         code: 200
-        duration: 127.542216ms
+        duration: 110.355288ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -212,34 +212,34 @@ interactions:
         proto_minor: 1
         content_length: 496
         host: api.scaleway.com
-        body: '{"data":"VWoyTzMxcFNpUG1Ibkthek9uRDlpM09udUUxNU82ak1Ud2pMeWxnNVVmaFEvS1pFbklkeFRxa2xlMTBvREFqS2F2bUpldlNUaTdWWFhYekZyTlVvN3gvNWJXVmUrc1I2dkRoMERhSmQwZHIrOTRoMTEwWjcxT05NL2JHWnRDOVJmQlBlWGFEcnM3SktIUms1UG5ubVBxUXdiRFlqTFNVN0R2N3JqMWlrTEhIR0VYY0RHQVpaaVFCbXpZdUVhZjBmTmlrMTZmelJZWFRvSlRNV2ZUWnJCeDZHUG1CaDl2NzlEei9FR2NYNmhMc3BHS1A0VnlTdDcycHZ1TXFKMFJwMzdaZGhOOXlDVE9FMHNPU2ZiVUtPREdadk5FWmtjbTdKK05LMWVDeU56bFZRS2xhU0IrSVJPbFBSWG5IY0VnK2hMTTVFaEpwbmoyY3RIRDVxdjJlbTZnPT0=","description":"version1"}'
+        body: '{"data":"RHViM2E3STR2QUhVMnVUcFYvc1oxWnQxbTJxcnEySTF4enNlQVU5dVRYd01UazVuc3kvTkhLeFcxUlA0VG1SaVZFMWxKTFhtTzhFMlI4bEpsQ24rSkdXV0NXU3lGajlSWnZpaUFGZEZ3WFJscmhBY2xwbzVudEREYkFUazlXT0EzREZtSjhLVWtaQVVYbERZeU9jNE1mMXVCaEFDNmhxVWxOb0J6Y0Ntc21HOEpKdUpMcUFPRFNacWhaV0ZxY01aVG5jZHlQUFhIdUIvTmVXc1FBMUlYaS80VUJzZXhObU1rdTlBdXp2V1FNbk1tQlI5aGQwTnNVY2t1THF0V1lXc0NlRGh1VFNyeDJlRnBoWDRPNGV3ZHAwQmVwajVXZERZdngra3Z2OTgrRndEa2xTb3R4NjhwSVQ4RTJzbDcrVzE2cXRsUkRxc216TGxmNDYvOWxBRzFBPT0=","description":"version1"}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5f1e5c6b-c6ed-4737-8cec-ade7b6b92b63/versions
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/fd998353-a9be-444d-afec-f8546785aac4/versions
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 312
-        body: '{"revision":1, "secret_id":"5f1e5c6b-c6ed-4737-8cec-ade7b6b92b63", "status":"enabled", "created_at":"2026-01-23T17:30:34.465528Z", "updated_at":"2026-01-23T17:30:34.465528Z", "deleted_at":null, "description":"version1", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 302
+        body: '{"revision":1,"secret_id":"fd998353-a9be-444d-afec-f8546785aac4","status":"enabled","created_at":"2026-07-03T15:28:19.949555Z","updated_at":"2026-07-03T15:28:19.949555Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "312"
+                - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:34 GMT
+                - Fri, 03 Jul 2026 15:28:19 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 85d2c0ad-8045-4950-9b64-f6a95a2eb590
+                - dbb1024b-603e-4973-bfeb-a23eabf57d94
         status: 200 OK
         code: 200
-        duration: 330.566915ms
+        duration: 312.379965ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -249,29 +249,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5f1e5c6b-c6ed-4737-8cec-ade7b6b92b63/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/fd998353-a9be-444d-afec-f8546785aac4/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 312
-        body: '{"revision":1, "secret_id":"5f1e5c6b-c6ed-4737-8cec-ade7b6b92b63", "status":"enabled", "created_at":"2026-01-23T17:30:34.465528Z", "updated_at":"2026-01-23T17:30:34.465528Z", "deleted_at":null, "description":"version1", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 302
+        body: '{"revision":1,"secret_id":"fd998353-a9be-444d-afec-f8546785aac4","status":"enabled","created_at":"2026-07-03T15:28:19.949555Z","updated_at":"2026-07-03T15:28:19.949555Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "312"
+                - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:34 GMT
+                - Fri, 03 Jul 2026 15:28:20 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 0c534b1f-3b5f-4fa6-a356-6211ade629a1
+                - e844af64-9d14-4f0b-91e6-137fe7e44735
         status: 200 OK
         code: 200
-        duration: 35.50923ms
+        duration: 53.776037ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -281,29 +281,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5f1e5c6b-c6ed-4737-8cec-ade7b6b92b63/versions/1/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/fd998353-a9be-444d-afec-f8546785aac4/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 573
-        body: '{"secret_id":"5f1e5c6b-c6ed-4737-8cec-ade7b6b92b63", "revision":1, "data":"VWoyTzMxcFNpUG1Ibkthek9uRDlpM09udUUxNU82ak1Ud2pMeWxnNVVmaFEvS1pFbklkeFRxa2xlMTBvREFqS2F2bUpldlNUaTdWWFhYekZyTlVvN3gvNWJXVmUrc1I2dkRoMERhSmQwZHIrOTRoMTEwWjcxT05NL2JHWnRDOVJmQlBlWGFEcnM3SktIUms1UG5ubVBxUXdiRFlqTFNVN0R2N3JqMWlrTEhIR0VYY0RHQVpaaVFCbXpZdUVhZjBmTmlrMTZmelJZWFRvSlRNV2ZUWnJCeDZHUG1CaDl2NzlEei9FR2NYNmhMc3BHS1A0VnlTdDcycHZ1TXFKMFJwMzdaZGhOOXlDVE9FMHNPU2ZiVUtPREdadk5FWmtjbTdKK05LMWVDeU56bFZRS2xhU0IrSVJPbFBSWG5IY0VnK2hMTTVFaEpwbmoyY3RIRDVxdjJlbTZnPT0=", "data_crc32":null, "type":"opaque"}'
+        content_length: 569
+        body: '{"secret_id":"fd998353-a9be-444d-afec-f8546785aac4","revision":1,"data":"RHViM2E3STR2QUhVMnVUcFYvc1oxWnQxbTJxcnEySTF4enNlQVU5dVRYd01UazVuc3kvTkhLeFcxUlA0VG1SaVZFMWxKTFhtTzhFMlI4bEpsQ24rSkdXV0NXU3lGajlSWnZpaUFGZEZ3WFJscmhBY2xwbzVudEREYkFUazlXT0EzREZtSjhLVWtaQVVYbERZeU9jNE1mMXVCaEFDNmhxVWxOb0J6Y0Ntc21HOEpKdUpMcUFPRFNacWhaV0ZxY01aVG5jZHlQUFhIdUIvTmVXc1FBMUlYaS80VUJzZXhObU1rdTlBdXp2V1FNbk1tQlI5aGQwTnNVY2t1THF0V1lXc0NlRGh1VFNyeDJlRnBoWDRPNGV3ZHAwQmVwajVXZERZdngra3Z2OTgrRndEa2xTb3R4NjhwSVQ4RTJzbDcrVzE2cXRsUkRxc216TGxmNDYvOWxBRzFBPT0=","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "573"
+                - "569"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:34 GMT
+                - Fri, 03 Jul 2026 15:28:20 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - bdd8e620-89e2-4525-afbe-e4875951cb6c
+                - c05bdae9-e510-430d-b745-9b48b3156bb4
         status: 200 OK
         code: 200
-        duration: 82.96192ms
+        duration: 272.737065ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -313,29 +313,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5f1e5c6b-c6ed-4737-8cec-ade7b6b92b63/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/fd998353-a9be-444d-afec-f8546785aac4/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 312
-        body: '{"revision":1, "secret_id":"5f1e5c6b-c6ed-4737-8cec-ade7b6b92b63", "status":"enabled", "created_at":"2026-01-23T17:30:34.465528Z", "updated_at":"2026-01-23T17:30:34.465528Z", "deleted_at":null, "description":"version1", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 302
+        body: '{"revision":1,"secret_id":"fd998353-a9be-444d-afec-f8546785aac4","status":"enabled","created_at":"2026-07-03T15:28:19.949555Z","updated_at":"2026-07-03T15:28:19.949555Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "312"
+                - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:34 GMT
+                - Fri, 03 Jul 2026 15:28:20 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - fd85defc-9f5f-4adf-a9fc-57c82a8d664a
+                - c663e1ab-56a2-4cb2-bce1-69bb59b0bcb0
         status: 200 OK
         code: 200
-        duration: 42.261154ms
+        duration: 52.127009ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -343,34 +343,34 @@ interactions:
         proto_minor: 1
         content_length: 416
         host: api.scaleway.com
-        body: '{"digest":"+wxGDJPL0C0K00FBHoXsjM0xaYYPTtIHSfdfjlvQEMs=","signature":"Uj2O31pSiPmHnKazOnD9i3OnuE15O6jMTwjLylg5UfhQ/KZEnIdxTqkle10oDAjKavmJevSTi7VXXXzFrNUo7x/5bWVe+sR6vDh0DaJd0dr+94h110Z71ONM/bGZtC9RfBPeXaDrs7JKHRk5PnnmPqQwbDYjLSU7Dv7rj1ikLHHGEXcDGAZZiQBmzYuEaf0fNik16fzRYXToJTMWfTZrBx6GPmBh9v79Dz/EGcX6hLspGKP4VySt72pvuMqJ0Rp37ZdhN9yCTOE0sOSfbUKODGZvNEZkcm7J+NK1eCyNzlVQKlaSB+IROlPRXnHcEg+hLM5EhJpnj2ctHD5qv2em6g=="}'
+        body: '{"digest":"+wxGDJPL0C0K00FBHoXsjM0xaYYPTtIHSfdfjlvQEMs=","signature":"Dub3a7I4vAHU2uTpV/sZ1Zt1m2qrq2I1xzseAU9uTXwMTk5nsy/NHKxW1RP4TmRiVE1lJLXmO8E2R8lJlCn+JGWWCWSyFj9RZviiAFdFwXRlrhAclpo5ntDDbATk9WOA3DFmJ8KUkZAUXlDYyOc4Mf1uBhAC6hqUlNoBzcCmsmG8JJuJLqAODSZqhZWFqcMZTncdyPPXHuB/NeWsQA1IXi/4UBsexNmMku9AuzvWQMnMmBR9hd0NsUckuLqtWYWsCeDhuTSrx2eFphX4O4ewdp0Bepj5WdDYvx+kvv98+FwDklSotx68pIT8E2sl7+W16qtlRDqsmzLlf46/9lAG1A=="}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/9e624e94-4092-426e-acdf-a51f748c0247/verify
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/7e6da60c-5bfa-475c-851d-c7cf98923041/verify
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 63
-        body: '{"key_id":"9e624e94-4092-426e-acdf-a51f748c0247", "valid":true}'
+        content_length: 62
+        body: '{"key_id":"7e6da60c-5bfa-475c-851d-c7cf98923041","valid":true}'
         headers:
             Content-Length:
-                - "63"
+                - "62"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:34 GMT
+                - Fri, 03 Jul 2026 15:28:20 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - faad9339-e45c-44cd-a73d-163b406d33bb
+                - 9e104f01-e370-43a3-9540-d64164a14812
         status: 200 OK
         code: 200
-        duration: 92.187419ms
+        duration: 106.6884ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -383,29 +383,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/9e624e94-4092-426e-acdf-a51f748c0247/sign
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/7e6da60c-5bfa-475c-851d-c7cf98923041/sign
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 409
-        body: '{"key_id":"9e624e94-4092-426e-acdf-a51f748c0247", "signature":"FXudcdCC4Ecw5V7erKbjM6Lc1nKs3hUgvGac7dveaRQjOHCRyrS4W6wSl7i0jZ6lshuEk2EOQ7RbuDlzZcVDzQz/DGdo757hDZuGj4+MtN3N1oohAJXF+sST37/WhoGLa8CQJyBDDkgf4vKcYjjtXN7oZrIzu4KYu6RMdhm2+l8gaL5pAV/u/0XxMN0MfbRk7exByfVVcecg7esNBZvtESGGQyU9vL7v13+K33nIufO2I/rkZltu2+U2ZIavRXAho6UCK/W85y09tmHG83sYNmhB2xZiRnsiBTiLTf7iZIgHon4DWWZetdUBf5of73+pyNkpaLTm/rPuaizUmsH8FA=="}'
+        content_length: 408
+        body: '{"key_id":"7e6da60c-5bfa-475c-851d-c7cf98923041","signature":"a/V7hvaqo0XfE9pM7ntzeO1rfzzfdAzPI/X2hy4AsjLlgZeVVpXJ56glZSX86mddx+DQIKmY3FxgmVRVb2ZhEtCsb6X/ntIsa1eRq9+OjTr4sFn2CZ/uqPVFK7+5Zgl3XfIWZpigMAyBppKSo+qXrGJ0j7PXuCxDLYx5BkYI5MSjeQvlaWQum0JsyHX8AF8fdA6XpbZ86XxFOKy1b+e1xFXFa/hHsezVV8ddJ9jk5h2MgZt6VvM4aQf+iSkt/jwZCCwk9mJgHwamOIQLuN/k4W8JaWP6vSMDGdwAWaVryQSokBVFuHAsubSjKqgJAC8LUySkFGb27UoOz6qwYYACSA=="}'
         headers:
             Content-Length:
-                - "409"
+                - "408"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:34 GMT
+                - Fri, 03 Jul 2026 15:28:20 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - a79fd95d-adb2-4afe-8623-f83e1ef03f20
+                - 60238588-e5d1-4301-a69c-b64c03a43af2
         status: 200 OK
         code: 200
-        duration: 89.961628ms
+        duration: 62.274218ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -415,29 +415,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5f1e5c6b-c6ed-4737-8cec-ade7b6b92b63/versions/1/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/fd998353-a9be-444d-afec-f8546785aac4/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 573
-        body: '{"secret_id":"5f1e5c6b-c6ed-4737-8cec-ade7b6b92b63", "revision":1, "data":"VWoyTzMxcFNpUG1Ibkthek9uRDlpM09udUUxNU82ak1Ud2pMeWxnNVVmaFEvS1pFbklkeFRxa2xlMTBvREFqS2F2bUpldlNUaTdWWFhYekZyTlVvN3gvNWJXVmUrc1I2dkRoMERhSmQwZHIrOTRoMTEwWjcxT05NL2JHWnRDOVJmQlBlWGFEcnM3SktIUms1UG5ubVBxUXdiRFlqTFNVN0R2N3JqMWlrTEhIR0VYY0RHQVpaaVFCbXpZdUVhZjBmTmlrMTZmelJZWFRvSlRNV2ZUWnJCeDZHUG1CaDl2NzlEei9FR2NYNmhMc3BHS1A0VnlTdDcycHZ1TXFKMFJwMzdaZGhOOXlDVE9FMHNPU2ZiVUtPREdadk5FWmtjbTdKK05LMWVDeU56bFZRS2xhU0IrSVJPbFBSWG5IY0VnK2hMTTVFaEpwbmoyY3RIRDVxdjJlbTZnPT0=", "data_crc32":null, "type":"opaque"}'
+        content_length: 569
+        body: '{"secret_id":"fd998353-a9be-444d-afec-f8546785aac4","revision":1,"data":"RHViM2E3STR2QUhVMnVUcFYvc1oxWnQxbTJxcnEySTF4enNlQVU5dVRYd01UazVuc3kvTkhLeFcxUlA0VG1SaVZFMWxKTFhtTzhFMlI4bEpsQ24rSkdXV0NXU3lGajlSWnZpaUFGZEZ3WFJscmhBY2xwbzVudEREYkFUazlXT0EzREZtSjhLVWtaQVVYbERZeU9jNE1mMXVCaEFDNmhxVWxOb0J6Y0Ntc21HOEpKdUpMcUFPRFNacWhaV0ZxY01aVG5jZHlQUFhIdUIvTmVXc1FBMUlYaS80VUJzZXhObU1rdTlBdXp2V1FNbk1tQlI5aGQwTnNVY2t1THF0V1lXc0NlRGh1VFNyeDJlRnBoWDRPNGV3ZHAwQmVwajVXZERZdngra3Z2OTgrRndEa2xTb3R4NjhwSVQ4RTJzbDcrVzE2cXRsUkRxc216TGxmNDYvOWxBRzFBPT0=","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "573"
+                - "569"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:35 GMT
+                - Fri, 03 Jul 2026 15:28:20 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 8db0fa8b-d780-4e19-a4a3-81be54345693
+                - 426cdb50-7fcc-408a-8de7-ef6e35baa9a8
         status: 200 OK
         code: 200
-        duration: 120.45679ms
+        duration: 38.762967ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -447,29 +447,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5f1e5c6b-c6ed-4737-8cec-ade7b6b92b63/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/fd998353-a9be-444d-afec-f8546785aac4/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 312
-        body: '{"revision":1, "secret_id":"5f1e5c6b-c6ed-4737-8cec-ade7b6b92b63", "status":"enabled", "created_at":"2026-01-23T17:30:34.465528Z", "updated_at":"2026-01-23T17:30:34.465528Z", "deleted_at":null, "description":"version1", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 302
+        body: '{"revision":1,"secret_id":"fd998353-a9be-444d-afec-f8546785aac4","status":"enabled","created_at":"2026-07-03T15:28:19.949555Z","updated_at":"2026-07-03T15:28:19.949555Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "312"
+                - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:35 GMT
+                - Fri, 03 Jul 2026 15:28:20 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - c280b729-2451-462d-be5e-04adc79217bf
+                - 71c2fd10-4e3e-4eea-b7ae-ae5f4c808d66
         status: 200 OK
         code: 200
-        duration: 91.902201ms
+        duration: 38.001618ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -477,34 +477,34 @@ interactions:
         proto_minor: 1
         content_length: 416
         host: api.scaleway.com
-        body: '{"digest":"+wxGDJPL0C0K00FBHoXsjM0xaYYPTtIHSfdfjlvQEMs=","signature":"Uj2O31pSiPmHnKazOnD9i3OnuE15O6jMTwjLylg5UfhQ/KZEnIdxTqkle10oDAjKavmJevSTi7VXXXzFrNUo7x/5bWVe+sR6vDh0DaJd0dr+94h110Z71ONM/bGZtC9RfBPeXaDrs7JKHRk5PnnmPqQwbDYjLSU7Dv7rj1ikLHHGEXcDGAZZiQBmzYuEaf0fNik16fzRYXToJTMWfTZrBx6GPmBh9v79Dz/EGcX6hLspGKP4VySt72pvuMqJ0Rp37ZdhN9yCTOE0sOSfbUKODGZvNEZkcm7J+NK1eCyNzlVQKlaSB+IROlPRXnHcEg+hLM5EhJpnj2ctHD5qv2em6g=="}'
+        body: '{"digest":"+wxGDJPL0C0K00FBHoXsjM0xaYYPTtIHSfdfjlvQEMs=","signature":"Dub3a7I4vAHU2uTpV/sZ1Zt1m2qrq2I1xzseAU9uTXwMTk5nsy/NHKxW1RP4TmRiVE1lJLXmO8E2R8lJlCn+JGWWCWSyFj9RZviiAFdFwXRlrhAclpo5ntDDbATk9WOA3DFmJ8KUkZAUXlDYyOc4Mf1uBhAC6hqUlNoBzcCmsmG8JJuJLqAODSZqhZWFqcMZTncdyPPXHuB/NeWsQA1IXi/4UBsexNmMku9AuzvWQMnMmBR9hd0NsUckuLqtWYWsCeDhuTSrx2eFphX4O4ewdp0Bepj5WdDYvx+kvv98+FwDklSotx68pIT8E2sl7+W16qtlRDqsmzLlf46/9lAG1A=="}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/9e624e94-4092-426e-acdf-a51f748c0247/verify
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/7e6da60c-5bfa-475c-851d-c7cf98923041/verify
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 63
-        body: '{"key_id":"9e624e94-4092-426e-acdf-a51f748c0247", "valid":true}'
+        content_length: 62
+        body: '{"key_id":"7e6da60c-5bfa-475c-851d-c7cf98923041","valid":true}'
         headers:
             Content-Length:
-                - "63"
+                - "62"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:35 GMT
+                - Fri, 03 Jul 2026 15:28:21 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 5cbc5e7f-2d30-4d25-bc24-ced580016cc1
+                - d52c17c6-88b9-4207-9dca-593fa5ad1022
         status: 200 OK
         code: 200
-        duration: 90.832628ms
+        duration: 97.401286ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -514,29 +514,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5f1e5c6b-c6ed-4737-8cec-ade7b6b92b63
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/fd998353-a9be-444d-afec-f8546785aac4
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 449
-        body: '{"id":"5f1e5c6b-c6ed-4737-8cec-ade7b6b92b63", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"test-verify-secret", "status":"ready", "created_at":"2026-01-23T17:30:33.795583Z", "updated_at":"2026-01-23T17:30:33.795583Z", "tags":[], "version_count":1, "description":"", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}'
+        content_length: 432
+        body: '{"id":"fd998353-a9be-444d-afec-f8546785aac4","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-verify-secret","status":"ready","created_at":"2026-07-03T15:28:18.803210Z","updated_at":"2026-07-03T15:28:18.803210Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "449"
+                - "432"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:35 GMT
+                - Fri, 03 Jul 2026 15:28:21 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 6ad4db2a-b337-4933-a59a-68f378bd0009
+                - 9a4af264-ced8-474b-81f0-b44367a2e441
         status: 200 OK
         code: 200
-        duration: 33.592003ms
+        duration: 42.443471ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -546,29 +546,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/9e624e94-4092-426e-acdf-a51f748c0247
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/7e6da60c-5bfa-475c-851d-c7cf98923041
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 516
-        body: '{"id":"9e624e94-4092-426e-acdf-a51f748c0247", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-verify-key", "usage":{"asymmetric_signing":"rsa_pss_2048_sha256"}, "state":"enabled", "rotation_count":1, "created_at":"2026-01-23T17:30:33.812404Z", "updated_at":"2026-01-23T17:30:33.898520Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-01-23T17:30:33.898520Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 530
+        body: '{"id":"7e6da60c-5bfa-475c-851d-c7cf98923041","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.283852Z","updated_at":"2026-07-03T15:28:19.368507Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.368507Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "516"
+                - "530"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:35 GMT
+                - Fri, 03 Jul 2026 15:28:21 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 1ddd25e2-cbd7-4f62-ba6d-455fd6141c90
+                - e816029b-e157-4e3e-9897-4b3db11f68d3
         status: 200 OK
         code: 200
-        duration: 78.381684ms
+        duration: 51.961077ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -581,29 +581,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5f1e5c6b-c6ed-4737-8cec-ade7b6b92b63/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/fd998353-a9be-444d-afec-f8546785aac4/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 344
-        body: '{"versions":[{"revision":1, "secret_id":"5f1e5c6b-c6ed-4737-8cec-ade7b6b92b63", "status":"enabled", "created_at":"2026-01-23T17:30:34.465528Z", "updated_at":"2026-01-23T17:30:34.465528Z", "deleted_at":null, "description":"version1", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}], "total_count":1}'
+        content_length: 333
+        body: '{"versions":[{"revision":1,"secret_id":"fd998353-a9be-444d-afec-f8546785aac4","status":"enabled","created_at":"2026-07-03T15:28:19.949555Z","updated_at":"2026-07-03T15:28:19.949555Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
-                - "344"
+                - "333"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:35 GMT
+                - Fri, 03 Jul 2026 15:28:21 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 529a23cb-ee1b-4a5e-885d-fe3abbdccbf4
+                - f3230e50-85ad-4b54-901d-08abd43d1d66
         status: 200 OK
         code: 200
-        duration: 84.763687ms
+        duration: 50.287303ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -616,29 +616,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/9e624e94-4092-426e-acdf-a51f748c0247/sign
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/7e6da60c-5bfa-475c-851d-c7cf98923041/sign
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 409
-        body: '{"key_id":"9e624e94-4092-426e-acdf-a51f748c0247", "signature":"K0U7zHzmOxWTOg/C65rhagS11gf6cQGMoDm5PgR+0e0E7FYcq5BvLT/vNfEhVBsJQnsMl3QBX1aac0YxGcU76DttAT9mHgfCRJAKtnv3+ySI9gYomRRVc6uJUxwXDGasQUky98/gQMFktrURo3uKQhKP8A7ooKqLOXIbrsE7fXjUwBZ4rjViPPFYqeQk36Xe3OTFPw1qRuTP8C5VDdOFocoo+e/LHn5Zcn6nxXXFbFx1ChmynQZKgHuOy6aTs54tOcfI4zhD0XPRCcRCvSRERYscxW5cDk1xonHxb1jBM9WrEWJhg1V6hsSH0omvoTH357wHOErvtWwAjqGx/PFUgg=="}'
+        content_length: 408
+        body: '{"key_id":"7e6da60c-5bfa-475c-851d-c7cf98923041","signature":"AHp0KxsxML2O1aW6aIlQTmAhnZ9sKtSKXidw613Xw9uBcrHKlVi19N7zzOxsXeDzjld4E9HerfxEsNvE946zNLRSxd0rbyDFnmsnPTc7HSWDo0lZcnpiFcfXPoeR7riO3ns0JP+fuAW6CDDcK9wRU31P9S9A3ObewJkHNjG8dN8H36VJuVeCQvkutWoGyV1nq0kraufqsn5pz/COTstTWXAk1yoENG0MeZSNI+d+tp6AHW7KyXJC0p0MG+8jm9haGh2QONIOY0lLKAwgr3lyz90TycZMkrfYC0uCZzib/EI6d9f17ubJeI6hDIJMhJkdaxOL8GelEDHtK1hM/KQZJA=="}'
         headers:
             Content-Length:
-                - "409"
+                - "408"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:35 GMT
+                - Fri, 03 Jul 2026 15:28:21 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - c4cae72a-c703-40ac-9406-e0b7f3897735
+                - 4b2f973f-8635-4e59-ac53-0c8ddf31c57b
         status: 200 OK
         code: 200
-        duration: 93.056045ms
+        duration: 71.091449ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -648,29 +648,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5f1e5c6b-c6ed-4737-8cec-ade7b6b92b63/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/fd998353-a9be-444d-afec-f8546785aac4/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 312
-        body: '{"revision":1, "secret_id":"5f1e5c6b-c6ed-4737-8cec-ade7b6b92b63", "status":"enabled", "created_at":"2026-01-23T17:30:34.465528Z", "updated_at":"2026-01-23T17:30:34.465528Z", "deleted_at":null, "description":"version1", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 302
+        body: '{"revision":1,"secret_id":"fd998353-a9be-444d-afec-f8546785aac4","status":"enabled","created_at":"2026-07-03T15:28:19.949555Z","updated_at":"2026-07-03T15:28:19.949555Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "312"
+                - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:35 GMT
+                - Fri, 03 Jul 2026 15:28:21 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 03ff2fe6-eee5-4977-8835-c454f19e675d
+                - 10249862-f978-42ad-b859-fc047bd52af3
         status: 200 OK
         code: 200
-        duration: 38.270663ms
+        duration: 36.84754ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -680,29 +680,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5f1e5c6b-c6ed-4737-8cec-ade7b6b92b63/versions/1/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/fd998353-a9be-444d-afec-f8546785aac4/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 573
-        body: '{"secret_id":"5f1e5c6b-c6ed-4737-8cec-ade7b6b92b63", "revision":1, "data":"VWoyTzMxcFNpUG1Ibkthek9uRDlpM09udUUxNU82ak1Ud2pMeWxnNVVmaFEvS1pFbklkeFRxa2xlMTBvREFqS2F2bUpldlNUaTdWWFhYekZyTlVvN3gvNWJXVmUrc1I2dkRoMERhSmQwZHIrOTRoMTEwWjcxT05NL2JHWnRDOVJmQlBlWGFEcnM3SktIUms1UG5ubVBxUXdiRFlqTFNVN0R2N3JqMWlrTEhIR0VYY0RHQVpaaVFCbXpZdUVhZjBmTmlrMTZmelJZWFRvSlRNV2ZUWnJCeDZHUG1CaDl2NzlEei9FR2NYNmhMc3BHS1A0VnlTdDcycHZ1TXFKMFJwMzdaZGhOOXlDVE9FMHNPU2ZiVUtPREdadk5FWmtjbTdKK05LMWVDeU56bFZRS2xhU0IrSVJPbFBSWG5IY0VnK2hMTTVFaEpwbmoyY3RIRDVxdjJlbTZnPT0=", "data_crc32":null, "type":"opaque"}'
+        content_length: 569
+        body: '{"secret_id":"fd998353-a9be-444d-afec-f8546785aac4","revision":1,"data":"RHViM2E3STR2QUhVMnVUcFYvc1oxWnQxbTJxcnEySTF4enNlQVU5dVRYd01UazVuc3kvTkhLeFcxUlA0VG1SaVZFMWxKTFhtTzhFMlI4bEpsQ24rSkdXV0NXU3lGajlSWnZpaUFGZEZ3WFJscmhBY2xwbzVudEREYkFUazlXT0EzREZtSjhLVWtaQVVYbERZeU9jNE1mMXVCaEFDNmhxVWxOb0J6Y0Ntc21HOEpKdUpMcUFPRFNacWhaV0ZxY01aVG5jZHlQUFhIdUIvTmVXc1FBMUlYaS80VUJzZXhObU1rdTlBdXp2V1FNbk1tQlI5aGQwTnNVY2t1THF0V1lXc0NlRGh1VFNyeDJlRnBoWDRPNGV3ZHAwQmVwajVXZERZdngra3Z2OTgrRndEa2xTb3R4NjhwSVQ4RTJzbDcrVzE2cXRsUkRxc216TGxmNDYvOWxBRzFBPT0=","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "573"
+                - "569"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:35 GMT
+                - Fri, 03 Jul 2026 15:28:21 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 3b3fc289-bbe4-490e-9168-5d57eb61810c
+                - 543dfdfb-43b3-4f1c-9189-56c49d874102
         status: 200 OK
         code: 200
-        duration: 118.400436ms
+        duration: 42.67204ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -712,29 +712,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5f1e5c6b-c6ed-4737-8cec-ade7b6b92b63/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/fd998353-a9be-444d-afec-f8546785aac4/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 312
-        body: '{"revision":1, "secret_id":"5f1e5c6b-c6ed-4737-8cec-ade7b6b92b63", "status":"enabled", "created_at":"2026-01-23T17:30:34.465528Z", "updated_at":"2026-01-23T17:30:34.465528Z", "deleted_at":null, "description":"version1", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 302
+        body: '{"revision":1,"secret_id":"fd998353-a9be-444d-afec-f8546785aac4","status":"enabled","created_at":"2026-07-03T15:28:19.949555Z","updated_at":"2026-07-03T15:28:19.949555Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "312"
+                - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:35 GMT
+                - Fri, 03 Jul 2026 15:28:21 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 8ee5fdf8-e7bd-42e8-b099-f8c0e63d67fd
+                - ae74c00f-5661-43f3-8220-c74f8864967e
         status: 200 OK
         code: 200
-        duration: 88.263904ms
+        duration: 46.864054ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -742,34 +742,34 @@ interactions:
         proto_minor: 1
         content_length: 416
         host: api.scaleway.com
-        body: '{"digest":"+wxGDJPL0C0K00FBHoXsjM0xaYYPTtIHSfdfjlvQEMs=","signature":"Uj2O31pSiPmHnKazOnD9i3OnuE15O6jMTwjLylg5UfhQ/KZEnIdxTqkle10oDAjKavmJevSTi7VXXXzFrNUo7x/5bWVe+sR6vDh0DaJd0dr+94h110Z71ONM/bGZtC9RfBPeXaDrs7JKHRk5PnnmPqQwbDYjLSU7Dv7rj1ikLHHGEXcDGAZZiQBmzYuEaf0fNik16fzRYXToJTMWfTZrBx6GPmBh9v79Dz/EGcX6hLspGKP4VySt72pvuMqJ0Rp37ZdhN9yCTOE0sOSfbUKODGZvNEZkcm7J+NK1eCyNzlVQKlaSB+IROlPRXnHcEg+hLM5EhJpnj2ctHD5qv2em6g=="}'
+        body: '{"digest":"+wxGDJPL0C0K00FBHoXsjM0xaYYPTtIHSfdfjlvQEMs=","signature":"Dub3a7I4vAHU2uTpV/sZ1Zt1m2qrq2I1xzseAU9uTXwMTk5nsy/NHKxW1RP4TmRiVE1lJLXmO8E2R8lJlCn+JGWWCWSyFj9RZviiAFdFwXRlrhAclpo5ntDDbATk9WOA3DFmJ8KUkZAUXlDYyOc4Mf1uBhAC6hqUlNoBzcCmsmG8JJuJLqAODSZqhZWFqcMZTncdyPPXHuB/NeWsQA1IXi/4UBsexNmMku9AuzvWQMnMmBR9hd0NsUckuLqtWYWsCeDhuTSrx2eFphX4O4ewdp0Bepj5WdDYvx+kvv98+FwDklSotx68pIT8E2sl7+W16qtlRDqsmzLlf46/9lAG1A=="}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/9e624e94-4092-426e-acdf-a51f748c0247/verify
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/7e6da60c-5bfa-475c-851d-c7cf98923041/verify
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 63
-        body: '{"key_id":"9e624e94-4092-426e-acdf-a51f748c0247", "valid":true}'
+        content_length: 62
+        body: '{"key_id":"7e6da60c-5bfa-475c-851d-c7cf98923041","valid":true}'
         headers:
             Content-Length:
-                - "63"
+                - "62"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:35 GMT
+                - Fri, 03 Jul 2026 15:28:21 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 145ae46c-ac37-4cca-bfc6-c15697fafc55
+                - debfadbe-0a64-404c-a984-6b417cbbe428
         status: 200 OK
         code: 200
-        duration: 79.188343ms
+        duration: 94.548007ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -779,8 +779,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5f1e5c6b-c6ed-4737-8cec-ade7b6b92b63/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/fd998353-a9be-444d-afec-f8546785aac4/versions/1
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -792,14 +792,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:36 GMT
+                - Fri, 03 Jul 2026 15:28:22 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 2c152278-0bf2-4f81-ba0e-1810dd058c1a
+                - c88c148e-c7cf-4bfb-b7e1-1ef14aa1c65e
         status: 204 No Content
         code: 204
-        duration: 106.533774ms
+        duration: 69.242797ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -809,8 +809,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/9e624e94-4092-426e-acdf-a51f748c0247
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/fd998353-a9be-444d-afec-f8546785aac4
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -822,14 +822,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:36 GMT
+                - Fri, 03 Jul 2026 15:28:22 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 465067b7-f133-4a45-ae0f-c0c34b4ab854
+                - 66693c61-95ff-47e4-b4e8-840890e4ac4a
         status: 204 No Content
         code: 204
-        duration: 70.876172ms
+        duration: 73.485757ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -839,8 +839,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5f1e5c6b-c6ed-4737-8cec-ade7b6b92b63
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/7e6da60c-5bfa-475c-851d-c7cf98923041
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -852,14 +852,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:36 GMT
+                - Fri, 03 Jul 2026 15:28:22 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 9574b642-30c8-425e-af5c-142390ebd53e
+                - 8b9e62d4-4489-4eb3-8303-33404ac04e85
         status: 204 No Content
         code: 204
-        duration: 78.042703ms
+        duration: 75.608734ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -869,29 +869,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/9e624e94-4092-426e-acdf-a51f748c0247
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/7e6da60c-5bfa-475c-851d-c7cf98923041
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 556
-        body: '{"id":"9e624e94-4092-426e-acdf-a51f748c0247", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-verify-key", "usage":{"asymmetric_signing":"rsa_pss_2048_sha256"}, "state":"scheduled_for_deletion", "rotation_count":1, "created_at":"2026-01-23T17:30:33.812404Z", "updated_at":"2026-01-23T17:30:33.898520Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-01-23T17:30:33.898520Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":"2026-01-23T17:30:36.335484Z", "region":"fr-par"}'
+        content_length: 570
+        body: '{"id":"7e6da60c-5bfa-475c-851d-c7cf98923041","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-03T15:28:19.283852Z","updated_at":"2026-07-03T15:28:22.411426Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.368507Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-03T15:28:22.411425Z","protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "556"
+                - "570"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:36 GMT
+                - Fri, 03 Jul 2026 15:28:22 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - fc1ca33b-46fa-48a2-9228-7290fcbe86fb
+                - 92630ff4-bd87-4a4b-a776-35557e55f2c8
         status: 200 OK
         code: 200
-        duration: 42.603762ms
+        duration: 47.582363ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -901,26 +901,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5f1e5c6b-c6ed-4737-8cec-ade7b6b92b63
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/fd998353-a9be-444d-afec-f8546785aac4
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 474
-        body: '{"id":"5f1e5c6b-c6ed-4737-8cec-ade7b6b92b63", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"test-verify-secret", "status":"ready", "created_at":"2026-01-23T17:30:33.795583Z", "updated_at":"2026-01-23T17:30:33.795583Z", "tags":[], "version_count":1, "description":"", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":"2026-01-23T17:30:36.335615Z", "key_id":null, "region":"fr-par"}'
+        content_length: 457
+        body: '{"id":"fd998353-a9be-444d-afec-f8546785aac4","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-verify-secret","status":"ready","created_at":"2026-07-03T15:28:18.803210Z","updated_at":"2026-07-03T15:28:22.407282Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-07-03T15:28:22.407282Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "474"
+                - "457"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:36 GMT
+                - Fri, 03 Jul 2026 15:28:22 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 27e381e5-015a-480a-bc68-76c49a7c183d
+                - f570a598-484c-4de3-b36e-3aefbf8c0b6d
         status: 200 OK
         code: 200
-        duration: 74.274171ms
+        duration: 47.878909ms

--- a/internal/services/keymanager/testdata/data-source-verify-invalid.cassette.yaml
+++ b/internal/services/keymanager/testdata/data-source-verify-invalid.cassette.yaml
@@ -13,29 +13,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 457
-        body: '{"id":"4653dfe8-1bb9-47e9-a26e-241ea4f4a0b8", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"test-verify-secret-invalid", "status":"ready", "created_at":"2026-01-23T17:30:33.765646Z", "updated_at":"2026-01-23T17:30:33.765646Z", "tags":[], "version_count":0, "description":"", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}'
+        content_length: 440
+        body: '{"id":"5222f140-1459-45f1-a13d-9fe4cd7f1517","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-verify-secret-invalid","status":"ready","created_at":"2026-07-03T15:28:18.729628Z","updated_at":"2026-07-03T15:28:18.729628Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "457"
+                - "440"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:33 GMT
+                - Fri, 03 Jul 2026 15:28:18 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - b3e069d7-e8d4-4752-90fe-996b23040f66
+                - 2dc6e086-bc59-4c41-a7f5-63a9b3b7c856
         status: 200 OK
         code: 200
-        duration: 231.497558ms
+        duration: 130.190613ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -45,29 +45,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/4653dfe8-1bb9-47e9-a26e-241ea4f4a0b8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5222f140-1459-45f1-a13d-9fe4cd7f1517
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 457
-        body: '{"id":"4653dfe8-1bb9-47e9-a26e-241ea4f4a0b8", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"test-verify-secret-invalid", "status":"ready", "created_at":"2026-01-23T17:30:33.765646Z", "updated_at":"2026-01-23T17:30:33.765646Z", "tags":[], "version_count":0, "description":"", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}'
+        content_length: 440
+        body: '{"id":"5222f140-1459-45f1-a13d-9fe4cd7f1517","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-verify-secret-invalid","status":"ready","created_at":"2026-07-03T15:28:18.729628Z","updated_at":"2026-07-03T15:28:18.729628Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "457"
+                - "440"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:33 GMT
+                - Fri, 03 Jul 2026 15:28:18 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - bf884f30-4319-4448-9699-69226d591d76
+                - 124480cf-29f2-492d-9772-71723dae3da0
         status: 200 OK
         code: 200
-        duration: 49.335542ms
+        duration: 61.195983ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -80,64 +80,64 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/4653dfe8-1bb9-47e9-a26e-241ea4f4a0b8/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5222f140-1459-45f1-a13d-9fe4cd7f1517/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 32
-        body: '{"versions":[], "total_count":0}'
+        content_length: 31
+        body: '{"versions":[],"total_count":0}'
         headers:
             Content-Length:
-                - "32"
+                - "31"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:33 GMT
+                - Fri, 03 Jul 2026 15:28:18 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - abeee65a-2fa4-4335-af01-fba3a201862d
+                - f0665d49-c900-4570-bf6b-d4885e602a70
         status: 200 OK
         code: 200
-        duration: 78.96679ms
+        duration: 50.93496ms
     - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 199
+        content_length: 245
         host: api.scaleway.com
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-key-invalid","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"tags":null,"unprotected":true,"origin":"unknown_origin"}'
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-key-invalid","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"tags":null,"unprotected":true,"origin":"unknown_origin","protection_level":"unknown_protection_level"}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 524
-        body: '{"id":"2547e627-ba3c-4ac8-b619-1e194e283778", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-verify-key-invalid", "usage":{"asymmetric_signing":"rsa_pss_2048_sha256"}, "state":"enabled", "rotation_count":1, "created_at":"2026-01-23T17:30:33.987413Z", "updated_at":"2026-01-23T17:30:34.091717Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-01-23T17:30:34.091717Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 538
+        body: '{"id":"969b2333-caec-45d2-99b0-aef0b1d49d12","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-key-invalid","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.543164Z","updated_at":"2026-07-03T15:28:19.841001Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.841001Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "524"
+                - "538"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:34 GMT
+                - Fri, 03 Jul 2026 15:28:19 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - bbb6d97a-38f7-4460-9015-84963348e7af
+                - 02ec31a4-d5f2-4ded-b931-29fbb6569e79
         status: 200 OK
         code: 200
-        duration: 559.703809ms
+        duration: 1.251528081s
     - id: 4
       request:
         proto: HTTP/1.1
@@ -147,29 +147,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/2547e627-ba3c-4ac8-b619-1e194e283778
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/969b2333-caec-45d2-99b0-aef0b1d49d12
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 524
-        body: '{"id":"2547e627-ba3c-4ac8-b619-1e194e283778", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-verify-key-invalid", "usage":{"asymmetric_signing":"rsa_pss_2048_sha256"}, "state":"enabled", "rotation_count":1, "created_at":"2026-01-23T17:30:33.987413Z", "updated_at":"2026-01-23T17:30:34.091717Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-01-23T17:30:34.091717Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 538
+        body: '{"id":"969b2333-caec-45d2-99b0-aef0b1d49d12","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-key-invalid","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.543164Z","updated_at":"2026-07-03T15:28:19.841001Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.841001Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "524"
+                - "538"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:34 GMT
+                - Fri, 03 Jul 2026 15:28:19 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - d5dd7352-b0db-41d8-9b14-ee5e222de076
+                - 0591e447-7ee6-4a7d-a272-c5fd3c690da1
         status: 200 OK
         code: 200
-        duration: 75.436681ms
+        duration: 48.154878ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -182,65 +182,100 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/2547e627-ba3c-4ac8-b619-1e194e283778/sign
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/969b2333-caec-45d2-99b0-aef0b1d49d12/sign
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 409
-        body: '{"key_id":"2547e627-ba3c-4ac8-b619-1e194e283778", "signature":"k/idvFxB/NdJbO3WXPuIAA/6B7ENtwgbKSQBylEBL3nMJs+OBEX1zlDUWC3zD90MX+7jHNPxqk6pDYaP1bbh3SWlBFraCz6MeNyc+sIH9fXkfVL6I4/+CdNCE+5YW807MPWGRCCc+YFm/VfVCYn6YKn+uFbUMlo9UuTmXK8deMYBMWxl7pDggvO6OCnResnnjYoDmWVSld/AUL1pGBb1rEHEyiSg8ghr1qTnkpkXTAxIBnVnGObHh+gcbNQB3XnxUikUvFa7Zb+pvckVvVpr88QC4jSbByTXQXLl0KK4otOha220nlpbBspa78lEhbdfFXlIsszkFeH7b89j7wg/wg=="}'
+        content_length: 408
+        body: '{"key_id":"969b2333-caec-45d2-99b0-aef0b1d49d12","signature":"AQwmaiVMqUfFmrA1Sp+7pNDMWHDD8OPnu7wxOLG6crBrPQqrwV+QF4ERZxdYvnZ/c9qqfa0WOf8eeoWuJso0TBrZbnd6VQb2DDxgXXKTMiCQew5Z93rWnSiEtV2xqtgQ7r3SCxuqlD5e8fqI88eVGrawhFTd5rhZVcKSOZpXtYkcMRgKk8KeFUiEavJPlOxIEg+qmor/cn7BXq24YrOMIVjVLDZllbLajVJ1DtM4dqP/URNCB1mN4i249qBC9tHTIhRkQDwDpsdNajtxsHtx7FPbo3+5DmAKLia3Qcuzt9J+jM9NjkKdV/yPVB8FG6eUZzC9BRl8N4vOYagvxDFRvQ=="}'
         headers:
             Content-Length:
-                - "409"
+                - "408"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:34 GMT
+                - Fri, 03 Jul 2026 15:28:20 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 5648da8b-e6bf-4200-a060-952791d2f75d
+                - 3b8212c2-2013-4cd5-a7d5-44f215dfc356
         status: 200 OK
         code: 200
-        duration: 88.577956ms
+        duration: 99.203581ms
     - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 197
+        content_length: 243
         host: api.scaleway.com
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-other-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"tags":null,"unprotected":true,"origin":"unknown_origin"}'
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-other-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"tags":null,"unprotected":true,"origin":"unknown_origin","protection_level":"unknown_protection_level"}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 522
-        body: '{"id":"fa24024f-b783-47d4-9dbe-3d0a0ab63f7e", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-verify-other-key", "usage":{"asymmetric_signing":"rsa_pss_2048_sha256"}, "state":"enabled", "rotation_count":1, "created_at":"2026-01-23T17:30:34.341595Z", "updated_at":"2026-01-23T17:30:34.399581Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-01-23T17:30:34.399581Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 536
+        body: '{"id":"b1132c2b-01d9-4c6c-950c-b4b15d787780","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-other-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.995464Z","updated_at":"2026-07-03T15:28:20.337904Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:20.337904Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "522"
+                - "536"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:34 GMT
+                - Fri, 03 Jul 2026 15:28:20 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 0d9737c5-8e56-4325-bc74-2f1b2195e561
+                - 6b827a7d-ad93-42fe-bf6e-20a56100bca8
         status: 200 OK
         code: 200
-        duration: 236.166634ms
+        duration: 420.474165ms
     - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 496
+        host: api.scaleway.com
+        body: '{"data":"QVF3bWFpVk1xVWZGbXJBMVNwKzdwTkRNV0hERDhPUG51N3d4T0xHNmNyQnJQUXFyd1YrUUY0RVJaeGRZdm5aL2M5cXFmYTBXT2Y4ZWVvV3VKc28wVEJyWmJuZDZWUWIyRER4Z1hYS1RNaUNRZXc1WjkzclduU2lFdFYyeHF0Z1E3cjNTQ3h1cWxENWU4ZnFJODhlVkdyYXdoRlRkNXJoWlZjS1NPWnBYdFlrY01SZ0trOEtlRlVpRWF2SlBsT3hJRWcrcW1vci9jbjdCWHEyNFlyT01JVmpWTERabGxiTGFqVkoxRHRNNGRxUC9VUk5DQjFtTjRpMjQ5cUJDOXRIVEloUmtRRHdEcHNkTmFqdHhzSHR4N0ZQYm8zKzVEbUFLTGlhM1FjdXp0OUorak05TmprS2RWL3lQVkI4Rkc2ZVVaekM5QlJsOE40dk9ZYWd2eERGUnZRPT0=","description":"version1"}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5222f140-1459-45f1-a13d-9fe4cd7f1517/versions
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 302
+        body: '{"revision":1,"secret_id":"5222f140-1459-45f1-a13d-9fe4cd7f1517","status":"enabled","created_at":"2026-07-03T15:28:20.360180Z","updated_at":"2026-07-03T15:28:20.360180Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "302"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:20 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - fa7ddbbc-54d7-40a7-89b4-3e5fa1c5a5a7
+        status: 200 OK
+        code: 200
+        duration: 349.52301ms
+    - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -249,64 +284,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/fa24024f-b783-47d4-9dbe-3d0a0ab63f7e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/b1132c2b-01d9-4c6c-950c-b4b15d787780
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 522
-        body: '{"id":"fa24024f-b783-47d4-9dbe-3d0a0ab63f7e", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-verify-other-key", "usage":{"asymmetric_signing":"rsa_pss_2048_sha256"}, "state":"enabled", "rotation_count":1, "created_at":"2026-01-23T17:30:34.341595Z", "updated_at":"2026-01-23T17:30:34.399581Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-01-23T17:30:34.399581Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 536
+        body: '{"id":"b1132c2b-01d9-4c6c-950c-b4b15d787780","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-other-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.995464Z","updated_at":"2026-07-03T15:28:20.337904Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:20.337904Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "522"
+                - "536"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:34 GMT
+                - Fri, 03 Jul 2026 15:28:20 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 881f358b-0961-4dba-8f93-8a55259a2845
+                - d0bf6142-2596-4d55-927e-f66a7f477c4d
         status: 200 OK
         code: 200
-        duration: 64.548113ms
-    - id: 8
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 496
-        host: api.scaleway.com
-        body: '{"data":"ay9pZHZGeEIvTmRKYk8zV1hQdUlBQS82QjdFTnR3Z2JLU1FCeWxFQkwzbk1KcytPQkVYMXpsRFVXQzN6RDkwTVgrN2pITlB4cWs2cERZYVAxYmJoM1NXbEJGcmFDejZNZU55YytzSUg5ZlhrZlZMNkk0LytDZE5DRSs1WVc4MDdNUFdHUkNDYytZRm0vVmZWQ1luNllLbit1RmJVTWxvOVV1VG1YSzhkZU1ZQk1XeGw3cERnZ3ZPNk9DblJlc25uallvRG1XVlNsZC9BVUwxcEdCYjFyRUhFeWlTZzhnaHIxcVRua3BrWFRBeElCblZuR09iSGgrZ2NiTlFCM1hueFVpa1V2RmE3WmIrcHZja1Z2VnByODhRQzRqU2JCeVRYUVhMbDBLSzRvdE9oYTIyMG5scGJCc3BhNzhsRWhiZGZGWGxJc3N6a0ZlSDdiODlqN3dnL3dnPT0=","description":"version1"}'
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/4653dfe8-1bb9-47e9-a26e-241ea4f4a0b8/versions
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 312
-        body: '{"revision":1, "secret_id":"4653dfe8-1bb9-47e9-a26e-241ea4f4a0b8", "status":"enabled", "created_at":"2026-01-23T17:30:34.608385Z", "updated_at":"2026-01-23T17:30:34.608385Z", "deleted_at":null, "description":"version1", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "312"
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 17:30:34 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            X-Request-Id:
-                - 6870231f-470d-4d81-97a1-7be5d6e0893b
-        status: 200 OK
-        code: 200
-        duration: 339.274643ms
+        duration: 45.910412ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -316,29 +316,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/4653dfe8-1bb9-47e9-a26e-241ea4f4a0b8/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5222f140-1459-45f1-a13d-9fe4cd7f1517/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 312
-        body: '{"revision":1, "secret_id":"4653dfe8-1bb9-47e9-a26e-241ea4f4a0b8", "status":"enabled", "created_at":"2026-01-23T17:30:34.608385Z", "updated_at":"2026-01-23T17:30:34.608385Z", "deleted_at":null, "description":"version1", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 302
+        body: '{"revision":1,"secret_id":"5222f140-1459-45f1-a13d-9fe4cd7f1517","status":"enabled","created_at":"2026-07-03T15:28:20.360180Z","updated_at":"2026-07-03T15:28:20.360180Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "312"
+                - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:34 GMT
+                - Fri, 03 Jul 2026 15:28:20 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - e78655d2-20b9-4133-9620-583a88e7bd3b
+                - faca93d1-674d-41eb-a573-39fb27797a1a
         status: 200 OK
         code: 200
-        duration: 75.892202ms
+        duration: 42.541324ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -348,29 +348,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/4653dfe8-1bb9-47e9-a26e-241ea4f4a0b8/versions/1/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5222f140-1459-45f1-a13d-9fe4cd7f1517/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 573
-        body: '{"secret_id":"4653dfe8-1bb9-47e9-a26e-241ea4f4a0b8", "revision":1, "data":"ay9pZHZGeEIvTmRKYk8zV1hQdUlBQS82QjdFTnR3Z2JLU1FCeWxFQkwzbk1KcytPQkVYMXpsRFVXQzN6RDkwTVgrN2pITlB4cWs2cERZYVAxYmJoM1NXbEJGcmFDejZNZU55YytzSUg5ZlhrZlZMNkk0LytDZE5DRSs1WVc4MDdNUFdHUkNDYytZRm0vVmZWQ1luNllLbit1RmJVTWxvOVV1VG1YSzhkZU1ZQk1XeGw3cERnZ3ZPNk9DblJlc25uallvRG1XVlNsZC9BVUwxcEdCYjFyRUhFeWlTZzhnaHIxcVRua3BrWFRBeElCblZuR09iSGgrZ2NiTlFCM1hueFVpa1V2RmE3WmIrcHZja1Z2VnByODhRQzRqU2JCeVRYUVhMbDBLSzRvdE9oYTIyMG5scGJCc3BhNzhsRWhiZGZGWGxJc3N6a0ZlSDdiODlqN3dnL3dnPT0=", "data_crc32":null, "type":"opaque"}'
+        content_length: 569
+        body: '{"secret_id":"5222f140-1459-45f1-a13d-9fe4cd7f1517","revision":1,"data":"QVF3bWFpVk1xVWZGbXJBMVNwKzdwTkRNV0hERDhPUG51N3d4T0xHNmNyQnJQUXFyd1YrUUY0RVJaeGRZdm5aL2M5cXFmYTBXT2Y4ZWVvV3VKc28wVEJyWmJuZDZWUWIyRER4Z1hYS1RNaUNRZXc1WjkzclduU2lFdFYyeHF0Z1E3cjNTQ3h1cWxENWU4ZnFJODhlVkdyYXdoRlRkNXJoWlZjS1NPWnBYdFlrY01SZ0trOEtlRlVpRWF2SlBsT3hJRWcrcW1vci9jbjdCWHEyNFlyT01JVmpWTERabGxiTGFqVkoxRHRNNGRxUC9VUk5DQjFtTjRpMjQ5cUJDOXRIVEloUmtRRHdEcHNkTmFqdHhzSHR4N0ZQYm8zKzVEbUFLTGlhM1FjdXp0OUorak05TmprS2RWL3lQVkI4Rkc2ZVVaekM5QlJsOE40dk9ZYWd2eERGUnZRPT0=","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "573"
+                - "569"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:34 GMT
+                - Fri, 03 Jul 2026 15:28:20 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 43d9f8dc-db92-45be-ab20-29f40c056bee
+                - b8d47c20-dea9-43dc-a21e-c373740945ed
         status: 200 OK
         code: 200
-        duration: 114.334235ms
+        duration: 155.451921ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -380,29 +380,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/4653dfe8-1bb9-47e9-a26e-241ea4f4a0b8/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5222f140-1459-45f1-a13d-9fe4cd7f1517/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 312
-        body: '{"revision":1, "secret_id":"4653dfe8-1bb9-47e9-a26e-241ea4f4a0b8", "status":"enabled", "created_at":"2026-01-23T17:30:34.608385Z", "updated_at":"2026-01-23T17:30:34.608385Z", "deleted_at":null, "description":"version1", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 302
+        body: '{"revision":1,"secret_id":"5222f140-1459-45f1-a13d-9fe4cd7f1517","status":"enabled","created_at":"2026-07-03T15:28:20.360180Z","updated_at":"2026-07-03T15:28:20.360180Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "312"
+                - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:34 GMT
+                - Fri, 03 Jul 2026 15:28:20 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - b8b6c7ff-6611-4084-bb0c-db7b8cdf53f7
+                - 6af2c7ee-a353-4aac-8212-8fd6c3de13dd
         status: 200 OK
         code: 200
-        duration: 37.961954ms
+        duration: 54.424844ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -410,34 +410,34 @@ interactions:
         proto_minor: 1
         content_length: 416
         host: api.scaleway.com
-        body: '{"digest":"+wxGDJPL0C0K00FBHoXsjM0xaYYPTtIHSfdfjlvQEMs=","signature":"k/idvFxB/NdJbO3WXPuIAA/6B7ENtwgbKSQBylEBL3nMJs+OBEX1zlDUWC3zD90MX+7jHNPxqk6pDYaP1bbh3SWlBFraCz6MeNyc+sIH9fXkfVL6I4/+CdNCE+5YW807MPWGRCCc+YFm/VfVCYn6YKn+uFbUMlo9UuTmXK8deMYBMWxl7pDggvO6OCnResnnjYoDmWVSld/AUL1pGBb1rEHEyiSg8ghr1qTnkpkXTAxIBnVnGObHh+gcbNQB3XnxUikUvFa7Zb+pvckVvVpr88QC4jSbByTXQXLl0KK4otOha220nlpbBspa78lEhbdfFXlIsszkFeH7b89j7wg/wg=="}'
+        body: '{"digest":"+wxGDJPL0C0K00FBHoXsjM0xaYYPTtIHSfdfjlvQEMs=","signature":"AQwmaiVMqUfFmrA1Sp+7pNDMWHDD8OPnu7wxOLG6crBrPQqrwV+QF4ERZxdYvnZ/c9qqfa0WOf8eeoWuJso0TBrZbnd6VQb2DDxgXXKTMiCQew5Z93rWnSiEtV2xqtgQ7r3SCxuqlD5e8fqI88eVGrawhFTd5rhZVcKSOZpXtYkcMRgKk8KeFUiEavJPlOxIEg+qmor/cn7BXq24YrOMIVjVLDZllbLajVJ1DtM4dqP/URNCB1mN4i249qBC9tHTIhRkQDwDpsdNajtxsHtx7FPbo3+5DmAKLia3Qcuzt9J+jM9NjkKdV/yPVB8FG6eUZzC9BRl8N4vOYagvxDFRvQ=="}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/fa24024f-b783-47d4-9dbe-3d0a0ab63f7e/verify
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/b1132c2b-01d9-4c6c-950c-b4b15d787780/verify
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 64
-        body: '{"key_id":"fa24024f-b783-47d4-9dbe-3d0a0ab63f7e", "valid":false}'
+        content_length: 63
+        body: '{"key_id":"b1132c2b-01d9-4c6c-950c-b4b15d787780","valid":false}'
         headers:
             Content-Length:
-                - "64"
+                - "63"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:34 GMT
+                - Fri, 03 Jul 2026 15:28:20 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 9141f712-3a08-4758-9a21-dd7afa62fa62
+                - 8b68b98a-6ab6-44bc-b058-a9ab549322f5
         status: 200 OK
         code: 200
-        duration: 74.311241ms
+        duration: 264.730215ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -450,29 +450,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/2547e627-ba3c-4ac8-b619-1e194e283778/sign
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/969b2333-caec-45d2-99b0-aef0b1d49d12/sign
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 409
-        body: '{"key_id":"2547e627-ba3c-4ac8-b619-1e194e283778", "signature":"p4e5m+VxaKgKhSe7a1gTba+cVEUIIXxjH6sm49WRlZtqO59eJjtcu81jLp6D/XWielZ3CemOcIWps3YQIu0qBmp+X8mNfjzxe9QzYfUG3Plcvx04DKqA5cGW/9t34/yKXJv/dWVBrwgAbT1Jopi3FjDaXUH/LDKkCghA8dsYX28JigaAOUefX+4E2Fu9mkb4jd+/Vm4Pz5xvwmq/3b5jpPlBY0Wdm4crwFyyEiAXCg1IqBjGd+nizMMH8DAVjokCfsNe6nGLQptcVbUuQb9x1ibZDljsAh865+RWTBl6e9t3Zfd77rlPAuSDsUOPzc/aD04m5KTlT1BS1kiw3yTeFQ=="}'
+        content_length: 408
+        body: '{"key_id":"969b2333-caec-45d2-99b0-aef0b1d49d12","signature":"kpQmMuyN5wF151mt2NPDrPWhnVW2Y/vNfYsfnpQYD75dfwuEgmN3ahbXvwHnv99LnxOBQAkqV/r0jlf3X4sqUgFL3XiuPYqxZpXa6mka7tkRw0WMo1/U8WUUM9KXctqQrENNQfJBMsnAVbgwY+1+x2fUuMIckNMoggRgMwTCTK8Bc9E4CuaiYVCUFR6ui1AUqqIv+DIKIHpK2AyU9rE8JbHKGJnrDB0MFnI7SDpPewZrv8cmADEEhvALwUXPCKmfcVhB8WI7qvwnQzJtUdI5U7fAqiOjgAeiDjWSpXgS/xltZDQU4QcogTmg9eXTVQ0LhixZBchyn9oZO1sQVjbMRA=="}'
         headers:
             Content-Length:
-                - "409"
+                - "408"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:35 GMT
+                - Fri, 03 Jul 2026 15:28:21 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - fa03d701-a6b1-4e60-a10b-3b5716f441f3
+                - 56958b8a-51d5-4bbc-b442-75a61100031d
         status: 200 OK
         code: 200
-        duration: 99.737659ms
+        duration: 171.826317ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -482,29 +482,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/4653dfe8-1bb9-47e9-a26e-241ea4f4a0b8/versions/1/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5222f140-1459-45f1-a13d-9fe4cd7f1517/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 573
-        body: '{"secret_id":"4653dfe8-1bb9-47e9-a26e-241ea4f4a0b8", "revision":1, "data":"ay9pZHZGeEIvTmRKYk8zV1hQdUlBQS82QjdFTnR3Z2JLU1FCeWxFQkwzbk1KcytPQkVYMXpsRFVXQzN6RDkwTVgrN2pITlB4cWs2cERZYVAxYmJoM1NXbEJGcmFDejZNZU55YytzSUg5ZlhrZlZMNkk0LytDZE5DRSs1WVc4MDdNUFdHUkNDYytZRm0vVmZWQ1luNllLbit1RmJVTWxvOVV1VG1YSzhkZU1ZQk1XeGw3cERnZ3ZPNk9DblJlc25uallvRG1XVlNsZC9BVUwxcEdCYjFyRUhFeWlTZzhnaHIxcVRua3BrWFRBeElCblZuR09iSGgrZ2NiTlFCM1hueFVpa1V2RmE3WmIrcHZja1Z2VnByODhRQzRqU2JCeVRYUVhMbDBLSzRvdE9oYTIyMG5scGJCc3BhNzhsRWhiZGZGWGxJc3N6a0ZlSDdiODlqN3dnL3dnPT0=", "data_crc32":null, "type":"opaque"}'
+        content_length: 569
+        body: '{"secret_id":"5222f140-1459-45f1-a13d-9fe4cd7f1517","revision":1,"data":"QVF3bWFpVk1xVWZGbXJBMVNwKzdwTkRNV0hERDhPUG51N3d4T0xHNmNyQnJQUXFyd1YrUUY0RVJaeGRZdm5aL2M5cXFmYTBXT2Y4ZWVvV3VKc28wVEJyWmJuZDZWUWIyRER4Z1hYS1RNaUNRZXc1WjkzclduU2lFdFYyeHF0Z1E3cjNTQ3h1cWxENWU4ZnFJODhlVkdyYXdoRlRkNXJoWlZjS1NPWnBYdFlrY01SZ0trOEtlRlVpRWF2SlBsT3hJRWcrcW1vci9jbjdCWHEyNFlyT01JVmpWTERabGxiTGFqVkoxRHRNNGRxUC9VUk5DQjFtTjRpMjQ5cUJDOXRIVEloUmtRRHdEcHNkTmFqdHhzSHR4N0ZQYm8zKzVEbUFLTGlhM1FjdXp0OUorak05TmprS2RWL3lQVkI4Rkc2ZVVaekM5QlJsOE40dk9ZYWd2eERGUnZRPT0=","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "573"
+                - "569"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:35 GMT
+                - Fri, 03 Jul 2026 15:28:21 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - c20f6e8b-abdf-43dc-84ac-fd273901d556
+                - c00c2105-e12e-4964-b9bd-c3b183fc1fac
         status: 200 OK
         code: 200
-        duration: 108.525961ms
+        duration: 73.877221ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -514,29 +514,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/4653dfe8-1bb9-47e9-a26e-241ea4f4a0b8/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5222f140-1459-45f1-a13d-9fe4cd7f1517/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 312
-        body: '{"revision":1, "secret_id":"4653dfe8-1bb9-47e9-a26e-241ea4f4a0b8", "status":"enabled", "created_at":"2026-01-23T17:30:34.608385Z", "updated_at":"2026-01-23T17:30:34.608385Z", "deleted_at":null, "description":"version1", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 302
+        body: '{"revision":1,"secret_id":"5222f140-1459-45f1-a13d-9fe4cd7f1517","status":"enabled","created_at":"2026-07-03T15:28:20.360180Z","updated_at":"2026-07-03T15:28:20.360180Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "312"
+                - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:35 GMT
+                - Fri, 03 Jul 2026 15:28:21 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 843bfad6-5bb4-482b-a59e-f1e73054c97f
+                - 554d7e66-e817-4323-af89-df630ce427ac
         status: 200 OK
         code: 200
-        duration: 89.703201ms
+        duration: 43.978333ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -544,34 +544,34 @@ interactions:
         proto_minor: 1
         content_length: 416
         host: api.scaleway.com
-        body: '{"digest":"+wxGDJPL0C0K00FBHoXsjM0xaYYPTtIHSfdfjlvQEMs=","signature":"k/idvFxB/NdJbO3WXPuIAA/6B7ENtwgbKSQBylEBL3nMJs+OBEX1zlDUWC3zD90MX+7jHNPxqk6pDYaP1bbh3SWlBFraCz6MeNyc+sIH9fXkfVL6I4/+CdNCE+5YW807MPWGRCCc+YFm/VfVCYn6YKn+uFbUMlo9UuTmXK8deMYBMWxl7pDggvO6OCnResnnjYoDmWVSld/AUL1pGBb1rEHEyiSg8ghr1qTnkpkXTAxIBnVnGObHh+gcbNQB3XnxUikUvFa7Zb+pvckVvVpr88QC4jSbByTXQXLl0KK4otOha220nlpbBspa78lEhbdfFXlIsszkFeH7b89j7wg/wg=="}'
+        body: '{"digest":"+wxGDJPL0C0K00FBHoXsjM0xaYYPTtIHSfdfjlvQEMs=","signature":"AQwmaiVMqUfFmrA1Sp+7pNDMWHDD8OPnu7wxOLG6crBrPQqrwV+QF4ERZxdYvnZ/c9qqfa0WOf8eeoWuJso0TBrZbnd6VQb2DDxgXXKTMiCQew5Z93rWnSiEtV2xqtgQ7r3SCxuqlD5e8fqI88eVGrawhFTd5rhZVcKSOZpXtYkcMRgKk8KeFUiEavJPlOxIEg+qmor/cn7BXq24YrOMIVjVLDZllbLajVJ1DtM4dqP/URNCB1mN4i249qBC9tHTIhRkQDwDpsdNajtxsHtx7FPbo3+5DmAKLia3Qcuzt9J+jM9NjkKdV/yPVB8FG6eUZzC9BRl8N4vOYagvxDFRvQ=="}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/fa24024f-b783-47d4-9dbe-3d0a0ab63f7e/verify
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/b1132c2b-01d9-4c6c-950c-b4b15d787780/verify
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 64
-        body: '{"key_id":"fa24024f-b783-47d4-9dbe-3d0a0ab63f7e", "valid":false}'
+        content_length: 63
+        body: '{"key_id":"b1132c2b-01d9-4c6c-950c-b4b15d787780","valid":false}'
         headers:
             Content-Length:
-                - "64"
+                - "63"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:35 GMT
+                - Fri, 03 Jul 2026 15:28:21 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 3fa1b6a4-ce3d-43bd-81e5-e525c0aaaee4
+                - 566020ef-451f-42a6-8007-2fd70b1d64e2
         status: 200 OK
         code: 200
-        duration: 89.399794ms
+        duration: 73.534688ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -581,29 +581,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/4653dfe8-1bb9-47e9-a26e-241ea4f4a0b8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5222f140-1459-45f1-a13d-9fe4cd7f1517
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 457
-        body: '{"id":"4653dfe8-1bb9-47e9-a26e-241ea4f4a0b8", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"test-verify-secret-invalid", "status":"ready", "created_at":"2026-01-23T17:30:33.765646Z", "updated_at":"2026-01-23T17:30:33.765646Z", "tags":[], "version_count":1, "description":"", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}'
+        content_length: 440
+        body: '{"id":"5222f140-1459-45f1-a13d-9fe4cd7f1517","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-verify-secret-invalid","status":"ready","created_at":"2026-07-03T15:28:18.729628Z","updated_at":"2026-07-03T15:28:18.729628Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "457"
+                - "440"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:35 GMT
+                - Fri, 03 Jul 2026 15:28:22 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 350304ce-eaeb-433e-abf2-dbb447643ecd
+                - d5839dde-bb67-4aa8-9826-3937f822c50c
         status: 200 OK
         code: 200
-        duration: 42.77256ms
+        duration: 42.820689ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -613,29 +613,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/2547e627-ba3c-4ac8-b619-1e194e283778
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/969b2333-caec-45d2-99b0-aef0b1d49d12
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 524
-        body: '{"id":"2547e627-ba3c-4ac8-b619-1e194e283778", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-verify-key-invalid", "usage":{"asymmetric_signing":"rsa_pss_2048_sha256"}, "state":"enabled", "rotation_count":1, "created_at":"2026-01-23T17:30:33.987413Z", "updated_at":"2026-01-23T17:30:34.091717Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-01-23T17:30:34.091717Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 538
+        body: '{"id":"969b2333-caec-45d2-99b0-aef0b1d49d12","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-key-invalid","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.543164Z","updated_at":"2026-07-03T15:28:19.841001Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.841001Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "524"
+                - "538"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:35 GMT
+                - Fri, 03 Jul 2026 15:28:22 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 837865dc-938b-4f0e-bac9-0ff7496b515f
+                - f827ce67-9250-491f-a0a9-136061c27b16
         status: 200 OK
         code: 200
-        duration: 42.831819ms
+        duration: 45.961178ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -648,30 +648,62 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/4653dfe8-1bb9-47e9-a26e-241ea4f4a0b8/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5222f140-1459-45f1-a13d-9fe4cd7f1517/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 344
-        body: '{"versions":[{"revision":1, "secret_id":"4653dfe8-1bb9-47e9-a26e-241ea4f4a0b8", "status":"enabled", "created_at":"2026-01-23T17:30:34.608385Z", "updated_at":"2026-01-23T17:30:34.608385Z", "deleted_at":null, "description":"version1", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}], "total_count":1}'
+        content_length: 333
+        body: '{"versions":[{"revision":1,"secret_id":"5222f140-1459-45f1-a13d-9fe4cd7f1517","status":"enabled","created_at":"2026-07-03T15:28:20.360180Z","updated_at":"2026-07-03T15:28:20.360180Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
-                - "344"
+                - "333"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:35 GMT
+                - Fri, 03 Jul 2026 15:28:22 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 171274bf-6fce-4a42-9a51-56a360511892
+                - be24d6c0-76fc-4be2-aed7-18e9d1999ab9
         status: 200 OK
         code: 200
-        duration: 47.95065ms
+        duration: 41.319079ms
     - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/b1132c2b-01d9-4c6c-950c-b4b15d787780
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 536
+        body: '{"id":"b1132c2b-01d9-4c6c-950c-b4b15d787780","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-other-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.995464Z","updated_at":"2026-07-03T15:28:20.337904Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:20.337904Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "536"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 8e4f5b98-6cae-4d2c-84d4-80907f0487d8
+        status: 200 OK
+        code: 200
+        duration: 49.473956ms
+    - id: 21
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -683,61 +715,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/2547e627-ba3c-4ac8-b619-1e194e283778/sign
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/969b2333-caec-45d2-99b0-aef0b1d49d12/sign
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 409
-        body: '{"key_id":"2547e627-ba3c-4ac8-b619-1e194e283778", "signature":"GSvWVq8CTqM3iEyvfVWo/zanUNP1j9LBeziGot0VeJPSfKSItAZTzNFDsDt1QnF4PnfDbfTUGpBnCdfahUCazF2F/EIsoh00/E/EwrKlM+MS56YfMTbQ+/07BcdsYPO9bS7mQAx8MxJn3wZyqPQY/Hki4BXU+xQWA29QuqAtKWwHgKnQP/cUe+lX2I8V49s/3jpX24eLFB//mHoWpAopq4CqE99dkTV1oic+nfaO8fTrrmenMavMGhJsuLA8zJF+rlcbbPA3B9cAPgNGQ7B6KuRmFX8z40wEgoKQD93cBeklPATzd6c2DFYMxpjET55dMfX0SPQWsD/Ws4o/fCrLGA=="}'
+        content_length: 408
+        body: '{"key_id":"969b2333-caec-45d2-99b0-aef0b1d49d12","signature":"1oOdw6HoGDtuZRVVJonjRbs773xb7TFtxJT4c6xAyFt6o22p1hkAFcLL57yUw9sIrRFvGgYNfmgU3cnoWYPmHqIz6obSs0mb+Xzf53GfsyoAyQDylKghwbnbjoS0wN7p7dWmkQlDGkTlTGxdbUaOx5XEFu3sF5VBe3eyKMvq6rrCl8rbaGTSRFoVpomiJ6nBkqAAE9J2oT5/4pVMm3mvjurGa838IqhftfYS9NKTgGbdV+4TcmD9FUuk0+4SzVTGZS8SoHCqDsVZ1wdPNfrmqrWNTwjnha2+h/KXZrcRbUh0iz1bjUfG2ho/HwhWKymhtoRHshO7G5hTy7Hx+OKzOg=="}'
         headers:
             Content-Length:
-                - "409"
+                - "408"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:35 GMT
+                - Fri, 03 Jul 2026 15:28:22 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 9c9d936e-d8f2-4140-9d6d-fb46140e2631
+                - 578a3386-d1a7-40fa-a348-84acbc99e129
         status: 200 OK
         code: 200
-        duration: 56.509577ms
-    - id: 21
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/fa24024f-b783-47d4-9dbe-3d0a0ab63f7e
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 522
-        body: '{"id":"fa24024f-b783-47d4-9dbe-3d0a0ab63f7e", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-verify-other-key", "usage":{"asymmetric_signing":"rsa_pss_2048_sha256"}, "state":"enabled", "rotation_count":1, "created_at":"2026-01-23T17:30:34.341595Z", "updated_at":"2026-01-23T17:30:34.399581Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-01-23T17:30:34.399581Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "522"
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 17:30:35 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            X-Request-Id:
-                - da7a1534-41d7-4c01-b8a4-ef5b52871b88
-        status: 200 OK
-        code: 200
-        duration: 73.036249ms
+        duration: 63.43607ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -747,29 +747,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/4653dfe8-1bb9-47e9-a26e-241ea4f4a0b8/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5222f140-1459-45f1-a13d-9fe4cd7f1517/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 312
-        body: '{"revision":1, "secret_id":"4653dfe8-1bb9-47e9-a26e-241ea4f4a0b8", "status":"enabled", "created_at":"2026-01-23T17:30:34.608385Z", "updated_at":"2026-01-23T17:30:34.608385Z", "deleted_at":null, "description":"version1", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 302
+        body: '{"revision":1,"secret_id":"5222f140-1459-45f1-a13d-9fe4cd7f1517","status":"enabled","created_at":"2026-07-03T15:28:20.360180Z","updated_at":"2026-07-03T15:28:20.360180Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "312"
+                - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:35 GMT
+                - Fri, 03 Jul 2026 15:28:22 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - e568081e-1f31-4e4e-bbac-8b4eb71a2daa
+                - 201ffb66-a4da-4330-b49f-3efce4d4ab3e
         status: 200 OK
         code: 200
-        duration: 35.485287ms
+        duration: 53.052417ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -779,29 +779,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/4653dfe8-1bb9-47e9-a26e-241ea4f4a0b8/versions/1/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5222f140-1459-45f1-a13d-9fe4cd7f1517/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 573
-        body: '{"secret_id":"4653dfe8-1bb9-47e9-a26e-241ea4f4a0b8", "revision":1, "data":"ay9pZHZGeEIvTmRKYk8zV1hQdUlBQS82QjdFTnR3Z2JLU1FCeWxFQkwzbk1KcytPQkVYMXpsRFVXQzN6RDkwTVgrN2pITlB4cWs2cERZYVAxYmJoM1NXbEJGcmFDejZNZU55YytzSUg5ZlhrZlZMNkk0LytDZE5DRSs1WVc4MDdNUFdHUkNDYytZRm0vVmZWQ1luNllLbit1RmJVTWxvOVV1VG1YSzhkZU1ZQk1XeGw3cERnZ3ZPNk9DblJlc25uallvRG1XVlNsZC9BVUwxcEdCYjFyRUhFeWlTZzhnaHIxcVRua3BrWFRBeElCblZuR09iSGgrZ2NiTlFCM1hueFVpa1V2RmE3WmIrcHZja1Z2VnByODhRQzRqU2JCeVRYUVhMbDBLSzRvdE9oYTIyMG5scGJCc3BhNzhsRWhiZGZGWGxJc3N6a0ZlSDdiODlqN3dnL3dnPT0=", "data_crc32":null, "type":"opaque"}'
+        content_length: 569
+        body: '{"secret_id":"5222f140-1459-45f1-a13d-9fe4cd7f1517","revision":1,"data":"QVF3bWFpVk1xVWZGbXJBMVNwKzdwTkRNV0hERDhPUG51N3d4T0xHNmNyQnJQUXFyd1YrUUY0RVJaeGRZdm5aL2M5cXFmYTBXT2Y4ZWVvV3VKc28wVEJyWmJuZDZWUWIyRER4Z1hYS1RNaUNRZXc1WjkzclduU2lFdFYyeHF0Z1E3cjNTQ3h1cWxENWU4ZnFJODhlVkdyYXdoRlRkNXJoWlZjS1NPWnBYdFlrY01SZ0trOEtlRlVpRWF2SlBsT3hJRWcrcW1vci9jbjdCWHEyNFlyT01JVmpWTERabGxiTGFqVkoxRHRNNGRxUC9VUk5DQjFtTjRpMjQ5cUJDOXRIVEloUmtRRHdEcHNkTmFqdHhzSHR4N0ZQYm8zKzVEbUFLTGlhM1FjdXp0OUorak05TmprS2RWL3lQVkI4Rkc2ZVVaekM5QlJsOE40dk9ZYWd2eERGUnZRPT0=","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "573"
+                - "569"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:35 GMT
+                - Fri, 03 Jul 2026 15:28:22 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - d7e5fd5c-31b6-408a-b86d-0a6990484ce1
+                - 79c98512-fc97-4965-8f60-44da9a39bc61
         status: 200 OK
         code: 200
-        duration: 50.995095ms
+        duration: 44.031763ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -811,29 +811,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/4653dfe8-1bb9-47e9-a26e-241ea4f4a0b8/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5222f140-1459-45f1-a13d-9fe4cd7f1517/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 312
-        body: '{"revision":1, "secret_id":"4653dfe8-1bb9-47e9-a26e-241ea4f4a0b8", "status":"enabled", "created_at":"2026-01-23T17:30:34.608385Z", "updated_at":"2026-01-23T17:30:34.608385Z", "deleted_at":null, "description":"version1", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 302
+        body: '{"revision":1,"secret_id":"5222f140-1459-45f1-a13d-9fe4cd7f1517","status":"enabled","created_at":"2026-07-03T15:28:20.360180Z","updated_at":"2026-07-03T15:28:20.360180Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "312"
+                - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:35 GMT
+                - Fri, 03 Jul 2026 15:28:22 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - fb661301-9c3e-4347-abd4-9fd77313f7fa
+                - 76370ccc-4b9d-4a37-baef-c4e3fa234103
         status: 200 OK
         code: 200
-        duration: 32.954007ms
+        duration: 50.24804ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -841,34 +841,34 @@ interactions:
         proto_minor: 1
         content_length: 416
         host: api.scaleway.com
-        body: '{"digest":"+wxGDJPL0C0K00FBHoXsjM0xaYYPTtIHSfdfjlvQEMs=","signature":"k/idvFxB/NdJbO3WXPuIAA/6B7ENtwgbKSQBylEBL3nMJs+OBEX1zlDUWC3zD90MX+7jHNPxqk6pDYaP1bbh3SWlBFraCz6MeNyc+sIH9fXkfVL6I4/+CdNCE+5YW807MPWGRCCc+YFm/VfVCYn6YKn+uFbUMlo9UuTmXK8deMYBMWxl7pDggvO6OCnResnnjYoDmWVSld/AUL1pGBb1rEHEyiSg8ghr1qTnkpkXTAxIBnVnGObHh+gcbNQB3XnxUikUvFa7Zb+pvckVvVpr88QC4jSbByTXQXLl0KK4otOha220nlpbBspa78lEhbdfFXlIsszkFeH7b89j7wg/wg=="}'
+        body: '{"digest":"+wxGDJPL0C0K00FBHoXsjM0xaYYPTtIHSfdfjlvQEMs=","signature":"AQwmaiVMqUfFmrA1Sp+7pNDMWHDD8OPnu7wxOLG6crBrPQqrwV+QF4ERZxdYvnZ/c9qqfa0WOf8eeoWuJso0TBrZbnd6VQb2DDxgXXKTMiCQew5Z93rWnSiEtV2xqtgQ7r3SCxuqlD5e8fqI88eVGrawhFTd5rhZVcKSOZpXtYkcMRgKk8KeFUiEavJPlOxIEg+qmor/cn7BXq24YrOMIVjVLDZllbLajVJ1DtM4dqP/URNCB1mN4i249qBC9tHTIhRkQDwDpsdNajtxsHtx7FPbo3+5DmAKLia3Qcuzt9J+jM9NjkKdV/yPVB8FG6eUZzC9BRl8N4vOYagvxDFRvQ=="}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/fa24024f-b783-47d4-9dbe-3d0a0ab63f7e/verify
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/b1132c2b-01d9-4c6c-950c-b4b15d787780/verify
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 64
-        body: '{"key_id":"fa24024f-b783-47d4-9dbe-3d0a0ab63f7e", "valid":false}'
+        content_length: 63
+        body: '{"key_id":"b1132c2b-01d9-4c6c-950c-b4b15d787780","valid":false}'
         headers:
             Content-Length:
-                - "64"
+                - "63"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:35 GMT
+                - Fri, 03 Jul 2026 15:28:22 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 4404bed1-45c4-4d5f-a706-77c51b506986
+                - 4409c359-1ffd-4713-bc32-cfb2cde52d69
         status: 200 OK
         code: 200
-        duration: 48.676612ms
+        duration: 90.20003ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -878,8 +878,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/fa24024f-b783-47d4-9dbe-3d0a0ab63f7e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/b1132c2b-01d9-4c6c-950c-b4b15d787780
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -891,14 +891,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:36 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 02a74eff-0df8-4dc1-b2fe-b26f4b686f0b
+                - f9547466-f325-4257-b5f1-61c7b8ed1084
         status: 204 No Content
         code: 204
-        duration: 101.793092ms
+        duration: 81.55909ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -908,8 +908,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/4653dfe8-1bb9-47e9-a26e-241ea4f4a0b8/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5222f140-1459-45f1-a13d-9fe4cd7f1517/versions/1
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -921,14 +921,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:36 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 5b7d358e-24d0-4252-b6c4-51c273d7108f
+                - 6fd54347-59eb-4fc5-97eb-f2233cd69c46
         status: 204 No Content
         code: 204
-        duration: 104.55311ms
+        duration: 99.772481ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -938,8 +938,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/2547e627-ba3c-4ac8-b619-1e194e283778
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5222f140-1459-45f1-a13d-9fe4cd7f1517
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -951,14 +951,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:36 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - fb5b1703-9bd9-48b2-abf8-165aa2fa59fa
+                - 0fd5389b-56ec-4a2c-b7d0-ebc5179aee97
         status: 204 No Content
         code: 204
-        duration: 93.41147ms
+        duration: 105.224711ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -968,8 +968,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/4653dfe8-1bb9-47e9-a26e-241ea4f4a0b8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/969b2333-caec-45d2-99b0-aef0b1d49d12
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -981,14 +981,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:36 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 2646a926-b356-4705-9109-9964d30d1324
+                - dee45a7a-4701-4166-8d06-360dd9f88a05
         status: 204 No Content
         code: 204
-        duration: 102.708658ms
+        duration: 105.315852ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -998,29 +998,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/2547e627-ba3c-4ac8-b619-1e194e283778
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/b1132c2b-01d9-4c6c-950c-b4b15d787780
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 564
-        body: '{"id":"2547e627-ba3c-4ac8-b619-1e194e283778", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-verify-key-invalid", "usage":{"asymmetric_signing":"rsa_pss_2048_sha256"}, "state":"scheduled_for_deletion", "rotation_count":1, "created_at":"2026-01-23T17:30:33.987413Z", "updated_at":"2026-01-23T17:30:34.091717Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-01-23T17:30:34.091717Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":"2026-01-23T17:30:36.341464Z", "region":"fr-par"}'
+        content_length: 576
+        body: '{"id":"b1132c2b-01d9-4c6c-950c-b4b15d787780","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-other-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-03T15:28:19.995464Z","updated_at":"2026-07-03T15:28:23.026381Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:20.337904Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-03T15:28:23.026381Z","protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "564"
+                - "576"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:36 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 818f5d31-a290-4c72-a198-fd56224eb578
+                - fda1c16f-c611-4018-a611-85cd18a958a7
         status: 200 OK
         code: 200
-        duration: 31.158301ms
+        duration: 55.292445ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1030,29 +1030,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/fa24024f-b783-47d4-9dbe-3d0a0ab63f7e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/969b2333-caec-45d2-99b0-aef0b1d49d12
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 562
-        body: '{"id":"fa24024f-b783-47d4-9dbe-3d0a0ab63f7e", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-verify-other-key", "usage":{"asymmetric_signing":"rsa_pss_2048_sha256"}, "state":"scheduled_for_deletion", "rotation_count":1, "created_at":"2026-01-23T17:30:34.341595Z", "updated_at":"2026-01-23T17:30:34.399581Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-01-23T17:30:34.399581Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":"2026-01-23T17:30:36.236503Z", "region":"fr-par"}'
+        content_length: 578
+        body: '{"id":"969b2333-caec-45d2-99b0-aef0b1d49d12","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-key-invalid","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-03T15:28:19.543164Z","updated_at":"2026-07-03T15:28:23.125848Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.841001Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-03T15:28:23.125848Z","protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "562"
+                - "578"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:36 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 8e693fde-5309-4702-ad00-557813911100
+                - 52c9277a-54fa-4657-b956-d20c968fd0ca
         status: 200 OK
         code: 200
-        duration: 49.057439ms
+        duration: 48.434693ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1062,26 +1062,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/4653dfe8-1bb9-47e9-a26e-241ea4f4a0b8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5222f140-1459-45f1-a13d-9fe4cd7f1517
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 482
-        body: '{"id":"4653dfe8-1bb9-47e9-a26e-241ea4f4a0b8", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"test-verify-secret-invalid", "status":"ready", "created_at":"2026-01-23T17:30:33.765646Z", "updated_at":"2026-01-23T17:30:33.765646Z", "tags":[], "version_count":1, "description":"", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":"2026-01-23T17:30:36.354379Z", "key_id":null, "region":"fr-par"}'
+        content_length: 465
+        body: '{"id":"5222f140-1459-45f1-a13d-9fe4cd7f1517","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-verify-secret-invalid","status":"ready","created_at":"2026-07-03T15:28:18.729628Z","updated_at":"2026-07-03T15:28:23.133471Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-07-03T15:28:23.133471Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "482"
+                - "465"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 17:30:36 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 215dc8b0-4b86-4a19-97da-c31cb611911c
+                - f1343c68-8139-450f-ac49-86ed700c637a
         status: 200 OK
         code: 200
-        duration: 76.414315ms
+        duration: 48.382806ms

--- a/internal/services/keymanager/testdata/decrypt-ephemeral-resource-basic.cassette.yaml
+++ b/internal/services/keymanager/testdata/decrypt-ephemeral-resource-basic.cassette.yaml
@@ -13,29 +13,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 450
-        body: '{"id":"de307ad2-b070-4d1b-bed2-49a51fca2fea", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"test-decrypt-secret", "status":"ready", "created_at":"2026-06-09T13:18:31.640158Z", "updated_at":"2026-06-09T13:18:31.640158Z", "tags":[], "version_count":0, "description":"", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}'
+        content_length: 433
+        body: '{"id":"3bb46cf5-824b-45b1-b249-6690e16b6742","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-decrypt-secret","status":"ready","created_at":"2026-07-03T15:28:18.762250Z","updated_at":"2026-07-03T15:28:18.762250Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "450"
+                - "433"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:31 GMT
+                - Fri, 03 Jul 2026 15:28:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - a5a09d06-adfa-4ea0-9374-28d1c98df53e
+                - 855905d0-5efd-4d78-b9d6-2170f94ec00d
         status: 200 OK
         code: 200
-        duration: 256.939361ms
+        duration: 141.144477ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -45,65 +45,30 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/de307ad2-b070-4d1b-bed2-49a51fca2fea
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bb46cf5-824b-45b1-b249-6690e16b6742
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 450
-        body: '{"id":"de307ad2-b070-4d1b-bed2-49a51fca2fea", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"test-decrypt-secret", "status":"ready", "created_at":"2026-06-09T13:18:31.640158Z", "updated_at":"2026-06-09T13:18:31.640158Z", "tags":[], "version_count":0, "description":"", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}'
+        content_length: 433
+        body: '{"id":"3bb46cf5-824b-45b1-b249-6690e16b6742","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-decrypt-secret","status":"ready","created_at":"2026-07-03T15:28:18.762250Z","updated_at":"2026-07-03T15:28:18.762250Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "450"
+                - "433"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:31 GMT
+                - Fri, 03 Jul 2026 15:28:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 06d01bdf-ae24-4f0a-9198-c632f24f9cb7
+                - 58256c49-a2f6-48bd-9bd8-04add01cd0af
         status: 200 OK
         code: 200
-        duration: 90.449128ms
+        duration: 55.496328ms
     - id: 2
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 186
-        host: api.scaleway.com
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-decrypt-key","usage":{"symmetric_encryption":"aes_256_gcm"},"tags":null,"unprotected":true,"origin":"unknown_origin"}'
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 511
-        body: '{"id":"8b121519-3d5f-4145-ba31-c2be493ec743", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-decrypt-key", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-09T13:18:31.757243Z", "updated_at":"2026-06-09T13:18:31.760319Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-09T13:18:31.760319Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "511"
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 09 Jun 2026 13:18:31 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            X-Request-Id:
-                - 65cd8291-d866-4905-a65f-c137996cbbd4
-        status: 200 OK
-        code: 200
-        duration: 388.140466ms
-    - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -115,29 +80,64 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/de307ad2-b070-4d1b-bed2-49a51fca2fea/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bb46cf5-824b-45b1-b249-6690e16b6742/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 32
-        body: '{"versions":[], "total_count":0}'
+        content_length: 31
+        body: '{"versions":[],"total_count":0}'
         headers:
             Content-Length:
-                - "32"
+                - "31"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:31 GMT
+                - Fri, 03 Jul 2026 15:28:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - d00de20f-5e22-4ed9-b455-6f8330e2bc30
+                - fcb8d000-3000-4ed4-bfae-c38a1c2bb0b8
         status: 200 OK
         code: 200
-        duration: 41.171876ms
+        duration: 53.849544ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 232
+        host: api.scaleway.com
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-decrypt-key","usage":{"symmetric_encryption":"aes_256_gcm"},"tags":null,"unprotected":true,"origin":"unknown_origin","protection_level":"unknown_protection_level"}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 525
+        body: '{"id":"f8880c35-46bf-4ecd-8185-c816231f0d78","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-decrypt-key","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.387100Z","updated_at":"2026-07-03T15:28:19.391480Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.391480Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "525"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:19 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 80f11f3a-1aa4-43bb-822f-7d58423f5d78
+        status: 200 OK
+        code: 200
+        duration: 773.315126ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -147,29 +147,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/8b121519-3d5f-4145-ba31-c2be493ec743
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/f8880c35-46bf-4ecd-8185-c816231f0d78
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 511
-        body: '{"id":"8b121519-3d5f-4145-ba31-c2be493ec743", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-decrypt-key", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-09T13:18:31.757243Z", "updated_at":"2026-06-09T13:18:31.760319Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-09T13:18:31.760319Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 525
+        body: '{"id":"f8880c35-46bf-4ecd-8185-c816231f0d78","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-decrypt-key","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.387100Z","updated_at":"2026-07-03T15:28:19.391480Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.391480Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "511"
+                - "525"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:31 GMT
+                - Fri, 03 Jul 2026 15:28:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 0ce57cae-34c6-4f1e-805e-b4a95016fec0
+                - 8e04d28d-481d-4e52-b9bd-63a71a7bef12
         status: 200 OK
         code: 200
-        duration: 46.213274ms
+        duration: 46.633901ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -182,29 +182,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/8b121519-3d5f-4145-ba31-c2be493ec743/encrypt
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/f8880c35-46bf-4ecd-8185-c816231f0d78/encrypt
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 142
-        body: '{"key_id":"8b121519-3d5f-4145-ba31-c2be493ec743", "ciphertext":"AQAAAAETWb4XiTltylh3iJu5A2XHpf2yKFp1L+tlGBYyL8UE5r4a0NlQuc3sgE5sdsphIm6Q/V2k"}'
+        content_length: 141
+        body: '{"key_id":"f8880c35-46bf-4ecd-8185-c816231f0d78","ciphertext":"AQAAAAHh0SpRwFRhgrqq4KZorrtG/Rtr8prBZviXJlDE7DlbHMXsd4aOjzDTM07Dd7AhGodmN5PY"}'
         headers:
             Content-Length:
-                - "142"
+                - "141"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:31 GMT
+                - Fri, 03 Jul 2026 15:28:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - b3b14d32-9e08-4fce-89fa-bba1c4417434
+                - 0cbe467f-2bd1-4cdd-805a-8850f694be0b
         status: 200 OK
         code: 200
-        duration: 87.329888ms
+        duration: 121.549704ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -212,34 +212,34 @@ interactions:
         proto_minor: 1
         content_length: 116
         host: api.scaleway.com
-        body: '{"ciphertext":"AQAAAAETWb4XiTltylh3iJu5A2XHpf2yKFp1L+tlGBYyL8UE5r4a0NlQuc3sgE5sdsphIm6Q/V2k","associated_data":null}'
+        body: '{"ciphertext":"AQAAAAHh0SpRwFRhgrqq4KZorrtG/Rtr8prBZviXJlDE7DlbHMXsd4aOjzDTM07Dd7AhGodmN5PY","associated_data":null}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/8b121519-3d5f-4145-ba31-c2be493ec743/decrypt
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/f8880c35-46bf-4ecd-8185-c816231f0d78/decrypt
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 116
-        body: '{"key_id":"8b121519-3d5f-4145-ba31-c2be493ec743", "plaintext":"dGhpcyBpcyBzb21lIHNlY3JldCBkYXRh", "ciphertext":null}'
+        content_length: 114
+        body: '{"key_id":"f8880c35-46bf-4ecd-8185-c816231f0d78","plaintext":"dGhpcyBpcyBzb21lIHNlY3JldCBkYXRh","ciphertext":null}'
         headers:
             Content-Length:
-                - "116"
+                - "114"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:32 GMT
+                - Fri, 03 Jul 2026 15:28:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - c40f89d3-0ea5-45f1-8bbb-588a03474a26
+                - 75727582-fcc5-47a3-a6a1-7cc5ec06f408
         status: 200 OK
         code: 200
-        duration: 94.74881ms
+        duration: 113.159655ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -252,29 +252,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/de307ad2-b070-4d1b-bed2-49a51fca2fea/versions
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bb46cf5-824b-45b1-b249-6690e16b6742/versions
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 318
-        body: '{"revision":1, "secret_id":"de307ad2-b070-4d1b-bed2-49a51fca2fea", "status":"enabled", "created_at":"2026-06-09T13:18:32.339205Z", "updated_at":"2026-06-09T13:18:32.339205Z", "deleted_at":null, "description":"test decrypted", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 308
+        body: '{"revision":1,"secret_id":"3bb46cf5-824b-45b1-b249-6690e16b6742","status":"enabled","created_at":"2026-07-03T15:28:20.088597Z","updated_at":"2026-07-03T15:28:20.088597Z","deleted_at":null,"description":"test decrypted","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "318"
+                - "308"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:32 GMT
+                - Fri, 03 Jul 2026 15:28:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 8f858c03-1b59-4654-80f2-9326ce3b3e3d
+                - f7fef8b7-839c-4fb2-a56e-8552c58fb75e
         status: 200 OK
         code: 200
-        duration: 324.636863ms
+        duration: 397.696362ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -284,29 +284,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/de307ad2-b070-4d1b-bed2-49a51fca2fea/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bb46cf5-824b-45b1-b249-6690e16b6742/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 318
-        body: '{"revision":1, "secret_id":"de307ad2-b070-4d1b-bed2-49a51fca2fea", "status":"enabled", "created_at":"2026-06-09T13:18:32.339205Z", "updated_at":"2026-06-09T13:18:32.339205Z", "deleted_at":null, "description":"test decrypted", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 308
+        body: '{"revision":1,"secret_id":"3bb46cf5-824b-45b1-b249-6690e16b6742","status":"enabled","created_at":"2026-07-03T15:28:20.088597Z","updated_at":"2026-07-03T15:28:20.088597Z","deleted_at":null,"description":"test decrypted","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "318"
+                - "308"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:32 GMT
+                - Fri, 03 Jul 2026 15:28:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 2462810e-b7a4-45e6-bb1c-2d8f20ca924b
+                - ee4d2116-0d3b-4702-8b7e-7160bc77deba
         status: 200 OK
         code: 200
-        duration: 100.264617ms
+        duration: 56.136429ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -316,29 +316,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/de307ad2-b070-4d1b-bed2-49a51fca2fea/versions/1/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bb46cf5-824b-45b1-b249-6690e16b6742/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 145
-        body: '{"secret_id":"de307ad2-b070-4d1b-bed2-49a51fca2fea", "revision":1, "data":"dGhpcyBpcyBzb21lIHNlY3JldCBkYXRh", "data_crc32":null, "type":"opaque"}'
+        content_length: 141
+        body: '{"secret_id":"3bb46cf5-824b-45b1-b249-6690e16b6742","revision":1,"data":"dGhpcyBpcyBzb21lIHNlY3JldCBkYXRh","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "145"
+                - "141"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:32 GMT
+                - Fri, 03 Jul 2026 15:28:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - d6df3fc2-6419-41e2-81f9-46bbcc0940a9
+                - 3851b9fc-491c-44f8-b80a-bbfeba5ec0d8
         status: 200 OK
         code: 200
-        duration: 78.717872ms
+        duration: 110.502895ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -348,29 +348,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/de307ad2-b070-4d1b-bed2-49a51fca2fea/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bb46cf5-824b-45b1-b249-6690e16b6742/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 318
-        body: '{"revision":1, "secret_id":"de307ad2-b070-4d1b-bed2-49a51fca2fea", "status":"enabled", "created_at":"2026-06-09T13:18:32.339205Z", "updated_at":"2026-06-09T13:18:32.339205Z", "deleted_at":null, "description":"test decrypted", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 308
+        body: '{"revision":1,"secret_id":"3bb46cf5-824b-45b1-b249-6690e16b6742","status":"enabled","created_at":"2026-07-03T15:28:20.088597Z","updated_at":"2026-07-03T15:28:20.088597Z","deleted_at":null,"description":"test decrypted","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "318"
+                - "308"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:32 GMT
+                - Fri, 03 Jul 2026 15:28:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 0a98fd33-9754-4f95-9572-aa20ad9f7d21
+                - 655a4c73-de10-4a27-93aa-c400da5aed7e
         status: 200 OK
         code: 200
-        duration: 47.994747ms
+        duration: 45.516562ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -383,29 +383,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/8b121519-3d5f-4145-ba31-c2be493ec743/encrypt
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/f8880c35-46bf-4ecd-8185-c816231f0d78/encrypt
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 142
-        body: '{"key_id":"8b121519-3d5f-4145-ba31-c2be493ec743", "ciphertext":"AQAAAAGOYmMYKwBdMBbeo40P83khgOiBu1OPm3UwpSEpAG/WCuuGvGiPU/jALYBo3L2BU3JO25pZ"}'
+        content_length: 141
+        body: '{"key_id":"f8880c35-46bf-4ecd-8185-c816231f0d78","ciphertext":"AQAAAAFLgCV6ib+VbWexq4+5STwMXhlGkssg+vloxZLtMaxt+WlTGYDjXRNUP2QfeXGekgTCvF/l"}'
         headers:
             Content-Length:
-                - "142"
+                - "141"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:32 GMT
+                - Fri, 03 Jul 2026 15:28:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 966e047b-1449-4a30-96c8-897fad27f723
+                - 80dfd9cf-8225-46aa-979e-f39faf8ec468
         status: 200 OK
         code: 200
-        duration: 41.632329ms
+        duration: 61.246007ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -413,34 +413,34 @@ interactions:
         proto_minor: 1
         content_length: 116
         host: api.scaleway.com
-        body: '{"ciphertext":"AQAAAAGOYmMYKwBdMBbeo40P83khgOiBu1OPm3UwpSEpAG/WCuuGvGiPU/jALYBo3L2BU3JO25pZ","associated_data":null}'
+        body: '{"ciphertext":"AQAAAAFLgCV6ib+VbWexq4+5STwMXhlGkssg+vloxZLtMaxt+WlTGYDjXRNUP2QfeXGekgTCvF/l","associated_data":null}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/8b121519-3d5f-4145-ba31-c2be493ec743/decrypt
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/f8880c35-46bf-4ecd-8185-c816231f0d78/decrypt
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 116
-        body: '{"key_id":"8b121519-3d5f-4145-ba31-c2be493ec743", "plaintext":"dGhpcyBpcyBzb21lIHNlY3JldCBkYXRh", "ciphertext":null}'
+        content_length: 114
+        body: '{"key_id":"f8880c35-46bf-4ecd-8185-c816231f0d78","plaintext":"dGhpcyBpcyBzb21lIHNlY3JldCBkYXRh","ciphertext":null}'
         headers:
             Content-Length:
-                - "116"
+                - "114"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:32 GMT
+                - Fri, 03 Jul 2026 15:28:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - eff15dca-c0f1-41ee-ab74-7da435dbb326
+                - e36bd4b5-caee-4c2d-bb93-8a4d186f91c8
         status: 200 OK
         code: 200
-        duration: 78.729121ms
+        duration: 86.61093ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -450,29 +450,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/de307ad2-b070-4d1b-bed2-49a51fca2fea/versions/1/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bb46cf5-824b-45b1-b249-6690e16b6742/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 145
-        body: '{"secret_id":"de307ad2-b070-4d1b-bed2-49a51fca2fea", "revision":1, "data":"dGhpcyBpcyBzb21lIHNlY3JldCBkYXRh", "data_crc32":null, "type":"opaque"}'
+        content_length: 141
+        body: '{"secret_id":"3bb46cf5-824b-45b1-b249-6690e16b6742","revision":1,"data":"dGhpcyBpcyBzb21lIHNlY3JldCBkYXRh","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "145"
+                - "141"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:33 GMT
+                - Fri, 03 Jul 2026 15:28:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - dd0f120b-31b7-4722-8dd1-3cf9aa8450de
+                - 287d83b4-ef82-4809-94fd-b0ca9d630dc5
         status: 200 OK
         code: 200
-        duration: 113.996238ms
+        duration: 51.881097ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -482,29 +482,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/de307ad2-b070-4d1b-bed2-49a51fca2fea/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bb46cf5-824b-45b1-b249-6690e16b6742/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 318
-        body: '{"revision":1, "secret_id":"de307ad2-b070-4d1b-bed2-49a51fca2fea", "status":"enabled", "created_at":"2026-06-09T13:18:32.339205Z", "updated_at":"2026-06-09T13:18:32.339205Z", "deleted_at":null, "description":"test decrypted", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 308
+        body: '{"revision":1,"secret_id":"3bb46cf5-824b-45b1-b249-6690e16b6742","status":"enabled","created_at":"2026-07-03T15:28:20.088597Z","updated_at":"2026-07-03T15:28:20.088597Z","deleted_at":null,"description":"test decrypted","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "318"
+                - "308"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:33 GMT
+                - Fri, 03 Jul 2026 15:28:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 7fc9ec8e-9d4d-473c-b83a-a7280b10c44b
+                - 4d5906de-8b94-4372-8d99-b1c77b0c74e7
         status: 200 OK
         code: 200
-        duration: 78.7124ms
+        duration: 36.992552ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -514,30 +514,62 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/de307ad2-b070-4d1b-bed2-49a51fca2fea
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/f8880c35-46bf-4ecd-8185-c816231f0d78
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 450
-        body: '{"id":"de307ad2-b070-4d1b-bed2-49a51fca2fea", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"test-decrypt-secret", "status":"ready", "created_at":"2026-06-09T13:18:31.640158Z", "updated_at":"2026-06-09T13:18:31.640158Z", "tags":[], "version_count":1, "description":"", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}'
+        content_length: 525
+        body: '{"id":"f8880c35-46bf-4ecd-8185-c816231f0d78","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-decrypt-key","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.387100Z","updated_at":"2026-07-03T15:28:19.391480Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.391480Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "450"
+                - "525"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:33 GMT
+                - Fri, 03 Jul 2026 15:28:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 27105ae8-bd4c-4588-8442-b10e5e44ad15
+                - a86cb6af-70ef-4026-9c8e-8cbb7b9ad192
         status: 200 OK
         code: 200
-        duration: 41.11217ms
+        duration: 46.139743ms
     - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bb46cf5-824b-45b1-b249-6690e16b6742
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 433
+        body: '{"id":"3bb46cf5-824b-45b1-b249-6690e16b6742","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-decrypt-secret","status":"ready","created_at":"2026-07-03T15:28:18.762250Z","updated_at":"2026-07-03T15:28:18.762250Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "433"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:21 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 949bbba1-6037-409a-8abd-1ec5c30c6ac6
+        status: 200 OK
+        code: 200
+        duration: 59.264665ms
+    - id: 17
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -549,61 +581,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/de307ad2-b070-4d1b-bed2-49a51fca2fea/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bb46cf5-824b-45b1-b249-6690e16b6742/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 350
-        body: '{"versions":[{"revision":1, "secret_id":"de307ad2-b070-4d1b-bed2-49a51fca2fea", "status":"enabled", "created_at":"2026-06-09T13:18:32.339205Z", "updated_at":"2026-06-09T13:18:32.339205Z", "deleted_at":null, "description":"test decrypted", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}], "total_count":1}'
+        content_length: 339
+        body: '{"versions":[{"revision":1,"secret_id":"3bb46cf5-824b-45b1-b249-6690e16b6742","status":"enabled","created_at":"2026-07-03T15:28:20.088597Z","updated_at":"2026-07-03T15:28:20.088597Z","deleted_at":null,"description":"test decrypted","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
-                - "350"
+                - "339"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:33 GMT
+                - Fri, 03 Jul 2026 15:28:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - b1d5d420-0ad9-4f59-9705-4e8aea0c18ac
+                - d441b70b-0674-4ba5-8886-9fad5156bdea
         status: 200 OK
         code: 200
-        duration: 37.600375ms
-    - id: 17
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/8b121519-3d5f-4145-ba31-c2be493ec743
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 511
-        body: '{"id":"8b121519-3d5f-4145-ba31-c2be493ec743", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-decrypt-key", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-09T13:18:31.757243Z", "updated_at":"2026-06-09T13:18:31.760319Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-09T13:18:31.760319Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "511"
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 09 Jun 2026 13:18:33 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            X-Request-Id:
-                - 74a3e5da-670d-47ed-9d8b-3812ee261dc9
-        status: 200 OK
-        code: 200
-        duration: 107.029378ms
+        duration: 53.833695ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -616,29 +616,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/8b121519-3d5f-4145-ba31-c2be493ec743/encrypt
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/f8880c35-46bf-4ecd-8185-c816231f0d78/encrypt
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 142
-        body: '{"key_id":"8b121519-3d5f-4145-ba31-c2be493ec743", "ciphertext":"AQAAAAHG94hN0yn63uaYtf+AERolv8yYVFrrMU38ThJb9kw58EIEP6+FPJeUWD9NTTHmG8df7oU/"}'
+        content_length: 141
+        body: '{"key_id":"f8880c35-46bf-4ecd-8185-c816231f0d78","ciphertext":"AQAAAAHqBHv085GRfqt5g7la8Jb4zL1oCTRlSkilytBAhuz0HpDZ3JC1yutNBnsmV0H1/kloO6ul"}'
         headers:
             Content-Length:
-                - "142"
+                - "141"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:33 GMT
+                - Fri, 03 Jul 2026 15:28:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 87b169c7-e50d-4bb4-837a-f0a3c8a892a4
+                - 5440a586-8152-4dbe-a056-5d76ae5091e9
         status: 200 OK
         code: 200
-        duration: 80.100085ms
+        duration: 87.044794ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -646,34 +646,34 @@ interactions:
         proto_minor: 1
         content_length: 116
         host: api.scaleway.com
-        body: '{"ciphertext":"AQAAAAHG94hN0yn63uaYtf+AERolv8yYVFrrMU38ThJb9kw58EIEP6+FPJeUWD9NTTHmG8df7oU/","associated_data":null}'
+        body: '{"ciphertext":"AQAAAAHqBHv085GRfqt5g7la8Jb4zL1oCTRlSkilytBAhuz0HpDZ3JC1yutNBnsmV0H1/kloO6ul","associated_data":null}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/8b121519-3d5f-4145-ba31-c2be493ec743/decrypt
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/f8880c35-46bf-4ecd-8185-c816231f0d78/decrypt
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 116
-        body: '{"key_id":"8b121519-3d5f-4145-ba31-c2be493ec743", "plaintext":"dGhpcyBpcyBzb21lIHNlY3JldCBkYXRh", "ciphertext":null}'
+        content_length: 114
+        body: '{"key_id":"f8880c35-46bf-4ecd-8185-c816231f0d78","plaintext":"dGhpcyBpcyBzb21lIHNlY3JldCBkYXRh","ciphertext":null}'
         headers:
             Content-Length:
-                - "116"
+                - "114"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:33 GMT
+                - Fri, 03 Jul 2026 15:28:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - acb16d7e-830f-4094-abf9-85db726f6039
+                - d486b48b-cbea-41d0-95af-b9ade3dfb18e
         status: 200 OK
         code: 200
-        duration: 94.856878ms
+        duration: 87.903787ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -683,29 +683,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/de307ad2-b070-4d1b-bed2-49a51fca2fea/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bb46cf5-824b-45b1-b249-6690e16b6742/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 318
-        body: '{"revision":1, "secret_id":"de307ad2-b070-4d1b-bed2-49a51fca2fea", "status":"enabled", "created_at":"2026-06-09T13:18:32.339205Z", "updated_at":"2026-06-09T13:18:32.339205Z", "deleted_at":null, "description":"test decrypted", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 308
+        body: '{"revision":1,"secret_id":"3bb46cf5-824b-45b1-b249-6690e16b6742","status":"enabled","created_at":"2026-07-03T15:28:20.088597Z","updated_at":"2026-07-03T15:28:20.088597Z","deleted_at":null,"description":"test decrypted","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "318"
+                - "308"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:33 GMT
+                - Fri, 03 Jul 2026 15:28:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 55a2ad28-59b9-419a-8198-b1dd7fe0a3b0
+                - c6b69dea-40da-434e-8512-8fef3d6c7a75
         status: 200 OK
         code: 200
-        duration: 95.239414ms
+        duration: 35.624763ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -715,29 +715,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/de307ad2-b070-4d1b-bed2-49a51fca2fea/versions/1/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bb46cf5-824b-45b1-b249-6690e16b6742/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 145
-        body: '{"secret_id":"de307ad2-b070-4d1b-bed2-49a51fca2fea", "revision":1, "data":"dGhpcyBpcyBzb21lIHNlY3JldCBkYXRh", "data_crc32":null, "type":"opaque"}'
+        content_length: 141
+        body: '{"secret_id":"3bb46cf5-824b-45b1-b249-6690e16b6742","revision":1,"data":"dGhpcyBpcyBzb21lIHNlY3JldCBkYXRh","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "145"
+                - "141"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:33 GMT
+                - Fri, 03 Jul 2026 15:28:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - e6ffe377-1aca-48c5-b377-aa511b77e5dc
+                - 5f7776fd-1672-4e88-89b7-1292aedc551b
         status: 200 OK
         code: 200
-        duration: 108.079336ms
+        duration: 45.615969ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -747,29 +747,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/de307ad2-b070-4d1b-bed2-49a51fca2fea/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bb46cf5-824b-45b1-b249-6690e16b6742/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 318
-        body: '{"revision":1, "secret_id":"de307ad2-b070-4d1b-bed2-49a51fca2fea", "status":"enabled", "created_at":"2026-06-09T13:18:32.339205Z", "updated_at":"2026-06-09T13:18:32.339205Z", "deleted_at":null, "description":"test decrypted", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 308
+        body: '{"revision":1,"secret_id":"3bb46cf5-824b-45b1-b249-6690e16b6742","status":"enabled","created_at":"2026-07-03T15:28:20.088597Z","updated_at":"2026-07-03T15:28:20.088597Z","deleted_at":null,"description":"test decrypted","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "318"
+                - "308"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:33 GMT
+                - Fri, 03 Jul 2026 15:28:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 1037ece8-4534-4ae5-a775-47fc167f80d8
+                - 04c3c220-52b3-43c6-9176-ff8ce0c459bd
         status: 200 OK
         code: 200
-        duration: 38.032555ms
+        duration: 48.205162ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -779,8 +779,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/de307ad2-b070-4d1b-bed2-49a51fca2fea/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bb46cf5-824b-45b1-b249-6690e16b6742/versions/1
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -792,14 +792,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:34 GMT
+                - Fri, 03 Jul 2026 15:28:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 925b9a01-c804-4274-8f4b-e2cb3605dfb3
+                - e8dc5307-9a81-47e0-8a9a-243dc12e79fc
         status: 204 No Content
         code: 204
-        duration: 107.509822ms
+        duration: 85.14712ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -809,8 +809,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/8b121519-3d5f-4145-ba31-c2be493ec743
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bb46cf5-824b-45b1-b249-6690e16b6742
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -822,14 +822,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:34 GMT
+                - Fri, 03 Jul 2026 15:28:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 4cd2705d-62b8-4614-9b1e-0afcfb52a4d3
+                - 034737e7-0adf-4cd6-b5af-d6a4272b8a9d
         status: 204 No Content
         code: 204
-        duration: 109.548365ms
+        duration: 59.611457ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -839,8 +839,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/de307ad2-b070-4d1b-bed2-49a51fca2fea
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/f8880c35-46bf-4ecd-8185-c816231f0d78
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -852,14 +852,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:34 GMT
+                - Fri, 03 Jul 2026 15:28:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 8d53c269-13b7-429c-b0b4-152419aaf393
+                - 668414bd-8f9b-4956-bb8d-a07e435c846a
         status: 204 No Content
         code: 204
-        duration: 109.672021ms
+        duration: 132.037092ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -869,29 +869,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/de307ad2-b070-4d1b-bed2-49a51fca2fea
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bb46cf5-824b-45b1-b249-6690e16b6742
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 475
-        body: '{"id":"de307ad2-b070-4d1b-bed2-49a51fca2fea", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"test-decrypt-secret", "status":"ready", "created_at":"2026-06-09T13:18:31.640158Z", "updated_at":"2026-06-09T13:18:31.640158Z", "tags":[], "version_count":1, "description":"", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":"2026-06-09T13:18:34.381195Z", "key_id":null, "region":"fr-par"}'
+        content_length: 458
+        body: '{"id":"3bb46cf5-824b-45b1-b249-6690e16b6742","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-decrypt-secret","status":"ready","created_at":"2026-07-03T15:28:18.762250Z","updated_at":"2026-07-03T15:28:22.238364Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-07-03T15:28:22.238364Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "475"
+                - "458"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:34 GMT
+                - Fri, 03 Jul 2026 15:28:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 2507e4e4-e2a1-4e03-8625-454facc4b478
+                - 88e84b89-8dc5-4e36-bd88-d914626ee54e
         status: 200 OK
         code: 200
-        duration: 49.028747ms
+        duration: 48.004005ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -901,26 +901,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/8b121519-3d5f-4145-ba31-c2be493ec743
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/f8880c35-46bf-4ecd-8185-c816231f0d78
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 551
-        body: '{"id":"8b121519-3d5f-4145-ba31-c2be493ec743", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-decrypt-key", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"scheduled_for_deletion", "rotation_count":1, "created_at":"2026-06-09T13:18:31.757243Z", "updated_at":"2026-06-09T13:18:31.760319Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-09T13:18:31.760319Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":"2026-06-09T13:18:34.377316Z", "region":"fr-par"}'
+        content_length: 565
+        body: '{"id":"f8880c35-46bf-4ecd-8185-c816231f0d78","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-decrypt-key","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-03T15:28:19.387100Z","updated_at":"2026-07-03T15:28:22.304500Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.391480Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-03T15:28:22.304500Z","protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "551"
+                - "565"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:34 GMT
+                - Fri, 03 Jul 2026 15:28:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 20630498-cc14-490c-a515-a202d16705e8
+                - 17b36121-77eb-40e9-947f-6946a9e66977
         status: 200 OK
         code: 200
-        duration: 82.73384ms
+        duration: 42.44319ms

--- a/internal/services/keymanager/testdata/decrypt-ephemeral-resource-invalid-associated-data.cassette.yaml
+++ b/internal/services/keymanager/testdata/decrypt-ephemeral-resource-invalid-associated-data.cassette.yaml
@@ -6,36 +6,36 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 194
+        content_length: 240
         host: api.scaleway.com
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-decrypt-key-invalid","usage":{"symmetric_encryption":"aes_256_gcm"},"tags":null,"unprotected":true,"origin":"unknown_origin"}'
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-decrypt-key-invalid","usage":{"symmetric_encryption":"aes_256_gcm"},"tags":null,"unprotected":true,"origin":"unknown_origin","protection_level":"unknown_protection_level"}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 519
-        body: '{"id":"e6bd7030-4fcf-43c9-8e49-35b25ea71196", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-decrypt-key-invalid", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-09T13:18:31.687885Z", "updated_at":"2026-06-09T13:18:31.690423Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-09T13:18:31.690423Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 533
+        body: '{"id":"ef551897-6a4b-4965-9d18-e9aa50f4917a","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-decrypt-key-invalid","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:23.133861Z","updated_at":"2026-07-03T15:28:23.137162Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:23.137162Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "519"
+                - "533"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:31 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 415c0491-9aea-4931-af14-3e770bca11a1
+                - 6e0213c4-271f-4a90-80d3-30999995380b
         status: 200 OK
         code: 200
-        duration: 284.053059ms
+        duration: 107.655286ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -45,29 +45,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/e6bd7030-4fcf-43c9-8e49-35b25ea71196
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/ef551897-6a4b-4965-9d18-e9aa50f4917a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 519
-        body: '{"id":"e6bd7030-4fcf-43c9-8e49-35b25ea71196", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-decrypt-key-invalid", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-09T13:18:31.687885Z", "updated_at":"2026-06-09T13:18:31.690423Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-09T13:18:31.690423Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 533
+        body: '{"id":"ef551897-6a4b-4965-9d18-e9aa50f4917a","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-decrypt-key-invalid","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:23.133861Z","updated_at":"2026-07-03T15:28:23.137162Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:23.137162Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "519"
+                - "533"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:31 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - c1e26f3f-e355-4456-924a-458c39c037e3
+                - 36114b8f-b56e-417d-b2fa-bbd1b852c63e
         status: 200 OK
         code: 200
-        duration: 80.968504ms
+        duration: 44.236207ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -80,29 +80,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/e6bd7030-4fcf-43c9-8e49-35b25ea71196/encrypt
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/ef551897-6a4b-4965-9d18-e9aa50f4917a/encrypt
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 130
-        body: '{"key_id":"e6bd7030-4fcf-43c9-8e49-35b25ea71196", "ciphertext":"AQAAAAHS78ZDBQtI9FG9H0uE3/30h7JuDKz76TyOtAM53wvxIWuYqXkebzW9o/E="}'
+        content_length: 129
+        body: '{"key_id":"ef551897-6a4b-4965-9d18-e9aa50f4917a","ciphertext":"AQAAAAFjN4NslHWdQ//M1QRcsn/OKy0IsfNjnk9cUsUzCnP8qltNrFE5jnoSUQA="}'
         headers:
             Content-Length:
-                - "130"
+                - "129"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:31 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 7e4424f3-db1c-49b8-9552-c36dde673bec
+                - 3ace15dc-5a4b-4b2e-9801-1dd030b0a1d1
         status: 200 OK
         code: 200
-        duration: 80.700169ms
+        duration: 89.837469ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -110,13 +110,13 @@ interactions:
         proto_minor: 1
         content_length: 110
         host: api.scaleway.com
-        body: '{"ciphertext":"AQAAAAHS78ZDBQtI9FG9H0uE3/30h7JuDKz76TyOtAM53wvxIWuYqXkebzW9o/E=","associated_data":"cXdlcnR5"}'
+        body: '{"ciphertext":"AQAAAAFjN4NslHWdQ//M1QRcsn/OKy0IsfNjnk9cUsUzCnP8qltNrFE5jnoSUQA=","associated_data":"cXdlcnR5"}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/e6bd7030-4fcf-43c9-8e49-35b25ea71196/decrypt
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/ef551897-6a4b-4965-9d18-e9aa50f4917a/decrypt
         method: POST
       response:
         proto: HTTP/2.0
@@ -130,14 +130,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:31 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - cd354595-0481-494c-a8e2-a460a5b5aae0
+                - 7aa57896-e75a-4622-936b-87a8f830edc8
         status: 400 Bad Request
         code: 400
-        duration: 106.386201ms
+        duration: 43.229737ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -147,8 +147,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/e6bd7030-4fcf-43c9-8e49-35b25ea71196
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/ef551897-6a4b-4965-9d18-e9aa50f4917a
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -160,14 +160,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:32 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 9584dbfc-d088-4b7f-88f7-36e93cfb96bb
+                - 2e80b9f5-8d13-4405-bdcb-7ba7b0730e77
         status: 204 No Content
         code: 204
-        duration: 129.993799ms
+        duration: 73.623105ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -177,26 +177,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/e6bd7030-4fcf-43c9-8e49-35b25ea71196
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/ef551897-6a4b-4965-9d18-e9aa50f4917a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 559
-        body: '{"id":"e6bd7030-4fcf-43c9-8e49-35b25ea71196", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-decrypt-key-invalid", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"scheduled_for_deletion", "rotation_count":1, "created_at":"2026-06-09T13:18:31.687885Z", "updated_at":"2026-06-09T13:18:31.690423Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-09T13:18:31.690423Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":"2026-06-09T13:18:32.277539Z", "region":"fr-par"}'
+        content_length: 573
+        body: '{"id":"ef551897-6a4b-4965-9d18-e9aa50f4917a","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-decrypt-key-invalid","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-03T15:28:23.133861Z","updated_at":"2026-07-03T15:28:23.719584Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:23.137162Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-03T15:28:23.719583Z","protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "559"
+                - "573"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:32 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 32b3487b-fc44-48d1-ba13-bd3181f8aea7
+                - d48f4914-eb61-418e-857e-8bb7db0b7268
         status: 200 OK
         code: 200
-        duration: 47.288262ms
+        duration: 37.641992ms

--- a/internal/services/keymanager/testdata/decrypt-ephemeral-resource-with-associated-data.cassette.yaml
+++ b/internal/services/keymanager/testdata/decrypt-ephemeral-resource-with-associated-data.cassette.yaml
@@ -6,6 +6,41 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
+        content_length: 235
+        host: api.scaleway.com
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-decrypt-key-ad","usage":{"symmetric_encryption":"aes_256_gcm"},"tags":null,"unprotected":true,"origin":"unknown_origin","protection_level":"unknown_protection_level"}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 528
+        body: '{"id":"2c3026cf-38d3-4155-a38a-09fbd05249d0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-decrypt-key-ad","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:23.280724Z","updated_at":"2026-07-03T15:28:23.284017Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:23.284017Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "528"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 03b8fba1-e1ee-4213-9a07-41d5f4b1d260
+        status: 200 OK
+        code: 200
+        duration: 77.943579ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
         content_length: 142
         host: api.scaleway.com
         body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-decrypt-secret-ad","tags":null,"type":"opaque","path":"/","protected":false}'
@@ -13,30 +48,30 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 453
-        body: '{"id":"10445698-1de3-4a5e-937b-167308bb059a", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"test-decrypt-secret-ad", "status":"ready", "created_at":"2026-06-09T13:18:31.667221Z", "updated_at":"2026-06-09T13:18:31.667221Z", "tags":[], "version_count":0, "description":"", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}'
+        content_length: 436
+        body: '{"id":"6fe76d8f-9b19-42a6-a13c-d37d9f7e1050","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-decrypt-secret-ad","status":"ready","created_at":"2026-07-03T15:28:23.295981Z","updated_at":"2026-07-03T15:28:23.295981Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "453"
+                - "436"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:31 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 1db82522-04fb-48ce-b319-e5c2324d3b1d
+                - a4ff6aad-e264-4128-92e4-b56832247ef7
         status: 200 OK
         code: 200
-        duration: 260.445624ms
-    - id: 1
+        duration: 82.423684ms
+    - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -45,30 +80,62 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/10445698-1de3-4a5e-937b-167308bb059a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/2c3026cf-38d3-4155-a38a-09fbd05249d0
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 453
-        body: '{"id":"10445698-1de3-4a5e-937b-167308bb059a", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"test-decrypt-secret-ad", "status":"ready", "created_at":"2026-06-09T13:18:31.667221Z", "updated_at":"2026-06-09T13:18:31.667221Z", "tags":[], "version_count":0, "description":"", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}'
+        content_length: 528
+        body: '{"id":"2c3026cf-38d3-4155-a38a-09fbd05249d0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-decrypt-key-ad","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:23.280724Z","updated_at":"2026-07-03T15:28:23.284017Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:23.284017Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "453"
+                - "528"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:31 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 81e0b6ef-8dd3-46d4-8532-24edd6da07ce
+                - 49d0de49-d8c3-413e-942d-1d8c87b59bd4
         status: 200 OK
         code: 200
-        duration: 84.893645ms
-    - id: 2
+        duration: 38.249333ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6fe76d8f-9b19-42a6-a13c-d37d9f7e1050
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 436
+        body: '{"id":"6fe76d8f-9b19-42a6-a13c-d37d9f7e1050","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-decrypt-secret-ad","status":"ready","created_at":"2026-07-03T15:28:23.295981Z","updated_at":"2026-07-03T15:28:23.295981Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "436"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 111a0299-999e-4464-abce-49f9a1e6dac3
+        status: 200 OK
+        code: 200
+        duration: 44.257928ms
+    - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -80,96 +147,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/10445698-1de3-4a5e-937b-167308bb059a/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6fe76d8f-9b19-42a6-a13c-d37d9f7e1050/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 32
-        body: '{"versions":[], "total_count":0}'
+        content_length: 31
+        body: '{"versions":[],"total_count":0}'
         headers:
             Content-Length:
-                - "32"
+                - "31"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:31 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - ed0271e2-808d-4015-94fb-39b3456de3ac
+                - 7fad7cb2-5d2e-4c11-bae1-bc648822d093
         status: 200 OK
         code: 200
-        duration: 84.460905ms
-    - id: 3
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 189
-        host: api.scaleway.com
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-decrypt-key-ad","usage":{"symmetric_encryption":"aes_256_gcm"},"tags":null,"unprotected":true,"origin":"unknown_origin"}'
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 514
-        body: '{"id":"9a45977a-7588-4eef-a9f3-92fe85061aa4", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-decrypt-key-ad", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-09T13:18:31.836202Z", "updated_at":"2026-06-09T13:18:31.842638Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-09T13:18:31.842638Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "514"
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 09 Jun 2026 13:18:31 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            X-Request-Id:
-                - c7198a7c-0b38-4462-ba2c-8eb846b7ecb5
-        status: 200 OK
-        code: 200
-        duration: 448.132734ms
-    - id: 4
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/9a45977a-7588-4eef-a9f3-92fe85061aa4
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 514
-        body: '{"id":"9a45977a-7588-4eef-a9f3-92fe85061aa4", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-decrypt-key-ad", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-09T13:18:31.836202Z", "updated_at":"2026-06-09T13:18:31.842638Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-09T13:18:31.842638Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "514"
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 09 Jun 2026 13:18:31 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            X-Request-Id:
-                - cbb8054a-982a-4623-9f38-2324f90a1373
-        status: 200 OK
-        code: 200
-        duration: 89.259979ms
+        duration: 48.856686ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -182,29 +182,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/9a45977a-7588-4eef-a9f3-92fe85061aa4/encrypt
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/2c3026cf-38d3-4155-a38a-09fbd05249d0/encrypt
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 142
-        body: '{"key_id":"9a45977a-7588-4eef-a9f3-92fe85061aa4", "ciphertext":"AQAAAAG7SJfFYuGj9eQ5662KZFeX2aY2o/TfeZcDKKxJ2xBpD4opQS24YFLggzwkDsNYjaMQYU92"}'
+        content_length: 141
+        body: '{"key_id":"2c3026cf-38d3-4155-a38a-09fbd05249d0","ciphertext":"AQAAAAGQLZrsTwm+ah6b9RCHvR0jkjAFYZsj7qQ6A4i+f5ycYEH2OQ9QI4RvqFGntvSxeh1FCaQK"}'
         headers:
             Content-Length:
-                - "142"
+                - "141"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:32 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 7f6f1fc8-6bee-432e-947c-3e64f89120d8
+                - cabddf4a-1744-4eb3-bd2a-6442dff46774
         status: 200 OK
         code: 200
-        duration: 78.890317ms
+        duration: 84.437046ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -212,34 +212,34 @@ interactions:
         proto_minor: 1
         content_length: 142
         host: api.scaleway.com
-        body: '{"ciphertext":"AQAAAAG7SJfFYuGj9eQ5662KZFeX2aY2o/TfeZcDKKxJ2xBpD4opQS24YFLggzwkDsNYjaMQYU92","associated_data":"c29tZSBhc3NvY2lhdGVkIGRhdGE="}'
+        body: '{"ciphertext":"AQAAAAGQLZrsTwm+ah6b9RCHvR0jkjAFYZsj7qQ6A4i+f5ycYEH2OQ9QI4RvqFGntvSxeh1FCaQK","associated_data":"c29tZSBhc3NvY2lhdGVkIGRhdGE="}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/9a45977a-7588-4eef-a9f3-92fe85061aa4/decrypt
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/2c3026cf-38d3-4155-a38a-09fbd05249d0/decrypt
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 116
-        body: '{"key_id":"9a45977a-7588-4eef-a9f3-92fe85061aa4", "plaintext":"dGhpcyBpcyBzb21lIHNlY3JldCBkYXRh", "ciphertext":null}'
+        content_length: 114
+        body: '{"key_id":"2c3026cf-38d3-4155-a38a-09fbd05249d0","plaintext":"dGhpcyBpcyBzb21lIHNlY3JldCBkYXRh","ciphertext":null}'
         headers:
             Content-Length:
-                - "116"
+                - "114"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:32 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 81425608-825f-45d2-8d4a-23bf6eab7aed
+                - f1c83f93-e5ee-475f-934b-3b68979eefa0
         status: 200 OK
         code: 200
-        duration: 90.870856ms
+        duration: 42.22503ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -252,29 +252,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/10445698-1de3-4a5e-937b-167308bb059a/versions
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6fe76d8f-9b19-42a6-a13c-d37d9f7e1050/versions
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 323
-        body: '{"revision":1, "secret_id":"10445698-1de3-4a5e-937b-167308bb059a", "status":"enabled", "created_at":"2026-06-09T13:18:32.425540Z", "updated_at":"2026-06-09T13:18:32.425540Z", "deleted_at":null, "description":"test decrypted data", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 313
+        body: '{"revision":1,"secret_id":"6fe76d8f-9b19-42a6-a13c-d37d9f7e1050","status":"enabled","created_at":"2026-07-03T15:28:23.759013Z","updated_at":"2026-07-03T15:28:23.759013Z","deleted_at":null,"description":"test decrypted data","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "323"
+                - "313"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:32 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 84b03611-77e1-4136-925e-eb27cbe9d1cf
+                - 2f29d1a4-6b68-4623-b615-1b0865a0850d
         status: 200 OK
         code: 200
-        duration: 312.05423ms
+        duration: 293.831096ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -284,29 +284,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/10445698-1de3-4a5e-937b-167308bb059a/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6fe76d8f-9b19-42a6-a13c-d37d9f7e1050/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 323
-        body: '{"revision":1, "secret_id":"10445698-1de3-4a5e-937b-167308bb059a", "status":"enabled", "created_at":"2026-06-09T13:18:32.425540Z", "updated_at":"2026-06-09T13:18:32.425540Z", "deleted_at":null, "description":"test decrypted data", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 313
+        body: '{"revision":1,"secret_id":"6fe76d8f-9b19-42a6-a13c-d37d9f7e1050","status":"enabled","created_at":"2026-07-03T15:28:23.759013Z","updated_at":"2026-07-03T15:28:23.759013Z","deleted_at":null,"description":"test decrypted data","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "323"
+                - "313"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:32 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - c450895d-dc7c-49dc-aae5-394377a86637
+                - cc9a690a-052c-432e-8208-237f29e2e884
         status: 200 OK
         code: 200
-        duration: 100.591933ms
+        duration: 36.949451ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -316,29 +316,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/10445698-1de3-4a5e-937b-167308bb059a/versions/1/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6fe76d8f-9b19-42a6-a13c-d37d9f7e1050/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 145
-        body: '{"secret_id":"10445698-1de3-4a5e-937b-167308bb059a", "revision":1, "data":"dGhpcyBpcyBzb21lIHNlY3JldCBkYXRh", "data_crc32":null, "type":"opaque"}'
+        content_length: 141
+        body: '{"secret_id":"6fe76d8f-9b19-42a6-a13c-d37d9f7e1050","revision":1,"data":"dGhpcyBpcyBzb21lIHNlY3JldCBkYXRh","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "145"
+                - "141"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:32 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 34b8aca7-1396-4239-b8c9-0c106bd4b31e
+                - b52ddbbe-3d02-4ccb-8c8f-b62533ad11e3
         status: 200 OK
         code: 200
-        duration: 109.331376ms
+        duration: 48.409657ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -348,29 +348,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/10445698-1de3-4a5e-937b-167308bb059a/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6fe76d8f-9b19-42a6-a13c-d37d9f7e1050/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 323
-        body: '{"revision":1, "secret_id":"10445698-1de3-4a5e-937b-167308bb059a", "status":"enabled", "created_at":"2026-06-09T13:18:32.425540Z", "updated_at":"2026-06-09T13:18:32.425540Z", "deleted_at":null, "description":"test decrypted data", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 313
+        body: '{"revision":1,"secret_id":"6fe76d8f-9b19-42a6-a13c-d37d9f7e1050","status":"enabled","created_at":"2026-07-03T15:28:23.759013Z","updated_at":"2026-07-03T15:28:23.759013Z","deleted_at":null,"description":"test decrypted data","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "323"
+                - "313"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:32 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - b2db8fa1-9225-4248-bb9c-3b3f01036a7b
+                - c12c540d-636b-4b18-a025-02b43c91a3ac
         status: 200 OK
         code: 200
-        duration: 51.556624ms
+        duration: 32.76455ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -383,29 +383,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/10445698-1de3-4a5e-937b-167308bb059a/versions
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6fe76d8f-9b19-42a6-a13c-d37d9f7e1050/versions
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 334
-        body: '{"revision":2, "secret_id":"10445698-1de3-4a5e-937b-167308bb059a", "status":"enabled", "created_at":"2026-06-09T13:18:32.745983Z", "updated_at":"2026-06-09T13:18:32.745983Z", "deleted_at":null, "description":"test decrypted associated data", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 324
+        body: '{"revision":2,"secret_id":"6fe76d8f-9b19-42a6-a13c-d37d9f7e1050","status":"enabled","created_at":"2026-07-03T15:28:23.962815Z","updated_at":"2026-07-03T15:28:23.962815Z","deleted_at":null,"description":"test decrypted associated data","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "334"
+                - "324"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:32 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 7d97b28a-62df-4ba9-b873-8fcc4b62a64f
+                - 48fc3a07-8b3f-4374-b68d-c8ea024ab7c7
         status: 200 OK
         code: 200
-        duration: 193.545173ms
+        duration: 164.621545ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -415,29 +415,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/10445698-1de3-4a5e-937b-167308bb059a/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6fe76d8f-9b19-42a6-a13c-d37d9f7e1050/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 334
-        body: '{"revision":2, "secret_id":"10445698-1de3-4a5e-937b-167308bb059a", "status":"enabled", "created_at":"2026-06-09T13:18:32.745983Z", "updated_at":"2026-06-09T13:18:32.745983Z", "deleted_at":null, "description":"test decrypted associated data", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 324
+        body: '{"revision":2,"secret_id":"6fe76d8f-9b19-42a6-a13c-d37d9f7e1050","status":"enabled","created_at":"2026-07-03T15:28:23.962815Z","updated_at":"2026-07-03T15:28:23.962815Z","deleted_at":null,"description":"test decrypted associated data","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "334"
+                - "324"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:32 GMT
+                - Fri, 03 Jul 2026 15:28:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 8b23eba8-7530-4aab-a42d-0fa46851f5d3
+                - 53b98fb3-3b4e-4f14-ba6b-6a2971cd6379
         status: 200 OK
         code: 200
-        duration: 85.464279ms
+        duration: 34.054364ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -447,29 +447,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/10445698-1de3-4a5e-937b-167308bb059a/versions/2/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6fe76d8f-9b19-42a6-a13c-d37d9f7e1050/versions/2/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 141
-        body: '{"secret_id":"10445698-1de3-4a5e-937b-167308bb059a", "revision":2, "data":"c29tZSBhc3NvY2lhdGVkIGRhdGE=", "data_crc32":null, "type":"opaque"}'
+        content_length: 137
+        body: '{"secret_id":"6fe76d8f-9b19-42a6-a13c-d37d9f7e1050","revision":2,"data":"c29tZSBhc3NvY2lhdGVkIGRhdGE=","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "141"
+                - "137"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:32 GMT
+                - Fri, 03 Jul 2026 15:28:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 25073094-ea89-4ad2-9508-7a09608d2ec7
+                - 1bd7e03b-b290-4f1b-9c12-1d57442984b1
         status: 200 OK
         code: 200
-        duration: 88.195955ms
+        duration: 45.852624ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -479,29 +479,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/10445698-1de3-4a5e-937b-167308bb059a/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6fe76d8f-9b19-42a6-a13c-d37d9f7e1050/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 334
-        body: '{"revision":2, "secret_id":"10445698-1de3-4a5e-937b-167308bb059a", "status":"enabled", "created_at":"2026-06-09T13:18:32.745983Z", "updated_at":"2026-06-09T13:18:32.745983Z", "deleted_at":null, "description":"test decrypted associated data", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 324
+        body: '{"revision":2,"secret_id":"6fe76d8f-9b19-42a6-a13c-d37d9f7e1050","status":"enabled","created_at":"2026-07-03T15:28:23.962815Z","updated_at":"2026-07-03T15:28:23.962815Z","deleted_at":null,"description":"test decrypted associated data","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "334"
+                - "324"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:32 GMT
+                - Fri, 03 Jul 2026 15:28:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 04df2f8a-96e0-4f48-af66-49f30823aff4
+                - f72c4184-2e02-44fc-bd02-60048a59854b
         status: 200 OK
         code: 200
-        duration: 43.348746ms
+        duration: 57.25456ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -514,29 +514,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/9a45977a-7588-4eef-a9f3-92fe85061aa4/encrypt
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/2c3026cf-38d3-4155-a38a-09fbd05249d0/encrypt
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 142
-        body: '{"key_id":"9a45977a-7588-4eef-a9f3-92fe85061aa4", "ciphertext":"AQAAAAG7QzrFY2ohm77tMV8VNDAtHjt1a9j61vInyHxF8XDOt0ybGxmSQLKhVYSIf1Mj900EBqaG"}'
+        content_length: 141
+        body: '{"key_id":"2c3026cf-38d3-4155-a38a-09fbd05249d0","ciphertext":"AQAAAAE8qm55MeAEjfAPNAoA5kbCDJH+PWUCe1HqPdn6fudyTdhwybY8KYqJZ1LwmmpPZf0KnyI7"}'
         headers:
             Content-Length:
-                - "142"
+                - "141"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:33 GMT
+                - Fri, 03 Jul 2026 15:28:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - eed87f35-f304-45f1-b35c-4d6d239f6348
+                - 4a6e89c5-fa5e-4693-a2e5-51de76612ce8
         status: 200 OK
         code: 200
-        duration: 51.161337ms
+        duration: 46.7287ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -544,34 +544,34 @@ interactions:
         proto_minor: 1
         content_length: 142
         host: api.scaleway.com
-        body: '{"ciphertext":"AQAAAAG7QzrFY2ohm77tMV8VNDAtHjt1a9j61vInyHxF8XDOt0ybGxmSQLKhVYSIf1Mj900EBqaG","associated_data":"c29tZSBhc3NvY2lhdGVkIGRhdGE="}'
+        body: '{"ciphertext":"AQAAAAE8qm55MeAEjfAPNAoA5kbCDJH+PWUCe1HqPdn6fudyTdhwybY8KYqJZ1LwmmpPZf0KnyI7","associated_data":"c29tZSBhc3NvY2lhdGVkIGRhdGE="}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/9a45977a-7588-4eef-a9f3-92fe85061aa4/decrypt
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/2c3026cf-38d3-4155-a38a-09fbd05249d0/decrypt
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 116
-        body: '{"key_id":"9a45977a-7588-4eef-a9f3-92fe85061aa4", "plaintext":"dGhpcyBpcyBzb21lIHNlY3JldCBkYXRh", "ciphertext":null}'
+        content_length: 114
+        body: '{"key_id":"2c3026cf-38d3-4155-a38a-09fbd05249d0","plaintext":"dGhpcyBpcyBzb21lIHNlY3JldCBkYXRh","ciphertext":null}'
         headers:
             Content-Length:
-                - "116"
+                - "114"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:33 GMT
+                - Fri, 03 Jul 2026 15:28:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 19568398-d89a-44aa-a22d-0ba674fa5ccb
+                - 89938142-aba5-4f14-841c-1e5ebaf79833
         status: 200 OK
         code: 200
-        duration: 82.292544ms
+        duration: 97.847384ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -581,29 +581,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/10445698-1de3-4a5e-937b-167308bb059a/versions/2/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6fe76d8f-9b19-42a6-a13c-d37d9f7e1050/versions/2/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 141
-        body: '{"secret_id":"10445698-1de3-4a5e-937b-167308bb059a", "revision":2, "data":"c29tZSBhc3NvY2lhdGVkIGRhdGE=", "data_crc32":null, "type":"opaque"}'
+        content_length: 137
+        body: '{"secret_id":"6fe76d8f-9b19-42a6-a13c-d37d9f7e1050","revision":2,"data":"c29tZSBhc3NvY2lhdGVkIGRhdGE=","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "141"
+                - "137"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:33 GMT
+                - Fri, 03 Jul 2026 15:28:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 013e5d24-6c95-4fe0-8795-47bff68b0216
+                - 9357d453-7476-43a1-aee2-de4fa291255a
         status: 200 OK
         code: 200
-        duration: 33.332251ms
+        duration: 41.321042ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -613,29 +613,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/10445698-1de3-4a5e-937b-167308bb059a/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6fe76d8f-9b19-42a6-a13c-d37d9f7e1050/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 334
-        body: '{"revision":2, "secret_id":"10445698-1de3-4a5e-937b-167308bb059a", "status":"enabled", "created_at":"2026-06-09T13:18:32.745983Z", "updated_at":"2026-06-09T13:18:32.745983Z", "deleted_at":null, "description":"test decrypted associated data", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 141
+        body: '{"secret_id":"6fe76d8f-9b19-42a6-a13c-d37d9f7e1050","revision":1,"data":"dGhpcyBpcyBzb21lIHNlY3JldCBkYXRh","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "334"
+                - "141"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:33 GMT
+                - Fri, 03 Jul 2026 15:28:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 4914f617-16c2-4205-89d7-5666a83c5731
+                - 6d84b379-99c5-4e6d-ac35-d68527fe78b3
         status: 200 OK
         code: 200
-        duration: 28.942855ms
+        duration: 84.595483ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -645,29 +645,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/10445698-1de3-4a5e-937b-167308bb059a/versions/1/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6fe76d8f-9b19-42a6-a13c-d37d9f7e1050/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 145
-        body: '{"secret_id":"10445698-1de3-4a5e-937b-167308bb059a", "revision":1, "data":"dGhpcyBpcyBzb21lIHNlY3JldCBkYXRh", "data_crc32":null, "type":"opaque"}'
+        content_length: 324
+        body: '{"revision":2,"secret_id":"6fe76d8f-9b19-42a6-a13c-d37d9f7e1050","status":"enabled","created_at":"2026-07-03T15:28:23.962815Z","updated_at":"2026-07-03T15:28:23.962815Z","deleted_at":null,"description":"test decrypted associated data","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "145"
+                - "324"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:33 GMT
+                - Fri, 03 Jul 2026 15:28:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - adfd1afc-edd8-43a1-a4e2-ec808ae31329
+                - 558f3341-0d00-42fe-9abf-71ae002a2ec1
         status: 200 OK
         code: 200
-        duration: 90.956014ms
+        duration: 38.569404ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -677,29 +677,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/10445698-1de3-4a5e-937b-167308bb059a/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6fe76d8f-9b19-42a6-a13c-d37d9f7e1050/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 324
-        body: '{"revision":1, "secret_id":"10445698-1de3-4a5e-937b-167308bb059a", "status":"enabled", "created_at":"2026-06-09T13:18:32.425540Z", "updated_at":"2026-06-09T13:18:32.425540Z", "deleted_at":null, "description":"test decrypted data", "latest":false, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 314
+        body: '{"revision":1,"secret_id":"6fe76d8f-9b19-42a6-a13c-d37d9f7e1050","status":"enabled","created_at":"2026-07-03T15:28:23.759013Z","updated_at":"2026-07-03T15:28:23.759013Z","deleted_at":null,"description":"test decrypted data","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "324"
+                - "314"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:33 GMT
+                - Fri, 03 Jul 2026 15:28:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - e00e49e6-1e6a-43e2-b4df-8f0114091ee2
+                - d00fabfc-16ec-4aa7-8fbc-599e76f7cd9f
         status: 200 OK
         code: 200
-        duration: 33.865438ms
+        duration: 41.342242ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -709,29 +709,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/10445698-1de3-4a5e-937b-167308bb059a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/2c3026cf-38d3-4155-a38a-09fbd05249d0
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 453
-        body: '{"id":"10445698-1de3-4a5e-937b-167308bb059a", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"test-decrypt-secret-ad", "status":"ready", "created_at":"2026-06-09T13:18:31.667221Z", "updated_at":"2026-06-09T13:18:31.667221Z", "tags":[], "version_count":2, "description":"", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}'
+        content_length: 528
+        body: '{"id":"2c3026cf-38d3-4155-a38a-09fbd05249d0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-decrypt-key-ad","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:23.280724Z","updated_at":"2026-07-03T15:28:23.284017Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:23.284017Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "453"
+                - "528"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:33 GMT
+                - Fri, 03 Jul 2026 15:28:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 9c5e9aea-787d-43ae-bec6-a876c99c193d
+                - d39bb2c7-a67d-4519-a03b-7ebbb966a7c1
         status: 200 OK
         code: 200
-        duration: 49.987754ms
+        duration: 46.289184ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -741,65 +741,30 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/9a45977a-7588-4eef-a9f3-92fe85061aa4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6fe76d8f-9b19-42a6-a13c-d37d9f7e1050
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 514
-        body: '{"id":"9a45977a-7588-4eef-a9f3-92fe85061aa4", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-decrypt-key-ad", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-09T13:18:31.836202Z", "updated_at":"2026-06-09T13:18:31.842638Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-09T13:18:31.842638Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 436
+        body: '{"id":"6fe76d8f-9b19-42a6-a13c-d37d9f7e1050","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-decrypt-secret-ad","status":"ready","created_at":"2026-07-03T15:28:23.295981Z","updated_at":"2026-07-03T15:28:23.295981Z","tags":[],"version_count":2,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "514"
+                - "436"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:33 GMT
+                - Fri, 03 Jul 2026 15:28:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - c1e4d90d-bd38-462f-ac22-47f4fed505ea
+                - 7b5eb86c-5325-41e0-bb78-c720b412571a
         status: 200 OK
         code: 200
-        duration: 74.180872ms
+        duration: 53.760397ms
     - id: 23
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        form:
-            page:
-                - "1"
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/10445698-1de3-4a5e-937b-167308bb059a/versions?page=1
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 692
-        body: '{"versions":[{"revision":2, "secret_id":"10445698-1de3-4a5e-937b-167308bb059a", "status":"enabled", "created_at":"2026-06-09T13:18:32.745983Z", "updated_at":"2026-06-09T13:18:32.745983Z", "deleted_at":null, "description":"test decrypted associated data", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}, {"revision":1, "secret_id":"10445698-1de3-4a5e-937b-167308bb059a", "status":"enabled", "created_at":"2026-06-09T13:18:32.425540Z", "updated_at":"2026-06-09T13:18:32.425540Z", "deleted_at":null, "description":"test decrypted data", "latest":false, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}], "total_count":2}'
-        headers:
-            Content-Length:
-                - "692"
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 09 Jun 2026 13:18:33 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            X-Request-Id:
-                - c2bb8cd7-4b78-476c-814d-4f011c06ed7a
-        status: 200 OK
-        code: 200
-        duration: 41.98298ms
-    - id: 24
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -811,29 +776,64 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/9a45977a-7588-4eef-a9f3-92fe85061aa4/encrypt
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/2c3026cf-38d3-4155-a38a-09fbd05249d0/encrypt
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 142
-        body: '{"key_id":"9a45977a-7588-4eef-a9f3-92fe85061aa4", "ciphertext":"AQAAAAGga9B3GEHu3csHHLlr1UraBcqfT7AWESGLyipBS+I1YoLrFWa1VL5aG+Z8tcT+S1qeeJlk"}'
+        content_length: 141
+        body: '{"key_id":"2c3026cf-38d3-4155-a38a-09fbd05249d0","ciphertext":"AQAAAAGOyXnjAgsIW0csUMoir0fo0EAM92X2mh9V/T57u0SYu7+jlsGv7Jrl9o2XVJPIQcUh5B2d"}'
         headers:
             Content-Length:
-                - "142"
+                - "141"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:33 GMT
+                - Fri, 03 Jul 2026 15:28:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 90c3937e-8d58-4fc4-845d-11651df2f0e3
+                - 5030a43b-263d-4948-9f11-b92a1ec1b6c8
         status: 200 OK
         code: 200
-        duration: 67.704042ms
+        duration: 46.563119ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6fe76d8f-9b19-42a6-a13c-d37d9f7e1050/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 670
+        body: '{"versions":[{"revision":2,"secret_id":"6fe76d8f-9b19-42a6-a13c-d37d9f7e1050","status":"enabled","created_at":"2026-07-03T15:28:23.962815Z","updated_at":"2026-07-03T15:28:23.962815Z","deleted_at":null,"description":"test decrypted associated data","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"6fe76d8f-9b19-42a6-a13c-d37d9f7e1050","status":"enabled","created_at":"2026-07-03T15:28:23.759013Z","updated_at":"2026-07-03T15:28:23.759013Z","deleted_at":null,"description":"test decrypted data","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":2}'
+        headers:
+            Content-Length:
+                - "670"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 12f6f50b-c9da-425e-b8d4-b6e28f6eff7a
+        status: 200 OK
+        code: 200
+        duration: 58.664949ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -841,34 +841,34 @@ interactions:
         proto_minor: 1
         content_length: 142
         host: api.scaleway.com
-        body: '{"ciphertext":"AQAAAAGga9B3GEHu3csHHLlr1UraBcqfT7AWESGLyipBS+I1YoLrFWa1VL5aG+Z8tcT+S1qeeJlk","associated_data":"c29tZSBhc3NvY2lhdGVkIGRhdGE="}'
+        body: '{"ciphertext":"AQAAAAGOyXnjAgsIW0csUMoir0fo0EAM92X2mh9V/T57u0SYu7+jlsGv7Jrl9o2XVJPIQcUh5B2d","associated_data":"c29tZSBhc3NvY2lhdGVkIGRhdGE="}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/9a45977a-7588-4eef-a9f3-92fe85061aa4/decrypt
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/2c3026cf-38d3-4155-a38a-09fbd05249d0/decrypt
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 116
-        body: '{"key_id":"9a45977a-7588-4eef-a9f3-92fe85061aa4", "plaintext":"dGhpcyBpcyBzb21lIHNlY3JldCBkYXRh", "ciphertext":null}'
+        content_length: 114
+        body: '{"key_id":"2c3026cf-38d3-4155-a38a-09fbd05249d0","plaintext":"dGhpcyBpcyBzb21lIHNlY3JldCBkYXRh","ciphertext":null}'
         headers:
             Content-Length:
-                - "116"
+                - "114"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:33 GMT
+                - Fri, 03 Jul 2026 15:28:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 75696cbc-4a91-49f7-bc41-3d8c4db76e16
+                - 816cbea1-dfc6-4c3b-a60e-60c2fb8b9bac
         status: 200 OK
         code: 200
-        duration: 90.441098ms
+        duration: 51.701379ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -878,29 +878,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/10445698-1de3-4a5e-937b-167308bb059a/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6fe76d8f-9b19-42a6-a13c-d37d9f7e1050/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 324
-        body: '{"revision":1, "secret_id":"10445698-1de3-4a5e-937b-167308bb059a", "status":"enabled", "created_at":"2026-06-09T13:18:32.425540Z", "updated_at":"2026-06-09T13:18:32.425540Z", "deleted_at":null, "description":"test decrypted data", "latest":false, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 314
+        body: '{"revision":1,"secret_id":"6fe76d8f-9b19-42a6-a13c-d37d9f7e1050","status":"enabled","created_at":"2026-07-03T15:28:23.759013Z","updated_at":"2026-07-03T15:28:23.759013Z","deleted_at":null,"description":"test decrypted data","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "324"
+                - "314"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:33 GMT
+                - Fri, 03 Jul 2026 15:28:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 90818782-690f-405e-a783-4cb6b243eb6b
+                - de352869-4b1c-4579-ba6d-ce62bf75031d
         status: 200 OK
         code: 200
-        duration: 30.981948ms
+        duration: 51.60034ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -910,29 +910,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/10445698-1de3-4a5e-937b-167308bb059a/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6fe76d8f-9b19-42a6-a13c-d37d9f7e1050/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 334
-        body: '{"revision":2, "secret_id":"10445698-1de3-4a5e-937b-167308bb059a", "status":"enabled", "created_at":"2026-06-09T13:18:32.745983Z", "updated_at":"2026-06-09T13:18:32.745983Z", "deleted_at":null, "description":"test decrypted associated data", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 324
+        body: '{"revision":2,"secret_id":"6fe76d8f-9b19-42a6-a13c-d37d9f7e1050","status":"enabled","created_at":"2026-07-03T15:28:23.962815Z","updated_at":"2026-07-03T15:28:23.962815Z","deleted_at":null,"description":"test decrypted associated data","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "334"
+                - "324"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:34 GMT
+                - Fri, 03 Jul 2026 15:28:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - f7012b58-ac62-4fd9-9e75-5dcba5805b49
+                - b8b08460-19b5-4810-abc0-573a020022d7
         status: 200 OK
         code: 200
-        duration: 44.600677ms
+        duration: 34.27597ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -942,29 +942,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/10445698-1de3-4a5e-937b-167308bb059a/versions/1/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6fe76d8f-9b19-42a6-a13c-d37d9f7e1050/versions/2/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 145
-        body: '{"secret_id":"10445698-1de3-4a5e-937b-167308bb059a", "revision":1, "data":"dGhpcyBpcyBzb21lIHNlY3JldCBkYXRh", "data_crc32":null, "type":"opaque"}'
+        content_length: 137
+        body: '{"secret_id":"6fe76d8f-9b19-42a6-a13c-d37d9f7e1050","revision":2,"data":"c29tZSBhc3NvY2lhdGVkIGRhdGE=","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "145"
+                - "137"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:34 GMT
+                - Fri, 03 Jul 2026 15:28:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - c483b67e-bdf8-4daf-a7ef-5b1a5027e9c7
+                - d5947a5b-f6dd-406b-9c05-904435cdd358
         status: 200 OK
         code: 200
-        duration: 88.962616ms
+        duration: 36.491321ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -974,29 +974,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/10445698-1de3-4a5e-937b-167308bb059a/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6fe76d8f-9b19-42a6-a13c-d37d9f7e1050/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 324
-        body: '{"revision":1, "secret_id":"10445698-1de3-4a5e-937b-167308bb059a", "status":"enabled", "created_at":"2026-06-09T13:18:32.425540Z", "updated_at":"2026-06-09T13:18:32.425540Z", "deleted_at":null, "description":"test decrypted data", "latest":false, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        body: '{"revision":2,"secret_id":"6fe76d8f-9b19-42a6-a13c-d37d9f7e1050","status":"enabled","created_at":"2026-07-03T15:28:23.962815Z","updated_at":"2026-07-03T15:28:23.962815Z","deleted_at":null,"description":"test decrypted associated data","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "324"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:34 GMT
+                - Fri, 03 Jul 2026 15:28:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - f194687b-25a9-4ef0-9d3b-956f5eb824ab
+                - 419bcf7a-1fc8-46d8-a3af-e103006921ef
         status: 200 OK
         code: 200
-        duration: 38.447527ms
+        duration: 35.077095ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1006,29 +1006,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/10445698-1de3-4a5e-937b-167308bb059a/versions/2/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6fe76d8f-9b19-42a6-a13c-d37d9f7e1050/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 141
-        body: '{"secret_id":"10445698-1de3-4a5e-937b-167308bb059a", "revision":2, "data":"c29tZSBhc3NvY2lhdGVkIGRhdGE=", "data_crc32":null, "type":"opaque"}'
+        body: '{"secret_id":"6fe76d8f-9b19-42a6-a13c-d37d9f7e1050","revision":1,"data":"dGhpcyBpcyBzb21lIHNlY3JldCBkYXRh","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
                 - "141"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:34 GMT
+                - Fri, 03 Jul 2026 15:28:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - a37c7ac0-bd8d-4834-96ef-fb994eaa33e1
+                - 8dab9fab-9973-41de-8636-62756a98a910
         status: 200 OK
         code: 200
-        duration: 99.368338ms
+        duration: 123.818035ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1038,29 +1038,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/10445698-1de3-4a5e-937b-167308bb059a/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6fe76d8f-9b19-42a6-a13c-d37d9f7e1050/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 334
-        body: '{"revision":2, "secret_id":"10445698-1de3-4a5e-937b-167308bb059a", "status":"enabled", "created_at":"2026-06-09T13:18:32.745983Z", "updated_at":"2026-06-09T13:18:32.745983Z", "deleted_at":null, "description":"test decrypted associated data", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 314
+        body: '{"revision":1,"secret_id":"6fe76d8f-9b19-42a6-a13c-d37d9f7e1050","status":"enabled","created_at":"2026-07-03T15:28:23.759013Z","updated_at":"2026-07-03T15:28:23.759013Z","deleted_at":null,"description":"test decrypted data","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "334"
+                - "314"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:34 GMT
+                - Fri, 03 Jul 2026 15:28:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - cd7b2726-7426-461c-8ab9-51fb2ddeeb8b
+                - 102f29af-2590-4601-924a-347a25ef84ba
         status: 200 OK
         code: 200
-        duration: 43.392514ms
+        duration: 32.714166ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1070,8 +1070,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/10445698-1de3-4a5e-937b-167308bb059a/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6fe76d8f-9b19-42a6-a13c-d37d9f7e1050/versions/2
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1083,14 +1083,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:34 GMT
+                - Fri, 03 Jul 2026 15:28:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 47d3fd3b-1f2c-471e-8da3-4cca65c1f255
+                - f2ced07b-f985-41bb-bb6b-8140dc8ebf40
         status: 204 No Content
         code: 204
-        duration: 104.832985ms
+        duration: 61.161088ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1100,8 +1100,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/10445698-1de3-4a5e-937b-167308bb059a/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6fe76d8f-9b19-42a6-a13c-d37d9f7e1050/versions/1
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1113,14 +1113,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:34 GMT
+                - Fri, 03 Jul 2026 15:28:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - e99c31ba-245c-4db1-8366-48e889d17d51
+                - 8ad10560-979b-4509-b41b-d51b8b7c0b77
         status: 204 No Content
         code: 204
-        duration: 57.143527ms
+        duration: 62.840612ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1130,8 +1130,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/9a45977a-7588-4eef-a9f3-92fe85061aa4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6fe76d8f-9b19-42a6-a13c-d37d9f7e1050
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1143,14 +1143,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:34 GMT
+                - Fri, 03 Jul 2026 15:28:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - d1196f04-17bd-429d-8d1a-19f4f520b2f4
+                - f11d38a5-7da2-4930-9c0c-08374a328901
         status: 204 No Content
         code: 204
-        duration: 107.420202ms
+        duration: 63.841903ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1160,8 +1160,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/10445698-1de3-4a5e-937b-167308bb059a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/2c3026cf-38d3-4155-a38a-09fbd05249d0
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1173,14 +1173,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:34 GMT
+                - Fri, 03 Jul 2026 15:28:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - b92efa19-f420-4904-8760-b67d56afdf70
+                - d987e034-b942-40b6-a3d7-fd26927f98a0
         status: 204 No Content
         code: 204
-        duration: 107.457503ms
+        duration: 74.569793ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1190,29 +1190,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/10445698-1de3-4a5e-937b-167308bb059a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6fe76d8f-9b19-42a6-a13c-d37d9f7e1050
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 478
-        body: '{"id":"10445698-1de3-4a5e-937b-167308bb059a", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"test-decrypt-secret-ad", "status":"ready", "created_at":"2026-06-09T13:18:31.667221Z", "updated_at":"2026-06-09T13:18:31.667221Z", "tags":[], "version_count":2, "description":"", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":"2026-06-09T13:18:34.718079Z", "key_id":null, "region":"fr-par"}'
+        content_length: 461
+        body: '{"id":"6fe76d8f-9b19-42a6-a13c-d37d9f7e1050","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-decrypt-secret-ad","status":"ready","created_at":"2026-07-03T15:28:23.295981Z","updated_at":"2026-07-03T15:28:26.014972Z","tags":[],"version_count":2,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-07-03T15:28:26.014972Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "478"
+                - "461"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:34 GMT
+                - Fri, 03 Jul 2026 15:28:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - f24bd7fd-9b42-4932-bde1-7736d8e16566
+                - def55065-feeb-4997-93c4-eb865ffe4cc4
         status: 200 OK
         code: 200
-        duration: 36.213972ms
+        duration: 36.231614ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1222,26 +1222,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/9a45977a-7588-4eef-a9f3-92fe85061aa4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/2c3026cf-38d3-4155-a38a-09fbd05249d0
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 554
-        body: '{"id":"9a45977a-7588-4eef-a9f3-92fe85061aa4", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-decrypt-key-ad", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"scheduled_for_deletion", "rotation_count":1, "created_at":"2026-06-09T13:18:31.836202Z", "updated_at":"2026-06-09T13:18:31.842638Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-09T13:18:31.842638Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":"2026-06-09T13:18:34.715012Z", "region":"fr-par"}'
+        content_length: 568
+        body: '{"id":"2c3026cf-38d3-4155-a38a-09fbd05249d0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-decrypt-key-ad","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-03T15:28:23.280724Z","updated_at":"2026-07-03T15:28:26.013901Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:23.284017Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-03T15:28:26.013901Z","protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "554"
+                - "568"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:34 GMT
+                - Fri, 03 Jul 2026 15:28:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 45638f1d-7022-4f0e-abd2-48e3592d921a
+                - 9868140a-5d40-4aee-8af4-3de967e615ea
         status: 200 OK
         code: 200
-        duration: 46.452729ms
+        duration: 43.425295ms

--- a/internal/services/keymanager/testdata/encrypt-ephemeral-resource-basic.cassette.yaml
+++ b/internal/services/keymanager/testdata/encrypt-ephemeral-resource-basic.cassette.yaml
@@ -6,36 +6,36 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 186
+        content_length: 232
         host: api.scaleway.com
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-encrypt-key","usage":{"symmetric_encryption":"aes_256_gcm"},"tags":null,"unprotected":true,"origin":"unknown_origin"}'
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-encrypt-key","usage":{"symmetric_encryption":"aes_256_gcm"},"tags":null,"unprotected":true,"origin":"unknown_origin","protection_level":"unknown_protection_level"}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 511
-        body: '{"id":"c7e712ce-2751-40c7-88b6-8174c1e839a4", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-encrypt-key", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-09T13:18:18.636421Z", "updated_at":"2026-06-09T13:18:18.639516Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-09T13:18:18.639516Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 525
+        body: '{"id":"b746988a-e0e2-4e6a-8bd7-c757769a28ce","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-encrypt-key","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:23.213364Z","updated_at":"2026-07-03T15:28:23.217444Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:23.217444Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "511"
+                - "525"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:18 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - f10ce518-96e3-4cc1-8a1a-e8e4b7c3ad31
+                - 36557826-faff-4297-b722-c87fad8c71f9
         status: 200 OK
         code: 200
-        duration: 274.192572ms
+        duration: 62.421034ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -48,29 +48,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 452
-        body: '{"id":"e7e7538a-90d7-4efc-8428-956bb1fe8f89", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"test-encrypted-secret", "status":"ready", "created_at":"2026-06-09T13:18:18.665797Z", "updated_at":"2026-06-09T13:18:18.665797Z", "tags":[], "version_count":0, "description":"", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}'
+        content_length: 435
+        body: '{"id":"a21f2b97-7e87-400a-bc96-ede7323c15fb","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-encrypted-secret","status":"ready","created_at":"2026-07-03T15:28:23.255629Z","updated_at":"2026-07-03T15:28:23.255629Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "452"
+                - "435"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:18 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 7bc6069b-ff24-44a8-b0d2-f61177f5a43c
+                - 1f957f31-a08b-4d34-a842-53d430959322
         status: 200 OK
         code: 200
-        duration: 289.047111ms
+        duration: 108.49318ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -80,29 +80,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/c7e712ce-2751-40c7-88b6-8174c1e839a4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/b746988a-e0e2-4e6a-8bd7-c757769a28ce
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 511
-        body: '{"id":"c7e712ce-2751-40c7-88b6-8174c1e839a4", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-encrypt-key", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-09T13:18:18.636421Z", "updated_at":"2026-06-09T13:18:18.639516Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-09T13:18:18.639516Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 525
+        body: '{"id":"b746988a-e0e2-4e6a-8bd7-c757769a28ce","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-encrypt-key","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:23.213364Z","updated_at":"2026-07-03T15:28:23.217444Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:23.217444Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "511"
+                - "525"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:18 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - a27e4e22-334b-4e4d-847a-9836809db1d9
+                - ed2878c6-b996-46c7-8182-5e43542cf5b2
         status: 200 OK
         code: 200
-        duration: 137.022417ms
+        duration: 48.460182ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -112,29 +112,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e7e7538a-90d7-4efc-8428-956bb1fe8f89
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a21f2b97-7e87-400a-bc96-ede7323c15fb
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 452
-        body: '{"id":"e7e7538a-90d7-4efc-8428-956bb1fe8f89", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"test-encrypted-secret", "status":"ready", "created_at":"2026-06-09T13:18:18.665797Z", "updated_at":"2026-06-09T13:18:18.665797Z", "tags":[], "version_count":0, "description":"", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}'
+        content_length: 435
+        body: '{"id":"a21f2b97-7e87-400a-bc96-ede7323c15fb","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-encrypted-secret","status":"ready","created_at":"2026-07-03T15:28:23.255629Z","updated_at":"2026-07-03T15:28:23.255629Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "452"
+                - "435"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:18 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - e4b4b5d3-e514-49f5-9484-3ce07912e68f
+                - f090787e-a3ba-4c7d-a235-a3f94a062dd3
         status: 200 OK
         code: 200
-        duration: 121.738796ms
+        duration: 48.409847ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -147,29 +147,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/c7e712ce-2751-40c7-88b6-8174c1e839a4/encrypt
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/b746988a-e0e2-4e6a-8bd7-c757769a28ce/encrypt
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 138
-        body: '{"key_id":"c7e712ce-2751-40c7-88b6-8174c1e839a4", "ciphertext":"AQAAAAFT2pbYnv29A+0lF25Yt9/YuVbrfLkvXnWwiD90R0jSZK2RJKm/B6Sdy3h/8JuzMA=="}'
+        content_length: 137
+        body: '{"key_id":"b746988a-e0e2-4e6a-8bd7-c757769a28ce","ciphertext":"AQAAAAEXmPppIC/ijYfMTte/ECmqfPezPX0T0Ny2hvQigLAW79EMACZdAUOnY9wNBEPZFw=="}'
         headers:
             Content-Length:
-                - "138"
+                - "137"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:18 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 1a0f4894-7930-40c5-906d-1f82fcddc6c8
+                - ae5c2889-63cb-4acf-bb96-407151b89ab2
         status: 200 OK
         code: 200
-        duration: 80.959995ms
+        duration: 47.196979ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -182,29 +182,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e7e7538a-90d7-4efc-8428-956bb1fe8f89/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a21f2b97-7e87-400a-bc96-ede7323c15fb/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 32
-        body: '{"versions":[], "total_count":0}'
+        content_length: 31
+        body: '{"versions":[],"total_count":0}'
         headers:
             Content-Length:
-                - "32"
+                - "31"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:18 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 48da2a4d-92d9-424e-ac3f-95ac60f7dd49
+                - e38d6398-3863-4523-9dd2-5171f5402c22
         status: 200 OK
         code: 200
-        duration: 92.444819ms
+        duration: 43.865511ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -212,34 +212,34 @@ interactions:
         proto_minor: 1
         content_length: 132
         host: api.scaleway.com
-        body: '{"data":"QVFBQUFBRlQycGJZbnYyOUErMGxGMjVZdDkvWXVWYnJmTGt2WG5Xd2lEOTBSMGpTWksyUkpLbS9CNlNkeTNoLzhKdXpNQT09","description":"version1"}'
+        body: '{"data":"QVFBQUFBRVhtUHBwSUMvaWpZZk1UdGUvRUNtcWZQZXpQWDBUME55Mmh2UWlnTEFXNzlFTUFDWmRBVU9uWTl3TkJFUFpGdz09","description":"version1"}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e7e7538a-90d7-4efc-8428-956bb1fe8f89/versions
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a21f2b97-7e87-400a-bc96-ede7323c15fb/versions
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 312
-        body: '{"revision":1, "secret_id":"e7e7538a-90d7-4efc-8428-956bb1fe8f89", "status":"enabled", "created_at":"2026-06-09T13:18:19.271143Z", "updated_at":"2026-06-09T13:18:19.271143Z", "deleted_at":null, "description":"version1", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 302
+        body: '{"revision":1,"secret_id":"a21f2b97-7e87-400a-bc96-ede7323c15fb","status":"enabled","created_at":"2026-07-03T15:28:23.647646Z","updated_at":"2026-07-03T15:28:23.647646Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "312"
+                - "302"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:19 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - fa7986b5-f747-4277-b9a4-7c9703dcd556
+                - ec43b200-48af-41a9-a2d7-95808f84f594
         status: 200 OK
         code: 200
-        duration: 396.494857ms
+        duration: 278.9526ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -249,29 +249,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e7e7538a-90d7-4efc-8428-956bb1fe8f89/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a21f2b97-7e87-400a-bc96-ede7323c15fb/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 312
-        body: '{"revision":1, "secret_id":"e7e7538a-90d7-4efc-8428-956bb1fe8f89", "status":"enabled", "created_at":"2026-06-09T13:18:19.271143Z", "updated_at":"2026-06-09T13:18:19.271143Z", "deleted_at":null, "description":"version1", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 302
+        body: '{"revision":1,"secret_id":"a21f2b97-7e87-400a-bc96-ede7323c15fb","status":"enabled","created_at":"2026-07-03T15:28:23.647646Z","updated_at":"2026-07-03T15:28:23.647646Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "312"
+                - "302"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:19 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 7e9e2994-1559-413e-9876-9baf93e8a155
+                - 762c4b3d-c3ea-425b-a81a-08f1b72dd818
         status: 200 OK
         code: 200
-        duration: 119.72873ms
+        duration: 34.964533ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -281,29 +281,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e7e7538a-90d7-4efc-8428-956bb1fe8f89/versions/1/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a21f2b97-7e87-400a-bc96-ede7323c15fb/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 209
-        body: '{"secret_id":"e7e7538a-90d7-4efc-8428-956bb1fe8f89", "revision":1, "data":"QVFBQUFBRlQycGJZbnYyOUErMGxGMjVZdDkvWXVWYnJmTGt2WG5Xd2lEOTBSMGpTWksyUkpLbS9CNlNkeTNoLzhKdXpNQT09", "data_crc32":null, "type":"opaque"}'
+        content_length: 205
+        body: '{"secret_id":"a21f2b97-7e87-400a-bc96-ede7323c15fb","revision":1,"data":"QVFBQUFBRVhtUHBwSUMvaWpZZk1UdGUvRUNtcWZQZXpQWDBUME55Mmh2UWlnTEFXNzlFTUFDWmRBVU9uWTl3TkJFUFpGdz09","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "209"
+                - "205"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:19 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 9e620c56-05eb-4491-9889-5d6d2c6f1b79
+                - 2c05483b-d8bb-467b-bc09-711f5c113d1b
         status: 200 OK
         code: 200
-        duration: 197.459295ms
+        duration: 48.452146ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -313,29 +313,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e7e7538a-90d7-4efc-8428-956bb1fe8f89/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a21f2b97-7e87-400a-bc96-ede7323c15fb/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 312
-        body: '{"revision":1, "secret_id":"e7e7538a-90d7-4efc-8428-956bb1fe8f89", "status":"enabled", "created_at":"2026-06-09T13:18:19.271143Z", "updated_at":"2026-06-09T13:18:19.271143Z", "deleted_at":null, "description":"version1", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 302
+        body: '{"revision":1,"secret_id":"a21f2b97-7e87-400a-bc96-ede7323c15fb","status":"enabled","created_at":"2026-07-03T15:28:23.647646Z","updated_at":"2026-07-03T15:28:23.647646Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "312"
+                - "302"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:19 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - dad9ed79-92da-496d-9fb1-39f22305d8c7
+                - 3dd30ab5-b85d-4819-a8cf-f04375f711fd
         status: 200 OK
         code: 200
-        duration: 37.177369ms
+        duration: 43.901169ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -348,29 +348,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/c7e712ce-2751-40c7-88b6-8174c1e839a4/encrypt
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/b746988a-e0e2-4e6a-8bd7-c757769a28ce/encrypt
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 138
-        body: '{"key_id":"c7e712ce-2751-40c7-88b6-8174c1e839a4", "ciphertext":"AQAAAAFSB2G8mTyqiPaSANwWdwu0VTIK02jcfVWTR1ZalvNLby0xnuL/oOSfcGHr8OmRCQ=="}'
+        content_length: 137
+        body: '{"key_id":"b746988a-e0e2-4e6a-8bd7-c757769a28ce","ciphertext":"AQAAAAG4pGdIHq5DudOE3+AiQj5e7t3yMDzr0lXS9jz/NP502j3dhYL8Z3QoOxg/khxP+A=="}'
         headers:
             Content-Length:
-                - "138"
+                - "137"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:19 GMT
+                - Fri, 03 Jul 2026 15:28:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 6bd2f3f5-6ca0-4aa1-bb06-137b94b3f28f
+                - 6ed52e5e-48e8-4ea2-95d7-3b3a308f20ba
         status: 200 OK
         code: 200
-        duration: 169.064092ms
+        duration: 47.43691ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -380,29 +380,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e7e7538a-90d7-4efc-8428-956bb1fe8f89/versions/1/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a21f2b97-7e87-400a-bc96-ede7323c15fb/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 209
-        body: '{"secret_id":"e7e7538a-90d7-4efc-8428-956bb1fe8f89", "revision":1, "data":"QVFBQUFBRlQycGJZbnYyOUErMGxGMjVZdDkvWXVWYnJmTGt2WG5Xd2lEOTBSMGpTWksyUkpLbS9CNlNkeTNoLzhKdXpNQT09", "data_crc32":null, "type":"opaque"}'
+        content_length: 205
+        body: '{"secret_id":"a21f2b97-7e87-400a-bc96-ede7323c15fb","revision":1,"data":"QVFBQUFBRVhtUHBwSUMvaWpZZk1UdGUvRUNtcWZQZXpQWDBUME55Mmh2UWlnTEFXNzlFTUFDWmRBVU9uWTl3TkJFUFpGdz09","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "209"
+                - "205"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:20 GMT
+                - Fri, 03 Jul 2026 15:28:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 2e06bba0-27c7-4725-9fe7-42252332f82a
+                - a51397d1-03b8-4e2f-a6d1-22987548f81e
         status: 200 OK
         code: 200
-        duration: 105.665622ms
+        duration: 74.020852ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -412,29 +412,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e7e7538a-90d7-4efc-8428-956bb1fe8f89/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a21f2b97-7e87-400a-bc96-ede7323c15fb/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 312
-        body: '{"revision":1, "secret_id":"e7e7538a-90d7-4efc-8428-956bb1fe8f89", "status":"enabled", "created_at":"2026-06-09T13:18:19.271143Z", "updated_at":"2026-06-09T13:18:19.271143Z", "deleted_at":null, "description":"version1", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 302
+        body: '{"revision":1,"secret_id":"a21f2b97-7e87-400a-bc96-ede7323c15fb","status":"enabled","created_at":"2026-07-03T15:28:23.647646Z","updated_at":"2026-07-03T15:28:23.647646Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "312"
+                - "302"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:20 GMT
+                - Fri, 03 Jul 2026 15:28:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - a25b3d7d-44c0-42ca-9dff-fb5ae867d532
+                - e4842d69-c303-4651-850b-4c05cede9a9a
         status: 200 OK
         code: 200
-        duration: 91.164086ms
+        duration: 35.669227ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -444,29 +444,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/c7e712ce-2751-40c7-88b6-8174c1e839a4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a21f2b97-7e87-400a-bc96-ede7323c15fb
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 511
-        body: '{"id":"c7e712ce-2751-40c7-88b6-8174c1e839a4", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-encrypt-key", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-09T13:18:18.636421Z", "updated_at":"2026-06-09T13:18:18.639516Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-09T13:18:18.639516Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 435
+        body: '{"id":"a21f2b97-7e87-400a-bc96-ede7323c15fb","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-encrypted-secret","status":"ready","created_at":"2026-07-03T15:28:23.255629Z","updated_at":"2026-07-03T15:28:23.255629Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "511"
+                - "435"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:20 GMT
+                - Fri, 03 Jul 2026 15:28:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 2c0bf2ae-8976-4f60-96a7-ed4372ce9c82
+                - f3094af0-c7cf-4492-aab5-b5ad2174e67e
         status: 200 OK
         code: 200
-        duration: 74.785495ms
+        duration: 41.904308ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -476,29 +476,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e7e7538a-90d7-4efc-8428-956bb1fe8f89
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/b746988a-e0e2-4e6a-8bd7-c757769a28ce
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 452
-        body: '{"id":"e7e7538a-90d7-4efc-8428-956bb1fe8f89", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"test-encrypted-secret", "status":"ready", "created_at":"2026-06-09T13:18:18.665797Z", "updated_at":"2026-06-09T13:18:18.665797Z", "tags":[], "version_count":1, "description":"", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}'
+        content_length: 525
+        body: '{"id":"b746988a-e0e2-4e6a-8bd7-c757769a28ce","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-encrypt-key","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:23.213364Z","updated_at":"2026-07-03T15:28:23.217444Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:23.217444Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "452"
+                - "525"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:20 GMT
+                - Fri, 03 Jul 2026 15:28:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 871028be-0169-4d9a-8c3f-889a425bbee3
+                - 9042811f-3a72-4983-aa7d-18ff597b187a
         status: 200 OK
         code: 200
-        duration: 93.365107ms
+        duration: 41.941818ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -511,29 +511,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e7e7538a-90d7-4efc-8428-956bb1fe8f89/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a21f2b97-7e87-400a-bc96-ede7323c15fb/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 344
-        body: '{"versions":[{"revision":1, "secret_id":"e7e7538a-90d7-4efc-8428-956bb1fe8f89", "status":"enabled", "created_at":"2026-06-09T13:18:19.271143Z", "updated_at":"2026-06-09T13:18:19.271143Z", "deleted_at":null, "description":"version1", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}], "total_count":1}'
+        content_length: 333
+        body: '{"versions":[{"revision":1,"secret_id":"a21f2b97-7e87-400a-bc96-ede7323c15fb","status":"enabled","created_at":"2026-07-03T15:28:23.647646Z","updated_at":"2026-07-03T15:28:23.647646Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
-                - "344"
+                - "333"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:20 GMT
+                - Fri, 03 Jul 2026 15:28:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - e111865b-5e89-4f69-9bdc-b8e76543e4bb
+                - 47076942-a87a-41a3-8438-46f87c40c565
         status: 200 OK
         code: 200
-        duration: 113.194964ms
+        duration: 47.217738ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -546,29 +546,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/c7e712ce-2751-40c7-88b6-8174c1e839a4/encrypt
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/b746988a-e0e2-4e6a-8bd7-c757769a28ce/encrypt
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 138
-        body: '{"key_id":"c7e712ce-2751-40c7-88b6-8174c1e839a4", "ciphertext":"AQAAAAF6/zIU3eI5uh/JESeAdxJyppxsIHtpdHoNP4G68trNcgZDElpLoTYprkUYtXBP/g=="}'
+        content_length: 137
+        body: '{"key_id":"b746988a-e0e2-4e6a-8bd7-c757769a28ce","ciphertext":"AQAAAAEpTTn4u4EcItYC3rVxW9P2azINymmwvYuF0QKGj1QHKFF+uSepbkfnaAzG7qwnLQ=="}'
         headers:
             Content-Length:
-                - "138"
+                - "137"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:20 GMT
+                - Fri, 03 Jul 2026 15:28:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 0b559fc0-7edd-4278-bebf-7456eb4375ef
+                - b5253609-d62e-41c0-bca6-733732c85bfd
         status: 200 OK
         code: 200
-        duration: 123.471412ms
+        duration: 47.288421ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -578,29 +578,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e7e7538a-90d7-4efc-8428-956bb1fe8f89/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a21f2b97-7e87-400a-bc96-ede7323c15fb/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 312
-        body: '{"revision":1, "secret_id":"e7e7538a-90d7-4efc-8428-956bb1fe8f89", "status":"enabled", "created_at":"2026-06-09T13:18:19.271143Z", "updated_at":"2026-06-09T13:18:19.271143Z", "deleted_at":null, "description":"version1", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 302
+        body: '{"revision":1,"secret_id":"a21f2b97-7e87-400a-bc96-ede7323c15fb","status":"enabled","created_at":"2026-07-03T15:28:23.647646Z","updated_at":"2026-07-03T15:28:23.647646Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "312"
+                - "302"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:20 GMT
+                - Fri, 03 Jul 2026 15:28:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 1bf5054c-cedc-4a9b-9d8a-9d6c397d6824
+                - afbf99cd-09bc-4ab2-a57e-d3ea3c3b1527
         status: 200 OK
         code: 200
-        duration: 35.737476ms
+        duration: 48.69368ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -610,29 +610,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e7e7538a-90d7-4efc-8428-956bb1fe8f89/versions/1/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a21f2b97-7e87-400a-bc96-ede7323c15fb/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 209
-        body: '{"secret_id":"e7e7538a-90d7-4efc-8428-956bb1fe8f89", "revision":1, "data":"QVFBQUFBRlQycGJZbnYyOUErMGxGMjVZdDkvWXVWYnJmTGt2WG5Xd2lEOTBSMGpTWksyUkpLbS9CNlNkeTNoLzhKdXpNQT09", "data_crc32":null, "type":"opaque"}'
+        content_length: 205
+        body: '{"secret_id":"a21f2b97-7e87-400a-bc96-ede7323c15fb","revision":1,"data":"QVFBQUFBRVhtUHBwSUMvaWpZZk1UdGUvRUNtcWZQZXpQWDBUME55Mmh2UWlnTEFXNzlFTUFDWmRBVU9uWTl3TkJFUFpGdz09","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "209"
+                - "205"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:20 GMT
+                - Fri, 03 Jul 2026 15:28:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 565719f5-914e-4606-9505-ec6ef9162da2
+                - 8c24cfae-6452-4253-88c2-926484a26dae
         status: 200 OK
         code: 200
-        duration: 157.405626ms
+        duration: 52.342022ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -642,29 +642,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e7e7538a-90d7-4efc-8428-956bb1fe8f89/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a21f2b97-7e87-400a-bc96-ede7323c15fb/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 312
-        body: '{"revision":1, "secret_id":"e7e7538a-90d7-4efc-8428-956bb1fe8f89", "status":"enabled", "created_at":"2026-06-09T13:18:19.271143Z", "updated_at":"2026-06-09T13:18:19.271143Z", "deleted_at":null, "description":"version1", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 302
+        body: '{"revision":1,"secret_id":"a21f2b97-7e87-400a-bc96-ede7323c15fb","status":"enabled","created_at":"2026-07-03T15:28:23.647646Z","updated_at":"2026-07-03T15:28:23.647646Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "312"
+                - "302"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:20 GMT
+                - Fri, 03 Jul 2026 15:28:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - f284e00c-80d3-4392-817c-909dd814025b
+                - 850f63d6-03a4-4dcb-a872-a35c447f90cc
         status: 200 OK
         code: 200
-        duration: 41.066898ms
+        duration: 34.656394ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -674,8 +674,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e7e7538a-90d7-4efc-8428-956bb1fe8f89/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a21f2b97-7e87-400a-bc96-ede7323c15fb/versions/1
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -687,14 +687,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:21 GMT
+                - Fri, 03 Jul 2026 15:28:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 83de2f6a-a379-489b-bbb0-d3dd80f74672
+                - bd232f29-ebd2-4d23-94ab-31c1c44b7576
         status: 204 No Content
         code: 204
-        duration: 152.975998ms
+        duration: 59.866436ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -704,8 +704,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e7e7538a-90d7-4efc-8428-956bb1fe8f89
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/b746988a-e0e2-4e6a-8bd7-c757769a28ce
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -717,14 +717,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:21 GMT
+                - Fri, 03 Jul 2026 15:28:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 5e508703-f8a1-413f-aab7-fc99c6cd1e4d
+                - 8a444731-cd93-480a-ba9d-1209f236803a
         status: 204 No Content
         code: 204
-        duration: 97.926307ms
+        duration: 62.34966ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -734,8 +734,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/c7e712ce-2751-40c7-88b6-8174c1e839a4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a21f2b97-7e87-400a-bc96-ede7323c15fb
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -747,14 +747,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:21 GMT
+                - Fri, 03 Jul 2026 15:28:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 11149397-acfe-4153-87b4-5ac4712a3219
+                - 82ade117-d166-4820-813a-09e4fc9c9ea6
         status: 204 No Content
         code: 204
-        duration: 102.918612ms
+        duration: 72.168994ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -764,29 +764,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e7e7538a-90d7-4efc-8428-956bb1fe8f89
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a21f2b97-7e87-400a-bc96-ede7323c15fb
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 477
-        body: '{"id":"e7e7538a-90d7-4efc-8428-956bb1fe8f89", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"test-encrypted-secret", "status":"ready", "created_at":"2026-06-09T13:18:18.665797Z", "updated_at":"2026-06-09T13:18:18.665797Z", "tags":[], "version_count":1, "description":"", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":"2026-06-09T13:18:21.406754Z", "key_id":null, "region":"fr-par"}'
+        content_length: 460
+        body: '{"id":"a21f2b97-7e87-400a-bc96-ede7323c15fb","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-encrypted-secret","status":"ready","created_at":"2026-07-03T15:28:23.255629Z","updated_at":"2026-07-03T15:28:25.473293Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-07-03T15:28:25.473293Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "477"
+                - "460"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:21 GMT
+                - Fri, 03 Jul 2026 15:28:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - cf5c996b-6a08-4479-a006-01dd2c22ab75
+                - 79fcb67a-6aaa-4bca-bd2f-d71c6d27b3cf
         status: 200 OK
         code: 200
-        duration: 72.18301ms
+        duration: 32.92876ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -796,26 +796,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/c7e712ce-2751-40c7-88b6-8174c1e839a4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/b746988a-e0e2-4e6a-8bd7-c757769a28ce
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 551
-        body: '{"id":"c7e712ce-2751-40c7-88b6-8174c1e839a4", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-encrypt-key", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"scheduled_for_deletion", "rotation_count":1, "created_at":"2026-06-09T13:18:18.636421Z", "updated_at":"2026-06-09T13:18:18.639516Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-09T13:18:18.639516Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":"2026-06-09T13:18:21.450285Z", "region":"fr-par"}'
+        content_length: 565
+        body: '{"id":"b746988a-e0e2-4e6a-8bd7-c757769a28ce","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-encrypt-key","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-03T15:28:23.213364Z","updated_at":"2026-07-03T15:28:25.470868Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:23.217444Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-03T15:28:25.470868Z","protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "551"
+                - "565"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:18:21 GMT
+                - Fri, 03 Jul 2026 15:28:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - e8bdb96f-36dd-4dcb-9723-8e5f4e5e9dcd
+                - abe04d9b-1649-4041-ae45-065f18c38a67
         status: 200 OK
         code: 200
-        duration: 123.170668ms
+        duration: 41.55432ms

--- a/internal/services/keymanager/testdata/generate-data-key-ephemeral-resource-basic.cassette.yaml
+++ b/internal/services/keymanager/testdata/generate-data-key-ephemeral-resource-basic.cassette.yaml
@@ -13,129 +13,62 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 451
-        body: '{"id":"3bf74147-d3cb-44d5-a6bd-696bcb228a0a", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"test-data-key-secret", "status":"ready", "created_at":"2026-06-09T13:25:52.463206Z", "updated_at":"2026-06-09T13:25:52.463206Z", "tags":[], "version_count":0, "description":"", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}'
+        content_length: 434
+        body: '{"id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-data-key-secret","status":"ready","created_at":"2026-07-03T15:28:21.122392Z","updated_at":"2026-07-03T15:28:21.122392Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "451"
+                - "434"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:52 GMT
+                - Fri, 03 Jul 2026 15:28:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 1b4005f2-4294-418a-80d3-f8a978b5fc0d
+                - cbabf27d-be9d-4434-9274-c6f98d37ae5e
         status: 200 OK
         code: 200
-        duration: 248.222373ms
+        duration: 108.462773ms
     - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 192
+        content_length: 0
         host: api.scaleway.com
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-generate-data-key","usage":{"symmetric_encryption":"aes_256_gcm"},"tags":null,"unprotected":true,"origin":"unknown_origin"}'
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys
-        method: POST
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 517
-        body: '{"id":"b45ce445-6827-4bd9-8a80-36d701b376cf", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-generate-data-key", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-09T13:25:52.480379Z", "updated_at":"2026-06-09T13:25:52.484329Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-09T13:25:52.484329Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 434
+        body: '{"id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-data-key-secret","status":"ready","created_at":"2026-07-03T15:28:21.122392Z","updated_at":"2026-07-03T15:28:21.122392Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "517"
+                - "434"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:52 GMT
+                - Fri, 03 Jul 2026 15:28:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - cc1a7fb9-4b22-4b39-b008-669a7cb6db67
+                - 97240b40-cc81-4010-9aef-a5bf4e38407b
         status: 200 OK
         code: 200
-        duration: 278.113847ms
+        duration: 49.26912ms
     - id: 2
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bf74147-d3cb-44d5-a6bd-696bcb228a0a
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 451
-        body: '{"id":"3bf74147-d3cb-44d5-a6bd-696bcb228a0a", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"test-data-key-secret", "status":"ready", "created_at":"2026-06-09T13:25:52.463206Z", "updated_at":"2026-06-09T13:25:52.463206Z", "tags":[], "version_count":0, "description":"", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "451"
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 09 Jun 2026 13:25:52 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            X-Request-Id:
-                - 31efebd4-9661-4ba0-837e-7af404be2167
-        status: 200 OK
-        code: 200
-        duration: 74.821222ms
-    - id: 3
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/b45ce445-6827-4bd9-8a80-36d701b376cf
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 517
-        body: '{"id":"b45ce445-6827-4bd9-8a80-36d701b376cf", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-generate-data-key", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-09T13:25:52.480379Z", "updated_at":"2026-06-09T13:25:52.484329Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-09T13:25:52.484329Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "517"
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 09 Jun 2026 13:25:52 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            X-Request-Id:
-                - 9b8ef657-65ff-43ca-b113-11ee96e7efa0
-        status: 200 OK
-        code: 200
-        duration: 76.124161ms
-    - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -147,29 +80,96 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bf74147-d3cb-44d5-a6bd-696bcb228a0a/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 32
-        body: '{"versions":[], "total_count":0}'
+        content_length: 31
+        body: '{"versions":[],"total_count":0}'
         headers:
             Content-Length:
-                - "32"
+                - "31"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:52 GMT
+                - Fri, 03 Jul 2026 15:28:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 4d445fb7-3bb9-405e-b9d0-c6636cc39c3b
+                - 728590d0-c95e-4243-af90-02e5203c2d6f
         status: 200 OK
         code: 200
-        duration: 79.637506ms
+        duration: 49.255605ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 238
+        host: api.scaleway.com
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-generate-data-key","usage":{"symmetric_encryption":"aes_256_gcm"},"tags":null,"unprotected":true,"origin":"unknown_origin","protection_level":"unknown_protection_level"}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 531
+        body: '{"id":"eb04b054-d2ff-4deb-9d9e-c3b297c9a814","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-generate-data-key","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:21.457910Z","updated_at":"2026-07-03T15:28:21.463281Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:21.463281Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "531"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:21 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 977fb914-18ac-4773-9437-920d07d0d53b
+        status: 200 OK
+        code: 200
+        duration: 455.611834ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/eb04b054-d2ff-4deb-9d9e-c3b297c9a814
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 531
+        body: '{"id":"eb04b054-d2ff-4deb-9d9e-c3b297c9a814","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-generate-data-key","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:21.457910Z","updated_at":"2026-07-03T15:28:21.463281Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:21.463281Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "531"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:21 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 57c16659-c972-4ff5-9558-5db293de4170
+        status: 200 OK
+        code: 200
+        duration: 47.09628ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -182,29 +182,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/b45ce445-6827-4bd9-8a80-36d701b376cf/generate-data-key
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/eb04b054-d2ff-4deb-9d9e-c3b297c9a814/generate-data-key
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 288
-        body: '{"key_id":"b45ce445-6827-4bd9-8a80-36d701b376cf", "algorithm":"aes_256_gcm", "ciphertext":"AQAAAAEWuqRPRzWlVQAvYYkoi/556jN0imSbtFZgFDhUIVi23x1x8oZ+QOkO1mn4e0/w8z0WNFre7AXSQszxUDc=", "plaintext":"cZYkp7DivFiQiQXFh8nHhc1QA6aUH2RTz1XRPB0DRqk=", "created_at":"2026-06-09T13:25:52.683903287Z"}'
+        content_length: 284
+        body: '{"key_id":"eb04b054-d2ff-4deb-9d9e-c3b297c9a814","algorithm":"aes_256_gcm","ciphertext":"AQAAAAEUGAFMTAyAWC00hLs5M97uE30RZBwuUD+Pru4GHUkPfBb+ou9pe8MZsNEugmq14RKzLNHa0+jLS2oRXI0=","plaintext":"LvdnBKEFJEGqQIi+LCXCI+dpZWlELeWfFTzVl/DmGgI=","created_at":"2026-07-03T15:28:21.636549274Z"}'
         headers:
             Content-Length:
-                - "288"
+                - "284"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:52 GMT
+                - Fri, 03 Jul 2026 15:28:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - a9ff9eec-8dbb-406c-957a-ced5fecc5fab
+                - 26c6d754-9c44-4a5c-8ed2-2fc6c85a4ac0
         status: 200 OK
         code: 200
-        duration: 93.042122ms
+        duration: 95.155337ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -212,34 +212,34 @@ interactions:
         proto_minor: 1
         content_length: 128
         host: api.scaleway.com
-        body: '{"ciphertext":"AQAAAAEWuqRPRzWlVQAvYYkoi/556jN0imSbtFZgFDhUIVi23x1x8oZ+QOkO1mn4e0/w8z0WNFre7AXSQszxUDc=","associated_data":null}'
+        body: '{"ciphertext":"AQAAAAEUGAFMTAyAWC00hLs5M97uE30RZBwuUD+Pru4GHUkPfBb+ou9pe8MZsNEugmq14RKzLNHa0+jLS2oRXI0=","associated_data":null}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/b45ce445-6827-4bd9-8a80-36d701b376cf/decrypt
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/eb04b054-d2ff-4deb-9d9e-c3b297c9a814/decrypt
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 128
-        body: '{"key_id":"b45ce445-6827-4bd9-8a80-36d701b376cf", "plaintext":"cZYkp7DivFiQiQXFh8nHhc1QA6aUH2RTz1XRPB0DRqk=", "ciphertext":null}'
+        content_length: 126
+        body: '{"key_id":"eb04b054-d2ff-4deb-9d9e-c3b297c9a814","plaintext":"LvdnBKEFJEGqQIi+LCXCI+dpZWlELeWfFTzVl/DmGgI=","ciphertext":null}'
         headers:
             Content-Length:
-                - "128"
+                - "126"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:52 GMT
+                - Fri, 03 Jul 2026 15:28:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 17c43361-f011-4d44-bc5c-3751ed533abf
+                - 488ea255-abee-4086-b734-cd457016863a
         status: 200 OK
         code: 200
-        duration: 88.950777ms
+        duration: 81.208983ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -247,34 +247,34 @@ interactions:
         proto_minor: 1
         content_length: 156
         host: api.scaleway.com
-        body: '{"data":"QVFBQUFBRVd1cVJQUnpXbFZRQXZZWWtvaS81NTZqTjBpbVNidEZaZ0ZEaFVJVmkyM3gxeDhvWitRT2tPMW1uNGUwL3c4ejBXTkZyZTdBWFNRc3p4VURjPQ==","description":"version1"}'
+        body: '{"data":"QVFBQUFBRVVHQUZNVEF5QVdDMDBoTHM1TTk3dUUzMFJaQnd1VUQrUHJ1NEdIVWtQZkJiK291OXBlOE1ac05FdWdtcTE0Ukt6TE5IYTArakxTMm9SWEkwPQ==","description":"version1"}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bf74147-d3cb-44d5-a6bd-696bcb228a0a/versions
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 312
-        body: '{"revision":1, "secret_id":"3bf74147-d3cb-44d5-a6bd-696bcb228a0a", "status":"enabled", "created_at":"2026-06-09T13:25:52.948906Z", "updated_at":"2026-06-09T13:25:52.948906Z", "deleted_at":null, "description":"version1", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 302
+        body: '{"revision":1,"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","status":"enabled","created_at":"2026-07-03T15:28:21.922749Z","updated_at":"2026-07-03T15:28:21.922749Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "312"
+                - "302"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:52 GMT
+                - Fri, 03 Jul 2026 15:28:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 7b0a3403-9141-44f8-9d9a-a9612919d61a
+                - 2fb8cfdf-b6c8-4fe1-8450-e3030fd66efb
         status: 200 OK
         code: 200
-        duration: 285.468386ms
+        duration: 300.921122ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -284,64 +284,61 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bf74147-d3cb-44d5-a6bd-696bcb228a0a/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 312
-        body: '{"revision":1, "secret_id":"3bf74147-d3cb-44d5-a6bd-696bcb228a0a", "status":"enabled", "created_at":"2026-06-09T13:25:52.948906Z", "updated_at":"2026-06-09T13:25:52.948906Z", "deleted_at":null, "description":"version1", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 302
+        body: '{"revision":1,"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","status":"enabled","created_at":"2026-07-03T15:28:21.922749Z","updated_at":"2026-07-03T15:28:21.922749Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "312"
+                - "302"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:53 GMT
+                - Fri, 03 Jul 2026 15:28:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - d3d54e58-b02c-403c-855b-72c2ae4e9c3d
+                - e08a9e41-e2d8-428b-a794-6d3d634a4d68
         status: 200 OK
         code: 200
-        duration: 82.830772ms
+        duration: 51.176142ms
     - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 116
+        content_length: 0
         host: api.scaleway.com
-        body: '{"data":"ce+/vSTvv73vv73vv73vv71Y77+977+9BcWH77+9x4Xvv71QA++/ve+/vR9kU++/vVXvv708HQNG77+9","description":"version2"}'
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bf74147-d3cb-44d5-a6bd-696bcb228a0a/versions
-        method: POST
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions/1/access
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 312
-        body: '{"revision":2, "secret_id":"3bf74147-d3cb-44d5-a6bd-696bcb228a0a", "status":"enabled", "created_at":"2026-06-09T13:25:53.157048Z", "updated_at":"2026-06-09T13:25:53.157048Z", "deleted_at":null, "description":"version2", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 229
+        body: '{"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","revision":1,"data":"QVFBQUFBRVVHQUZNVEF5QVdDMDBoTHM1TTk3dUUzMFJaQnd1VUQrUHJ1NEdIVWtQZkJiK291OXBlOE1ac05FdWdtcTE0Ukt6TE5IYTArakxTMm9SWEkwPQ==","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "312"
+                - "229"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:53 GMT
+                - Fri, 03 Jul 2026 15:28:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 05c999c8-6099-49b9-ac6b-438f30e2e61d
+                - a19654a6-6af2-49f0-aaa5-5a536e767f01
         status: 200 OK
         code: 200
-        duration: 104.306207ms
+        duration: 93.346991ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -351,61 +348,64 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bf74147-d3cb-44d5-a6bd-696bcb228a0a/versions/1/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 233
-        body: '{"secret_id":"3bf74147-d3cb-44d5-a6bd-696bcb228a0a", "revision":1, "data":"QVFBQUFBRVd1cVJQUnpXbFZRQXZZWWtvaS81NTZqTjBpbVNidEZaZ0ZEaFVJVmkyM3gxeDhvWitRT2tPMW1uNGUwL3c4ejBXTkZyZTdBWFNRc3p4VURjPQ==", "data_crc32":null, "type":"opaque"}'
+        content_length: 302
+        body: '{"revision":1,"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","status":"enabled","created_at":"2026-07-03T15:28:21.922749Z","updated_at":"2026-07-03T15:28:21.922749Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "233"
+                - "302"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:53 GMT
+                - Fri, 03 Jul 2026 15:28:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 2f89622a-0ad0-421f-869a-200d6209f061
+                - 7a657127-74c9-41d3-a6ef-fa8082579f60
         status: 200 OK
         code: 200
-        duration: 110.639522ms
+        duration: 36.05441ms
     - id: 11
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 108
         host: api.scaleway.com
+        body: '{"data":"Lu+/vWcE77+9BSRB77+9QO+/ve+/vSwl77+9I++/vWllaUQt77+977+9FTzVl++/ve+/vRoC","description":"version2"}'
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bf74147-d3cb-44d5-a6bd-696bcb228a0a/versions/2
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 312
-        body: '{"revision":2, "secret_id":"3bf74147-d3cb-44d5-a6bd-696bcb228a0a", "status":"enabled", "created_at":"2026-06-09T13:25:53.157048Z", "updated_at":"2026-06-09T13:25:53.157048Z", "deleted_at":null, "description":"version2", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 302
+        body: '{"revision":2,"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","status":"enabled","created_at":"2026-07-03T15:28:22.122929Z","updated_at":"2026-07-03T15:28:22.122929Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "312"
+                - "302"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:53 GMT
+                - Fri, 03 Jul 2026 15:28:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 105dc57b-937c-423d-bbc2-6cf315490fff
+                - 0b499655-769b-42f1-be4c-289b4df6d110
         status: 200 OK
         code: 200
-        duration: 34.293638ms
+        duration: 139.239029ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -415,29 +415,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bf74147-d3cb-44d5-a6bd-696bcb228a0a/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 313
-        body: '{"revision":1, "secret_id":"3bf74147-d3cb-44d5-a6bd-696bcb228a0a", "status":"enabled", "created_at":"2026-06-09T13:25:52.948906Z", "updated_at":"2026-06-09T13:25:52.948906Z", "deleted_at":null, "description":"version1", "latest":false, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 302
+        body: '{"revision":2,"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","status":"enabled","created_at":"2026-07-03T15:28:22.122929Z","updated_at":"2026-07-03T15:28:22.122929Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "313"
+                - "302"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:53 GMT
+                - Fri, 03 Jul 2026 15:28:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - ff852c20-e17a-4e2e-9507-d260e774c8f6
+                - 69e1c994-9137-4bf2-9f2a-ca57995b75b7
         status: 200 OK
         code: 200
-        duration: 38.670875ms
+        duration: 57.186873ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -447,30 +447,65 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bf74147-d3cb-44d5-a6bd-696bcb228a0a/versions/2/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions/2/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 193
-        body: '{"secret_id":"3bf74147-d3cb-44d5-a6bd-696bcb228a0a", "revision":2, "data":"ce+/vSTvv73vv73vv73vv71Y77+977+9BcWH77+9x4Xvv71QA++/ve+/vR9kU++/vVXvv708HQNG77+9", "data_crc32":null, "type":"opaque"}'
+        content_length: 181
+        body: '{"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","revision":2,"data":"Lu+/vWcE77+9BSRB77+9QO+/ve+/vSwl77+9I++/vWllaUQt77+977+9FTzVl++/ve+/vRoC","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "193"
+                - "181"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:53 GMT
+                - Fri, 03 Jul 2026 15:28:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - b0a663f5-b5bf-4751-b824-91673acb2780
+                - ddd39684-6616-4536-ba05-e416f93fa4e5
         status: 200 OK
         code: 200
-        duration: 84.713408ms
+        duration: 64.965493ms
     - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 108
+        host: api.scaleway.com
+        body: '{"data":"Lu+/vWcE77+9BSRB77+9QO+/ve+/vSwl77+9I++/vWllaUQt77+977+9FTzVl++/ve+/vRoC","description":"version3"}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 302
+        body: '{"revision":3,"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","status":"enabled","created_at":"2026-07-03T15:28:22.280312Z","updated_at":"2026-07-03T15:28:22.280312Z","deleted_at":null,"description":"version3","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "302"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - c952ec07-edfb-4047-a554-600ab865d1c6
+        status: 200 OK
+        code: 200
+        duration: 86.124876ms
+    - id: 15
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -479,64 +514,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bf74147-d3cb-44d5-a6bd-696bcb228a0a/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 312
-        body: '{"revision":2, "secret_id":"3bf74147-d3cb-44d5-a6bd-696bcb228a0a", "status":"enabled", "created_at":"2026-06-09T13:25:53.157048Z", "updated_at":"2026-06-09T13:25:53.157048Z", "deleted_at":null, "description":"version2", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 303
+        body: '{"revision":2,"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","status":"enabled","created_at":"2026-07-03T15:28:22.122929Z","updated_at":"2026-07-03T15:28:22.122929Z","deleted_at":null,"description":"version2","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "312"
+                - "303"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:53 GMT
+                - Fri, 03 Jul 2026 15:28:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 52c4ade4-8b3f-4e4c-8d70-71f7a59203d2
+                - 2cece84a-e8cc-423d-8bf5-096998d1fad0
         status: 200 OK
         code: 200
-        duration: 31.128303ms
-    - id: 15
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 116
-        host: api.scaleway.com
-        body: '{"data":"ce+/vSTvv73vv73vv73vv71Y77+977+9BcWH77+9x4Xvv71QA++/ve+/vR9kU++/vVXvv708HQNG77+9","description":"version3"}'
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bf74147-d3cb-44d5-a6bd-696bcb228a0a/versions
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 312
-        body: '{"revision":3, "secret_id":"3bf74147-d3cb-44d5-a6bd-696bcb228a0a", "status":"enabled", "created_at":"2026-06-09T13:25:53.323072Z", "updated_at":"2026-06-09T13:25:53.323072Z", "deleted_at":null, "description":"version3", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "312"
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 09 Jun 2026 13:25:53 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            X-Request-Id:
-                - 739a8f8b-afa5-4b35-9c21-0c171848a35e
-        status: 200 OK
-        code: 200
-        duration: 129.045736ms
+        duration: 49.839492ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -546,29 +546,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bf74147-d3cb-44d5-a6bd-696bcb228a0a/versions/3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions/3
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 312
-        body: '{"revision":3, "secret_id":"3bf74147-d3cb-44d5-a6bd-696bcb228a0a", "status":"enabled", "created_at":"2026-06-09T13:25:53.323072Z", "updated_at":"2026-06-09T13:25:53.323072Z", "deleted_at":null, "description":"version3", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 302
+        body: '{"revision":3,"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","status":"enabled","created_at":"2026-07-03T15:28:22.280312Z","updated_at":"2026-07-03T15:28:22.280312Z","deleted_at":null,"description":"version3","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "312"
+                - "302"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:53 GMT
+                - Fri, 03 Jul 2026 15:28:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 37739af4-55c0-4618-afac-b9e590bf7f2e
+                - aa941cc9-9264-475d-99a4-5f75352c7297
         status: 200 OK
         code: 200
-        duration: 33.391543ms
+        duration: 43.156861ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -578,29 +578,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bf74147-d3cb-44d5-a6bd-696bcb228a0a/versions/3/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions/3/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 193
-        body: '{"secret_id":"3bf74147-d3cb-44d5-a6bd-696bcb228a0a", "revision":3, "data":"ce+/vSTvv73vv73vv73vv71Y77+977+9BcWH77+9x4Xvv71QA++/ve+/vR9kU++/vVXvv708HQNG77+9", "data_crc32":null, "type":"opaque"}'
+        content_length: 181
+        body: '{"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","revision":3,"data":"Lu+/vWcE77+9BSRB77+9QO+/ve+/vSwl77+9I++/vWllaUQt77+977+9FTzVl++/ve+/vRoC","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "193"
+                - "181"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:53 GMT
+                - Fri, 03 Jul 2026 15:28:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - d22877b0-ae36-4a4b-b782-1940c7892745
+                - 89e1e510-f6e4-407c-af68-b1f0b8526e17
         status: 200 OK
         code: 200
-        duration: 120.477793ms
+        duration: 46.988176ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -610,29 +610,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bf74147-d3cb-44d5-a6bd-696bcb228a0a/versions/3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions/3
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 312
-        body: '{"revision":3, "secret_id":"3bf74147-d3cb-44d5-a6bd-696bcb228a0a", "status":"enabled", "created_at":"2026-06-09T13:25:53.323072Z", "updated_at":"2026-06-09T13:25:53.323072Z", "deleted_at":null, "description":"version3", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 302
+        body: '{"revision":3,"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","status":"enabled","created_at":"2026-07-03T15:28:22.280312Z","updated_at":"2026-07-03T15:28:22.280312Z","deleted_at":null,"description":"version3","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "312"
+                - "302"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:53 GMT
+                - Fri, 03 Jul 2026 15:28:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 702043ae-235a-40bb-9d7e-40ebd65a8bb2
+                - c041158d-2bb2-4062-8c76-e8283f048a8d
         status: 200 OK
         code: 200
-        duration: 35.625931ms
+        duration: 39.708814ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -645,29 +645,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/b45ce445-6827-4bd9-8a80-36d701b376cf/generate-data-key
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/eb04b054-d2ff-4deb-9d9e-c3b297c9a814/generate-data-key
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 288
-        body: '{"key_id":"b45ce445-6827-4bd9-8a80-36d701b376cf", "algorithm":"aes_256_gcm", "ciphertext":"AQAAAAF4iij+YOrjSO2HLqkBS6FB+KBeTCaUh6aXOej5IEr8oLFQTpvggHv6WBAPmlj+UiK7KkJOrvaHv1maHTg=", "plaintext":"QFMqPd44Y58t3eqlFL+VkVfrBuH6feyPTcPn9DdVHjU=", "created_at":"2026-06-09T13:25:53.831111764Z"}'
+        content_length: 284
+        body: '{"key_id":"eb04b054-d2ff-4deb-9d9e-c3b297c9a814","algorithm":"aes_256_gcm","ciphertext":"AQAAAAHPEtEhiRruGiRXxODWg8Q2Oacu2ASP7C+iSkIXXrr5WZL5cXqggNYp2LWHQpysgC21d6YdJGK0sEwlKOk=","plaintext":"eV5g4IJjCPfSqDLlXXalCqkSx+y8K8PiYGSzbbA6quA=","created_at":"2026-07-03T15:28:22.891834439Z"}'
         headers:
             Content-Length:
-                - "288"
+                - "284"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:53 GMT
+                - Fri, 03 Jul 2026 15:28:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 91a78310-7b4e-42c9-a565-52e391c962e9
+                - 6c2b31db-7219-4b4c-9519-3ace9c6532dc
         status: 200 OK
         code: 200
-        duration: 81.298957ms
+        duration: 57.846252ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -677,29 +677,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bf74147-d3cb-44d5-a6bd-696bcb228a0a/versions/1/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 233
-        body: '{"secret_id":"3bf74147-d3cb-44d5-a6bd-696bcb228a0a", "revision":1, "data":"QVFBQUFBRVd1cVJQUnpXbFZRQXZZWWtvaS81NTZqTjBpbVNidEZaZ0ZEaFVJVmkyM3gxeDhvWitRT2tPMW1uNGUwL3c4ejBXTkZyZTdBWFNRc3p4VURjPQ==", "data_crc32":null, "type":"opaque"}'
+        content_length: 229
+        body: '{"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","revision":1,"data":"QVFBQUFBRVVHQUZNVEF5QVdDMDBoTHM1TTk3dUUzMFJaQnd1VUQrUHJ1NEdIVWtQZkJiK291OXBlOE1ac05FdWdtcTE0Ukt6TE5IYTArakxTMm9SWEkwPQ==","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "233"
+                - "229"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:53 GMT
+                - Fri, 03 Jul 2026 15:28:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 56b9a4fb-0f68-41a0-9503-543fcb293879
+                - aff828d6-73ad-4baa-8e5d-c531fe44cb90
         status: 200 OK
         code: 200
-        duration: 53.889864ms
+        duration: 41.310823ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -709,29 +709,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bf74147-d3cb-44d5-a6bd-696bcb228a0a/versions/2/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions/2/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 193
-        body: '{"secret_id":"3bf74147-d3cb-44d5-a6bd-696bcb228a0a", "revision":2, "data":"ce+/vSTvv73vv73vv73vv71Y77+977+9BcWH77+9x4Xvv71QA++/ve+/vR9kU++/vVXvv708HQNG77+9", "data_crc32":null, "type":"opaque"}'
+        content_length: 181
+        body: '{"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","revision":2,"data":"Lu+/vWcE77+9BSRB77+9QO+/ve+/vSwl77+9I++/vWllaUQt77+977+9FTzVl++/ve+/vRoC","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "193"
+                - "181"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:53 GMT
+                - Fri, 03 Jul 2026 15:28:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 1f2bbc0f-ed3a-4867-91be-abbfcf64e3bc
+                - 2fa6382f-3107-4055-8d36-8ffdf8bea074
         status: 200 OK
         code: 200
-        duration: 64.594745ms
+        duration: 41.402475ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -739,34 +739,34 @@ interactions:
         proto_minor: 1
         content_length: 128
         host: api.scaleway.com
-        body: '{"ciphertext":"AQAAAAF4iij+YOrjSO2HLqkBS6FB+KBeTCaUh6aXOej5IEr8oLFQTpvggHv6WBAPmlj+UiK7KkJOrvaHv1maHTg=","associated_data":null}'
+        body: '{"ciphertext":"AQAAAAHPEtEhiRruGiRXxODWg8Q2Oacu2ASP7C+iSkIXXrr5WZL5cXqggNYp2LWHQpysgC21d6YdJGK0sEwlKOk=","associated_data":null}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/b45ce445-6827-4bd9-8a80-36d701b376cf/decrypt
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/eb04b054-d2ff-4deb-9d9e-c3b297c9a814/decrypt
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 128
-        body: '{"key_id":"b45ce445-6827-4bd9-8a80-36d701b376cf", "plaintext":"QFMqPd44Y58t3eqlFL+VkVfrBuH6feyPTcPn9DdVHjU=", "ciphertext":null}'
+        content_length: 126
+        body: '{"key_id":"eb04b054-d2ff-4deb-9d9e-c3b297c9a814","plaintext":"eV5g4IJjCPfSqDLlXXalCqkSx+y8K8PiYGSzbbA6quA=","ciphertext":null}'
         headers:
             Content-Length:
-                - "128"
+                - "126"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:53 GMT
+                - Fri, 03 Jul 2026 15:28:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 6e3da9ed-8630-4cee-bf40-7866ecb40bd1
+                - 0d13aa58-d228-45ae-805e-7fcbcb6ae7a4
         status: 200 OK
         code: 200
-        duration: 72.081715ms
+        duration: 80.984581ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -776,29 +776,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bf74147-d3cb-44d5-a6bd-696bcb228a0a/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 313
-        body: '{"revision":1, "secret_id":"3bf74147-d3cb-44d5-a6bd-696bcb228a0a", "status":"enabled", "created_at":"2026-06-09T13:25:52.948906Z", "updated_at":"2026-06-09T13:25:52.948906Z", "deleted_at":null, "description":"version1", "latest":false, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 303
+        body: '{"revision":1,"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","status":"enabled","created_at":"2026-07-03T15:28:21.922749Z","updated_at":"2026-07-03T15:28:21.922749Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "313"
+                - "303"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:53 GMT
+                - Fri, 03 Jul 2026 15:28:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 345db4ce-8974-4f3c-b9d2-db38d7163592
+                - 8cebe839-dba9-4427-b4c8-e244a6ec5a52
         status: 200 OK
         code: 200
-        duration: 35.659623ms
+        duration: 39.131129ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -808,29 +808,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bf74147-d3cb-44d5-a6bd-696bcb228a0a/versions/3/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 193
-        body: '{"secret_id":"3bf74147-d3cb-44d5-a6bd-696bcb228a0a", "revision":3, "data":"ce+/vSTvv73vv73vv73vv71Y77+977+9BcWH77+9x4Xvv71QA++/ve+/vR9kU++/vVXvv708HQNG77+9", "data_crc32":null, "type":"opaque"}'
+        content_length: 303
+        body: '{"revision":2,"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","status":"enabled","created_at":"2026-07-03T15:28:22.122929Z","updated_at":"2026-07-03T15:28:22.122929Z","deleted_at":null,"description":"version2","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "193"
+                - "303"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:53 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - db0d8a1f-18c4-4892-a71c-9de22af5144d
+                - 68625260-1e88-4379-bdbc-029d896f6d8e
         status: 200 OK
         code: 200
-        duration: 47.838557ms
+        duration: 47.673213ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -840,29 +840,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bf74147-d3cb-44d5-a6bd-696bcb228a0a/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions/3/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 313
-        body: '{"revision":2, "secret_id":"3bf74147-d3cb-44d5-a6bd-696bcb228a0a", "status":"enabled", "created_at":"2026-06-09T13:25:53.157048Z", "updated_at":"2026-06-09T13:25:53.157048Z", "deleted_at":null, "description":"version2", "latest":false, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 181
+        body: '{"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","revision":3,"data":"Lu+/vWcE77+9BSRB77+9QO+/ve+/vSwl77+9I++/vWllaUQt77+977+9FTzVl++/ve+/vRoC","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "313"
+                - "181"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:53 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 153001d4-9088-4ad9-980e-6c5c4bc4fb01
+                - aed112c3-e658-4546-8a9b-fa6f764036a9
         status: 200 OK
         code: 200
-        duration: 84.559467ms
+        duration: 60.647924ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -872,29 +872,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bf74147-d3cb-44d5-a6bd-696bcb228a0a/versions/3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions/3
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 312
-        body: '{"revision":3, "secret_id":"3bf74147-d3cb-44d5-a6bd-696bcb228a0a", "status":"enabled", "created_at":"2026-06-09T13:25:53.323072Z", "updated_at":"2026-06-09T13:25:53.323072Z", "deleted_at":null, "description":"version3", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 302
+        body: '{"revision":3,"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","status":"enabled","created_at":"2026-07-03T15:28:22.280312Z","updated_at":"2026-07-03T15:28:22.280312Z","deleted_at":null,"description":"version3","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "312"
+                - "302"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:53 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - a4876d37-18ea-414e-ac3d-127c8a45aaba
+                - c0e8b7bc-de58-40a1-9dda-78a0dd3c4fed
         status: 200 OK
         code: 200
-        duration: 38.18248ms
+        duration: 49.250295ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -904,29 +904,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/b45ce445-6827-4bd9-8a80-36d701b376cf
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 517
-        body: '{"id":"b45ce445-6827-4bd9-8a80-36d701b376cf", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-generate-data-key", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-09T13:25:52.480379Z", "updated_at":"2026-06-09T13:25:52.484329Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-09T13:25:52.484329Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 434
+        body: '{"id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-data-key-secret","status":"ready","created_at":"2026-07-03T15:28:21.122392Z","updated_at":"2026-07-03T15:28:21.122392Z","tags":[],"version_count":3,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "517"
+                - "434"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:54 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 0ba15831-fcf0-49e2-b66e-90250c4e400c
+                - c3b5f65a-32a6-431f-8b9a-3eb78b59a602
         status: 200 OK
         code: 200
-        duration: 75.871941ms
+        duration: 33.192836ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -936,65 +936,30 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bf74147-d3cb-44d5-a6bd-696bcb228a0a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/eb04b054-d2ff-4deb-9d9e-c3b297c9a814
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 451
-        body: '{"id":"3bf74147-d3cb-44d5-a6bd-696bcb228a0a", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"test-data-key-secret", "status":"ready", "created_at":"2026-06-09T13:25:52.463206Z", "updated_at":"2026-06-09T13:25:52.463206Z", "tags":[], "version_count":3, "description":"", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}'
+        content_length: 531
+        body: '{"id":"eb04b054-d2ff-4deb-9d9e-c3b297c9a814","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-generate-data-key","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:21.457910Z","updated_at":"2026-07-03T15:28:21.463281Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:21.463281Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "451"
+                - "531"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:54 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - d62aa7fb-5d59-4cbb-af5b-ca4cd2d21de5
+                - 4d95dd51-433c-4f7b-a09c-df0cf33d1c02
         status: 200 OK
         code: 200
-        duration: 80.968415ms
+        duration: 43.738353ms
     - id: 29
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 53
-        host: api.scaleway.com
-        body: '{"algorithm":"aes_256_gcm","without_plaintext":false}'
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/b45ce445-6827-4bd9-8a80-36d701b376cf/generate-data-key
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 288
-        body: '{"key_id":"b45ce445-6827-4bd9-8a80-36d701b376cf", "algorithm":"aes_256_gcm", "ciphertext":"AQAAAAE9U7snqoyYu6mWDlzXEeD9x9A01DD1h+hZTtUqPdFJ+CTgEvUc8Q83PT1tT+6TQs+/Fu/r8USgDalgWrg=", "plaintext":"Gd3j81ngsP9vZ/bxxDunH40TriQbYo4P/CPTOzaLkSY=", "created_at":"2026-06-09T13:25:54.310391518Z"}'
-        headers:
-            Content-Length:
-                - "288"
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 09 Jun 2026 13:25:54 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            X-Request-Id:
-                - 166fa953-064b-4ef7-a3c9-0113bf7dc5f9
-        status: 200 OK
-        code: 200
-        duration: 51.253183ms
-    - id: 30
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1006,65 +971,65 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bf74147-d3cb-44d5-a6bd-696bcb228a0a/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 974
-        body: '{"versions":[{"revision":3, "secret_id":"3bf74147-d3cb-44d5-a6bd-696bcb228a0a", "status":"enabled", "created_at":"2026-06-09T13:25:53.323072Z", "updated_at":"2026-06-09T13:25:53.323072Z", "deleted_at":null, "description":"version3", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}, {"revision":2, "secret_id":"3bf74147-d3cb-44d5-a6bd-696bcb228a0a", "status":"enabled", "created_at":"2026-06-09T13:25:53.157048Z", "updated_at":"2026-06-09T13:25:53.157048Z", "deleted_at":null, "description":"version2", "latest":false, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}, {"revision":1, "secret_id":"3bf74147-d3cb-44d5-a6bd-696bcb228a0a", "status":"enabled", "created_at":"2026-06-09T13:25:52.948906Z", "updated_at":"2026-06-09T13:25:52.948906Z", "deleted_at":null, "description":"version1", "latest":false, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}], "total_count":3}'
+        content_length: 941
+        body: '{"versions":[{"revision":3,"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","status":"enabled","created_at":"2026-07-03T15:28:22.280312Z","updated_at":"2026-07-03T15:28:22.280312Z","deleted_at":null,"description":"version3","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":2,"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","status":"enabled","created_at":"2026-07-03T15:28:22.122929Z","updated_at":"2026-07-03T15:28:22.122929Z","deleted_at":null,"description":"version2","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","status":"enabled","created_at":"2026-07-03T15:28:21.922749Z","updated_at":"2026-07-03T15:28:21.922749Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":3}'
         headers:
             Content-Length:
-                - "974"
+                - "941"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:54 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 94055811-a135-4507-8d68-c8aa73d48a2b
+                - 859c77d6-13c9-4106-b430-3e7fbb1fd335
         status: 200 OK
         code: 200
-        duration: 92.360442ms
-    - id: 31
+        duration: 41.749336ms
+    - id: 30
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 128
+        content_length: 53
         host: api.scaleway.com
-        body: '{"ciphertext":"AQAAAAE9U7snqoyYu6mWDlzXEeD9x9A01DD1h+hZTtUqPdFJ+CTgEvUc8Q83PT1tT+6TQs+/Fu/r8USgDalgWrg=","associated_data":null}'
+        body: '{"algorithm":"aes_256_gcm","without_plaintext":false}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/b45ce445-6827-4bd9-8a80-36d701b376cf/decrypt
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/eb04b054-d2ff-4deb-9d9e-c3b297c9a814/generate-data-key
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 128
-        body: '{"key_id":"b45ce445-6827-4bd9-8a80-36d701b376cf", "plaintext":"Gd3j81ngsP9vZ/bxxDunH40TriQbYo4P/CPTOzaLkSY=", "ciphertext":null}'
+        content_length: 284
+        body: '{"key_id":"eb04b054-d2ff-4deb-9d9e-c3b297c9a814","algorithm":"aes_256_gcm","ciphertext":"AQAAAAGcYRABqL8zbcZhme/KgKtFZoAmMWWKAHzuUUQ8wjmt9h2khq2+bpbqxJaCBEddatX7bRiZ+d/1QV5oL9A=","plaintext":"lnNAeuC5v/IO49bA1sv5YeN0N9vliIuTt4i8QQv91P0=","created_at":"2026-07-03T15:28:23.465028788Z"}'
         headers:
             Content-Length:
-                - "128"
+                - "284"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:54 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 1d079200-bcf6-46ab-a9a0-5fd8c290576b
+                - 77255f97-93c2-4a17-a9f0-2eba762f6044
         status: 200 OK
         code: 200
-        duration: 36.394549ms
-    - id: 32
+        duration: 94.985298ms
+    - id: 31
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1073,29 +1038,64 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bf74147-d3cb-44d5-a6bd-696bcb228a0a/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 313
-        body: '{"revision":1, "secret_id":"3bf74147-d3cb-44d5-a6bd-696bcb228a0a", "status":"enabled", "created_at":"2026-06-09T13:25:52.948906Z", "updated_at":"2026-06-09T13:25:52.948906Z", "deleted_at":null, "description":"version1", "latest":false, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 303
+        body: '{"revision":1,"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","status":"enabled","created_at":"2026-07-03T15:28:21.922749Z","updated_at":"2026-07-03T15:28:21.922749Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "313"
+                - "303"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:54 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 4abc13a0-a157-4e3e-8310-5b58006c355a
+                - 3f8379bc-760f-43a9-80ba-dfcd8e0c1071
         status: 200 OK
         code: 200
-        duration: 37.017251ms
+        duration: 47.266229ms
+    - id: 32
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 128
+        host: api.scaleway.com
+        body: '{"ciphertext":"AQAAAAGcYRABqL8zbcZhme/KgKtFZoAmMWWKAHzuUUQ8wjmt9h2khq2+bpbqxJaCBEddatX7bRiZ+d/1QV5oL9A=","associated_data":null}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/eb04b054-d2ff-4deb-9d9e-c3b297c9a814/decrypt
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 126
+        body: '{"key_id":"eb04b054-d2ff-4deb-9d9e-c3b297c9a814","plaintext":"lnNAeuC5v/IO49bA1sv5YeN0N9vliIuTt4i8QQv91P0=","ciphertext":null}'
+        headers:
+            Content-Length:
+                - "126"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - d3f1dbfc-40e6-4847-9d04-e661a9d99eba
+        status: 200 OK
+        code: 200
+        duration: 55.897471ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1105,29 +1105,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bf74147-d3cb-44d5-a6bd-696bcb228a0a/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 313
-        body: '{"revision":2, "secret_id":"3bf74147-d3cb-44d5-a6bd-696bcb228a0a", "status":"enabled", "created_at":"2026-06-09T13:25:53.157048Z", "updated_at":"2026-06-09T13:25:53.157048Z", "deleted_at":null, "description":"version2", "latest":false, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 303
+        body: '{"revision":2,"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","status":"enabled","created_at":"2026-07-03T15:28:22.122929Z","updated_at":"2026-07-03T15:28:22.122929Z","deleted_at":null,"description":"version2","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "313"
+                - "303"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:54 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 8c5d5cbe-f770-4d11-b8ab-3ceb42541d99
+                - d078b877-2712-4c1d-a437-dc1681509bc4
         status: 200 OK
         code: 200
-        duration: 33.536269ms
+        duration: 34.802369ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1137,29 +1137,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bf74147-d3cb-44d5-a6bd-696bcb228a0a/versions/3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 312
-        body: '{"revision":3, "secret_id":"3bf74147-d3cb-44d5-a6bd-696bcb228a0a", "status":"enabled", "created_at":"2026-06-09T13:25:53.323072Z", "updated_at":"2026-06-09T13:25:53.323072Z", "deleted_at":null, "description":"version3", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 229
+        body: '{"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","revision":1,"data":"QVFBQUFBRVVHQUZNVEF5QVdDMDBoTHM1TTk3dUUzMFJaQnd1VUQrUHJ1NEdIVWtQZkJiK291OXBlOE1ac05FdWdtcTE0Ukt6TE5IYTArakxTMm9SWEkwPQ==","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "312"
+                - "229"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:54 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 74abce48-ef6e-42d1-bb6d-5c7480d341db
+                - 9bd450ad-3f49-4fe7-800d-c09cde19dc75
         status: 200 OK
         code: 200
-        duration: 31.281244ms
+        duration: 50.927465ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1169,29 +1169,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bf74147-d3cb-44d5-a6bd-696bcb228a0a/versions/1/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions/2/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 233
-        body: '{"secret_id":"3bf74147-d3cb-44d5-a6bd-696bcb228a0a", "revision":1, "data":"QVFBQUFBRVd1cVJQUnpXbFZRQXZZWWtvaS81NTZqTjBpbVNidEZaZ0ZEaFVJVmkyM3gxeDhvWitRT2tPMW1uNGUwL3c4ejBXTkZyZTdBWFNRc3p4VURjPQ==", "data_crc32":null, "type":"opaque"}'
+        content_length: 181
+        body: '{"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","revision":2,"data":"Lu+/vWcE77+9BSRB77+9QO+/ve+/vSwl77+9I++/vWllaUQt77+977+9FTzVl++/ve+/vRoC","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "233"
+                - "181"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:54 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 7c6e882a-70f8-4c4f-bd7e-9aa6757ff50a
+                - dff4acc0-486b-4cf8-af85-387c5f5d83ff
         status: 200 OK
         code: 200
-        duration: 104.660955ms
+        duration: 34.129164ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1201,29 +1201,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bf74147-d3cb-44d5-a6bd-696bcb228a0a/versions/3/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions/3
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 193
-        body: '{"secret_id":"3bf74147-d3cb-44d5-a6bd-696bcb228a0a", "revision":3, "data":"ce+/vSTvv73vv73vv73vv71Y77+977+9BcWH77+9x4Xvv71QA++/ve+/vR9kU++/vVXvv708HQNG77+9", "data_crc32":null, "type":"opaque"}'
+        content_length: 302
+        body: '{"revision":3,"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","status":"enabled","created_at":"2026-07-03T15:28:22.280312Z","updated_at":"2026-07-03T15:28:22.280312Z","deleted_at":null,"description":"version3","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "193"
+                - "302"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:54 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 98b73ecc-37cd-4abd-9acd-1e8750b0cc55
+                - 5805b27a-ae5e-4b1c-b4ca-8982168eb60e
         status: 200 OK
         code: 200
-        duration: 37.662815ms
+        duration: 38.281894ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1233,29 +1233,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bf74147-d3cb-44d5-a6bd-696bcb228a0a/versions/2/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 193
-        body: '{"secret_id":"3bf74147-d3cb-44d5-a6bd-696bcb228a0a", "revision":2, "data":"ce+/vSTvv73vv73vv73vv71Y77+977+9BcWH77+9x4Xvv71QA++/ve+/vR9kU++/vVXvv708HQNG77+9", "data_crc32":null, "type":"opaque"}'
+        content_length: 303
+        body: '{"revision":1,"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","status":"enabled","created_at":"2026-07-03T15:28:21.922749Z","updated_at":"2026-07-03T15:28:21.922749Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "193"
+                - "303"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:54 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 614c510c-9ce7-4388-a8df-246380c2dcfc
+                - ebe0bae6-1009-43e2-94f1-ed2d13a9822e
         status: 200 OK
         code: 200
-        duration: 86.405704ms
+        duration: 37.087771ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1265,29 +1265,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bf74147-d3cb-44d5-a6bd-696bcb228a0a/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 313
-        body: '{"revision":1, "secret_id":"3bf74147-d3cb-44d5-a6bd-696bcb228a0a", "status":"enabled", "created_at":"2026-06-09T13:25:52.948906Z", "updated_at":"2026-06-09T13:25:52.948906Z", "deleted_at":null, "description":"version1", "latest":false, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 303
+        body: '{"revision":2,"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","status":"enabled","created_at":"2026-07-03T15:28:22.122929Z","updated_at":"2026-07-03T15:28:22.122929Z","deleted_at":null,"description":"version2","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "313"
+                - "303"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:54 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 5ac89cd2-f240-4555-9590-9e0ac23ca8bf
+                - 3137d21a-43e9-4619-bc4c-125a6187f59c
         status: 200 OK
         code: 200
-        duration: 35.537909ms
+        duration: 40.273334ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1297,29 +1297,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bf74147-d3cb-44d5-a6bd-696bcb228a0a/versions/3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions/3/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 312
-        body: '{"revision":3, "secret_id":"3bf74147-d3cb-44d5-a6bd-696bcb228a0a", "status":"enabled", "created_at":"2026-06-09T13:25:53.323072Z", "updated_at":"2026-06-09T13:25:53.323072Z", "deleted_at":null, "description":"version3", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 181
+        body: '{"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","revision":3,"data":"Lu+/vWcE77+9BSRB77+9QO+/ve+/vSwl77+9I++/vWllaUQt77+977+9FTzVl++/ve+/vRoC","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "312"
+                - "181"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:54 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 731420ca-4b4e-436d-934c-b78c0a12a646
+                - 79dad355-7dfb-4493-b7ff-38c997f3e603
         status: 200 OK
         code: 200
-        duration: 33.052712ms
+        duration: 41.328056ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -1329,29 +1329,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bf74147-d3cb-44d5-a6bd-696bcb228a0a/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions/3
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 313
-        body: '{"revision":2, "secret_id":"3bf74147-d3cb-44d5-a6bd-696bcb228a0a", "status":"enabled", "created_at":"2026-06-09T13:25:53.157048Z", "updated_at":"2026-06-09T13:25:53.157048Z", "deleted_at":null, "description":"version2", "latest":false, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 302
+        body: '{"revision":3,"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","status":"enabled","created_at":"2026-07-03T15:28:22.280312Z","updated_at":"2026-07-03T15:28:22.280312Z","deleted_at":null,"description":"version3","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "313"
+                - "302"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:54 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 835e9d7b-2b77-484f-a61b-0b61d1b44017
+                - fe09a149-009c-4df1-92c8-d551f507ea94
         status: 200 OK
         code: 200
-        duration: 33.581291ms
+        duration: 36.951465ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -1361,8 +1361,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bf74147-d3cb-44d5-a6bd-696bcb228a0a/versions/3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions/3
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1374,14 +1374,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:54 GMT
+                - Fri, 03 Jul 2026 15:28:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - c11d5091-718d-4064-8eb6-0dc3616e1ebf
+                - b4ed9767-a2e1-4a9c-a1d1-b48fceef391f
         status: 204 No Content
         code: 204
-        duration: 95.504628ms
+        duration: 68.708644ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -1391,8 +1391,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bf74147-d3cb-44d5-a6bd-696bcb228a0a/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions/2
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1404,14 +1404,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:55 GMT
+                - Fri, 03 Jul 2026 15:28:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 9095d118-f6a1-4062-b6ac-fc7b506a7fce
+                - 6738a058-96ed-45f4-865a-1b0934fdc20f
         status: 204 No Content
         code: 204
-        duration: 99.093462ms
+        duration: 76.660189ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -1421,8 +1421,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bf74147-d3cb-44d5-a6bd-696bcb228a0a/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions/1
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1434,14 +1434,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:55 GMT
+                - Fri, 03 Jul 2026 15:28:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 46b8d326-10ee-4e59-b224-eef91309095d
+                - b0687318-3ccd-46ea-9d04-26cedecd1e91
         status: 204 No Content
         code: 204
-        duration: 54.832137ms
+        duration: 60.39015ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -1451,8 +1451,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/b45ce445-6827-4bd9-8a80-36d701b376cf
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1464,14 +1464,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:55 GMT
+                - Fri, 03 Jul 2026 15:28:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - f8a319c4-1ec4-4e2a-94ec-fd9998cded0f
+                - bde4f5be-53a8-4702-b565-bed3134ac82a
         status: 204 No Content
         code: 204
-        duration: 114.649263ms
+        duration: 68.479113ms
     - id: 45
       request:
         proto: HTTP/1.1
@@ -1481,8 +1481,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bf74147-d3cb-44d5-a6bd-696bcb228a0a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/eb04b054-d2ff-4deb-9d9e-c3b297c9a814
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1494,11 +1494,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:55 GMT
+                - Fri, 03 Jul 2026 15:28:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 412a8b39-8e40-4062-bd03-2080566f8068
+                - 29c878e2-f5c7-44a1-970c-b3b8b0876ff3
         status: 204 No Content
         code: 204
-        duration: 115.36792ms
+        duration: 71.95949ms

--- a/internal/services/keymanager/testdata/generate-data-key-ephemeral-resource-without-plaintext.cassette.yaml
+++ b/internal/services/keymanager/testdata/generate-data-key-ephemeral-resource-without-plaintext.cassette.yaml
@@ -6,6 +6,41 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
+        content_length: 242
+        host: api.scaleway.com
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-generate-no-plaintext","usage":{"symmetric_encryption":"aes_256_gcm"},"tags":null,"unprotected":true,"origin":"unknown_origin","protection_level":"unknown_protection_level"}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 535
+        body: '{"id":"23871059-a682-4a9d-9cc7-f9e5588a7555","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-generate-no-plaintext","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:22.769593Z","updated_at":"2026-07-03T15:28:22.772636Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:22.772636Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "535"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 6435db61-4cf2-4d3f-81aa-aa9554d5535b
+        status: 200 OK
+        code: 200
+        duration: 97.903429ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
         content_length: 153
         host: api.scaleway.com
         body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-data-key-secret-no-plaintext","tags":null,"type":"opaque","path":"/","protected":false}'
@@ -13,30 +48,30 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 464
-        body: '{"id":"8d173cae-bb8b-43ec-a539-274ef498f9db", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"test-data-key-secret-no-plaintext", "status":"ready", "created_at":"2026-06-09T13:25:52.437340Z", "updated_at":"2026-06-09T13:25:52.437340Z", "tags":[], "version_count":0, "description":"", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}'
+        content_length: 447
+        body: '{"id":"64b52306-403c-4d7c-be75-1ae72babf99d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-data-key-secret-no-plaintext","status":"ready","created_at":"2026-07-03T15:28:22.792157Z","updated_at":"2026-07-03T15:28:22.792157Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "464"
+                - "447"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:52 GMT
+                - Fri, 03 Jul 2026 15:28:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - db0b4415-3e15-4f6c-ae8e-6e4184b51d39
+                - ae31fde5-37b1-4332-8c19-8d104a9821c3
         status: 200 OK
         code: 200
-        duration: 228.982354ms
-    - id: 1
+        duration: 126.964464ms
+    - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -45,64 +80,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8d173cae-bb8b-43ec-a539-274ef498f9db
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/23871059-a682-4a9d-9cc7-f9e5588a7555
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 464
-        body: '{"id":"8d173cae-bb8b-43ec-a539-274ef498f9db", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"test-data-key-secret-no-plaintext", "status":"ready", "created_at":"2026-06-09T13:25:52.437340Z", "updated_at":"2026-06-09T13:25:52.437340Z", "tags":[], "version_count":0, "description":"", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}'
+        content_length: 535
+        body: '{"id":"23871059-a682-4a9d-9cc7-f9e5588a7555","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-generate-no-plaintext","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:22.769593Z","updated_at":"2026-07-03T15:28:22.772636Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:22.772636Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "464"
+                - "535"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:52 GMT
+                - Fri, 03 Jul 2026 15:28:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - e9e18bff-9373-4532-8330-5a04c220d14b
+                - 1e9e5205-7dbf-403e-8b33-33491d4d1d52
         status: 200 OK
         code: 200
-        duration: 87.276466ms
-    - id: 2
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 196
-        host: api.scaleway.com
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-generate-no-plaintext","usage":{"symmetric_encryption":"aes_256_gcm"},"tags":null,"unprotected":true,"origin":"unknown_origin"}'
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 521
-        body: '{"id":"a5ff5882-80a6-4b81-8d28-f3450cfc2f73", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-generate-no-plaintext", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-09T13:25:52.555111Z", "updated_at":"2026-06-09T13:25:52.558456Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-09T13:25:52.558456Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "521"
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 09 Jun 2026 13:25:52 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            X-Request-Id:
-                - 74223927-1a29-4dd6-8c5b-c53d7cea90f8
-        status: 200 OK
-        code: 200
-        duration: 351.678554ms
+        duration: 45.368264ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -110,67 +110,32 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: api.scaleway.com
-        form:
-            page:
-                - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8d173cae-bb8b-43ec-a539-274ef498f9db/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/64b52306-403c-4d7c-be75-1ae72babf99d
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 32
-        body: '{"versions":[], "total_count":0}'
+        content_length: 447
+        body: '{"id":"64b52306-403c-4d7c-be75-1ae72babf99d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-data-key-secret-no-plaintext","status":"ready","created_at":"2026-07-03T15:28:22.792157Z","updated_at":"2026-07-03T15:28:22.792157Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "32"
+                - "447"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:52 GMT
+                - Fri, 03 Jul 2026 15:28:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - fdf3d4ee-db2e-4037-a4a7-bc35910c4b2d
+                - c7f6d893-318d-456d-a135-2b5e55513926
         status: 200 OK
         code: 200
-        duration: 78.868174ms
+        duration: 48.322573ms
     - id: 4
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/a5ff5882-80a6-4b81-8d28-f3450cfc2f73
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 521
-        body: '{"id":"a5ff5882-80a6-4b81-8d28-f3450cfc2f73", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-generate-no-plaintext", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-09T13:25:52.555111Z", "updated_at":"2026-06-09T13:25:52.558456Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-09T13:25:52.558456Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "521"
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 09 Jun 2026 13:25:52 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            X-Request-Id:
-                - a61cfa34-2fbf-46c1-b0c3-7d165983e5bf
-        status: 200 OK
-        code: 200
-        duration: 82.892616ms
-    - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -182,29 +147,64 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/a5ff5882-80a6-4b81-8d28-f3450cfc2f73/generate-data-key
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/23871059-a682-4a9d-9cc7-f9e5588a7555/generate-data-key
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 246
-        body: '{"key_id":"a5ff5882-80a6-4b81-8d28-f3450cfc2f73", "algorithm":"aes_256_gcm", "ciphertext":"AQAAAAGkK78eSSAP78R6hidK0Y1rS3z6eD1m9UXwYPnc+fEaNIFWf2oUIvj9wjLDhlOgHVmN5o+Umx3MQZPjpPo=", "plaintext":null, "created_at":"2026-06-09T13:25:52.752191226Z"}'
+        content_length: 242
+        body: '{"key_id":"23871059-a682-4a9d-9cc7-f9e5588a7555","algorithm":"aes_256_gcm","ciphertext":"AQAAAAEGUgHxjUD/MrVtJ7GNV+R8iqUwPBD49I8Y9jawCNLQSbLTfu4dvk64yL8hYKIb6fe1O0WCGiwjnByWhug=","plaintext":null,"created_at":"2026-07-03T15:28:22.920607339Z"}'
         headers:
             Content-Length:
-                - "246"
+                - "242"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:52 GMT
+                - Fri, 03 Jul 2026 15:28:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 9b7a9760-74a4-4177-bf62-6774ef3ccb74
+                - 8b7386ac-ca95-43de-b099-ab4bff88c442
         status: 200 OK
         code: 200
-        duration: 86.950629ms
+        duration: 57.640474ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/64b52306-403c-4d7c-be75-1ae72babf99d/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 31
+        body: '{"versions":[],"total_count":0}'
+        headers:
+            Content-Length:
+                - "31"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 40e1c0bf-b4c1-4a1c-8d3d-0366440c7049
+        status: 200 OK
+        code: 200
+        duration: 40.539134ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -212,34 +212,34 @@ interactions:
         proto_minor: 1
         content_length: 156
         host: api.scaleway.com
-        body: '{"data":"QVFBQUFBR2tLNzhlU1NBUDc4UjZoaWRLMFkxclMzejZlRDFtOVVYd1lQbmMrZkVhTklGV2Yyb1VJdmo5d2pMRGhsT2dIVm1ONW8rVW14M01RWlBqcFBvPQ==","description":"version1"}'
+        body: '{"data":"QVFBQUFBRUdVZ0h4alVEL01yVnRKN0dOVitSOGlxVXdQQkQ0OUk4WTlqYXdDTkxRU2JMVGZ1NGR2azY0eUw4aFlLSWI2ZmUxTzBXQ0dpd2puQnlXaHVnPQ==","description":"version1"}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8d173cae-bb8b-43ec-a539-274ef498f9db/versions
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/64b52306-403c-4d7c-be75-1ae72babf99d/versions
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 312
-        body: '{"revision":1, "secret_id":"8d173cae-bb8b-43ec-a539-274ef498f9db", "status":"enabled", "created_at":"2026-06-09T13:25:53.080358Z", "updated_at":"2026-06-09T13:25:53.080358Z", "deleted_at":null, "description":"version1", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 302
+        body: '{"revision":1,"secret_id":"64b52306-403c-4d7c-be75-1ae72babf99d","status":"enabled","created_at":"2026-07-03T15:28:23.222459Z","updated_at":"2026-07-03T15:28:23.222459Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "312"
+                - "302"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:53 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 5c67312b-55ab-4c3a-b54a-6f3e9786d1a1
+                - 5ece8538-afec-4c07-9319-6d03085f9d1a
         status: 200 OK
         code: 200
-        duration: 367.13941ms
+        duration: 299.622704ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -249,29 +249,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8d173cae-bb8b-43ec-a539-274ef498f9db/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/64b52306-403c-4d7c-be75-1ae72babf99d/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 312
-        body: '{"revision":1, "secret_id":"8d173cae-bb8b-43ec-a539-274ef498f9db", "status":"enabled", "created_at":"2026-06-09T13:25:53.080358Z", "updated_at":"2026-06-09T13:25:53.080358Z", "deleted_at":null, "description":"version1", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 302
+        body: '{"revision":1,"secret_id":"64b52306-403c-4d7c-be75-1ae72babf99d","status":"enabled","created_at":"2026-07-03T15:28:23.222459Z","updated_at":"2026-07-03T15:28:23.222459Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "312"
+                - "302"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:53 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 9c078348-71ab-47e3-a82d-4e540d5674d6
+                - 616890f9-7e8a-4100-aeff-898e8848a1fd
         status: 200 OK
         code: 200
-        duration: 31.276786ms
+        duration: 39.750091ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -281,30 +281,62 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8d173cae-bb8b-43ec-a539-274ef498f9db/versions/1/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/64b52306-403c-4d7c-be75-1ae72babf99d/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 233
-        body: '{"secret_id":"8d173cae-bb8b-43ec-a539-274ef498f9db", "revision":1, "data":"QVFBQUFBR2tLNzhlU1NBUDc4UjZoaWRLMFkxclMzejZlRDFtOVVYd1lQbmMrZkVhTklGV2Yyb1VJdmo5d2pMRGhsT2dIVm1ONW8rVW14M01RWlBqcFBvPQ==", "data_crc32":null, "type":"opaque"}'
+        content_length: 229
+        body: '{"secret_id":"64b52306-403c-4d7c-be75-1ae72babf99d","revision":1,"data":"QVFBQUFBRUdVZ0h4alVEL01yVnRKN0dOVitSOGlxVXdQQkQ0OUk4WTlqYXdDTkxRU2JMVGZ1NGR2azY0eUw4aFlLSWI2ZmUxTzBXQ0dpd2puQnlXaHVnPQ==","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "233"
+                - "229"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:53 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 710f3359-5e88-4a73-b1c5-6367385cc5a2
+                - 9cb83b0b-b07a-49bc-97e7-ebb3a1a97f4d
         status: 200 OK
         code: 200
-        duration: 101.495664ms
+        duration: 76.031658ms
     - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/64b52306-403c-4d7c-be75-1ae72babf99d/versions/1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 302
+        body: '{"revision":1,"secret_id":"64b52306-403c-4d7c-be75-1ae72babf99d","status":"enabled","created_at":"2026-07-03T15:28:23.222459Z","updated_at":"2026-07-03T15:28:23.222459Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "302"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 91813379-f087-4ca1-9012-d06d26ebbad8
+        status: 200 OK
+        code: 200
+        duration: 36.188051ms
+    - id: 10
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -316,61 +348,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8d173cae-bb8b-43ec-a539-274ef498f9db/versions
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/64b52306-403c-4d7c-be75-1ae72babf99d/versions
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 312
-        body: '{"revision":2, "secret_id":"8d173cae-bb8b-43ec-a539-274ef498f9db", "status":"enabled", "created_at":"2026-06-09T13:25:53.269888Z", "updated_at":"2026-06-09T13:25:53.269888Z", "deleted_at":null, "description":"version2", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 302
+        body: '{"revision":2,"secret_id":"64b52306-403c-4d7c-be75-1ae72babf99d","status":"enabled","created_at":"2026-07-03T15:28:23.416588Z","updated_at":"2026-07-03T15:28:23.416588Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "312"
+                - "302"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:53 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 0657f93a-0e87-4e18-9245-56986e8a5a3d
+                - b4b33060-c52a-4d27-93be-99b9a559e135
         status: 200 OK
         code: 200
-        duration: 123.255367ms
-    - id: 10
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8d173cae-bb8b-43ec-a539-274ef498f9db/versions/1
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 313
-        body: '{"revision":1, "secret_id":"8d173cae-bb8b-43ec-a539-274ef498f9db", "status":"enabled", "created_at":"2026-06-09T13:25:53.080358Z", "updated_at":"2026-06-09T13:25:53.080358Z", "deleted_at":null, "description":"version1", "latest":false, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "313"
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 09 Jun 2026 13:25:53 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            X-Request-Id:
-                - 9e258d7b-31fc-4b37-9864-7a412d492cce
-        status: 200 OK
-        code: 200
-        duration: 47.525353ms
+        duration: 144.465476ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -380,29 +380,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8d173cae-bb8b-43ec-a539-274ef498f9db/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/64b52306-403c-4d7c-be75-1ae72babf99d/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 312
-        body: '{"revision":2, "secret_id":"8d173cae-bb8b-43ec-a539-274ef498f9db", "status":"enabled", "created_at":"2026-06-09T13:25:53.269888Z", "updated_at":"2026-06-09T13:25:53.269888Z", "deleted_at":null, "description":"version2", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 302
+        body: '{"revision":2,"secret_id":"64b52306-403c-4d7c-be75-1ae72babf99d","status":"enabled","created_at":"2026-07-03T15:28:23.416588Z","updated_at":"2026-07-03T15:28:23.416588Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "312"
+                - "302"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:53 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - a3e43be3-7c6b-4476-b7e1-51deb5d9b120
+                - f8f8155d-2f78-45ac-ac2d-a81c4bfea295
         status: 200 OK
         code: 200
-        duration: 33.224618ms
+        duration: 40.7397ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -412,29 +412,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8d173cae-bb8b-43ec-a539-274ef498f9db/versions/2/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/64b52306-403c-4d7c-be75-1ae72babf99d/versions/2/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 141
-        body: '{"secret_id":"8d173cae-bb8b-43ec-a539-274ef498f9db", "revision":2, "data":"cGxhaW50ZXh0IHdhcyBlbXB0eQ==", "data_crc32":null, "type":"opaque"}'
+        content_length: 137
+        body: '{"secret_id":"64b52306-403c-4d7c-be75-1ae72babf99d","revision":2,"data":"cGxhaW50ZXh0IHdhcyBlbXB0eQ==","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "141"
+                - "137"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:53 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 9cea20a1-a49c-4a45-a2b2-db9a59a556c0
+                - 364a9b50-6f5a-4335-84ce-a21a206a3076
         status: 200 OK
         code: 200
-        duration: 102.067963ms
+        duration: 122.385434ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -444,29 +444,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8d173cae-bb8b-43ec-a539-274ef498f9db/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/64b52306-403c-4d7c-be75-1ae72babf99d/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 312
-        body: '{"revision":2, "secret_id":"8d173cae-bb8b-43ec-a539-274ef498f9db", "status":"enabled", "created_at":"2026-06-09T13:25:53.269888Z", "updated_at":"2026-06-09T13:25:53.269888Z", "deleted_at":null, "description":"version2", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 302
+        body: '{"revision":2,"secret_id":"64b52306-403c-4d7c-be75-1ae72babf99d","status":"enabled","created_at":"2026-07-03T15:28:23.416588Z","updated_at":"2026-07-03T15:28:23.416588Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "312"
+                - "302"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:53 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 60ad53d7-5c0a-48e5-865d-a52168644d6c
+                - ae84374a-f129-4dcf-b79b-1b1d9bfe3cd9
         status: 200 OK
         code: 200
-        duration: 34.832656ms
+        duration: 45.701851ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -479,29 +479,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/a5ff5882-80a6-4b81-8d28-f3450cfc2f73/generate-data-key
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/23871059-a682-4a9d-9cc7-f9e5588a7555/generate-data-key
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 246
-        body: '{"key_id":"a5ff5882-80a6-4b81-8d28-f3450cfc2f73", "algorithm":"aes_256_gcm", "ciphertext":"AQAAAAFAjAysYyw84VG9B8IPrE2HHKJxGqKrS1gJr5uftAk4BxQF3zah5sLY+5fJuCSKSX2KPybFhnKA2WUAjfc=", "plaintext":null, "created_at":"2026-06-09T13:25:53.681651688Z"}'
+        content_length: 242
+        body: '{"key_id":"23871059-a682-4a9d-9cc7-f9e5588a7555","algorithm":"aes_256_gcm","ciphertext":"AQAAAAHlMIVz7r5O4Ox3i2OABVwlBq9mFsoDiORz1JscCAaYp77d1Ao8wCZI64VeyeidHhxuUwrcJaPyaMa+zhk=","plaintext":null,"created_at":"2026-07-03T15:28:24.001504920Z"}'
         headers:
             Content-Length:
-                - "246"
+                - "242"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:53 GMT
+                - Fri, 03 Jul 2026 15:28:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - e496276a-ef8f-47d4-9ba7-774d5707e344
+                - 12516d92-baae-45a0-a421-cf74d133ae6f
         status: 200 OK
         code: 200
-        duration: 43.215599ms
+        duration: 56.47201ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -511,29 +511,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8d173cae-bb8b-43ec-a539-274ef498f9db/versions/2/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/64b52306-403c-4d7c-be75-1ae72babf99d/versions/2/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 141
-        body: '{"secret_id":"8d173cae-bb8b-43ec-a539-274ef498f9db", "revision":2, "data":"cGxhaW50ZXh0IHdhcyBlbXB0eQ==", "data_crc32":null, "type":"opaque"}'
+        content_length: 137
+        body: '{"secret_id":"64b52306-403c-4d7c-be75-1ae72babf99d","revision":2,"data":"cGxhaW50ZXh0IHdhcyBlbXB0eQ==","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "141"
+                - "137"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:53 GMT
+                - Fri, 03 Jul 2026 15:28:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - bfb95544-aede-4cc4-bff2-de972a55b695
+                - 0662ceb9-10c1-4891-afe7-a84f3a4f7bb9
         status: 200 OK
         code: 200
-        duration: 37.197363ms
+        duration: 62.086326ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -543,29 +543,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8d173cae-bb8b-43ec-a539-274ef498f9db/versions/1/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/64b52306-403c-4d7c-be75-1ae72babf99d/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 233
-        body: '{"secret_id":"8d173cae-bb8b-43ec-a539-274ef498f9db", "revision":1, "data":"QVFBQUFBR2tLNzhlU1NBUDc4UjZoaWRLMFkxclMzejZlRDFtOVVYd1lQbmMrZkVhTklGV2Yyb1VJdmo5d2pMRGhsT2dIVm1ONW8rVW14M01RWlBqcFBvPQ==", "data_crc32":null, "type":"opaque"}'
+        content_length: 229
+        body: '{"secret_id":"64b52306-403c-4d7c-be75-1ae72babf99d","revision":1,"data":"QVFBQUFBRUdVZ0h4alVEL01yVnRKN0dOVitSOGlxVXdQQkQ0OUk4WTlqYXdDTkxRU2JMVGZ1NGR2azY0eUw4aFlLSWI2ZmUxTzBXQ0dpd2puQnlXaHVnPQ==","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "233"
+                - "229"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:53 GMT
+                - Fri, 03 Jul 2026 15:28:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - ac417107-3773-4d8a-9f84-ab096c49876f
+                - a37044dd-cdef-48fd-bd11-f8075e97ad82
         status: 200 OK
         code: 200
-        duration: 125.991765ms
+        duration: 65.836079ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -575,29 +575,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8d173cae-bb8b-43ec-a539-274ef498f9db/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/64b52306-403c-4d7c-be75-1ae72babf99d/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 312
-        body: '{"revision":2, "secret_id":"8d173cae-bb8b-43ec-a539-274ef498f9db", "status":"enabled", "created_at":"2026-06-09T13:25:53.269888Z", "updated_at":"2026-06-09T13:25:53.269888Z", "deleted_at":null, "description":"version2", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 302
+        body: '{"revision":2,"secret_id":"64b52306-403c-4d7c-be75-1ae72babf99d","status":"enabled","created_at":"2026-07-03T15:28:23.416588Z","updated_at":"2026-07-03T15:28:23.416588Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "312"
+                - "302"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:53 GMT
+                - Fri, 03 Jul 2026 15:28:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 7c6f0ed7-3457-4cfc-adc1-250453f386e7
+                - f77590db-d50e-4c8b-8365-b73dedc41136
         status: 200 OK
         code: 200
-        duration: 92.333562ms
+        duration: 41.112701ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -607,29 +607,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8d173cae-bb8b-43ec-a539-274ef498f9db/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/64b52306-403c-4d7c-be75-1ae72babf99d/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 313
-        body: '{"revision":1, "secret_id":"8d173cae-bb8b-43ec-a539-274ef498f9db", "status":"enabled", "created_at":"2026-06-09T13:25:53.080358Z", "updated_at":"2026-06-09T13:25:53.080358Z", "deleted_at":null, "description":"version1", "latest":false, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 303
+        body: '{"revision":1,"secret_id":"64b52306-403c-4d7c-be75-1ae72babf99d","status":"enabled","created_at":"2026-07-03T15:28:23.222459Z","updated_at":"2026-07-03T15:28:23.222459Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "313"
+                - "303"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:53 GMT
+                - Fri, 03 Jul 2026 15:28:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - bcaac489-f652-45f4-8e91-1992ced9b337
+                - f42b963d-fb3f-4a73-b1b8-dd1178db68db
         status: 200 OK
         code: 200
-        duration: 32.70767ms
+        duration: 42.120744ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -639,30 +639,62 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8d173cae-bb8b-43ec-a539-274ef498f9db
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/64b52306-403c-4d7c-be75-1ae72babf99d
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 464
-        body: '{"id":"8d173cae-bb8b-43ec-a539-274ef498f9db", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"test-data-key-secret-no-plaintext", "status":"ready", "created_at":"2026-06-09T13:25:52.437340Z", "updated_at":"2026-06-09T13:25:52.437340Z", "tags":[], "version_count":2, "description":"", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}'
+        content_length: 447
+        body: '{"id":"64b52306-403c-4d7c-be75-1ae72babf99d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-data-key-secret-no-plaintext","status":"ready","created_at":"2026-07-03T15:28:22.792157Z","updated_at":"2026-07-03T15:28:22.792157Z","tags":[],"version_count":2,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "464"
+                - "447"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:54 GMT
+                - Fri, 03 Jul 2026 15:28:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 69f9f088-7a3f-424d-8899-df1c7637bb7c
+                - da4c3dad-7d10-4bf9-9ebb-5fa8bb07f378
         status: 200 OK
         code: 200
-        duration: 36.845175ms
+        duration: 36.802846ms
     - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/23871059-a682-4a9d-9cc7-f9e5588a7555
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 535
+        body: '{"id":"23871059-a682-4a9d-9cc7-f9e5588a7555","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-generate-no-plaintext","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:22.769593Z","updated_at":"2026-07-03T15:28:22.772636Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:22.772636Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "535"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:24 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - b76fc425-2b6f-48ab-988e-d4a0533a644c
+        status: 200 OK
+        code: 200
+        duration: 46.637559ms
+    - id: 21
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -674,61 +706,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8d173cae-bb8b-43ec-a539-274ef498f9db/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/64b52306-403c-4d7c-be75-1ae72babf99d/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 659
-        body: '{"versions":[{"revision":2, "secret_id":"8d173cae-bb8b-43ec-a539-274ef498f9db", "status":"enabled", "created_at":"2026-06-09T13:25:53.269888Z", "updated_at":"2026-06-09T13:25:53.269888Z", "deleted_at":null, "description":"version2", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}, {"revision":1, "secret_id":"8d173cae-bb8b-43ec-a539-274ef498f9db", "status":"enabled", "created_at":"2026-06-09T13:25:53.080358Z", "updated_at":"2026-06-09T13:25:53.080358Z", "deleted_at":null, "description":"version1", "latest":false, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}], "total_count":2}'
+        content_length: 637
+        body: '{"versions":[{"revision":2,"secret_id":"64b52306-403c-4d7c-be75-1ae72babf99d","status":"enabled","created_at":"2026-07-03T15:28:23.416588Z","updated_at":"2026-07-03T15:28:23.416588Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"64b52306-403c-4d7c-be75-1ae72babf99d","status":"enabled","created_at":"2026-07-03T15:28:23.222459Z","updated_at":"2026-07-03T15:28:23.222459Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":2}'
         headers:
             Content-Length:
-                - "659"
+                - "637"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:54 GMT
+                - Fri, 03 Jul 2026 15:28:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 6d37030f-eb87-4917-af94-6c682c65c2a5
+                - 077b0593-fb5d-4248-abc6-fe653930fe54
         status: 200 OK
         code: 200
-        duration: 40.85665ms
-    - id: 21
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/a5ff5882-80a6-4b81-8d28-f3450cfc2f73
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 521
-        body: '{"id":"a5ff5882-80a6-4b81-8d28-f3450cfc2f73", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-generate-no-plaintext", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-09T13:25:52.555111Z", "updated_at":"2026-06-09T13:25:52.558456Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-09T13:25:52.558456Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "521"
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 09 Jun 2026 13:25:54 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            X-Request-Id:
-                - 02f1aae9-f9dd-4f61-b680-320200c62440
-        status: 200 OK
-        code: 200
-        duration: 90.110768ms
+        duration: 41.476985ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -741,29 +741,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/a5ff5882-80a6-4b81-8d28-f3450cfc2f73/generate-data-key
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/23871059-a682-4a9d-9cc7-f9e5588a7555/generate-data-key
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 246
-        body: '{"key_id":"a5ff5882-80a6-4b81-8d28-f3450cfc2f73", "algorithm":"aes_256_gcm", "ciphertext":"AQAAAAETsdfrR2OqAGZp6oK/Z/DXsdDpPrtEgSuKMhn1xybvLFkPUP8f8I2ScayeZcx3bQpj0ikwF2Gay57FJcw=", "plaintext":null, "created_at":"2026-06-09T13:25:54.236336603Z"}'
+        content_length: 242
+        body: '{"key_id":"23871059-a682-4a9d-9cc7-f9e5588a7555","algorithm":"aes_256_gcm","ciphertext":"AQAAAAGLdycwGEFXsfGt26yDotp01yTUbx/Y4EfXrtekKNYg6wcc3X+fONq33LRy2Ls1sCEmvMIlKAsXgjhdm0E=","plaintext":null,"created_at":"2026-07-03T15:28:24.605492584Z"}'
         headers:
             Content-Length:
-                - "246"
+                - "242"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:54 GMT
+                - Fri, 03 Jul 2026 15:28:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - d53ef4d5-67e7-4915-8c72-2e40586b2a24
+                - 57fdc5fc-f624-4f2c-8be5-31c11e3b716d
         status: 200 OK
         code: 200
-        duration: 85.099048ms
+        duration: 54.813214ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -773,29 +773,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8d173cae-bb8b-43ec-a539-274ef498f9db/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/64b52306-403c-4d7c-be75-1ae72babf99d/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 313
-        body: '{"revision":1, "secret_id":"8d173cae-bb8b-43ec-a539-274ef498f9db", "status":"enabled", "created_at":"2026-06-09T13:25:53.080358Z", "updated_at":"2026-06-09T13:25:53.080358Z", "deleted_at":null, "description":"version1", "latest":false, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 303
+        body: '{"revision":1,"secret_id":"64b52306-403c-4d7c-be75-1ae72babf99d","status":"enabled","created_at":"2026-07-03T15:28:23.222459Z","updated_at":"2026-07-03T15:28:23.222459Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "313"
+                - "303"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:54 GMT
+                - Fri, 03 Jul 2026 15:28:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 7c409e1d-c9a8-4c1a-97de-f16623b7f644
+                - b19fb4f7-43e1-4354-8cfc-8dfae0789e08
         status: 200 OK
         code: 200
-        duration: 33.707633ms
+        duration: 33.294085ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -805,29 +805,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8d173cae-bb8b-43ec-a539-274ef498f9db/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/64b52306-403c-4d7c-be75-1ae72babf99d/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 312
-        body: '{"revision":2, "secret_id":"8d173cae-bb8b-43ec-a539-274ef498f9db", "status":"enabled", "created_at":"2026-06-09T13:25:53.269888Z", "updated_at":"2026-06-09T13:25:53.269888Z", "deleted_at":null, "description":"version2", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 229
+        body: '{"secret_id":"64b52306-403c-4d7c-be75-1ae72babf99d","revision":1,"data":"QVFBQUFBRUdVZ0h4alVEL01yVnRKN0dOVitSOGlxVXdQQkQ0OUk4WTlqYXdDTkxRU2JMVGZ1NGR2azY0eUw4aFlLSWI2ZmUxTzBXQ0dpd2puQnlXaHVnPQ==","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "312"
+                - "229"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:54 GMT
+                - Fri, 03 Jul 2026 15:28:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 62ac512e-02f2-4bac-a02a-d9e763e1f5d5
+                - 2a42a9f4-85a0-4764-82b2-c4072f997180
         status: 200 OK
         code: 200
-        duration: 80.042558ms
+        duration: 49.820897ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -837,29 +837,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8d173cae-bb8b-43ec-a539-274ef498f9db/versions/1/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/64b52306-403c-4d7c-be75-1ae72babf99d/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 233
-        body: '{"secret_id":"8d173cae-bb8b-43ec-a539-274ef498f9db", "revision":1, "data":"QVFBQUFBR2tLNzhlU1NBUDc4UjZoaWRLMFkxclMzejZlRDFtOVVYd1lQbmMrZkVhTklGV2Yyb1VJdmo5d2pMRGhsT2dIVm1ONW8rVW14M01RWlBqcFBvPQ==", "data_crc32":null, "type":"opaque"}'
+        content_length: 302
+        body: '{"revision":2,"secret_id":"64b52306-403c-4d7c-be75-1ae72babf99d","status":"enabled","created_at":"2026-07-03T15:28:23.416588Z","updated_at":"2026-07-03T15:28:23.416588Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "233"
+                - "302"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:54 GMT
+                - Fri, 03 Jul 2026 15:28:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - daf4b4e2-55c2-49f6-811a-f41f8717865e
+                - e9487c3e-d9fd-4577-b4b6-98e026567831
         status: 200 OK
         code: 200
-        duration: 98.84936ms
+        duration: 53.762171ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -869,29 +869,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8d173cae-bb8b-43ec-a539-274ef498f9db/versions/2/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/64b52306-403c-4d7c-be75-1ae72babf99d/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 141
-        body: '{"secret_id":"8d173cae-bb8b-43ec-a539-274ef498f9db", "revision":2, "data":"cGxhaW50ZXh0IHdhcyBlbXB0eQ==", "data_crc32":null, "type":"opaque"}'
+        content_length: 303
+        body: '{"revision":1,"secret_id":"64b52306-403c-4d7c-be75-1ae72babf99d","status":"enabled","created_at":"2026-07-03T15:28:23.222459Z","updated_at":"2026-07-03T15:28:23.222459Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "141"
+                - "303"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:54 GMT
+                - Fri, 03 Jul 2026 15:28:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 98f37c3c-6c51-4e2b-be90-c89813ed47c6
+                - 6aaa39fb-79ed-475f-905b-f1ccb9517f3c
         status: 200 OK
         code: 200
-        duration: 49.770695ms
+        duration: 37.501858ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -901,29 +901,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8d173cae-bb8b-43ec-a539-274ef498f9db/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/64b52306-403c-4d7c-be75-1ae72babf99d/versions/2/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 313
-        body: '{"revision":1, "secret_id":"8d173cae-bb8b-43ec-a539-274ef498f9db", "status":"enabled", "created_at":"2026-06-09T13:25:53.080358Z", "updated_at":"2026-06-09T13:25:53.080358Z", "deleted_at":null, "description":"version1", "latest":false, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 137
+        body: '{"secret_id":"64b52306-403c-4d7c-be75-1ae72babf99d","revision":2,"data":"cGxhaW50ZXh0IHdhcyBlbXB0eQ==","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "313"
+                - "137"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:54 GMT
+                - Fri, 03 Jul 2026 15:28:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 93de55ef-581d-469e-83ad-17dbc56015f0
+                - e4b5bc7c-f684-41bc-a0dd-870a804930df
         status: 200 OK
         code: 200
-        duration: 43.929705ms
+        duration: 50.708385ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -933,29 +933,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8d173cae-bb8b-43ec-a539-274ef498f9db/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/64b52306-403c-4d7c-be75-1ae72babf99d/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 312
-        body: '{"revision":2, "secret_id":"8d173cae-bb8b-43ec-a539-274ef498f9db", "status":"enabled", "created_at":"2026-06-09T13:25:53.269888Z", "updated_at":"2026-06-09T13:25:53.269888Z", "deleted_at":null, "description":"version2", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 302
+        body: '{"revision":2,"secret_id":"64b52306-403c-4d7c-be75-1ae72babf99d","status":"enabled","created_at":"2026-07-03T15:28:23.416588Z","updated_at":"2026-07-03T15:28:23.416588Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "312"
+                - "302"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:54 GMT
+                - Fri, 03 Jul 2026 15:28:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 52cc9bff-9989-49a6-a3ae-cb721dfa9587
+                - 060ce88a-9327-4d34-b5e9-90f45e88003f
         status: 200 OK
         code: 200
-        duration: 32.486604ms
+        duration: 40.620237ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -965,8 +965,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8d173cae-bb8b-43ec-a539-274ef498f9db/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/64b52306-403c-4d7c-be75-1ae72babf99d/versions/2
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -978,14 +978,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:54 GMT
+                - Fri, 03 Jul 2026 15:28:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - a2924c85-8bb2-4b49-b5bd-deaef05505a0
+                - 50a50b38-a47c-41e7-9607-198e4ca297c6
         status: 204 No Content
         code: 204
-        duration: 97.427313ms
+        duration: 60.711463ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -995,8 +995,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8d173cae-bb8b-43ec-a539-274ef498f9db/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/64b52306-403c-4d7c-be75-1ae72babf99d/versions/1
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1008,14 +1008,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:54 GMT
+                - Fri, 03 Jul 2026 15:28:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 894e0875-e1b4-4ac4-9961-d77fc823e7fe
+                - c0791bbd-33b1-40e6-8f71-9e978fc4a069
         status: 204 No Content
         code: 204
-        duration: 93.816142ms
+        duration: 64.778693ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1025,8 +1025,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8d173cae-bb8b-43ec-a539-274ef498f9db
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/23871059-a682-4a9d-9cc7-f9e5588a7555
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1038,14 +1038,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:55 GMT
+                - Fri, 03 Jul 2026 15:28:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - b7fbfae4-e6aa-420b-9b59-abba28dbe006
+                - ce97ca39-bd70-4d75-8e02-340ae3e60872
         status: 204 No Content
         code: 204
-        duration: 124.275702ms
+        duration: 65.639088ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1055,8 +1055,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/a5ff5882-80a6-4b81-8d28-f3450cfc2f73
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/64b52306-403c-4d7c-be75-1ae72babf99d
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1068,11 +1068,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 09 Jun 2026 13:25:55 GMT
+                - Fri, 03 Jul 2026 15:28:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 48ed98ed-ffe4-4c64-bb75-4671c51bf513
+                - f29c1631-60f9-4f23-9c5e-72290bfd8baf
         status: 204 No Content
         code: 204
-        duration: 133.173864ms
+        duration: 79.904713ms

--- a/internal/services/keymanager/testdata/key-manager-key-basic.cassette.yaml
+++ b/internal/services/keymanager/testdata/key-manager-key-basic.cassette.yaml
@@ -6,36 +6,36 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 228
+        content_length: 274
         host: api.scaleway.com
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-unprotected","usage":{"symmetric_encryption":"aes_256_gcm"},"description":"Test key","tags":["tf","test"],"unprotected":true,"origin":"unknown_origin"}'
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-unprotected","usage":{"symmetric_encryption":"aes_256_gcm"},"description":"Test key","tags":["tf","test"],"unprotected":true,"origin":"unknown_origin","protection_level":"unknown_protection_level"}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 520
-        body: '{"id":"305d7194-c84d-4ea2-9822-5e255de06009","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-unprotected","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-06-05T16:02:09.309179Z","updated_at":"2026-06-05T16:02:09.312639Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-06-05T16:02:09.312639Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 550
+        body: '{"id":"b8ef9b77-3c91-4dba-8e1f-116757ff70f8","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-unprotected","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:24.115257Z","updated_at":"2026-07-03T15:28:24.119858Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:24.119858Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "520"
+                - "550"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Jun 2026 16:02:09 GMT
+                - Fri, 03 Jul 2026 15:28:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 864616bc-2181-47ca-8fc8-e026f4da53f5
+                - dc0cac25-b5b9-4d89-a910-79aa64f30515
         status: 200 OK
         code: 200
-        duration: 255.926494ms
+        duration: 204.280496ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -45,29 +45,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/305d7194-c84d-4ea2-9822-5e255de06009
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/b8ef9b77-3c91-4dba-8e1f-116757ff70f8
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 520
-        body: '{"id":"305d7194-c84d-4ea2-9822-5e255de06009","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-unprotected","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-06-05T16:02:09.309179Z","updated_at":"2026-06-05T16:02:09.312639Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-06-05T16:02:09.312639Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 550
+        body: '{"id":"b8ef9b77-3c91-4dba-8e1f-116757ff70f8","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-unprotected","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:24.115257Z","updated_at":"2026-07-03T15:28:24.119858Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:24.119858Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "520"
+                - "550"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Jun 2026 16:02:09 GMT
+                - Fri, 03 Jul 2026 15:28:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - e8c3250d-3557-4346-b729-bc14d2086b6f
+                - 35804dc3-db65-4e2f-888f-aa08e73e7c1b
         status: 200 OK
         code: 200
-        duration: 75.825473ms
+        duration: 48.347299ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -77,29 +77,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/305d7194-c84d-4ea2-9822-5e255de06009
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/b8ef9b77-3c91-4dba-8e1f-116757ff70f8
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 520
-        body: '{"id":"305d7194-c84d-4ea2-9822-5e255de06009","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-unprotected","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-06-05T16:02:09.309179Z","updated_at":"2026-06-05T16:02:09.312639Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-06-05T16:02:09.312639Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 550
+        body: '{"id":"b8ef9b77-3c91-4dba-8e1f-116757ff70f8","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-unprotected","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:24.115257Z","updated_at":"2026-07-03T15:28:24.119858Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:24.119858Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "520"
+                - "550"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Jun 2026 16:02:09 GMT
+                - Fri, 03 Jul 2026 15:28:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 156da7f6-0689-4685-8cee-1a87436e3bc6
+                - 31e345c2-8102-4db6-b929-80fd8e0b06ad
         status: 200 OK
         code: 200
-        duration: 159.508379ms
+        duration: 45.700669ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -109,8 +109,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/305d7194-c84d-4ea2-9822-5e255de06009
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/b8ef9b77-3c91-4dba-8e1f-116757ff70f8
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -122,14 +122,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Jun 2026 16:02:10 GMT
+                - Fri, 03 Jul 2026 15:28:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 597443b6-f540-41d7-acfb-02b16aa75e8c
+                - 9afe390a-8256-470b-9cf3-d117794f1cf8
         status: 204 No Content
         code: 204
-        duration: 100.703898ms
+        duration: 64.871496ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -139,26 +139,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/305d7194-c84d-4ea2-9822-5e255de06009
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/b8ef9b77-3c91-4dba-8e1f-116757ff70f8
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 560
-        body: '{"id":"305d7194-c84d-4ea2-9822-5e255de06009","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-unprotected","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-06-05T16:02:09.309179Z","updated_at":"2026-06-05T16:02:09.312639Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-06-05T16:02:09.312639Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-06-05T16:02:10.201531Z","region":"fr-par"}'
+        content_length: 590
+        body: '{"id":"b8ef9b77-3c91-4dba-8e1f-116757ff70f8","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-unprotected","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-03T15:28:24.115257Z","updated_at":"2026-07-03T15:28:25.465791Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:24.119858Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-03T15:28:25.465790Z","protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "560"
+                - "590"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Jun 2026 16:02:10 GMT
+                - Fri, 03 Jul 2026 15:28:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 12fa06c5-87b2-47e9-ac6e-9ed341c6a6a2
+                - c769c94a-52ae-411f-ade1-0715b1173200
         status: 200 OK
         code: 200
-        duration: 43.877584ms
+        duration: 40.056787ms

--- a/internal/services/keymanager/testdata/key-manager-key-default-algorithm.cassette.yaml
+++ b/internal/services/keymanager/testdata/key-manager-key-default-algorithm.cassette.yaml
@@ -6,36 +6,36 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 253
+        content_length: 299
         host: api.scaleway.com
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-default-alg","usage":{"asymmetric_encryption":"rsa_oaep_3072_sha256"},"description":"Test key with RSA-3072 algorithm","tags":null,"unprotected":true,"origin":"unknown_origin"}'
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-default-alg","usage":{"asymmetric_encryption":"rsa_oaep_3072_sha256"},"description":"Test key with RSA-3072 algorithm","tags":null,"unprotected":true,"origin":"unknown_origin","protection_level":"unknown_protection_level"}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 543
-        body: '{"id":"e9252d24-e463-4a3a-86a5-90a356f374ab","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-default-alg","usage":{"asymmetric_encryption":"rsa_oaep_3072_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-06-05T16:02:09.557573Z","updated_at":"2026-06-05T16:02:10.353754Z","protected":false,"locked":false,"description":"Test key with RSA-3072 algorithm","tags":[],"rotated_at":"2026-06-05T16:02:10.353754Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 573
+        body: '{"id":"c8c5298c-7ee8-4e8f-a430-5b5c3d8144c8","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-default-alg","usage":{"asymmetric_encryption":"rsa_oaep_3072_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:18.735474Z","updated_at":"2026-07-03T15:28:19.161311Z","protected":false,"locked":false,"description":"Test key with RSA-3072 algorithm","tags":[],"rotated_at":"2026-07-03T15:28:19.161311Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "543"
+                - "573"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Jun 2026 16:02:10 GMT
+                - Fri, 03 Jul 2026 15:28:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 50c49546-c23e-4992-a21f-9acb2948d3fd
+                - 884c922d-12a3-43df-9df1-91a02e8aff79
         status: 200 OK
         code: 200
-        duration: 1.299745176s
+        duration: 705.9361ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -45,29 +45,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/e9252d24-e463-4a3a-86a5-90a356f374ab
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/c8c5298c-7ee8-4e8f-a430-5b5c3d8144c8
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 543
-        body: '{"id":"e9252d24-e463-4a3a-86a5-90a356f374ab","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-default-alg","usage":{"asymmetric_encryption":"rsa_oaep_3072_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-06-05T16:02:09.557573Z","updated_at":"2026-06-05T16:02:10.353754Z","protected":false,"locked":false,"description":"Test key with RSA-3072 algorithm","tags":[],"rotated_at":"2026-06-05T16:02:10.353754Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 573
+        body: '{"id":"c8c5298c-7ee8-4e8f-a430-5b5c3d8144c8","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-default-alg","usage":{"asymmetric_encryption":"rsa_oaep_3072_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:18.735474Z","updated_at":"2026-07-03T15:28:19.161311Z","protected":false,"locked":false,"description":"Test key with RSA-3072 algorithm","tags":[],"rotated_at":"2026-07-03T15:28:19.161311Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "543"
+                - "573"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Jun 2026 16:02:10 GMT
+                - Fri, 03 Jul 2026 15:28:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 85941b39-4541-47b2-9d97-480227a776a2
+                - 5514f908-0898-4dcb-8682-330e63e4cdbb
         status: 200 OK
         code: 200
-        duration: 43.607798ms
+        duration: 87.571593ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -77,29 +77,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/e9252d24-e463-4a3a-86a5-90a356f374ab
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/c8c5298c-7ee8-4e8f-a430-5b5c3d8144c8
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 543
-        body: '{"id":"e9252d24-e463-4a3a-86a5-90a356f374ab","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-default-alg","usage":{"asymmetric_encryption":"rsa_oaep_3072_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-06-05T16:02:09.557573Z","updated_at":"2026-06-05T16:02:10.353754Z","protected":false,"locked":false,"description":"Test key with RSA-3072 algorithm","tags":[],"rotated_at":"2026-06-05T16:02:10.353754Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 573
+        body: '{"id":"c8c5298c-7ee8-4e8f-a430-5b5c3d8144c8","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-default-alg","usage":{"asymmetric_encryption":"rsa_oaep_3072_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:18.735474Z","updated_at":"2026-07-03T15:28:19.161311Z","protected":false,"locked":false,"description":"Test key with RSA-3072 algorithm","tags":[],"rotated_at":"2026-07-03T15:28:19.161311Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "543"
+                - "573"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Jun 2026 16:02:10 GMT
+                - Fri, 03 Jul 2026 15:28:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 61101e4d-ecd0-414c-8f86-8bd4a8794f71
+                - 57b5b742-65b4-4896-a051-504f313b1506
         status: 200 OK
         code: 200
-        duration: 109.390791ms
+        duration: 46.720323ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -109,8 +109,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/e9252d24-e463-4a3a-86a5-90a356f374ab
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/c8c5298c-7ee8-4e8f-a430-5b5c3d8144c8
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -122,14 +122,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Jun 2026 16:02:11 GMT
+                - Fri, 03 Jul 2026 15:28:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 9eab1844-7f15-417b-a4f2-8a501732edd9
+                - 83feeac2-9cc4-46d4-be0e-6aee687f283f
         status: 204 No Content
         code: 204
-        duration: 79.612679ms
+        duration: 102.37005ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -139,26 +139,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/e9252d24-e463-4a3a-86a5-90a356f374ab
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/c8c5298c-7ee8-4e8f-a430-5b5c3d8144c8
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 583
-        body: '{"id":"e9252d24-e463-4a3a-86a5-90a356f374ab","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-default-alg","usage":{"asymmetric_encryption":"rsa_oaep_3072_sha256"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-06-05T16:02:09.557573Z","updated_at":"2026-06-05T16:02:10.353754Z","protected":false,"locked":false,"description":"Test key with RSA-3072 algorithm","tags":[],"rotated_at":"2026-06-05T16:02:10.353754Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-06-05T16:02:11.109986Z","region":"fr-par"}'
+        content_length: 613
+        body: '{"id":"c8c5298c-7ee8-4e8f-a430-5b5c3d8144c8","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-default-alg","usage":{"asymmetric_encryption":"rsa_oaep_3072_sha256"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-03T15:28:18.735474Z","updated_at":"2026-07-03T15:28:20.321046Z","protected":false,"locked":false,"description":"Test key with RSA-3072 algorithm","tags":[],"rotated_at":"2026-07-03T15:28:19.161311Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-03T15:28:20.321046Z","protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "583"
+                - "613"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Jun 2026 16:02:11 GMT
+                - Fri, 03 Jul 2026 15:28:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - ff1c3d16-8348-462d-bd81-45279f9d00f5
+                - a00ea9cd-88e6-40e0-8b57-e582f8c82aa8
         status: 200 OK
         code: 200
-        duration: 40.532559ms
+        duration: 59.857118ms

--- a/internal/services/keymanager/testdata/key-manager-key-update.cassette.yaml
+++ b/internal/services/keymanager/testdata/key-manager-key-update.cassette.yaml
@@ -6,36 +6,36 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 223
+        content_length: 269
         host: api.scaleway.com
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-update","usage":{"symmetric_encryption":"aes_256_gcm"},"description":"Test key","tags":["tf","test"],"unprotected":true,"origin":"unknown_origin"}'
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-update","usage":{"symmetric_encryption":"aes_256_gcm"},"description":"Test key","tags":["tf","test"],"unprotected":true,"origin":"unknown_origin","protection_level":"unknown_protection_level"}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 515
-        body: '{"id":"fbb79521-f01a-4ab1-9467-2505388bf8b6","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-update","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-06-05T16:02:09.477240Z","updated_at":"2026-06-05T16:02:09.481066Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-06-05T16:02:09.481066Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 545
+        body: '{"id":"727f3036-5b41-4ff2-ba78-b622b07430ab","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-update","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:23.841284Z","updated_at":"2026-07-03T15:28:23.844354Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:23.844354Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "515"
+                - "545"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Jun 2026 16:02:09 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 0b119db3-d5f4-4277-8d08-b94558cf4214
+                - 616a2b9e-b801-44be-9144-1c884eae6681
         status: 200 OK
         code: 200
-        duration: 425.713378ms
+        duration: 91.357785ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -45,29 +45,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/fbb79521-f01a-4ab1-9467-2505388bf8b6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/727f3036-5b41-4ff2-ba78-b622b07430ab
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 515
-        body: '{"id":"fbb79521-f01a-4ab1-9467-2505388bf8b6","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-update","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-06-05T16:02:09.477240Z","updated_at":"2026-06-05T16:02:09.481066Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-06-05T16:02:09.481066Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 545
+        body: '{"id":"727f3036-5b41-4ff2-ba78-b622b07430ab","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-update","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:23.841284Z","updated_at":"2026-07-03T15:28:23.844354Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:23.844354Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "515"
+                - "545"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Jun 2026 16:02:09 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 880b45d1-8aac-4f9e-b148-d36f01b0acb6
+                - 1daf77e4-19c1-421d-a673-298bdfe51905
         status: 200 OK
         code: 200
-        duration: 152.410763ms
+        duration: 45.265661ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -77,29 +77,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/fbb79521-f01a-4ab1-9467-2505388bf8b6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/727f3036-5b41-4ff2-ba78-b622b07430ab
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 515
-        body: '{"id":"fbb79521-f01a-4ab1-9467-2505388bf8b6","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-update","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-06-05T16:02:09.477240Z","updated_at":"2026-06-05T16:02:09.481066Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-06-05T16:02:09.481066Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 545
+        body: '{"id":"727f3036-5b41-4ff2-ba78-b622b07430ab","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-update","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:23.841284Z","updated_at":"2026-07-03T15:28:23.844354Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:23.844354Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "515"
+                - "545"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Jun 2026 16:02:10 GMT
+                - Fri, 03 Jul 2026 15:28:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 5fdbc9b0-f6c0-461c-b71a-f21bcbac2bf4
+                - af9c86b3-c73f-4ea2-807c-39a39ea1dbde
         status: 200 OK
         code: 200
-        duration: 45.851593ms
+        duration: 47.143519ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -109,29 +109,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/fbb79521-f01a-4ab1-9467-2505388bf8b6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/727f3036-5b41-4ff2-ba78-b622b07430ab
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 515
-        body: '{"id":"fbb79521-f01a-4ab1-9467-2505388bf8b6","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-update","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-06-05T16:02:09.477240Z","updated_at":"2026-06-05T16:02:09.481066Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-06-05T16:02:09.481066Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 545
+        body: '{"id":"727f3036-5b41-4ff2-ba78-b622b07430ab","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-update","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:23.841284Z","updated_at":"2026-07-03T15:28:23.844354Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:23.844354Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "515"
+                - "545"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Jun 2026 16:02:10 GMT
+                - Fri, 03 Jul 2026 15:28:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 49827e1c-197a-4dcb-82b0-27d4eb467b3a
+                - 287f6099-f4b0-48f2-8fa1-a3169033f171
         status: 200 OK
         code: 200
-        duration: 71.552064ms
+        duration: 50.082468ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -144,29 +144,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/fbb79521-f01a-4ab1-9467-2505388bf8b6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/727f3036-5b41-4ff2-ba78-b622b07430ab
         method: PATCH
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 527
-        body: '{"id":"fbb79521-f01a-4ab1-9467-2505388bf8b6","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-updated","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-06-05T16:02:09.477240Z","updated_at":"2026-06-05T16:02:10.621317Z","protected":false,"locked":false,"description":"Test key updated","tags":["tf","updated"],"rotated_at":"2026-06-05T16:02:09.481066Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 557
+        body: '{"id":"727f3036-5b41-4ff2-ba78-b622b07430ab","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-updated","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:23.841284Z","updated_at":"2026-07-03T15:28:25.302477Z","protected":false,"locked":false,"description":"Test key updated","tags":["tf","updated"],"rotated_at":"2026-07-03T15:28:23.844354Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "527"
+                - "557"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Jun 2026 16:02:10 GMT
+                - Fri, 03 Jul 2026 15:28:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - be330f10-e30e-436b-af58-4c5fe941f7f1
+                - 2d10a794-bdee-4b75-a806-df221cbb1edb
         status: 200 OK
         code: 200
-        duration: 360.00279ms
+        duration: 91.364458ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -176,29 +176,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/fbb79521-f01a-4ab1-9467-2505388bf8b6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/727f3036-5b41-4ff2-ba78-b622b07430ab
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 527
-        body: '{"id":"fbb79521-f01a-4ab1-9467-2505388bf8b6","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-updated","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-06-05T16:02:09.477240Z","updated_at":"2026-06-05T16:02:10.621317Z","protected":false,"locked":false,"description":"Test key updated","tags":["tf","updated"],"rotated_at":"2026-06-05T16:02:09.481066Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 557
+        body: '{"id":"727f3036-5b41-4ff2-ba78-b622b07430ab","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-updated","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:23.841284Z","updated_at":"2026-07-03T15:28:25.302477Z","protected":false,"locked":false,"description":"Test key updated","tags":["tf","updated"],"rotated_at":"2026-07-03T15:28:23.844354Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "527"
+                - "557"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Jun 2026 16:02:10 GMT
+                - Fri, 03 Jul 2026 15:28:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 1faea6e9-72af-420d-bb0a-5f7bdf506fa8
+                - 9ae8f715-3d43-4dc7-8b01-499c47cb282b
         status: 200 OK
         code: 200
-        duration: 47.598826ms
+        duration: 39.36582ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -208,29 +208,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/fbb79521-f01a-4ab1-9467-2505388bf8b6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/727f3036-5b41-4ff2-ba78-b622b07430ab
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 527
-        body: '{"id":"fbb79521-f01a-4ab1-9467-2505388bf8b6","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-updated","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-06-05T16:02:09.477240Z","updated_at":"2026-06-05T16:02:10.621317Z","protected":false,"locked":false,"description":"Test key updated","tags":["tf","updated"],"rotated_at":"2026-06-05T16:02:09.481066Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 557
+        body: '{"id":"727f3036-5b41-4ff2-ba78-b622b07430ab","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-updated","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:23.841284Z","updated_at":"2026-07-03T15:28:25.302477Z","protected":false,"locked":false,"description":"Test key updated","tags":["tf","updated"],"rotated_at":"2026-07-03T15:28:23.844354Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "527"
+                - "557"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Jun 2026 16:02:11 GMT
+                - Fri, 03 Jul 2026 15:28:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - fc9afb65-9bea-4c6a-a388-5e58097d214a
+                - 4ab26d69-43d3-4b4d-8250-27418af82daa
         status: 200 OK
         code: 200
-        duration: 55.917938ms
+        duration: 52.759757ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -240,8 +240,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/fbb79521-f01a-4ab1-9467-2505388bf8b6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/727f3036-5b41-4ff2-ba78-b622b07430ab
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -253,14 +253,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Jun 2026 16:02:11 GMT
+                - Fri, 03 Jul 2026 15:28:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - e27aeecf-a4df-4e00-b7f3-27f052da53e3
+                - 7715483a-572c-4295-9002-2c460754f4c9
         status: 204 No Content
         code: 204
-        duration: 104.640976ms
+        duration: 63.379364ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -270,26 +270,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/fbb79521-f01a-4ab1-9467-2505388bf8b6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/727f3036-5b41-4ff2-ba78-b622b07430ab
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 567
-        body: '{"id":"fbb79521-f01a-4ab1-9467-2505388bf8b6","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-updated","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-06-05T16:02:09.477240Z","updated_at":"2026-06-05T16:02:10.621317Z","protected":false,"locked":false,"description":"Test key updated","tags":["tf","updated"],"rotated_at":"2026-06-05T16:02:09.481066Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-06-05T16:02:11.510969Z","region":"fr-par"}'
+        content_length: 597
+        body: '{"id":"727f3036-5b41-4ff2-ba78-b622b07430ab","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-updated","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-03T15:28:23.841284Z","updated_at":"2026-07-03T15:28:26.091009Z","protected":false,"locked":false,"description":"Test key updated","tags":["tf","updated"],"rotated_at":"2026-07-03T15:28:23.844354Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-03T15:28:26.091009Z","protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "567"
+                - "597"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Jun 2026 16:02:11 GMT
+                - Fri, 03 Jul 2026 15:28:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 97f4c646-09d8-42c4-9c1d-9d5a41ed5b41
+                - e0ccaf61-f810-4ac5-881a-fc2b980e0310
         status: 200 OK
         code: 200
-        duration: 33.250516ms
+        duration: 31.545431ms

--- a/internal/services/keymanager/testdata/key-manager-key-with-custom-algorithm.cassette.yaml
+++ b/internal/services/keymanager/testdata/key-manager-key-with-custom-algorithm.cassette.yaml
@@ -6,36 +6,36 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 249
+        content_length: 295
         host: api.scaleway.com
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rsa4096","usage":{"asymmetric_encryption":"rsa_oaep_4096_sha256"},"description":"Test key with RSA-4096 algorithm","tags":null,"unprotected":true,"origin":"unknown_origin"}'
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rsa4096","usage":{"asymmetric_encryption":"rsa_oaep_4096_sha256"},"description":"Test key with RSA-4096 algorithm","tags":null,"unprotected":true,"origin":"unknown_origin","protection_level":"unknown_protection_level"}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 539
-        body: '{"id":"a34645d0-4d68-4f52-8773-55ec94d3870d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rsa4096","usage":{"asymmetric_encryption":"rsa_oaep_4096_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-06-05T16:02:10.445801Z","updated_at":"2026-06-05T16:02:10.793381Z","protected":false,"locked":false,"description":"Test key with RSA-4096 algorithm","tags":[],"rotated_at":"2026-06-05T16:02:10.793381Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 569
+        body: '{"id":"886e4b8a-67b9-4e2b-afd2-2db763ca34ad","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rsa4096","usage":{"asymmetric_encryption":"rsa_oaep_4096_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:23.867332Z","updated_at":"2026-07-03T15:28:24.075023Z","protected":false,"locked":false,"description":"Test key with RSA-4096 algorithm","tags":[],"rotated_at":"2026-07-03T15:28:24.075023Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "539"
+                - "569"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Jun 2026 16:02:10 GMT
+                - Fri, 03 Jul 2026 15:28:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 545370fd-95ed-4e81-b843-7f3503bb896f
+                - 9ae680c2-5213-47c0-bb7a-018e232d1109
         status: 200 OK
         code: 200
-        duration: 1.725045978s
+        duration: 281.298035ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -45,29 +45,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/a34645d0-4d68-4f52-8773-55ec94d3870d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/886e4b8a-67b9-4e2b-afd2-2db763ca34ad
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 539
-        body: '{"id":"a34645d0-4d68-4f52-8773-55ec94d3870d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rsa4096","usage":{"asymmetric_encryption":"rsa_oaep_4096_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-06-05T16:02:10.445801Z","updated_at":"2026-06-05T16:02:10.793381Z","protected":false,"locked":false,"description":"Test key with RSA-4096 algorithm","tags":[],"rotated_at":"2026-06-05T16:02:10.793381Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 569
+        body: '{"id":"886e4b8a-67b9-4e2b-afd2-2db763ca34ad","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rsa4096","usage":{"asymmetric_encryption":"rsa_oaep_4096_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:23.867332Z","updated_at":"2026-07-03T15:28:24.075023Z","protected":false,"locked":false,"description":"Test key with RSA-4096 algorithm","tags":[],"rotated_at":"2026-07-03T15:28:24.075023Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "539"
+                - "569"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Jun 2026 16:02:10 GMT
+                - Fri, 03 Jul 2026 15:28:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - cc928806-35fd-4070-ba02-2cd3808c7e8d
+                - 4d9989f3-f228-4194-a15a-93a6d1241d07
         status: 200 OK
         code: 200
-        duration: 43.711162ms
+        duration: 52.880705ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -77,29 +77,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/a34645d0-4d68-4f52-8773-55ec94d3870d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/886e4b8a-67b9-4e2b-afd2-2db763ca34ad
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 539
-        body: '{"id":"a34645d0-4d68-4f52-8773-55ec94d3870d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rsa4096","usage":{"asymmetric_encryption":"rsa_oaep_4096_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-06-05T16:02:10.445801Z","updated_at":"2026-06-05T16:02:10.793381Z","protected":false,"locked":false,"description":"Test key with RSA-4096 algorithm","tags":[],"rotated_at":"2026-06-05T16:02:10.793381Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 569
+        body: '{"id":"886e4b8a-67b9-4e2b-afd2-2db763ca34ad","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rsa4096","usage":{"asymmetric_encryption":"rsa_oaep_4096_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:23.867332Z","updated_at":"2026-07-03T15:28:24.075023Z","protected":false,"locked":false,"description":"Test key with RSA-4096 algorithm","tags":[],"rotated_at":"2026-07-03T15:28:24.075023Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "539"
+                - "569"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Jun 2026 16:02:11 GMT
+                - Fri, 03 Jul 2026 15:28:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 7cbe1ac5-0f9e-43d7-8e5b-f5c1b10f6221
+                - e3dc39b6-028d-475b-9616-537601c3e4ad
         status: 200 OK
         code: 200
-        duration: 32.466924ms
+        duration: 45.411585ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -109,8 +109,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/a34645d0-4d68-4f52-8773-55ec94d3870d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/886e4b8a-67b9-4e2b-afd2-2db763ca34ad
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -122,14 +122,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Jun 2026 16:02:11 GMT
+                - Fri, 03 Jul 2026 15:28:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 5a225068-26ee-4b5d-8948-35532fe44eb4
+                - e3d532ca-9326-4311-9fe4-b3372c0c6ca6
         status: 204 No Content
         code: 204
-        duration: 118.500598ms
+        duration: 68.450469ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -139,26 +139,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/a34645d0-4d68-4f52-8773-55ec94d3870d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/886e4b8a-67b9-4e2b-afd2-2db763ca34ad
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 579
-        body: '{"id":"a34645d0-4d68-4f52-8773-55ec94d3870d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rsa4096","usage":{"asymmetric_encryption":"rsa_oaep_4096_sha256"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-06-05T16:02:10.445801Z","updated_at":"2026-06-05T16:02:10.793381Z","protected":false,"locked":false,"description":"Test key with RSA-4096 algorithm","tags":[],"rotated_at":"2026-06-05T16:02:10.793381Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-06-05T16:02:11.575025Z","region":"fr-par"}'
+        content_length: 609
+        body: '{"id":"886e4b8a-67b9-4e2b-afd2-2db763ca34ad","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rsa4096","usage":{"asymmetric_encryption":"rsa_oaep_4096_sha256"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-03T15:28:23.867332Z","updated_at":"2026-07-03T15:28:25.444364Z","protected":false,"locked":false,"description":"Test key with RSA-4096 algorithm","tags":[],"rotated_at":"2026-07-03T15:28:24.075023Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-03T15:28:25.444364Z","protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "579"
+                - "609"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Jun 2026 16:02:11 GMT
+                - Fri, 03 Jul 2026 15:28:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 086f4095-b813-4cb1-8cbe-790489423a9f
+                - 20b9ba12-7331-4ce4-a640-a36e30b527cb
         status: 200 OK
         code: 200
-        duration: 35.032104ms
+        duration: 47.731042ms

--- a/internal/services/keymanager/testdata/key-manager-key-with-rotation-policy.cassette.yaml
+++ b/internal/services/keymanager/testdata/key-manager-key-with-rotation-policy.cassette.yaml
@@ -6,36 +6,36 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 341
+        content_length: 387
         host: api.scaleway.com
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation","usage":{"symmetric_encryption":"aes_256_gcm"},"description":"Test key with rotation policy","tags":null,"rotation_policy":{"rotation_period":"3153600000.000000000s","next_rotation_at":"2027-01-01T00:00:00Z"},"unprotected":true,"origin":"unknown_origin"}'
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation","usage":{"symmetric_encryption":"aes_256_gcm"},"description":"Test key with rotation policy","tags":null,"rotation_policy":{"rotation_period":"3153600000.000000000s","next_rotation_at":"2027-01-01T00:00:00Z"},"unprotected":true,"origin":"unknown_origin","protection_level":"unknown_protection_level"}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 598
-        body: '{"id":"40bdc7c3-41e9-4551-8baa-b68ed628998e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-06-05T16:02:09.394434Z","updated_at":"2026-06-05T16:02:09.400155Z","protected":false,"locked":false,"description":"Test key with rotation policy","tags":[],"rotated_at":"2026-06-05T16:02:09.400155Z","rotation_policy":{"rotation_period":"3153600000s","next_rotation_at":"2027-01-01T00:00:00Z"},"origin":"scaleway_kms","deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 628
+        body: '{"id":"d2371ecf-fbac-4d74-9be4-43f6c89a764f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:24.096639Z","updated_at":"2026-07-03T15:28:24.099582Z","protected":false,"locked":false,"description":"Test key with rotation policy","tags":[],"rotated_at":"2026-07-03T15:28:24.099582Z","rotation_policy":{"rotation_period":"3153600000s","next_rotation_at":"2027-01-01T00:00:00Z"},"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "598"
+                - "628"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Jun 2026 16:02:09 GMT
+                - Fri, 03 Jul 2026 15:28:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 7f9e0a7b-e48c-4660-9bb6-ba423e03c3eb
+                - b35da050-beb2-45ef-8f46-d730dd284b4a
         status: 200 OK
         code: 200
-        duration: 340.042956ms
+        duration: 281.881111ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -45,29 +45,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/40bdc7c3-41e9-4551-8baa-b68ed628998e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/d2371ecf-fbac-4d74-9be4-43f6c89a764f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 598
-        body: '{"id":"40bdc7c3-41e9-4551-8baa-b68ed628998e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-06-05T16:02:09.394434Z","updated_at":"2026-06-05T16:02:09.400155Z","protected":false,"locked":false,"description":"Test key with rotation policy","tags":[],"rotated_at":"2026-06-05T16:02:09.400155Z","rotation_policy":{"rotation_period":"3153600000s","next_rotation_at":"2027-01-01T00:00:00Z"},"origin":"scaleway_kms","deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 628
+        body: '{"id":"d2371ecf-fbac-4d74-9be4-43f6c89a764f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:24.096639Z","updated_at":"2026-07-03T15:28:24.099582Z","protected":false,"locked":false,"description":"Test key with rotation policy","tags":[],"rotated_at":"2026-07-03T15:28:24.099582Z","rotation_policy":{"rotation_period":"3153600000s","next_rotation_at":"2027-01-01T00:00:00Z"},"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "598"
+                - "628"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Jun 2026 16:02:09 GMT
+                - Fri, 03 Jul 2026 15:28:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 85c17a35-ae6f-4bc0-9f5e-ba611e2d7bcd
+                - 07bb7804-c420-48fc-9392-7299d6147f25
         status: 200 OK
         code: 200
-        duration: 43.906038ms
+        duration: 44.872383ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -77,29 +77,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/40bdc7c3-41e9-4551-8baa-b68ed628998e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/d2371ecf-fbac-4d74-9be4-43f6c89a764f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 598
-        body: '{"id":"40bdc7c3-41e9-4551-8baa-b68ed628998e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-06-05T16:02:09.394434Z","updated_at":"2026-06-05T16:02:09.400155Z","protected":false,"locked":false,"description":"Test key with rotation policy","tags":[],"rotated_at":"2026-06-05T16:02:09.400155Z","rotation_policy":{"rotation_period":"3153600000s","next_rotation_at":"2027-01-01T00:00:00Z"},"origin":"scaleway_kms","deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 628
+        body: '{"id":"d2371ecf-fbac-4d74-9be4-43f6c89a764f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:24.096639Z","updated_at":"2026-07-03T15:28:24.099582Z","protected":false,"locked":false,"description":"Test key with rotation policy","tags":[],"rotated_at":"2026-07-03T15:28:24.099582Z","rotation_policy":{"rotation_period":"3153600000s","next_rotation_at":"2027-01-01T00:00:00Z"},"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "598"
+                - "628"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Jun 2026 16:02:09 GMT
+                - Fri, 03 Jul 2026 15:28:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 61437cea-eced-4ca5-a8af-8ab05ee8c8c4
+                - 31216260-89b9-46ba-b923-d8171158376f
         status: 200 OK
         code: 200
-        duration: 39.329498ms
+        duration: 34.824159ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -109,8 +109,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/40bdc7c3-41e9-4551-8baa-b68ed628998e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/d2371ecf-fbac-4d74-9be4-43f6c89a764f
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -122,14 +122,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Jun 2026 16:02:10 GMT
+                - Fri, 03 Jul 2026 15:28:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 820a296c-44bd-4bcf-8ab2-39bdc65c905e
+                - 769dbb0e-fffd-4ad4-be08-76fe96280d11
         status: 204 No Content
         code: 204
-        duration: 276.893811ms
+        duration: 59.856617ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -139,26 +139,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/40bdc7c3-41e9-4551-8baa-b68ed628998e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/d2371ecf-fbac-4d74-9be4-43f6c89a764f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 638
-        body: '{"id":"40bdc7c3-41e9-4551-8baa-b68ed628998e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-06-05T16:02:09.394434Z","updated_at":"2026-06-05T16:02:09.400155Z","protected":false,"locked":false,"description":"Test key with rotation policy","tags":[],"rotated_at":"2026-06-05T16:02:09.400155Z","rotation_policy":{"rotation_period":"3153600000s","next_rotation_at":"2027-01-01T00:00:00Z"},"origin":"scaleway_kms","deletion_requested_at":"2026-06-05T16:02:10.258527Z","region":"fr-par"}'
+        content_length: 668
+        body: '{"id":"d2371ecf-fbac-4d74-9be4-43f6c89a764f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-03T15:28:24.096639Z","updated_at":"2026-07-03T15:28:25.466926Z","protected":false,"locked":false,"description":"Test key with rotation policy","tags":[],"rotated_at":"2026-07-03T15:28:24.099582Z","rotation_policy":{"rotation_period":"3153600000s","next_rotation_at":"2027-01-01T00:00:00Z"},"origin":"scaleway_kms","deletion_requested_at":"2026-07-03T15:28:25.466926Z","protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "638"
+                - "668"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Jun 2026 16:02:10 GMT
+                - Fri, 03 Jul 2026 15:28:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 3d90f405-3f3e-4146-9dff-670b76c074e9
+                - daf5fe5e-3a80-4b23-8ffa-02d37698e092
         status: 200 OK
         code: 200
-        duration: 39.0056ms
+        duration: 42.940635ms

--- a/internal/services/keymanager/testdata/list-key-manager-keys-by-name.cassette.yaml
+++ b/internal/services/keymanager/testdata/list-key-manager-keys-by-name.cassette.yaml
@@ -13,29 +13,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 559
-        body: '{"id":"d24a46fd-6fff-4252-a602-204289dd23d8", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-name-1", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:08.437363Z", "updated_at":"2026-06-17T08:18:08.440373Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:08.440373Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}'
+        content_length: 526
+        body: '{"id":"ed5bf6af-a425-41a4-a24b-5523d83431fd","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-name-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.254887Z","updated_at":"2026-07-03T15:28:19.259815Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.259815Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "559"
+                - "526"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:08 GMT
+                - Fri, 03 Jul 2026 15:28:19 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - a2b0584d-7578-475c-9a81-e77781db89e2
+                - 8caa34fb-ebfe-44e2-8963-256c440593d7
         status: 200 OK
         code: 200
-        duration: 220.695333ms
+        duration: 653.421864ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -45,29 +45,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/d24a46fd-6fff-4252-a602-204289dd23d8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/ed5bf6af-a425-41a4-a24b-5523d83431fd
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 559
-        body: '{"id":"d24a46fd-6fff-4252-a602-204289dd23d8", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-name-1", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:08.437363Z", "updated_at":"2026-06-17T08:18:08.440373Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:08.440373Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}'
+        content_length: 526
+        body: '{"id":"ed5bf6af-a425-41a4-a24b-5523d83431fd","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-name-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.254887Z","updated_at":"2026-07-03T15:28:19.259815Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.259815Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "559"
+                - "526"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:08 GMT
+                - Fri, 03 Jul 2026 15:28:19 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 7fe73f6a-6607-4910-9a51-d952dab4c2e1
+                - 0c7901b7-64b6-4b17-9986-354e2a644d43
         status: 200 OK
         code: 200
-        duration: 209.604875ms
+        duration: 80.727097ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -77,29 +77,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/d24a46fd-6fff-4252-a602-204289dd23d8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/ed5bf6af-a425-41a4-a24b-5523d83431fd
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 559
-        body: '{"id":"d24a46fd-6fff-4252-a602-204289dd23d8", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-name-1", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:08.437363Z", "updated_at":"2026-06-17T08:18:08.440373Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:08.440373Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}'
+        content_length: 526
+        body: '{"id":"ed5bf6af-a425-41a4-a24b-5523d83431fd","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-name-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.254887Z","updated_at":"2026-07-03T15:28:19.259815Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.259815Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "559"
+                - "526"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:09 GMT
+                - Fri, 03 Jul 2026 15:28:19 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 74dca872-360b-4e34-9a9d-3fc764fa1475
+                - 65b87e78-f935-4d42-82aa-a4d6445d78f5
         status: 200 OK
         code: 200
-        duration: 206.357125ms
+        duration: 48.64589ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -109,29 +109,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/d24a46fd-6fff-4252-a602-204289dd23d8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/ed5bf6af-a425-41a4-a24b-5523d83431fd
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 559
-        body: '{"id":"d24a46fd-6fff-4252-a602-204289dd23d8", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-name-1", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:08.437363Z", "updated_at":"2026-06-17T08:18:08.440373Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:08.440373Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}'
+        content_length: 526
+        body: '{"id":"ed5bf6af-a425-41a4-a24b-5523d83431fd","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-name-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.254887Z","updated_at":"2026-07-03T15:28:19.259815Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.259815Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "559"
+                - "526"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:09 GMT
+                - Fri, 03 Jul 2026 15:28:20 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - ce79e153-1f21-4e67-bce4-13807984fce9
+                - 070e4f6c-6974-4299-a3a9-6692cef7b70e
         status: 200 OK
         code: 200
-        duration: 229.7935ms
+        duration: 45.369997ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -144,29 +144,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 559
-        body: '{"id":"af1371f8-62b2-4d27-b667-37dd98c26916", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-name-2", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:10.226337Z", "updated_at":"2026-06-17T08:18:10.229222Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:10.229222Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}'
+        content_length: 526
+        body: '{"id":"cf1aa736-f399-45e7-a58b-d9247b130fd0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-name-2","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:20.438308Z","updated_at":"2026-07-03T15:28:20.443489Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:20.443489Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "559"
+                - "526"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:10 GMT
+                - Fri, 03 Jul 2026 15:28:20 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 93fcf77f-c800-4bdd-ba1e-c9c5041d4b65
+                - 0750a503-4ce0-4121-8e13-f665cca98d4e
         status: 200 OK
         code: 200
-        duration: 371.899417ms
+        duration: 95.91296ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -176,29 +176,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/af1371f8-62b2-4d27-b667-37dd98c26916
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/cf1aa736-f399-45e7-a58b-d9247b130fd0
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 559
-        body: '{"id":"af1371f8-62b2-4d27-b667-37dd98c26916", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-name-2", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:10.226337Z", "updated_at":"2026-06-17T08:18:10.229222Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:10.229222Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}'
+        content_length: 526
+        body: '{"id":"cf1aa736-f399-45e7-a58b-d9247b130fd0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-name-2","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:20.438308Z","updated_at":"2026-07-03T15:28:20.443489Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:20.443489Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "559"
+                - "526"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:10 GMT
+                - Fri, 03 Jul 2026 15:28:20 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 44330699-d7f2-401d-85cb-649f4ef86a0f
+                - b2e65495-2d9d-4ee7-bc39-6f3c8cda6610
         status: 200 OK
         code: 200
-        duration: 153.025375ms
+        duration: 46.570952ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -208,29 +208,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/d24a46fd-6fff-4252-a602-204289dd23d8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/ed5bf6af-a425-41a4-a24b-5523d83431fd
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 559
-        body: '{"id":"d24a46fd-6fff-4252-a602-204289dd23d8", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-name-1", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:08.437363Z", "updated_at":"2026-06-17T08:18:08.440373Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:08.440373Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}'
+        content_length: 526
+        body: '{"id":"ed5bf6af-a425-41a4-a24b-5523d83431fd","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-name-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.254887Z","updated_at":"2026-07-03T15:28:19.259815Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.259815Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "559"
+                - "526"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:10 GMT
+                - Fri, 03 Jul 2026 15:28:20 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 77c722ca-bc5b-4af8-be7e-43be7f9768a8
+                - e74cae61-9aa2-4eeb-a954-f1697b89edf3
         status: 200 OK
         code: 200
-        duration: 53.24625ms
+        duration: 48.948979ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -240,29 +240,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/af1371f8-62b2-4d27-b667-37dd98c26916
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/cf1aa736-f399-45e7-a58b-d9247b130fd0
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 559
-        body: '{"id":"af1371f8-62b2-4d27-b667-37dd98c26916", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-name-2", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:10.226337Z", "updated_at":"2026-06-17T08:18:10.229222Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:10.229222Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}'
+        content_length: 526
+        body: '{"id":"cf1aa736-f399-45e7-a58b-d9247b130fd0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-name-2","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:20.438308Z","updated_at":"2026-07-03T15:28:20.443489Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:20.443489Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "559"
+                - "526"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:10 GMT
+                - Fri, 03 Jul 2026 15:28:21 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - c00fad0e-8d20-4bee-8387-771a926888c2
+                - 125eaf27-ad4e-4380-a71a-c1c19f7b570a
         status: 200 OK
         code: 200
-        duration: 173.918875ms
+        duration: 153.978103ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -287,29 +287,29 @@ interactions:
                 - unknown_usage
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys?name=tf-test-km-by-name-1&order_by=name_asc&page=1&project_id=105bdce1-64c0-48ab-899d-868455867ecf&protection_level=unknown_protection_level&scheduled_for_deletion=false&usage=unknown_usage
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 587
-        body: '{"keys":[{"id":"d24a46fd-6fff-4252-a602-204289dd23d8", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-name-1", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:08.437363Z", "updated_at":"2026-06-17T08:18:08.440373Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:08.440373Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}], "total_count":1}'
+        content_length: 553
+        body: '{"keys":[{"id":"ed5bf6af-a425-41a4-a24b-5523d83431fd","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-name-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.254887Z","updated_at":"2026-07-03T15:28:19.259815Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.259815Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
-                - "587"
+                - "553"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:11 GMT
+                - Fri, 03 Jul 2026 15:28:21 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 3221532e-f4b4-473f-baec-6c43a1429ac6
+                - 9350cb49-40fa-49f9-b4dc-9eedcd12ba06
         status: 200 OK
         code: 200
-        duration: 285.376208ms
+        duration: 99.416902ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -319,8 +319,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/af1371f8-62b2-4d27-b667-37dd98c26916
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/cf1aa736-f399-45e7-a58b-d9247b130fd0
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -332,14 +332,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:11 GMT
+                - Fri, 03 Jul 2026 15:28:21 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 5402bb4a-3239-4418-9dab-8d6eaf51f345
+                - 9b7638c6-146e-44ed-bd71-0828793862d6
         status: 204 No Content
         code: 204
-        duration: 301.122792ms
+        duration: 117.539221ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -349,8 +349,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/d24a46fd-6fff-4252-a602-204289dd23d8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/ed5bf6af-a425-41a4-a24b-5523d83431fd
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -362,14 +362,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:11 GMT
+                - Fri, 03 Jul 2026 15:28:21 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 820f21c4-ff8d-4729-adbd-bd09c20e994b
+                - 8432ba63-115d-44f1-acdf-64b159f4a8ed
         status: 204 No Content
         code: 204
-        duration: 301.074584ms
+        duration: 117.881704ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -379,29 +379,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/d24a46fd-6fff-4252-a602-204289dd23d8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/ed5bf6af-a425-41a4-a24b-5523d83431fd
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 599
-        body: '{"id":"d24a46fd-6fff-4252-a602-204289dd23d8", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-name-1", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"scheduled_for_deletion", "rotation_count":1, "created_at":"2026-06-17T08:18:08.437363Z", "updated_at":"2026-06-17T08:18:08.440373Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:08.440373Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":"2026-06-17T08:18:11.905332Z", "protection_level":"unknown_protection_level", "region":"fr-par"}'
+        content_length: 566
+        body: '{"id":"ed5bf6af-a425-41a4-a24b-5523d83431fd","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-name-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-03T15:28:19.254887Z","updated_at":"2026-07-03T15:28:21.815663Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.259815Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-03T15:28:21.815662Z","protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "599"
+                - "566"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:12 GMT
+                - Fri, 03 Jul 2026 15:28:21 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 9c54a47c-537c-45e9-993c-063ab6bc635e
+                - 57dcf78f-7312-47c1-977b-c2b9f229fb84
         status: 200 OK
         code: 200
-        duration: 107.070292ms
+        duration: 44.935671ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -411,26 +411,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/af1371f8-62b2-4d27-b667-37dd98c26916
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/cf1aa736-f399-45e7-a58b-d9247b130fd0
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 599
-        body: '{"id":"af1371f8-62b2-4d27-b667-37dd98c26916", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-name-2", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"scheduled_for_deletion", "rotation_count":1, "created_at":"2026-06-17T08:18:10.226337Z", "updated_at":"2026-06-17T08:18:10.229222Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:10.229222Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":"2026-06-17T08:18:11.884435Z", "protection_level":"unknown_protection_level", "region":"fr-par"}'
+        content_length: 566
+        body: '{"id":"cf1aa736-f399-45e7-a58b-d9247b130fd0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-name-2","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-03T15:28:20.438308Z","updated_at":"2026-07-03T15:28:21.815405Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:20.443489Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-03T15:28:21.815405Z","protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "599"
+                - "566"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:12 GMT
+                - Fri, 03 Jul 2026 15:28:21 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - aa0d0fde-5457-4ac0-ba94-c698f6295833
+                - 08a74dc7-1483-4206-a9d7-18f518b2c525
         status: 200 OK
         code: 200
-        duration: 239.194958ms
+        duration: 45.920501ms

--- a/internal/services/keymanager/testdata/list-key-manager-keys-by-project-ids.cassette.yaml
+++ b/internal/services/keymanager/testdata/list-key-manager-keys-by-project-ids.cassette.yaml
@@ -13,29 +13,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 562
-        body: '{"id":"07979ec6-ec27-4d18-9ef8-b753cbd17f8b", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-proj-id-1", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:08.808278Z", "updated_at":"2026-06-17T08:18:08.812876Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:08.812876Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}'
+        content_length: 529
+        body: '{"id":"50757a9f-ef9d-4621-b926-7793034d5f23","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-proj-id-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.178853Z","updated_at":"2026-07-03T15:28:19.183840Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.183840Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "562"
+                - "529"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:08 GMT
+                - Fri, 03 Jul 2026 15:28:19 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - d6197d24-bd0a-4fc4-96cc-0bf8215543eb
+                - 0f0937e7-9efc-4f94-ae10-cbc419d9fc3e
         status: 200 OK
         code: 200
-        duration: 186.272083ms
+        duration: 596.838595ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -45,29 +45,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/07979ec6-ec27-4d18-9ef8-b753cbd17f8b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/50757a9f-ef9d-4621-b926-7793034d5f23
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 562
-        body: '{"id":"07979ec6-ec27-4d18-9ef8-b753cbd17f8b", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-proj-id-1", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:08.808278Z", "updated_at":"2026-06-17T08:18:08.812876Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:08.812876Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}'
+        content_length: 529
+        body: '{"id":"50757a9f-ef9d-4621-b926-7793034d5f23","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-proj-id-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.178853Z","updated_at":"2026-07-03T15:28:19.183840Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.183840Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "562"
+                - "529"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:08 GMT
+                - Fri, 03 Jul 2026 15:28:19 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 62f707d6-8f05-493f-884b-1c241cbd08f0
+                - ebb31e2a-7a6a-43f4-96fe-4ffefb667604
         status: 200 OK
         code: 200
-        duration: 40.119208ms
+        duration: 89.810168ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -77,29 +77,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/07979ec6-ec27-4d18-9ef8-b753cbd17f8b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/50757a9f-ef9d-4621-b926-7793034d5f23
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 562
-        body: '{"id":"07979ec6-ec27-4d18-9ef8-b753cbd17f8b", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-proj-id-1", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:08.808278Z", "updated_at":"2026-06-17T08:18:08.812876Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:08.812876Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}'
+        content_length: 529
+        body: '{"id":"50757a9f-ef9d-4621-b926-7793034d5f23","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-proj-id-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.178853Z","updated_at":"2026-07-03T15:28:19.183840Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.183840Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "562"
+                - "529"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:09 GMT
+                - Fri, 03 Jul 2026 15:28:19 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - ee351687-ad25-48a3-a3f1-a98f4307c24c
+                - 09183d54-e332-4f1f-bf7d-c21fe2ea237e
         status: 200 OK
         code: 200
-        duration: 266.339292ms
+        duration: 134.710734ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -122,29 +122,29 @@ interactions:
                 - unknown_usage
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys?order_by=name_asc&page=1&project_id=105bdce1-64c0-48ab-899d-868455867ecf&protection_level=unknown_protection_level&scheduled_for_deletion=false&usage=unknown_usage
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 7959
-        body: '{"keys":[{"id":"f82bf0a8-1bd6-4ee5-985a-4549bcee5182", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-decrypt-key-ad", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:08.061842Z", "updated_at":"2026-06-17T08:18:08.065106Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:08.065106Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}, {"id":"58f8c929-2be8-46b3-8176-4196ea11357f", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-encrypt-key", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:06.276344Z", "updated_at":"2026-06-17T08:18:06.283266Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:06.283266Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}, {"id":"f91cb446-5a27-4790-a71d-5c63ed704c61", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-generate-data-key", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:07.245240Z", "updated_at":"2026-06-17T08:18:07.249909Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:07.249909Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}, {"id":"8489f97f-5602-4319-ae89-7af007d7afc1", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-generate-no-plaintext", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:06.837832Z", "updated_at":"2026-06-17T08:18:06.846052Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:06.846052Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}, {"id":"d24a46fd-6fff-4252-a602-204289dd23d8", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-name-1", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:08.437363Z", "updated_at":"2026-06-17T08:18:08.440373Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:08.440373Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}, {"id":"07979ec6-ec27-4d18-9ef8-b753cbd17f8b", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-proj-id-1", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:08.808278Z", "updated_at":"2026-06-17T08:18:08.812876Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:08.812876Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}, {"id":"20e66fb8-c308-4552-9101-eac53e33349f", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-scheduled-1", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:06.660362Z", "updated_at":"2026-06-17T08:18:06.663034Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:06.663034Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}, {"id":"22bc8896-3411-4fa1-aab8-6551094389cf", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-scheduled-2", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:08.300974Z", "updated_at":"2026-06-17T08:18:08.305046Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:08.305046Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}, {"id":"e80439f0-7aa1-4b4a-bf7e-9ae6e35bebe9", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-tags-1", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:07.339678Z", "updated_at":"2026-06-17T08:18:07.343509Z", "protected":false, "locked":false, "description":null, "tags":["env:test", "team:test"], "rotated_at":"2026-06-17T08:18:07.343509Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}, {"id":"25088be1-345f-4ab8-a70d-99bf324e89f9", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-tags-2", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:09.411566Z", "updated_at":"2026-06-17T08:18:09.418665Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:09.418665Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}, {"id":"95dd1a29-c2b3-475e-86e8-9ca48aea09fa", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-usage-1", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:07.460947Z", "updated_at":"2026-06-17T08:18:07.465475Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:07.465475Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}, {"id":"6f0fad85-6b41-40ff-8045-c1d0014d95e4", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-verify-key", "usage":{"asymmetric_signing":"rsa_pss_2048_sha256"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:06.356810Z", "updated_at":"2026-06-17T08:18:06.583668Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:06.583668Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}, {"id":"a398f1bd-e979-4a69-90a0-668acacd458d", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-verify-key-invalid", "usage":{"asymmetric_signing":"rsa_pss_2048_sha256"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:04.873870Z", "updated_at":"2026-06-17T08:18:05.025043Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:05.025043Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}, {"id":"9c08d709-d1c9-418a-8331-3f7ab1a0bdc7", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-verify-other-key", "usage":{"asymmetric_signing":"rsa_pss_2048_sha256"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:07.117551Z", "updated_at":"2026-06-17T08:18:07.168248Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:07.168248Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}], "total_count":14}'
+        content_length: 5392
+        body: '{"keys":[{"id":"f8880c35-46bf-4ecd-8185-c816231f0d78","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-decrypt-key","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.387100Z","updated_at":"2026-07-03T15:28:19.391480Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.391480Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"ed5bf6af-a425-41a4-a24b-5523d83431fd","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-name-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.254887Z","updated_at":"2026-07-03T15:28:19.259815Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.259815Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"50757a9f-ef9d-4621-b926-7793034d5f23","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-proj-id-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.178853Z","updated_at":"2026-07-03T15:28:19.183840Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.183840Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"04814e7e-4300-4b22-984e-eff1eec32557","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-scheduled-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.210917Z","updated_at":"2026-07-03T15:28:19.215546Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.215546Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"62a30059-9199-4f5b-b16d-7fc491b85dd0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-tags-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.878293Z","updated_at":"2026-07-03T15:28:19.882699Z","protected":false,"locked":false,"description":null,"tags":["env:test","team:test"],"rotated_at":"2026-07-03T15:28:19.882699Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"5180620d-12d4-4ff6-8d8e-fae5a52e6219","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-usage-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.233790Z","updated_at":"2026-07-03T15:28:19.237469Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.237469Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"c8c5298c-7ee8-4e8f-a430-5b5c3d8144c8","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-default-alg","usage":{"asymmetric_encryption":"rsa_oaep_3072_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:18.735474Z","updated_at":"2026-07-03T15:28:19.161311Z","protected":false,"locked":false,"description":"Test key with RSA-3072 algorithm","tags":[],"rotated_at":"2026-07-03T15:28:19.161311Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"1157fe98-a66f-4fbc-803c-30a07685869e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-sign-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.410788Z","updated_at":"2026-07-03T15:28:19.523205Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.523205Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"7e6da60c-5bfa-475c-851d-c7cf98923041","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.283852Z","updated_at":"2026-07-03T15:28:19.368507Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.368507Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"969b2333-caec-45d2-99b0-aef0b1d49d12","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-key-invalid","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.543164Z","updated_at":"2026-07-03T15:28:19.841001Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.841001Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}],"total_count":10}'
         headers:
             Content-Length:
-                - "7959"
+                - "5392"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:09 GMT
+                - Fri, 03 Jul 2026 15:28:20 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 0312861e-6bf4-44a4-a8b3-2353db2f5c44
+                - 1adfbbe4-6a74-4890-b9ab-6b32c389286d
         status: 200 OK
         code: 200
-        duration: 212.886ms
+        duration: 92.6439ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -154,8 +154,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/07979ec6-ec27-4d18-9ef8-b753cbd17f8b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/50757a9f-ef9d-4621-b926-7793034d5f23
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -167,14 +167,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:10 GMT
+                - Fri, 03 Jul 2026 15:28:20 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 98f78b4f-4568-46fb-8271-4a90c14d19f5
+                - 14ab0aa9-c7b4-4184-8c79-14859be93842
         status: 204 No Content
         code: 204
-        duration: 219.133292ms
+        duration: 127.754949ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -184,26 +184,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/07979ec6-ec27-4d18-9ef8-b753cbd17f8b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/50757a9f-ef9d-4621-b926-7793034d5f23
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 602
-        body: '{"id":"07979ec6-ec27-4d18-9ef8-b753cbd17f8b", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-proj-id-1", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"scheduled_for_deletion", "rotation_count":1, "created_at":"2026-06-17T08:18:08.808278Z", "updated_at":"2026-06-17T08:18:08.812876Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:08.812876Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":"2026-06-17T08:18:10.200287Z", "protection_level":"unknown_protection_level", "region":"fr-par"}'
+        content_length: 569
+        body: '{"id":"50757a9f-ef9d-4621-b926-7793034d5f23","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-proj-id-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-03T15:28:19.178853Z","updated_at":"2026-07-03T15:28:20.568559Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.183840Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-03T15:28:20.568559Z","protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "602"
+                - "569"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:10 GMT
+                - Fri, 03 Jul 2026 15:28:20 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 7be7a9ae-f014-4a26-b9e3-b1cf51b6bdff
+                - c7bc3d98-ab58-4f4c-b82e-289d9ad6bae3
         status: 200 OK
         code: 200
-        duration: 119.647458ms
+        duration: 54.612297ms

--- a/internal/services/keymanager/testdata/list-key-manager-keys-by-regions.cassette.yaml
+++ b/internal/services/keymanager/testdata/list-key-manager-keys-by-regions.cassette.yaml
@@ -13,29 +13,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 560
-        body: '{"id":"770791c8-f2a5-41fd-87e5-f3cc351794ce", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-key-by-region", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:10.128935Z", "updated_at":"2026-06-17T08:18:10.133414Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:10.133414Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}'
+        content_length: 527
+        body: '{"id":"2b4fe63f-f7b7-4973-8ae1-39ae8546eab4","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-key-by-region","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:24.409873Z","updated_at":"2026-07-03T15:28:24.414509Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:24.414509Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "560"
+                - "527"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:10 GMT
+                - Fri, 03 Jul 2026 15:28:24 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - a96eb246-8248-4979-beff-e62902119598
+                - 1d149c8a-3f2c-4410-b608-46a2952eb264
         status: 200 OK
         code: 200
-        duration: 592.258458ms
+        duration: 70.447059ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -45,29 +45,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/770791c8-f2a5-41fd-87e5-f3cc351794ce
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/2b4fe63f-f7b7-4973-8ae1-39ae8546eab4
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 560
-        body: '{"id":"770791c8-f2a5-41fd-87e5-f3cc351794ce", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-key-by-region", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:10.128935Z", "updated_at":"2026-06-17T08:18:10.133414Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:10.133414Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}'
+        content_length: 527
+        body: '{"id":"2b4fe63f-f7b7-4973-8ae1-39ae8546eab4","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-key-by-region","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:24.409873Z","updated_at":"2026-07-03T15:28:24.414509Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:24.414509Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "560"
+                - "527"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:10 GMT
+                - Fri, 03 Jul 2026 15:28:24 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 1bb79a60-0b61-4f46-9b4f-00b28af471ae
+                - 355f9b31-8dc9-4233-b3db-83cd63e750d5
         status: 200 OK
         code: 200
-        duration: 154.561875ms
+        duration: 42.358401ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -77,29 +77,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/770791c8-f2a5-41fd-87e5-f3cc351794ce
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/2b4fe63f-f7b7-4973-8ae1-39ae8546eab4
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 560
-        body: '{"id":"770791c8-f2a5-41fd-87e5-f3cc351794ce", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-key-by-region", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:10.128935Z", "updated_at":"2026-06-17T08:18:10.133414Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:10.133414Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}'
+        content_length: 527
+        body: '{"id":"2b4fe63f-f7b7-4973-8ae1-39ae8546eab4","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-key-by-region","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:24.409873Z","updated_at":"2026-07-03T15:28:24.414509Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:24.414509Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "560"
+                - "527"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:10 GMT
+                - Fri, 03 Jul 2026 15:28:25 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 7ea07fb8-2cae-4dfc-8d37-e153c55a06ae
+                - f0d8d026-182b-4aa2-84b3-6fb17c936710
         status: 200 OK
         code: 200
-        duration: 61.013084ms
+        duration: 48.116015ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -122,29 +122,29 @@ interactions:
                 - unknown_usage
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys?order_by=name_asc&page=1&project_id=105bdce1-64c0-48ab-899d-868455867ecf&protection_level=unknown_protection_level&scheduled_for_deletion=false&usage=unknown_usage
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 5108
-        body: '{"keys":[{"id":"f82bf0a8-1bd6-4ee5-985a-4549bcee5182", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-decrypt-key-ad", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:08.061842Z", "updated_at":"2026-06-17T08:18:08.065106Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:08.065106Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}, {"id":"f91cb446-5a27-4790-a71d-5c63ed704c61", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-generate-data-key", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:07.245240Z", "updated_at":"2026-06-17T08:18:07.249909Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:07.249909Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}, {"id":"8489f97f-5602-4319-ae89-7af007d7afc1", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-generate-no-plaintext", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:06.837832Z", "updated_at":"2026-06-17T08:18:06.846052Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:06.846052Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}, {"id":"770791c8-f2a5-41fd-87e5-f3cc351794ce", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-key-by-region", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:10.128935Z", "updated_at":"2026-06-17T08:18:10.133414Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:10.133414Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}, {"id":"d24a46fd-6fff-4252-a602-204289dd23d8", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-name-1", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:08.437363Z", "updated_at":"2026-06-17T08:18:08.440373Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:08.440373Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}, {"id":"af1371f8-62b2-4d27-b667-37dd98c26916", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-name-2", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:10.226337Z", "updated_at":"2026-06-17T08:18:10.229222Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:10.229222Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}, {"id":"95dd1a29-c2b3-475e-86e8-9ca48aea09fa", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-usage-1", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:07.460947Z", "updated_at":"2026-06-17T08:18:07.465475Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:07.465475Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}, {"id":"fc9d4560-7413-4d34-8f61-8ec278577a7c", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-usage-2", "usage":{"asymmetric_encryption":"rsa_oaep_4096_sha256"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:09.559660Z", "updated_at":"2026-06-17T08:18:10.041872Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:10.041872Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}, {"id":"6f0fad85-6b41-40ff-8045-c1d0014d95e4", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-verify-key", "usage":{"asymmetric_signing":"rsa_pss_2048_sha256"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:06.356810Z", "updated_at":"2026-06-17T08:18:06.583668Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:06.583668Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}], "total_count":9}'
+        content_length: 2732
+        body: '{"keys":[{"id":"2c3026cf-38d3-4155-a38a-09fbd05249d0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-decrypt-key-ad","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:23.280724Z","updated_at":"2026-07-03T15:28:23.284017Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:23.284017Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"23871059-a682-4a9d-9cc7-f9e5588a7555","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-generate-no-plaintext","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:22.769593Z","updated_at":"2026-07-03T15:28:22.772636Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:22.772636Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"2b4fe63f-f7b7-4973-8ae1-39ae8546eab4","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-key-by-region","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:24.409873Z","updated_at":"2026-07-03T15:28:24.414509Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:24.414509Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"866337c1-b045-426a-91c8-6d3ab6194e9e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation-action","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":2,"created_at":"2026-07-03T15:28:23.813688Z","updated_at":"2026-07-03T15:28:24.080715Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:24.080715Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"727f3036-5b41-4ff2-ba78-b622b07430ab","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-updated","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:23.841284Z","updated_at":"2026-07-03T15:28:25.302477Z","protected":false,"locked":false,"description":"Test key updated","tags":["tf","updated"],"rotated_at":"2026-07-03T15:28:23.844354Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}],"total_count":5}'
         headers:
             Content-Length:
-                - "5108"
+                - "2732"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:11 GMT
+                - Fri, 03 Jul 2026 15:28:25 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 2f214786-8718-4da5-965f-0677869e4e56
+                - aaac2c91-e81f-4cbd-8333-eeeaeba3405e
         status: 200 OK
         code: 200
-        duration: 215.095917ms
+        duration: 52.421432ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -154,8 +154,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/770791c8-f2a5-41fd-87e5-f3cc351794ce
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/2b4fe63f-f7b7-4973-8ae1-39ae8546eab4
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -167,14 +167,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:11 GMT
+                - Fri, 03 Jul 2026 15:28:25 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 71207f79-8bcd-4c69-825c-5cf311c29861
+                - 6a96471b-41df-4dc6-9575-27b898dd6e3e
         status: 204 No Content
         code: 204
-        duration: 123.517917ms
+        duration: 73.654454ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -184,26 +184,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/770791c8-f2a5-41fd-87e5-f3cc351794ce
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/2b4fe63f-f7b7-4973-8ae1-39ae8546eab4
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 600
-        body: '{"id":"770791c8-f2a5-41fd-87e5-f3cc351794ce", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-key-by-region", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"scheduled_for_deletion", "rotation_count":1, "created_at":"2026-06-17T08:18:10.128935Z", "updated_at":"2026-06-17T08:18:10.133414Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:10.133414Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":"2026-06-17T08:18:11.629300Z", "protection_level":"unknown_protection_level", "region":"fr-par"}'
+        content_length: 567
+        body: '{"id":"2b4fe63f-f7b7-4973-8ae1-39ae8546eab4","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-key-by-region","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-03T15:28:24.409873Z","updated_at":"2026-07-03T15:28:25.750478Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:24.414509Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-03T15:28:25.750478Z","protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "600"
+                - "567"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:11 GMT
+                - Fri, 03 Jul 2026 15:28:25 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - ecffcfc5-80b4-45bb-a21a-8b98e9d21938
+                - 2cba899a-b5c3-4aef-95f5-fe493380ce27
         status: 200 OK
         code: 200
-        duration: 181.000959ms
+        duration: 56.92451ms

--- a/internal/services/keymanager/testdata/list-key-manager-keys-by-scheduled-for-deletion.cassette.yaml
+++ b/internal/services/keymanager/testdata/list-key-manager-keys-by-scheduled-for-deletion.cassette.yaml
@@ -13,29 +13,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 564
-        body: '{"id":"20e66fb8-c308-4552-9101-eac53e33349f", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-scheduled-1", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:06.660362Z", "updated_at":"2026-06-17T08:18:06.663034Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:06.663034Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}'
+        content_length: 531
+        body: '{"id":"04814e7e-4300-4b22-984e-eff1eec32557","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-scheduled-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.210917Z","updated_at":"2026-07-03T15:28:19.215546Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.215546Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "564"
+                - "531"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:06 GMT
+                - Fri, 03 Jul 2026 15:28:19 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 180bb34f-1bd0-4681-aeac-f3b5c030168a
+                - 3160f904-1b45-4b3f-9274-351c98142fa2
         status: 200 OK
         code: 200
-        duration: 3.675831041s
+        duration: 615.494897ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -45,29 +45,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/20e66fb8-c308-4552-9101-eac53e33349f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/04814e7e-4300-4b22-984e-eff1eec32557
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 564
-        body: '{"id":"20e66fb8-c308-4552-9101-eac53e33349f", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-scheduled-1", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:06.660362Z", "updated_at":"2026-06-17T08:18:06.663034Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:06.663034Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}'
+        content_length: 531
+        body: '{"id":"04814e7e-4300-4b22-984e-eff1eec32557","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-scheduled-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.210917Z","updated_at":"2026-07-03T15:28:19.215546Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.215546Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "564"
+                - "531"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:06 GMT
+                - Fri, 03 Jul 2026 15:28:19 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - a3a9a233-88ee-4dab-b6c0-155adac80e3a
+                - 4436acb7-0bc4-4d79-b05f-1d58a6b2d612
         status: 200 OK
         code: 200
-        duration: 152.70075ms
+        duration: 82.571111ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -77,29 +77,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/20e66fb8-c308-4552-9101-eac53e33349f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/04814e7e-4300-4b22-984e-eff1eec32557
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 564
-        body: '{"id":"20e66fb8-c308-4552-9101-eac53e33349f", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-scheduled-1", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:06.660362Z", "updated_at":"2026-06-17T08:18:06.663034Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:06.663034Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}'
+        content_length: 531
+        body: '{"id":"04814e7e-4300-4b22-984e-eff1eec32557","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-scheduled-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.210917Z","updated_at":"2026-07-03T15:28:19.215546Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.215546Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "564"
+                - "531"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:07 GMT
+                - Fri, 03 Jul 2026 15:28:19 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 868e4715-6c3a-4db3-a1c9-699cf0eed7ee
+                - 3a727abd-f382-4cb0-b69b-7eb8bf54e9a5
         status: 200 OK
         code: 200
-        duration: 234.35ms
+        duration: 121.85633ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -109,29 +109,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/20e66fb8-c308-4552-9101-eac53e33349f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/04814e7e-4300-4b22-984e-eff1eec32557
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 564
-        body: '{"id":"20e66fb8-c308-4552-9101-eac53e33349f", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-scheduled-1", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:06.660362Z", "updated_at":"2026-06-17T08:18:06.663034Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:06.663034Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}'
+        content_length: 531
+        body: '{"id":"04814e7e-4300-4b22-984e-eff1eec32557","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-scheduled-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.210917Z","updated_at":"2026-07-03T15:28:19.215546Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.215546Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "564"
+                - "531"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:07 GMT
+                - Fri, 03 Jul 2026 15:28:20 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 6808178e-0321-4a64-ba18-6ca151c814d4
+                - 5ee3b748-eb76-4026-b6e4-f19886aa3720
         status: 200 OK
         code: 200
-        duration: 157.049083ms
+        duration: 135.570318ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -144,29 +144,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 564
-        body: '{"id":"22bc8896-3411-4fa1-aab8-6551094389cf", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-scheduled-2", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:08.300974Z", "updated_at":"2026-06-17T08:18:08.305046Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:08.305046Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}'
+        content_length: 531
+        body: '{"id":"09ba6785-9f2f-40e4-9aa5-caa8d05b42c3","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-scheduled-2","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:21.428537Z","updated_at":"2026-07-03T15:28:21.431824Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:21.431824Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "564"
+                - "531"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:08 GMT
+                - Fri, 03 Jul 2026 15:28:21 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 9cee2d25-4f6f-4ea8-a200-e311462ef0c2
+                - a7f997a6-1158-460e-a904-0dc6e31fef56
         status: 200 OK
         code: 200
-        duration: 197.350125ms
+        duration: 900.609813ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -176,29 +176,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/22bc8896-3411-4fa1-aab8-6551094389cf
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/09ba6785-9f2f-40e4-9aa5-caa8d05b42c3
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 564
-        body: '{"id":"22bc8896-3411-4fa1-aab8-6551094389cf", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-scheduled-2", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:08.300974Z", "updated_at":"2026-06-17T08:18:08.305046Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:08.305046Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}'
+        content_length: 531
+        body: '{"id":"09ba6785-9f2f-40e4-9aa5-caa8d05b42c3","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-scheduled-2","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:21.428537Z","updated_at":"2026-07-03T15:28:21.431824Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:21.431824Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "564"
+                - "531"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:08 GMT
+                - Fri, 03 Jul 2026 15:28:21 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 59caea66-9e4c-4b56-8d95-4b54126cc91e
+                - 9c45f854-e5ed-4f77-a2d5-318172c2a1b3
         status: 200 OK
         code: 200
-        duration: 154.627584ms
+        duration: 54.399117ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -208,29 +208,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/20e66fb8-c308-4552-9101-eac53e33349f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/09ba6785-9f2f-40e4-9aa5-caa8d05b42c3
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 564
-        body: '{"id":"20e66fb8-c308-4552-9101-eac53e33349f", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-scheduled-1", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:06.660362Z", "updated_at":"2026-06-17T08:18:06.663034Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:06.663034Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}'
+        content_length: 531
+        body: '{"id":"09ba6785-9f2f-40e4-9aa5-caa8d05b42c3","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-scheduled-2","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:21.428537Z","updated_at":"2026-07-03T15:28:21.431824Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:21.431824Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "564"
+                - "531"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:09 GMT
+                - Fri, 03 Jul 2026 15:28:22 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - b6eec683-00ba-47b5-b613-ad0c33e5f248
+                - f283c9bf-f88f-4960-b327-591b135f8bf5
         status: 200 OK
         code: 200
-        duration: 277.2775ms
+        duration: 46.000963ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -240,29 +240,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/22bc8896-3411-4fa1-aab8-6551094389cf
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/04814e7e-4300-4b22-984e-eff1eec32557
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 564
-        body: '{"id":"22bc8896-3411-4fa1-aab8-6551094389cf", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-scheduled-2", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:08.300974Z", "updated_at":"2026-06-17T08:18:08.305046Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:08.305046Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}'
+        content_length: 531
+        body: '{"id":"04814e7e-4300-4b22-984e-eff1eec32557","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-scheduled-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.210917Z","updated_at":"2026-07-03T15:28:19.215546Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.215546Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "564"
+                - "531"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:09 GMT
+                - Fri, 03 Jul 2026 15:28:22 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 4414ca00-8ee1-4180-861f-1a10f6376cbe
+                - 715d190d-92a2-478a-9f2b-5464eee1e34f
         status: 200 OK
         code: 200
-        duration: 277.653209ms
+        duration: 50.353578ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -285,29 +285,29 @@ interactions:
                 - unknown_usage
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys?order_by=name_asc&page=1&project_id=105bdce1-64c0-48ab-899d-868455867ecf&protection_level=unknown_protection_level&scheduled_for_deletion=false&usage=unknown_usage
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 7959
-        body: '{"keys":[{"id":"f82bf0a8-1bd6-4ee5-985a-4549bcee5182", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-decrypt-key-ad", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:08.061842Z", "updated_at":"2026-06-17T08:18:08.065106Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:08.065106Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}, {"id":"58f8c929-2be8-46b3-8176-4196ea11357f", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-encrypt-key", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:06.276344Z", "updated_at":"2026-06-17T08:18:06.283266Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:06.283266Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}, {"id":"f91cb446-5a27-4790-a71d-5c63ed704c61", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-generate-data-key", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:07.245240Z", "updated_at":"2026-06-17T08:18:07.249909Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:07.249909Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}, {"id":"8489f97f-5602-4319-ae89-7af007d7afc1", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-generate-no-plaintext", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:06.837832Z", "updated_at":"2026-06-17T08:18:06.846052Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:06.846052Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}, {"id":"d24a46fd-6fff-4252-a602-204289dd23d8", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-name-1", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:08.437363Z", "updated_at":"2026-06-17T08:18:08.440373Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:08.440373Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}, {"id":"07979ec6-ec27-4d18-9ef8-b753cbd17f8b", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-proj-id-1", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:08.808278Z", "updated_at":"2026-06-17T08:18:08.812876Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:08.812876Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}, {"id":"20e66fb8-c308-4552-9101-eac53e33349f", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-scheduled-1", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:06.660362Z", "updated_at":"2026-06-17T08:18:06.663034Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:06.663034Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}, {"id":"22bc8896-3411-4fa1-aab8-6551094389cf", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-scheduled-2", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:08.300974Z", "updated_at":"2026-06-17T08:18:08.305046Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:08.305046Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}, {"id":"e80439f0-7aa1-4b4a-bf7e-9ae6e35bebe9", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-tags-1", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:07.339678Z", "updated_at":"2026-06-17T08:18:07.343509Z", "protected":false, "locked":false, "description":null, "tags":["env:test", "team:test"], "rotated_at":"2026-06-17T08:18:07.343509Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}, {"id":"25088be1-345f-4ab8-a70d-99bf324e89f9", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-tags-2", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:09.411566Z", "updated_at":"2026-06-17T08:18:09.418665Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:09.418665Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}, {"id":"95dd1a29-c2b3-475e-86e8-9ca48aea09fa", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-usage-1", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:07.460947Z", "updated_at":"2026-06-17T08:18:07.465475Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:07.465475Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}, {"id":"6f0fad85-6b41-40ff-8045-c1d0014d95e4", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-verify-key", "usage":{"asymmetric_signing":"rsa_pss_2048_sha256"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:06.356810Z", "updated_at":"2026-06-17T08:18:06.583668Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:06.583668Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}, {"id":"a398f1bd-e979-4a69-90a0-668acacd458d", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-verify-key-invalid", "usage":{"asymmetric_signing":"rsa_pss_2048_sha256"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:04.873870Z", "updated_at":"2026-06-17T08:18:05.025043Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:05.025043Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}, {"id":"9c08d709-d1c9-418a-8331-3f7ab1a0bdc7", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-verify-other-key", "usage":{"asymmetric_signing":"rsa_pss_2048_sha256"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:07.117551Z", "updated_at":"2026-06-17T08:18:07.168248Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:07.168248Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}], "total_count":14}'
+        content_length: 5383
+        body: '{"keys":[{"id":"eb04b054-d2ff-4deb-9d9e-c3b297c9a814","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-generate-data-key","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:21.457910Z","updated_at":"2026-07-03T15:28:21.463281Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:21.463281Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"04814e7e-4300-4b22-984e-eff1eec32557","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-scheduled-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.210917Z","updated_at":"2026-07-03T15:28:19.215546Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.215546Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"09ba6785-9f2f-40e4-9aa5-caa8d05b42c3","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-scheduled-2","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:21.428537Z","updated_at":"2026-07-03T15:28:21.431824Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:21.431824Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"62a30059-9199-4f5b-b16d-7fc491b85dd0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-tags-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.878293Z","updated_at":"2026-07-03T15:28:19.882699Z","protected":false,"locked":false,"description":null,"tags":["env:test","team:test"],"rotated_at":"2026-07-03T15:28:19.882699Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"b5d0e5ed-511f-4084-9ae1-5c4238ddd21b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-tags-2","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:21.485131Z","updated_at":"2026-07-03T15:28:21.488381Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:21.488381Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"5180620d-12d4-4ff6-8d8e-fae5a52e6219","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-usage-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.233790Z","updated_at":"2026-07-03T15:28:19.237469Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.237469Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"a6bcfe1d-58dc-4ff7-8cd8-641dd5374f13","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-usage-2","usage":{"asymmetric_encryption":"rsa_oaep_4096_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:20.545511Z","updated_at":"2026-07-03T15:28:21.411434Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:21.411434Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"3ce11279-c8b9-4f12-aaaf-e26766a2967c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-ds","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:21.508255Z","updated_at":"2026-07-03T15:28:21.511698Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:21.511698Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"969b2333-caec-45d2-99b0-aef0b1d49d12","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-key-invalid","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.543164Z","updated_at":"2026-07-03T15:28:19.841001Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.841001Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"b1132c2b-01d9-4c6c-950c-b4b15d787780","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-other-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.995464Z","updated_at":"2026-07-03T15:28:20.337904Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:20.337904Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}],"total_count":10}'
         headers:
             Content-Length:
-                - "7959"
+                - "5383"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:09 GMT
+                - Fri, 03 Jul 2026 15:28:22 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 5df68827-c1bb-43d8-8cd6-e1eb6dbf446c
+                - 0c0eec0c-cc6c-48c1-9732-47af59d9e0fc
         status: 200 OK
         code: 200
-        duration: 266.121958ms
+        duration: 96.516705ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -317,8 +317,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/20e66fb8-c308-4552-9101-eac53e33349f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/09ba6785-9f2f-40e4-9aa5-caa8d05b42c3
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -330,14 +330,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:10 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 36e4d1bc-8306-472d-a73d-1ba93b7a93aa
+                - 1bfefaba-020f-45bc-a13f-47ee7b660392
         status: 204 No Content
         code: 204
-        duration: 304.303625ms
+        duration: 78.553575ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -347,8 +347,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/22bc8896-3411-4fa1-aab8-6551094389cf
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/04814e7e-4300-4b22-984e-eff1eec32557
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -360,14 +360,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:10 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 1cda4618-442c-4f80-a9a8-6e88b900347e
+                - b420e2f3-09d5-401d-8fe3-4f81b0a0c357
         status: 204 No Content
         code: 204
-        duration: 304.371916ms
+        duration: 94.538299ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -377,29 +377,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/20e66fb8-c308-4552-9101-eac53e33349f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/04814e7e-4300-4b22-984e-eff1eec32557
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 604
-        body: '{"id":"20e66fb8-c308-4552-9101-eac53e33349f", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-scheduled-1", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"scheduled_for_deletion", "rotation_count":1, "created_at":"2026-06-17T08:18:06.660362Z", "updated_at":"2026-06-17T08:18:06.663034Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:06.663034Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":"2026-06-17T08:18:10.212305Z", "protection_level":"unknown_protection_level", "region":"fr-par"}'
+        content_length: 571
+        body: '{"id":"04814e7e-4300-4b22-984e-eff1eec32557","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-scheduled-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-03T15:28:19.210917Z","updated_at":"2026-07-03T15:28:23.054282Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.215546Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-03T15:28:23.054282Z","protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "604"
+                - "571"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:10 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 8fd3d247-530f-42ab-ae97-014f613b33ae
+                - aa252546-5980-40fc-83fa-15cdd3a4fb6f
         status: 200 OK
         code: 200
-        duration: 119.467ms
+        duration: 49.577761ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -409,26 +409,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/22bc8896-3411-4fa1-aab8-6551094389cf
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/09ba6785-9f2f-40e4-9aa5-caa8d05b42c3
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 604
-        body: '{"id":"22bc8896-3411-4fa1-aab8-6551094389cf", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-scheduled-2", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"scheduled_for_deletion", "rotation_count":1, "created_at":"2026-06-17T08:18:08.300974Z", "updated_at":"2026-06-17T08:18:08.305046Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:08.305046Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":"2026-06-17T08:18:10.203630Z", "protection_level":"unknown_protection_level", "region":"fr-par"}'
+        content_length: 571
+        body: '{"id":"09ba6785-9f2f-40e4-9aa5-caa8d05b42c3","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-scheduled-2","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-03T15:28:21.428537Z","updated_at":"2026-07-03T15:28:23.046695Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:21.431824Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-03T15:28:23.046695Z","protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "604"
+                - "571"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:10 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - fff19e7e-654b-4e4d-8f90-4d8e669eaad0
+                - c0105273-6faf-438e-8614-f6aa3d05500b
         status: 200 OK
         code: 200
-        duration: 175.202125ms
+        duration: 47.706406ms

--- a/internal/services/keymanager/testdata/list-key-manager-keys-by-tags.cassette.yaml
+++ b/internal/services/keymanager/testdata/list-key-manager-keys-by-tags.cassette.yaml
@@ -13,29 +13,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 582
-        body: '{"id":"e80439f0-7aa1-4b4a-bf7e-9ae6e35bebe9", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-tags-1", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:07.339678Z", "updated_at":"2026-06-17T08:18:07.343509Z", "protected":false, "locked":false, "description":null, "tags":["env:test", "team:test"], "rotated_at":"2026-06-17T08:18:07.343509Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}'
+        content_length: 548
+        body: '{"id":"62a30059-9199-4f5b-b16d-7fc491b85dd0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-tags-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.878293Z","updated_at":"2026-07-03T15:28:19.882699Z","protected":false,"locked":false,"description":null,"tags":["env:test","team:test"],"rotated_at":"2026-07-03T15:28:19.882699Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "582"
+                - "548"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:07 GMT
+                - Fri, 03 Jul 2026 15:28:19 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 50cdd2fd-3248-4deb-8528-76a8c2e1abb2
+                - 9e225c65-4eb3-4120-94b3-12c11a3f66d0
         status: 200 OK
         code: 200
-        duration: 1.258220958s
+        duration: 1.269782838s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -45,29 +45,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/e80439f0-7aa1-4b4a-bf7e-9ae6e35bebe9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/62a30059-9199-4f5b-b16d-7fc491b85dd0
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 582
-        body: '{"id":"e80439f0-7aa1-4b4a-bf7e-9ae6e35bebe9", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-tags-1", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:07.339678Z", "updated_at":"2026-06-17T08:18:07.343509Z", "protected":false, "locked":false, "description":null, "tags":["env:test", "team:test"], "rotated_at":"2026-06-17T08:18:07.343509Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}'
+        content_length: 548
+        body: '{"id":"62a30059-9199-4f5b-b16d-7fc491b85dd0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-tags-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.878293Z","updated_at":"2026-07-03T15:28:19.882699Z","protected":false,"locked":false,"description":null,"tags":["env:test","team:test"],"rotated_at":"2026-07-03T15:28:19.882699Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "582"
+                - "548"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:07 GMT
+                - Fri, 03 Jul 2026 15:28:19 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - a6a5ab35-232a-4717-9cb9-d7d22b41e083
+                - 39bb7934-9bac-4d2e-9b98-1397df853862
         status: 200 OK
         code: 200
-        duration: 198.803917ms
+        duration: 55.028258ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -77,29 +77,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/e80439f0-7aa1-4b4a-bf7e-9ae6e35bebe9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/62a30059-9199-4f5b-b16d-7fc491b85dd0
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 582
-        body: '{"id":"e80439f0-7aa1-4b4a-bf7e-9ae6e35bebe9", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-tags-1", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:07.339678Z", "updated_at":"2026-06-17T08:18:07.343509Z", "protected":false, "locked":false, "description":null, "tags":["env:test", "team:test"], "rotated_at":"2026-06-17T08:18:07.343509Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}'
+        content_length: 548
+        body: '{"id":"62a30059-9199-4f5b-b16d-7fc491b85dd0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-tags-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.878293Z","updated_at":"2026-07-03T15:28:19.882699Z","protected":false,"locked":false,"description":null,"tags":["env:test","team:test"],"rotated_at":"2026-07-03T15:28:19.882699Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "582"
+                - "548"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:08 GMT
+                - Fri, 03 Jul 2026 15:28:20 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - d48fb666-786b-468f-ba9a-403541a77db6
+                - 12c0d6cf-cde9-41c2-88db-d468fad57c2b
         status: 200 OK
         code: 200
-        duration: 156.555ms
+        duration: 47.07536ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -109,29 +109,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/e80439f0-7aa1-4b4a-bf7e-9ae6e35bebe9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/62a30059-9199-4f5b-b16d-7fc491b85dd0
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 582
-        body: '{"id":"e80439f0-7aa1-4b4a-bf7e-9ae6e35bebe9", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-tags-1", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:07.339678Z", "updated_at":"2026-06-17T08:18:07.343509Z", "protected":false, "locked":false, "description":null, "tags":["env:test", "team:test"], "rotated_at":"2026-06-17T08:18:07.343509Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}'
+        content_length: 548
+        body: '{"id":"62a30059-9199-4f5b-b16d-7fc491b85dd0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-tags-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.878293Z","updated_at":"2026-07-03T15:28:19.882699Z","protected":false,"locked":false,"description":null,"tags":["env:test","team:test"],"rotated_at":"2026-07-03T15:28:19.882699Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "582"
+                - "548"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:08 GMT
+                - Fri, 03 Jul 2026 15:28:20 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 5b3c3044-cf1e-4b1b-b3a8-44493372585c
+                - 48c3e693-7f99-4f83-8b3d-e0ea45d950ae
         status: 200 OK
         code: 200
-        duration: 144.175375ms
+        duration: 133.933544ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -144,29 +144,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 559
-        body: '{"id":"25088be1-345f-4ab8-a70d-99bf324e89f9", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-tags-2", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:09.411566Z", "updated_at":"2026-06-17T08:18:09.418665Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:09.418665Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}'
+        content_length: 526
+        body: '{"id":"b5d0e5ed-511f-4084-9ae1-5c4238ddd21b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-tags-2","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:21.485131Z","updated_at":"2026-07-03T15:28:21.488381Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:21.488381Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "559"
+                - "526"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:09 GMT
+                - Fri, 03 Jul 2026 15:28:21 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - fb3327c0-7a01-45b6-bb2c-2a4aa1e217e8
+                - f93bc5f0-f26c-4874-bcaf-94b245297ecf
         status: 200 OK
         code: 200
-        duration: 425.656208ms
+        duration: 351.560727ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -176,29 +176,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/25088be1-345f-4ab8-a70d-99bf324e89f9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/b5d0e5ed-511f-4084-9ae1-5c4238ddd21b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 559
-        body: '{"id":"25088be1-345f-4ab8-a70d-99bf324e89f9", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-tags-2", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:09.411566Z", "updated_at":"2026-06-17T08:18:09.418665Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:09.418665Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}'
+        content_length: 526
+        body: '{"id":"b5d0e5ed-511f-4084-9ae1-5c4238ddd21b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-tags-2","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:21.485131Z","updated_at":"2026-07-03T15:28:21.488381Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:21.488381Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "559"
+                - "526"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:09 GMT
+                - Fri, 03 Jul 2026 15:28:21 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 010cda78-2eb9-436f-9757-8b009a74deda
+                - 77d4358d-e4db-47cd-b92b-d0a6802d669f
         status: 200 OK
         code: 200
-        duration: 153.730416ms
+        duration: 43.519892ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -208,29 +208,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/25088be1-345f-4ab8-a70d-99bf324e89f9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/62a30059-9199-4f5b-b16d-7fc491b85dd0
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 559
-        body: '{"id":"25088be1-345f-4ab8-a70d-99bf324e89f9", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-tags-2", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:09.411566Z", "updated_at":"2026-06-17T08:18:09.418665Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:09.418665Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}'
+        content_length: 548
+        body: '{"id":"62a30059-9199-4f5b-b16d-7fc491b85dd0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-tags-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.878293Z","updated_at":"2026-07-03T15:28:19.882699Z","protected":false,"locked":false,"description":null,"tags":["env:test","team:test"],"rotated_at":"2026-07-03T15:28:19.882699Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "559"
+                - "548"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:09 GMT
+                - Fri, 03 Jul 2026 15:28:22 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - d9a11d60-40bb-4be6-a0c1-07aae02b5f2c
+                - 028daa46-1e5f-418c-88f5-a1cb3bbd6413
         status: 200 OK
         code: 200
-        duration: 60.143292ms
+        duration: 44.683478ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -240,29 +240,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/e80439f0-7aa1-4b4a-bf7e-9ae6e35bebe9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/b5d0e5ed-511f-4084-9ae1-5c4238ddd21b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 582
-        body: '{"id":"e80439f0-7aa1-4b4a-bf7e-9ae6e35bebe9", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-tags-1", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:07.339678Z", "updated_at":"2026-06-17T08:18:07.343509Z", "protected":false, "locked":false, "description":null, "tags":["env:test", "team:test"], "rotated_at":"2026-06-17T08:18:07.343509Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}'
+        content_length: 526
+        body: '{"id":"b5d0e5ed-511f-4084-9ae1-5c4238ddd21b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-tags-2","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:21.485131Z","updated_at":"2026-07-03T15:28:21.488381Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:21.488381Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "582"
+                - "526"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:10 GMT
+                - Fri, 03 Jul 2026 15:28:22 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - f62643d0-98ea-41c3-b8fc-4aae4e017389
+                - 3f7060df-7f4b-41ce-af16-5f67126c2fbe
         status: 200 OK
         code: 200
-        duration: 179.55775ms
+        duration: 48.01752ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -287,29 +287,29 @@ interactions:
                 - unknown_usage
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys?order_by=name_asc&page=1&project_id=105bdce1-64c0-48ab-899d-868455867ecf&protection_level=unknown_protection_level&scheduled_for_deletion=false&tags=env%3Atest&usage=unknown_usage
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 610
-        body: '{"keys":[{"id":"e80439f0-7aa1-4b4a-bf7e-9ae6e35bebe9", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-tags-1", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:07.339678Z", "updated_at":"2026-06-17T08:18:07.343509Z", "protected":false, "locked":false, "description":null, "tags":["env:test", "team:test"], "rotated_at":"2026-06-17T08:18:07.343509Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}], "total_count":1}'
+        content_length: 575
+        body: '{"keys":[{"id":"62a30059-9199-4f5b-b16d-7fc491b85dd0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-tags-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.878293Z","updated_at":"2026-07-03T15:28:19.882699Z","protected":false,"locked":false,"description":null,"tags":["env:test","team:test"],"rotated_at":"2026-07-03T15:28:19.882699Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
-                - "610"
+                - "575"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:10 GMT
+                - Fri, 03 Jul 2026 15:28:22 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 5b015850-5fbe-453a-9b97-d527375be966
+                - 07a194f5-9148-4726-9844-fa7bc1ade1cb
         status: 200 OK
         code: 200
-        duration: 207.703459ms
+        duration: 42.021117ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -319,8 +319,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/e80439f0-7aa1-4b4a-bf7e-9ae6e35bebe9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/b5d0e5ed-511f-4084-9ae1-5c4238ddd21b
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -332,14 +332,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:10 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - e6d2997c-dfc0-4c69-bd3e-998e95358212
+                - 9491f53f-94d4-480d-945a-ce5d2c311f0d
         status: 204 No Content
         code: 204
-        duration: 252.218417ms
+        duration: 95.767739ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -349,8 +349,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/25088be1-345f-4ab8-a70d-99bf324e89f9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/62a30059-9199-4f5b-b16d-7fc491b85dd0
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -362,14 +362,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:10 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - cd52de4b-a55f-4517-bfba-8b51e606c872
+                - 78fdf19b-6860-4a63-9663-2c5fe6f47bca
         status: 204 No Content
         code: 204
-        duration: 252.411125ms
+        duration: 149.346905ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -379,29 +379,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/e80439f0-7aa1-4b4a-bf7e-9ae6e35bebe9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/62a30059-9199-4f5b-b16d-7fc491b85dd0
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 622
-        body: '{"id":"e80439f0-7aa1-4b4a-bf7e-9ae6e35bebe9", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-tags-1", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"scheduled_for_deletion", "rotation_count":1, "created_at":"2026-06-17T08:18:07.339678Z", "updated_at":"2026-06-17T08:18:07.343509Z", "protected":false, "locked":false, "description":null, "tags":["env:test", "team:test"], "rotated_at":"2026-06-17T08:18:07.343509Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":"2026-06-17T08:18:10.850492Z", "protection_level":"unknown_protection_level", "region":"fr-par"}'
+        content_length: 588
+        body: '{"id":"62a30059-9199-4f5b-b16d-7fc491b85dd0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-tags-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-03T15:28:19.878293Z","updated_at":"2026-07-03T15:28:23.098681Z","protected":false,"locked":false,"description":null,"tags":["env:test","team:test"],"rotated_at":"2026-07-03T15:28:19.882699Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-03T15:28:23.098681Z","protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "622"
+                - "588"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:11 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - d9691ed7-a9a3-430c-ac35-47f73087e7c9
+                - c7f6de34-1081-44fa-bb77-f4c35da9b510
         status: 200 OK
         code: 200
-        duration: 106.5745ms
+        duration: 47.635694ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -411,26 +411,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/25088be1-345f-4ab8-a70d-99bf324e89f9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/b5d0e5ed-511f-4084-9ae1-5c4238ddd21b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 599
-        body: '{"id":"25088be1-345f-4ab8-a70d-99bf324e89f9", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-tags-2", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"scheduled_for_deletion", "rotation_count":1, "created_at":"2026-06-17T08:18:09.411566Z", "updated_at":"2026-06-17T08:18:09.418665Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:09.418665Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":"2026-06-17T08:18:10.934675Z", "protection_level":"unknown_protection_level", "region":"fr-par"}'
+        content_length: 566
+        body: '{"id":"b5d0e5ed-511f-4084-9ae1-5c4238ddd21b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-tags-2","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-03T15:28:21.485131Z","updated_at":"2026-07-03T15:28:23.074937Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:21.488381Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-03T15:28:23.074937Z","protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "599"
+                - "566"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:11 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 634696b8-4da9-4887-a168-366d638468e7
+                - 32db6817-402f-49e5-b3e2-004359567248
         status: 200 OK
         code: 200
-        duration: 223.039792ms
+        duration: 47.029294ms

--- a/internal/services/keymanager/testdata/list-key-manager-keys-by-usage.cassette.yaml
+++ b/internal/services/keymanager/testdata/list-key-manager-keys-by-usage.cassette.yaml
@@ -13,29 +13,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 560
-        body: '{"id":"95dd1a29-c2b3-475e-86e8-9ca48aea09fa", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-usage-1", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:07.460947Z", "updated_at":"2026-06-17T08:18:07.465475Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:07.465475Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}'
+        content_length: 527
+        body: '{"id":"5180620d-12d4-4ff6-8d8e-fae5a52e6219","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-usage-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.233790Z","updated_at":"2026-07-03T15:28:19.237469Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.237469Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "560"
+                - "527"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:07 GMT
+                - Fri, 03 Jul 2026 15:28:19 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - e2609124-51b3-4290-9963-399ab128b96a
+                - 1ebe49e5-c092-4fac-a20f-6207ce2b7635
         status: 200 OK
         code: 200
-        duration: 1.311907625s
+        duration: 616.743943ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -45,29 +45,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/95dd1a29-c2b3-475e-86e8-9ca48aea09fa
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/5180620d-12d4-4ff6-8d8e-fae5a52e6219
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 560
-        body: '{"id":"95dd1a29-c2b3-475e-86e8-9ca48aea09fa", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-usage-1", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:07.460947Z", "updated_at":"2026-06-17T08:18:07.465475Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:07.465475Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}'
+        content_length: 527
+        body: '{"id":"5180620d-12d4-4ff6-8d8e-fae5a52e6219","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-usage-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.233790Z","updated_at":"2026-07-03T15:28:19.237469Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.237469Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "560"
+                - "527"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:07 GMT
+                - Fri, 03 Jul 2026 15:28:19 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - ccc0a7d7-3648-4913-8e28-408682742d1c
+                - 5069fcec-822d-454f-9276-68ba999a7ec1
         status: 200 OK
         code: 200
-        duration: 324.588875ms
+        duration: 82.550823ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -77,29 +77,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/95dd1a29-c2b3-475e-86e8-9ca48aea09fa
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/5180620d-12d4-4ff6-8d8e-fae5a52e6219
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 560
-        body: '{"id":"95dd1a29-c2b3-475e-86e8-9ca48aea09fa", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-usage-1", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:07.460947Z", "updated_at":"2026-06-17T08:18:07.465475Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:07.465475Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}'
+        content_length: 527
+        body: '{"id":"5180620d-12d4-4ff6-8d8e-fae5a52e6219","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-usage-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.233790Z","updated_at":"2026-07-03T15:28:19.237469Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.237469Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "560"
+                - "527"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:08 GMT
+                - Fri, 03 Jul 2026 15:28:19 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 539d7dac-c5b3-4aca-bac8-2bbc8eb97391
+                - dc1da4bf-73b3-4880-bb66-0a98fdde8b82
         status: 200 OK
         code: 200
-        duration: 83.06525ms
+        duration: 49.654945ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -109,29 +109,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/95dd1a29-c2b3-475e-86e8-9ca48aea09fa
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/5180620d-12d4-4ff6-8d8e-fae5a52e6219
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 560
-        body: '{"id":"95dd1a29-c2b3-475e-86e8-9ca48aea09fa", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-usage-1", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:07.460947Z", "updated_at":"2026-06-17T08:18:07.465475Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:07.465475Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}'
+        content_length: 527
+        body: '{"id":"5180620d-12d4-4ff6-8d8e-fae5a52e6219","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-usage-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.233790Z","updated_at":"2026-07-03T15:28:19.237469Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.237469Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "560"
+                - "527"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:08 GMT
+                - Fri, 03 Jul 2026 15:28:20 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 368442e2-2c13-4199-b6c9-ec2ef7f7cd48
+                - 64311b7d-604e-4539-b572-55af28393fa5
         status: 200 OK
         code: 200
-        duration: 114.03775ms
+        duration: 154.717381ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -144,29 +144,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 570
-        body: '{"id":"fc9d4560-7413-4d34-8f61-8ec278577a7c", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-usage-2", "usage":{"asymmetric_encryption":"rsa_oaep_4096_sha256"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:09.559660Z", "updated_at":"2026-06-17T08:18:10.041872Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:10.041872Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}'
+        content_length: 537
+        body: '{"id":"a6bcfe1d-58dc-4ff7-8cd8-641dd5374f13","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-usage-2","usage":{"asymmetric_encryption":"rsa_oaep_4096_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:20.545511Z","updated_at":"2026-07-03T15:28:21.411434Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:21.411434Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "570"
+                - "537"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:10 GMT
+                - Fri, 03 Jul 2026 15:28:21 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - a81b850f-e255-4544-8d17-1844f6409495
+                - 218cebf8-b67b-4b54-a6dc-7c66413b97e9
         status: 200 OK
         code: 200
-        duration: 1.04398125s
+        duration: 949.366811ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -176,29 +176,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/fc9d4560-7413-4d34-8f61-8ec278577a7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/a6bcfe1d-58dc-4ff7-8cd8-641dd5374f13
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 570
-        body: '{"id":"fc9d4560-7413-4d34-8f61-8ec278577a7c", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-usage-2", "usage":{"asymmetric_encryption":"rsa_oaep_4096_sha256"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:09.559660Z", "updated_at":"2026-06-17T08:18:10.041872Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:10.041872Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}'
+        content_length: 537
+        body: '{"id":"a6bcfe1d-58dc-4ff7-8cd8-641dd5374f13","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-usage-2","usage":{"asymmetric_encryption":"rsa_oaep_4096_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:20.545511Z","updated_at":"2026-07-03T15:28:21.411434Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:21.411434Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "570"
+                - "537"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:10 GMT
+                - Fri, 03 Jul 2026 15:28:21 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 1c05e194-9a1f-4f74-b503-544d47f237ab
+                - e7ce2bfc-a8ab-4f23-b8ce-e6386e0412b1
         status: 200 OK
         code: 200
-        duration: 209.954458ms
+        duration: 47.920718ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -208,29 +208,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/95dd1a29-c2b3-475e-86e8-9ca48aea09fa
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/a6bcfe1d-58dc-4ff7-8cd8-641dd5374f13
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 560
-        body: '{"id":"95dd1a29-c2b3-475e-86e8-9ca48aea09fa", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-usage-1", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:07.460947Z", "updated_at":"2026-06-17T08:18:07.465475Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:07.465475Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}'
+        content_length: 537
+        body: '{"id":"a6bcfe1d-58dc-4ff7-8cd8-641dd5374f13","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-usage-2","usage":{"asymmetric_encryption":"rsa_oaep_4096_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:20.545511Z","updated_at":"2026-07-03T15:28:21.411434Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:21.411434Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "560"
+                - "537"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:10 GMT
+                - Fri, 03 Jul 2026 15:28:21 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - f08b1ce2-935e-47e8-8b00-8117cf4e4fe2
+                - 409febf2-05c8-401b-9936-d1693b9748f5
         status: 200 OK
         code: 200
-        duration: 198.297375ms
+        duration: 43.301683ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -240,29 +240,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/fc9d4560-7413-4d34-8f61-8ec278577a7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/5180620d-12d4-4ff6-8d8e-fae5a52e6219
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 570
-        body: '{"id":"fc9d4560-7413-4d34-8f61-8ec278577a7c", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-usage-2", "usage":{"asymmetric_encryption":"rsa_oaep_4096_sha256"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:09.559660Z", "updated_at":"2026-06-17T08:18:10.041872Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:10.041872Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}'
+        content_length: 527
+        body: '{"id":"5180620d-12d4-4ff6-8d8e-fae5a52e6219","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-usage-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.233790Z","updated_at":"2026-07-03T15:28:19.237469Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.237469Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "570"
+                - "527"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:10 GMT
+                - Fri, 03 Jul 2026 15:28:21 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 9d99add3-cfef-45c1-a7c5-068e8823e699
+                - 6751dd8d-7a0c-4001-8fab-a98336482dcb
         status: 200 OK
         code: 200
-        duration: 204.399625ms
+        duration: 43.678811ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -285,29 +285,29 @@ interactions:
                 - asymmetric_encryption
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys?order_by=name_asc&page=1&project_id=105bdce1-64c0-48ab-899d-868455867ecf&protection_level=unknown_protection_level&scheduled_for_deletion=false&usage=asymmetric_encryption
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 598
-        body: '{"keys":[{"id":"fc9d4560-7413-4d34-8f61-8ec278577a7c", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-usage-2", "usage":{"asymmetric_encryption":"rsa_oaep_4096_sha256"}, "state":"enabled", "rotation_count":1, "created_at":"2026-06-17T08:18:09.559660Z", "updated_at":"2026-06-17T08:18:10.041872Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:10.041872Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"unknown_protection_level", "region":"fr-par"}], "total_count":1}'
+        content_length: 564
+        body: '{"keys":[{"id":"a6bcfe1d-58dc-4ff7-8cd8-641dd5374f13","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-usage-2","usage":{"asymmetric_encryption":"rsa_oaep_4096_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:20.545511Z","updated_at":"2026-07-03T15:28:21.411434Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:21.411434Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
-                - "598"
+                - "564"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:11 GMT
+                - Fri, 03 Jul 2026 15:28:22 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 6cebd711-b78c-4608-8bb0-dd565cbf0792
+                - 5e89ab59-3c8a-44f0-9452-68e3caabb631
         status: 200 OK
         code: 200
-        duration: 232.144375ms
+        duration: 128.083225ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -317,8 +317,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/95dd1a29-c2b3-475e-86e8-9ca48aea09fa
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/5180620d-12d4-4ff6-8d8e-fae5a52e6219
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -330,14 +330,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:11 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - e29ec32a-6457-4cf1-842f-d4aa20d6ca7b
+                - 8bb586b3-1079-4a57-83f8-2bd4235ef9e9
         status: 204 No Content
         code: 204
-        duration: 105.232875ms
+        duration: 102.32789ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -347,8 +347,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/fc9d4560-7413-4d34-8f61-8ec278577a7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/a6bcfe1d-58dc-4ff7-8cd8-641dd5374f13
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -360,14 +360,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:11 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - dc4610b7-ff33-4f81-9aef-e96cf91917cf
+                - 42523fd0-8bd0-433a-933a-fb7da826ce60
         status: 204 No Content
         code: 204
-        duration: 314.809ms
+        duration: 103.633342ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -377,29 +377,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/fc9d4560-7413-4d34-8f61-8ec278577a7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/a6bcfe1d-58dc-4ff7-8cd8-641dd5374f13
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 610
-        body: '{"id":"fc9d4560-7413-4d34-8f61-8ec278577a7c", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-usage-2", "usage":{"asymmetric_encryption":"rsa_oaep_4096_sha256"}, "state":"scheduled_for_deletion", "rotation_count":1, "created_at":"2026-06-17T08:18:09.559660Z", "updated_at":"2026-06-17T08:18:10.041872Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:10.041872Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":"2026-06-17T08:18:11.701156Z", "protection_level":"unknown_protection_level", "region":"fr-par"}'
+        content_length: 577
+        body: '{"id":"a6bcfe1d-58dc-4ff7-8cd8-641dd5374f13","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-usage-2","usage":{"asymmetric_encryption":"rsa_oaep_4096_sha256"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-03T15:28:20.545511Z","updated_at":"2026-07-03T15:28:23.037779Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:21.411434Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-03T15:28:23.037778Z","protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "610"
+                - "577"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:11 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 1d984896-9f32-481a-9e9d-e457952ffbac
+                - 5f8cbb49-6428-4702-9d48-69d87655c1a3
         status: 200 OK
         code: 200
-        duration: 143.064584ms
+        duration: 45.937964ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -409,26 +409,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/95dd1a29-c2b3-475e-86e8-9ca48aea09fa
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/5180620d-12d4-4ff6-8d8e-fae5a52e6219
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 600
-        body: '{"id":"95dd1a29-c2b3-475e-86e8-9ca48aea09fa", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-km-by-usage-1", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"scheduled_for_deletion", "rotation_count":1, "created_at":"2026-06-17T08:18:07.460947Z", "updated_at":"2026-06-17T08:18:07.465475Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-06-17T08:18:07.465475Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":"2026-06-17T08:18:11.631495Z", "protection_level":"unknown_protection_level", "region":"fr-par"}'
+        content_length: 567
+        body: '{"id":"5180620d-12d4-4ff6-8d8e-fae5a52e6219","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-usage-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-03T15:28:19.233790Z","updated_at":"2026-07-03T15:28:23.029298Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.237469Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-03T15:28:23.029298Z","protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "600"
+                - "567"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 17 Jun 2026 08:18:12 GMT
+                - Fri, 03 Jul 2026 15:28:23 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 5cff3e76-c86c-4364-8fe3-84243f053b82
+                - afdeffe2-ae4e-4ced-ae8c-efd515ea5df8
         status: 200 OK
         code: 200
-        duration: 106.987458ms
+        duration: 44.712533ms

--- a/internal/services/keymanager/testdata/sign-ephemeral-resource-basic.cassette.yaml
+++ b/internal/services/keymanager/testdata/sign-ephemeral-resource-basic.cassette.yaml
@@ -13,7 +13,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets
         method: POST
       response:
@@ -21,21 +21,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 430
-        body: '{"id":"d56237fa-e1c3-40e1-ba83-41dddfacae31","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-sign-secret","status":"ready","created_at":"2026-01-30T16:15:05.262533Z","updated_at":"2026-01-30T16:15:05.262533Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"8353536d-27ba-4e9d-bcf7-4d29355a1a29","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-sign-secret","status":"ready","created_at":"2026-07-03T15:28:18.835051Z","updated_at":"2026-07-03T15:28:18.835051Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "430"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 30 Jan 2026 16:15:05 GMT
+                - Fri, 03 Jul 2026 15:28:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - dad9ad40-6a6e-46e1-87a7-2c6baa1e479c
+                - 62179fa0-b4a9-49bb-807d-aa2b4d6be6ff
         status: 200 OK
         code: 200
-        duration: 268.027259ms
+        duration: 207.725565ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -45,29 +45,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/d56237fa-e1c3-40e1-ba83-41dddfacae31
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8353536d-27ba-4e9d-bcf7-4d29355a1a29
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 430
-        body: '{"id":"d56237fa-e1c3-40e1-ba83-41dddfacae31","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-sign-secret","status":"ready","created_at":"2026-01-30T16:15:05.262533Z","updated_at":"2026-01-30T16:15:05.262533Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"8353536d-27ba-4e9d-bcf7-4d29355a1a29","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-sign-secret","status":"ready","created_at":"2026-07-03T15:28:18.835051Z","updated_at":"2026-07-03T15:28:18.835051Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "430"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 30 Jan 2026 16:15:05 GMT
+                - Fri, 03 Jul 2026 15:28:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - bf220b42-3580-426b-bf7f-5ac817ac933b
+                - 517e1c3c-dd5b-4174-a5e4-0bcc2529d19a
         status: 200 OK
         code: 200
-        duration: 83.141879ms
+        duration: 50.340443ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -80,8 +80,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/d56237fa-e1c3-40e1-ba83-41dddfacae31/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8353536d-27ba-4e9d-bcf7-4d29355a1a29/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -95,49 +95,49 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 30 Jan 2026 16:15:05 GMT
+                - Fri, 03 Jul 2026 15:28:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - f52e2698-5d4c-48f2-ac9b-c6ed8489a285
+                - 0a9438b5-3fae-4a62-8f0b-eb7905d839c8
         status: 200 OK
         code: 200
-        duration: 46.010113ms
+        duration: 36.665187ms
     - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 189
+        content_length: 235
         host: api.scaleway.com
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-sign-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"tags":null,"unprotected":true,"origin":"unknown_origin"}'
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-sign-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"tags":null,"unprotected":true,"origin":"unknown_origin","protection_level":"unknown_protection_level"}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 498
-        body: '{"id":"9398c1ca-68c4-4519-8d88-e3eb876aaf5a","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-sign-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-01-30T16:15:05.381560Z","updated_at":"2026-01-30T16:15:05.424645Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-01-30T16:15:05.424645Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 528
+        body: '{"id":"1157fe98-a66f-4fbc-803c-30a07685869e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-sign-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.410788Z","updated_at":"2026-07-03T15:28:19.523205Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.523205Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "498"
+                - "528"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 30 Jan 2026 16:15:05 GMT
+                - Fri, 03 Jul 2026 15:28:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 9b885f1e-679a-400b-8faf-fb21e2f4d85f
+                - c340a495-a43b-4730-83a8-c7df8ffedb4e
         status: 200 OK
         code: 200
-        duration: 445.937937ms
+        duration: 900.942565ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -147,29 +147,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/9398c1ca-68c4-4519-8d88-e3eb876aaf5a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/1157fe98-a66f-4fbc-803c-30a07685869e
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 498
-        body: '{"id":"9398c1ca-68c4-4519-8d88-e3eb876aaf5a","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-sign-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-01-30T16:15:05.381560Z","updated_at":"2026-01-30T16:15:05.424645Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-01-30T16:15:05.424645Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 528
+        body: '{"id":"1157fe98-a66f-4fbc-803c-30a07685869e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-sign-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.410788Z","updated_at":"2026-07-03T15:28:19.523205Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.523205Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "498"
+                - "528"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 30 Jan 2026 16:15:05 GMT
+                - Fri, 03 Jul 2026 15:28:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - ba57134c-bf75-4cf5-af83-6a9b2860c73c
+                - ea34bdf2-fbaa-485f-9acc-7a65781296f2
         status: 200 OK
         code: 200
-        duration: 77.102512ms
+        duration: 39.855389ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -182,29 +182,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/9398c1ca-68c4-4519-8d88-e3eb876aaf5a/sign
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/1157fe98-a66f-4fbc-803c-30a07685869e/sign
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 408
-        body: '{"key_id":"9398c1ca-68c4-4519-8d88-e3eb876aaf5a","signature":"HW3+vxV5JfypLlh2uOv+eD2brR+p92N+RHxl1OjalDreNzAmguvteDlbpYBvLcXaXvIHY3b29W6BhS/bN67SzwNDbLoYBvSvgbNn5MsKkvQTbcUu3odzog95S9JwTx87pxRQ6W8C77jkZA7nvdSOoFuaizvOBBV06h7qbJwsoVpu33/i7lX67pfyJFuU8Ai0Uj4/b68YDPVjmjleQTC7mRufdKkjVmDBPbblB4jVP4ywI75U9cZNvq8Q7HkcXyC9oXB1op5Fql//PeVBs40YPe5KhMqBajfRr+sj6RcuNXaX2RbdGZxT96M7vowW6rYbSD2LfnPiStbSzstX/CO9iA=="}'
+        body: '{"key_id":"1157fe98-a66f-4fbc-803c-30a07685869e","signature":"FzrsLiGj7FkF3IcLwnCaLKbYrgSp/Gw4zMa9uTSvU9s3Tqfosg8ASbTzz7YnB/XIvwwEshNcZCeLt55JTz7JTFQBPhlfDfBRo9cVGiGGCuLqO2pl+v65nLq2eGGUxroJ5hEARHq2gzysWvRKDtpTsjQFVmN2tD9tf4fl33nIEMuFMbNH67STOdyHRDoWCZFx6urwk7X4WdiABdzKxr/1Dwrzq44k+t5Au+Gb5lCmvF7aBGLnJ9IsBXyR9c2xoYirY6//1ehdT00y2o6TFNMjZZvU39/Ip717cmgpvzrFMNeCZ7NOcMgLX4UwsQoXQvA6EeNs4+3PIWh0wztYAx/eQg=="}'
         headers:
             Content-Length:
                 - "408"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 30 Jan 2026 16:15:05 GMT
+                - Fri, 03 Jul 2026 15:28:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 024d3913-039b-4922-ab0d-a787f7f2af5b
+                - 53e2a72b-3f4f-4046-bddf-f8a1f9686b4c
         status: 200 OK
         code: 200
-        duration: 128.936928ms
+        duration: 246.666266ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -212,34 +212,34 @@ interactions:
         proto_minor: 1
         content_length: 496
         host: api.scaleway.com
-        body: '{"data":"SFczK3Z4VjVKZnlwTGxoMnVPditlRDJiclIrcDkyTitSSHhsMU9qYWxEcmVOekFtZ3V2dGVEbGJwWUJ2TGNYYVh2SUhZM2IyOVc2QmhTL2JONjdTendORGJMb1lCdlN2Z2JObjVNc0trdlFUYmNVdTNvZHpvZzk1UzlKd1R4ODdweFJRNlc4Qzc3amtaQTdudmRTT29GdWFpenZPQkJWMDZoN3FiSndzb1ZwdTMzL2k3bFg2N3BmeUpGdVU4QWkwVWo0L2I2OFlEUFZqbWpsZVFUQzdtUnVmZEtralZtREJQYmJsQjRqVlA0eXdJNzVVOWNaTnZxOFE3SGtjWHlDOW9YQjFvcDVGcWwvL1BlVkJzNDBZUGU1S2hNcUJhamZScitzajZSY3VOWGFYMlJiZEdaeFQ5Nk03dm93VzZyWWJTRDJMZm5QaVN0YlN6c3RYL0NPOWlBPT0=","description":"version1"}'
+        body: '{"data":"Rnpyc0xpR2o3RmtGM0ljTHduQ2FMS2JZcmdTcC9HdzR6TWE5dVRTdlU5czNUcWZvc2c4QVNiVHp6N1luQi9YSXZ3d0VzaE5jWkNlTHQ1NUpUejdKVEZRQlBobGZEZkJSbzljVkdpR0dDdUxxTzJwbCt2NjVuTHEyZUdHVXhyb0o1aEVBUkhxMmd6eXNXdlJLRHRwVHNqUUZWbU4ydEQ5dGY0ZmwzM25JRU11Rk1iTkg2N1NUT2R5SFJEb1dDWkZ4NnVyd2s3WDRXZGlBQmR6S3hyLzFEd3J6cTQ0ayt0NUF1K0diNWxDbXZGN2FCR0xuSjlJc0JYeVI5YzJ4b1lpclk2Ly8xZWhkVDAweTJvNlRGTk1qWlp2VTM5L0lwNzE3Y21ncHZ6ckZNTmVDWjdOT2NNZ0xYNFV3c1FvWFF2QTZFZU5zNCszUElXaDB3enRZQXgvZVFnPT0=","description":"version1"}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/d56237fa-e1c3-40e1-ba83-41dddfacae31/versions
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8353536d-27ba-4e9d-bcf7-4d29355a1a29/versions
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"d56237fa-e1c3-40e1-ba83-41dddfacae31","status":"enabled","created_at":"2026-01-30T16:15:05.982171Z","updated_at":"2026-01-30T16:15:05.982171Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"8353536d-27ba-4e9d-bcf7-4d29355a1a29","status":"enabled","created_at":"2026-07-03T15:28:20.211273Z","updated_at":"2026-07-03T15:28:20.211273Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 30 Jan 2026 16:15:06 GMT
+                - Fri, 03 Jul 2026 15:28:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - abd67403-bb9b-41e6-bc0e-f94732f23242
+                - e227b879-ae52-4e25-852f-e88cf99e547d
         status: 200 OK
         code: 200
-        duration: 393.785443ms
+        duration: 384.075358ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -249,29 +249,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/d56237fa-e1c3-40e1-ba83-41dddfacae31/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8353536d-27ba-4e9d-bcf7-4d29355a1a29/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"d56237fa-e1c3-40e1-ba83-41dddfacae31","status":"enabled","created_at":"2026-01-30T16:15:05.982171Z","updated_at":"2026-01-30T16:15:05.982171Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"8353536d-27ba-4e9d-bcf7-4d29355a1a29","status":"enabled","created_at":"2026-07-03T15:28:20.211273Z","updated_at":"2026-07-03T15:28:20.211273Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 30 Jan 2026 16:15:06 GMT
+                - Fri, 03 Jul 2026 15:28:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 9222d763-6836-45cd-bccc-4408b6a7f75f
+                - 86bea314-f6be-4cab-bf95-2c77fd2a6b1f
         status: 200 OK
         code: 200
-        duration: 95.148072ms
+        duration: 48.525273ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -281,29 +281,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/d56237fa-e1c3-40e1-ba83-41dddfacae31/versions/1/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8353536d-27ba-4e9d-bcf7-4d29355a1a29/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 569
-        body: '{"secret_id":"d56237fa-e1c3-40e1-ba83-41dddfacae31","revision":1,"data":"SFczK3Z4VjVKZnlwTGxoMnVPditlRDJiclIrcDkyTitSSHhsMU9qYWxEcmVOekFtZ3V2dGVEbGJwWUJ2TGNYYVh2SUhZM2IyOVc2QmhTL2JONjdTendORGJMb1lCdlN2Z2JObjVNc0trdlFUYmNVdTNvZHpvZzk1UzlKd1R4ODdweFJRNlc4Qzc3amtaQTdudmRTT29GdWFpenZPQkJWMDZoN3FiSndzb1ZwdTMzL2k3bFg2N3BmeUpGdVU4QWkwVWo0L2I2OFlEUFZqbWpsZVFUQzdtUnVmZEtralZtREJQYmJsQjRqVlA0eXdJNzVVOWNaTnZxOFE3SGtjWHlDOW9YQjFvcDVGcWwvL1BlVkJzNDBZUGU1S2hNcUJhamZScitzajZSY3VOWGFYMlJiZEdaeFQ5Nk03dm93VzZyWWJTRDJMZm5QaVN0YlN6c3RYL0NPOWlBPT0=","data_crc32":null,"type":"opaque"}'
+        body: '{"secret_id":"8353536d-27ba-4e9d-bcf7-4d29355a1a29","revision":1,"data":"Rnpyc0xpR2o3RmtGM0ljTHduQ2FMS2JZcmdTcC9HdzR6TWE5dVRTdlU5czNUcWZvc2c4QVNiVHp6N1luQi9YSXZ3d0VzaE5jWkNlTHQ1NUpUejdKVEZRQlBobGZEZkJSbzljVkdpR0dDdUxxTzJwbCt2NjVuTHEyZUdHVXhyb0o1aEVBUkhxMmd6eXNXdlJLRHRwVHNqUUZWbU4ydEQ5dGY0ZmwzM25JRU11Rk1iTkg2N1NUT2R5SFJEb1dDWkZ4NnVyd2s3WDRXZGlBQmR6S3hyLzFEd3J6cTQ0ayt0NUF1K0diNWxDbXZGN2FCR0xuSjlJc0JYeVI5YzJ4b1lpclk2Ly8xZWhkVDAweTJvNlRGTk1qWlp2VTM5L0lwNzE3Y21ncHZ6ckZNTmVDWjdOT2NNZ0xYNFV3c1FvWFF2QTZFZU5zNCszUElXaDB3enRZQXgvZVFnPT0=","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
                 - "569"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 30 Jan 2026 16:15:06 GMT
+                - Fri, 03 Jul 2026 15:28:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 56f6f4c0-f779-47dc-af69-a53c94849ff3
+                - fafa41bb-0b3e-4663-bca5-b801ab38b214
         status: 200 OK
         code: 200
-        duration: 116.930602ms
+        duration: 71.373148ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -313,29 +313,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/d56237fa-e1c3-40e1-ba83-41dddfacae31/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8353536d-27ba-4e9d-bcf7-4d29355a1a29/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"d56237fa-e1c3-40e1-ba83-41dddfacae31","status":"enabled","created_at":"2026-01-30T16:15:05.982171Z","updated_at":"2026-01-30T16:15:05.982171Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"8353536d-27ba-4e9d-bcf7-4d29355a1a29","status":"enabled","created_at":"2026-07-03T15:28:20.211273Z","updated_at":"2026-07-03T15:28:20.211273Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 30 Jan 2026 16:15:06 GMT
+                - Fri, 03 Jul 2026 15:28:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 9dbb0274-a12b-49af-aec3-f85acbaab283
+                - 7d579a2f-87b1-40fc-b65e-10999d323f2f
         status: 200 OK
         code: 200
-        duration: 52.872156ms
+        duration: 37.237332ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -348,29 +348,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/9398c1ca-68c4-4519-8d88-e3eb876aaf5a/sign
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/1157fe98-a66f-4fbc-803c-30a07685869e/sign
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 408
-        body: '{"key_id":"9398c1ca-68c4-4519-8d88-e3eb876aaf5a","signature":"tqfe/y2Imohfx6PMtSzgZ57515UDJQ2olWaHIVNISTziMHi2Yt3+UstvKuanepMFhS47jWdtc/37TYlX7wQgudGsk3BofooUJN+15dBBV/OIXtJT3h1xG32p1duCg4cU7V3PLKyV/URmd6k7LU7FeeBjyvyymkitkg7GaKY+5rpRVRsrOaJQzNahGz5zOAmlimbuj8qNXI3KlXYjIwVHunskIk5X0WtD24mQGRUXqzKlMJ76t9bbEsB9vKAPMi7yTu9pYXoqiLWBNq/vknmRhAOWnQ1mWskDvrKaTUp2Bb+EGzl5pa3I/kfrliCH0vYYI8hhfz9hl6FP7uoPFZCrvA=="}'
+        body: '{"key_id":"1157fe98-a66f-4fbc-803c-30a07685869e","signature":"kywbmZtY1X0MWRRup8DvYdHAetUHFWewRkameYz561DH6hIx981ErqzlqlnbNCVnc0sEug2IM9YE3ZAui/WpQt6E3XgT8pqPOAQOvF0KePa/W64ahVlm+KfX907C09k0O/NrNEIXxuyvfhYtJYQX1i0DMRn6OF2qv3tmMHx9onxH19QYcuYZZDPFpaRsa/sLZfjcRhgrn+tGamMwtrcwweW3vI+vLHMgs4NNLUH0nudf496rTAhxZRg1IJbvsm6FQuKkHcRNRzqwCRl9nkM0f4TQT2b3cebuoUDcOZYl1uKzFBtcxPYWLl7+/8u0rg/MzuV+0V9xK70ocMhuo6w3fA=="}'
         headers:
             Content-Length:
                 - "408"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 30 Jan 2026 16:15:06 GMT
+                - Fri, 03 Jul 2026 15:28:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 936c6f09-02ce-47ff-9c4d-56acd3b044e9
+                - d65c9be6-4b07-493d-815c-4efb008e76f3
         status: 200 OK
         code: 200
-        duration: 113.489607ms
+        duration: 98.808359ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -380,29 +380,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/d56237fa-e1c3-40e1-ba83-41dddfacae31/versions/1/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8353536d-27ba-4e9d-bcf7-4d29355a1a29/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 569
-        body: '{"secret_id":"d56237fa-e1c3-40e1-ba83-41dddfacae31","revision":1,"data":"SFczK3Z4VjVKZnlwTGxoMnVPditlRDJiclIrcDkyTitSSHhsMU9qYWxEcmVOekFtZ3V2dGVEbGJwWUJ2TGNYYVh2SUhZM2IyOVc2QmhTL2JONjdTendORGJMb1lCdlN2Z2JObjVNc0trdlFUYmNVdTNvZHpvZzk1UzlKd1R4ODdweFJRNlc4Qzc3amtaQTdudmRTT29GdWFpenZPQkJWMDZoN3FiSndzb1ZwdTMzL2k3bFg2N3BmeUpGdVU4QWkwVWo0L2I2OFlEUFZqbWpsZVFUQzdtUnVmZEtralZtREJQYmJsQjRqVlA0eXdJNzVVOWNaTnZxOFE3SGtjWHlDOW9YQjFvcDVGcWwvL1BlVkJzNDBZUGU1S2hNcUJhamZScitzajZSY3VOWGFYMlJiZEdaeFQ5Nk03dm93VzZyWWJTRDJMZm5QaVN0YlN6c3RYL0NPOWlBPT0=","data_crc32":null,"type":"opaque"}'
+        body: '{"secret_id":"8353536d-27ba-4e9d-bcf7-4d29355a1a29","revision":1,"data":"Rnpyc0xpR2o3RmtGM0ljTHduQ2FMS2JZcmdTcC9HdzR6TWE5dVRTdlU5czNUcWZvc2c4QVNiVHp6N1luQi9YSXZ3d0VzaE5jWkNlTHQ1NUpUejdKVEZRQlBobGZEZkJSbzljVkdpR0dDdUxxTzJwbCt2NjVuTHEyZUdHVXhyb0o1aEVBUkhxMmd6eXNXdlJLRHRwVHNqUUZWbU4ydEQ5dGY0ZmwzM25JRU11Rk1iTkg2N1NUT2R5SFJEb1dDWkZ4NnVyd2s3WDRXZGlBQmR6S3hyLzFEd3J6cTQ0ayt0NUF1K0diNWxDbXZGN2FCR0xuSjlJc0JYeVI5YzJ4b1lpclk2Ly8xZWhkVDAweTJvNlRGTk1qWlp2VTM5L0lwNzE3Y21ncHZ6ckZNTmVDWjdOT2NNZ0xYNFV3c1FvWFF2QTZFZU5zNCszUElXaDB3enRZQXgvZVFnPT0=","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
                 - "569"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 30 Jan 2026 16:15:06 GMT
+                - Fri, 03 Jul 2026 15:28:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - dfa3839f-6d0b-4643-bb1c-7424f77e856f
+                - 3ae7bf10-d99d-448c-8dca-d2d8e40ca6be
         status: 200 OK
         code: 200
-        duration: 133.266622ms
+        duration: 45.094781ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -412,29 +412,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/d56237fa-e1c3-40e1-ba83-41dddfacae31/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8353536d-27ba-4e9d-bcf7-4d29355a1a29/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"d56237fa-e1c3-40e1-ba83-41dddfacae31","status":"enabled","created_at":"2026-01-30T16:15:05.982171Z","updated_at":"2026-01-30T16:15:05.982171Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"8353536d-27ba-4e9d-bcf7-4d29355a1a29","status":"enabled","created_at":"2026-07-03T15:28:20.211273Z","updated_at":"2026-07-03T15:28:20.211273Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 30 Jan 2026 16:15:06 GMT
+                - Fri, 03 Jul 2026 15:28:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - f43792e1-7ab8-4f30-9ba8-e6f71725823b
+                - 40e604bf-c592-4cb3-beb2-bebe8c6fa785
         status: 200 OK
         code: 200
-        duration: 37.162203ms
+        duration: 39.225667ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -444,29 +444,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/d56237fa-e1c3-40e1-ba83-41dddfacae31
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/1157fe98-a66f-4fbc-803c-30a07685869e
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 430
-        body: '{"id":"d56237fa-e1c3-40e1-ba83-41dddfacae31","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-sign-secret","status":"ready","created_at":"2026-01-30T16:15:05.262533Z","updated_at":"2026-01-30T16:15:05.262533Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        content_length: 528
+        body: '{"id":"1157fe98-a66f-4fbc-803c-30a07685869e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-sign-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.410788Z","updated_at":"2026-07-03T15:28:19.523205Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.523205Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "430"
+                - "528"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 30 Jan 2026 16:15:06 GMT
+                - Fri, 03 Jul 2026 15:28:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 0548038d-069d-4564-ab1f-9b467000e5af
+                - a8957b08-903b-4f83-91ec-c5a6cf9f7e4c
         status: 200 OK
         code: 200
-        duration: 49.347294ms
+        duration: 59.663024ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -476,29 +476,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/9398c1ca-68c4-4519-8d88-e3eb876aaf5a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8353536d-27ba-4e9d-bcf7-4d29355a1a29
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 498
-        body: '{"id":"9398c1ca-68c4-4519-8d88-e3eb876aaf5a","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-sign-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-01-30T16:15:05.381560Z","updated_at":"2026-01-30T16:15:05.424645Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-01-30T16:15:05.424645Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 430
+        body: '{"id":"8353536d-27ba-4e9d-bcf7-4d29355a1a29","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-sign-secret","status":"ready","created_at":"2026-07-03T15:28:18.835051Z","updated_at":"2026-07-03T15:28:18.835051Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "498"
+                - "430"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 30 Jan 2026 16:15:06 GMT
+                - Fri, 03 Jul 2026 15:28:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 63c592d2-3298-477b-a39a-06305dfcf9ef
+                - 8d4a001f-4f8c-4305-9e43-9eef8283627a
         status: 200 OK
         code: 200
-        duration: 79.224414ms
+        duration: 59.609173ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -511,29 +511,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/d56237fa-e1c3-40e1-ba83-41dddfacae31/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8353536d-27ba-4e9d-bcf7-4d29355a1a29/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 333
-        body: '{"versions":[{"revision":1,"secret_id":"d56237fa-e1c3-40e1-ba83-41dddfacae31","status":"enabled","created_at":"2026-01-30T16:15:05.982171Z","updated_at":"2026-01-30T16:15:05.982171Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        body: '{"versions":[{"revision":1,"secret_id":"8353536d-27ba-4e9d-bcf7-4d29355a1a29","status":"enabled","created_at":"2026-07-03T15:28:20.211273Z","updated_at":"2026-07-03T15:28:20.211273Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "333"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 30 Jan 2026 16:15:07 GMT
+                - Fri, 03 Jul 2026 15:28:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - c0a0630c-5c8e-4b7d-9323-f42c50429345
+                - 6a59041c-2198-4314-8ab5-04c0b82322bd
         status: 200 OK
         code: 200
-        duration: 39.84502ms
+        duration: 52.599276ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -546,29 +546,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/9398c1ca-68c4-4519-8d88-e3eb876aaf5a/sign
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/1157fe98-a66f-4fbc-803c-30a07685869e/sign
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 408
-        body: '{"key_id":"9398c1ca-68c4-4519-8d88-e3eb876aaf5a","signature":"l75bUMXY6kYSgqtJsd4DzdWRpXhhHV2hXPO+/JYsP41KeJiPl/SFeCYdQhEfbjD0o+b92s0+vyzOKdo+2DSPvBdCbWq3IZxIdqxB44tASxai70Y8xi+HkO/r/sPti9CoNzujMaOY5nvcEVugMIk6hRDO/NTqRGSIt2fb27iiPeya46yMx81QSNYTJmz2AZMJZON3hU47HeYAF3Rpb1lAphAVJe/Viknq8eqS6/mJleEjequHqP34WiJslBbVd2Sau1exqcg2byWAI7OBd86oKjIbk3KETZn5meRPqfo3+T+59xNJHyF5sVPsAV/Ox/pR5LItTaV6yCaLUn92sRornQ=="}'
+        body: '{"key_id":"1157fe98-a66f-4fbc-803c-30a07685869e","signature":"gA4u3RlMXo2GDO4bVdDgLhLSNxy6HVxVprdnBXYOAxPK4wLQ83LFI4ritnzZJj00KkEycJ8iVyozMLvS3f8n5BUd0Yl5JOubmTAHiQWBDjN/9rTrT4RmkdFEM6dSQXdF7gRZ5Y3p2KHRFjXDM4MscmoWsl6VWFr37Pp6Hea92eUzwd/0ZuADMGtuVAEdKB6yro0a9fKghHksBqK8hrsb741RzmjvctTftVWxa3v0bxoszLTvXPReDNb10VXw7X7YNFgIJDh4t3f/Pcdx6zfC83f1HG0/Xx+dwfuaaM124jwfX/27IMsRU6i9gB7P0UeZ7rCcQAMrcRtFTiyjXDhbMg=="}'
         headers:
             Content-Length:
                 - "408"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 30 Jan 2026 16:15:07 GMT
+                - Fri, 03 Jul 2026 15:28:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - ff43e6cd-25c0-430a-b5ef-580244154807
+                - ffe949fd-109e-4752-a387-b7cb22db4f85
         status: 200 OK
         code: 200
-        duration: 146.571775ms
+        duration: 49.880118ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -578,29 +578,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/d56237fa-e1c3-40e1-ba83-41dddfacae31/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8353536d-27ba-4e9d-bcf7-4d29355a1a29/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"d56237fa-e1c3-40e1-ba83-41dddfacae31","status":"enabled","created_at":"2026-01-30T16:15:05.982171Z","updated_at":"2026-01-30T16:15:05.982171Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"8353536d-27ba-4e9d-bcf7-4d29355a1a29","status":"enabled","created_at":"2026-07-03T15:28:20.211273Z","updated_at":"2026-07-03T15:28:20.211273Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 30 Jan 2026 16:15:07 GMT
+                - Fri, 03 Jul 2026 15:28:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - eea88ef4-0fc1-408d-bdd4-bc6808f6513e
+                - 113392c7-9d5b-413b-9794-b0b06fe2b95b
         status: 200 OK
         code: 200
-        duration: 80.916898ms
+        duration: 43.380321ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -610,29 +610,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/d56237fa-e1c3-40e1-ba83-41dddfacae31/versions/1/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8353536d-27ba-4e9d-bcf7-4d29355a1a29/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 569
-        body: '{"secret_id":"d56237fa-e1c3-40e1-ba83-41dddfacae31","revision":1,"data":"SFczK3Z4VjVKZnlwTGxoMnVPditlRDJiclIrcDkyTitSSHhsMU9qYWxEcmVOekFtZ3V2dGVEbGJwWUJ2TGNYYVh2SUhZM2IyOVc2QmhTL2JONjdTendORGJMb1lCdlN2Z2JObjVNc0trdlFUYmNVdTNvZHpvZzk1UzlKd1R4ODdweFJRNlc4Qzc3amtaQTdudmRTT29GdWFpenZPQkJWMDZoN3FiSndzb1ZwdTMzL2k3bFg2N3BmeUpGdVU4QWkwVWo0L2I2OFlEUFZqbWpsZVFUQzdtUnVmZEtralZtREJQYmJsQjRqVlA0eXdJNzVVOWNaTnZxOFE3SGtjWHlDOW9YQjFvcDVGcWwvL1BlVkJzNDBZUGU1S2hNcUJhamZScitzajZSY3VOWGFYMlJiZEdaeFQ5Nk03dm93VzZyWWJTRDJMZm5QaVN0YlN6c3RYL0NPOWlBPT0=","data_crc32":null,"type":"opaque"}'
+        body: '{"secret_id":"8353536d-27ba-4e9d-bcf7-4d29355a1a29","revision":1,"data":"Rnpyc0xpR2o3RmtGM0ljTHduQ2FMS2JZcmdTcC9HdzR6TWE5dVRTdlU5czNUcWZvc2c4QVNiVHp6N1luQi9YSXZ3d0VzaE5jWkNlTHQ1NUpUejdKVEZRQlBobGZEZkJSbzljVkdpR0dDdUxxTzJwbCt2NjVuTHEyZUdHVXhyb0o1aEVBUkhxMmd6eXNXdlJLRHRwVHNqUUZWbU4ydEQ5dGY0ZmwzM25JRU11Rk1iTkg2N1NUT2R5SFJEb1dDWkZ4NnVyd2s3WDRXZGlBQmR6S3hyLzFEd3J6cTQ0ayt0NUF1K0diNWxDbXZGN2FCR0xuSjlJc0JYeVI5YzJ4b1lpclk2Ly8xZWhkVDAweTJvNlRGTk1qWlp2VTM5L0lwNzE3Y21ncHZ6ckZNTmVDWjdOT2NNZ0xYNFV3c1FvWFF2QTZFZU5zNCszUElXaDB3enRZQXgvZVFnPT0=","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
                 - "569"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 30 Jan 2026 16:15:07 GMT
+                - Fri, 03 Jul 2026 15:28:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 4f56c519-1174-437b-b6f9-cea7dc413c9b
+                - 81804942-7409-4fdc-94cd-ad11b1678714
         status: 200 OK
         code: 200
-        duration: 95.753675ms
+        duration: 135.940654ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -642,29 +642,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/d56237fa-e1c3-40e1-ba83-41dddfacae31/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8353536d-27ba-4e9d-bcf7-4d29355a1a29/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"d56237fa-e1c3-40e1-ba83-41dddfacae31","status":"enabled","created_at":"2026-01-30T16:15:05.982171Z","updated_at":"2026-01-30T16:15:05.982171Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"8353536d-27ba-4e9d-bcf7-4d29355a1a29","status":"enabled","created_at":"2026-07-03T15:28:20.211273Z","updated_at":"2026-07-03T15:28:20.211273Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 30 Jan 2026 16:15:07 GMT
+                - Fri, 03 Jul 2026 15:28:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - a2ab57e3-bae8-45c0-b3af-c08d87cb2a77
+                - 615fbfc5-7630-4c83-b18c-93e68acbaeb7
         status: 200 OK
         code: 200
-        duration: 32.154674ms
+        duration: 54.559307ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -674,8 +674,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/d56237fa-e1c3-40e1-ba83-41dddfacae31/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8353536d-27ba-4e9d-bcf7-4d29355a1a29/versions/1
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -687,14 +687,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 30 Jan 2026 16:15:07 GMT
+                - Fri, 03 Jul 2026 15:28:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - f74a5b21-45f2-4f0f-bb27-592aca2db1fe
+                - 5e715a05-d947-4fe9-9d54-8387db9b467d
         status: 204 No Content
         code: 204
-        duration: 92.577733ms
+        duration: 63.390114ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -704,8 +704,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/9398c1ca-68c4-4519-8d88-e3eb876aaf5a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8353536d-27ba-4e9d-bcf7-4d29355a1a29
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -717,14 +717,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 30 Jan 2026 16:15:07 GMT
+                - Fri, 03 Jul 2026 15:28:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 855b8a31-1bfb-48bc-8797-4d04fd847258
+                - bab2bb39-80d8-435f-aad5-9f314c78c932
         status: 204 No Content
         code: 204
-        duration: 113.808956ms
+        duration: 64.633539ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -734,8 +734,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/d56237fa-e1c3-40e1-ba83-41dddfacae31
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/1157fe98-a66f-4fbc-803c-30a07685869e
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -747,14 +747,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 30 Jan 2026 16:15:07 GMT
+                - Fri, 03 Jul 2026 15:28:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 1abbfeed-a047-4d2f-a062-51ba293c27f5
+                - c763d436-de39-4a81-9459-5412aff63967
         status: 204 No Content
         code: 204
-        duration: 154.668677ms
+        duration: 69.855719ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -764,29 +764,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/9398c1ca-68c4-4519-8d88-e3eb876aaf5a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/1157fe98-a66f-4fbc-803c-30a07685869e
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 538
-        body: '{"id":"9398c1ca-68c4-4519-8d88-e3eb876aaf5a","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-sign-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-01-30T16:15:05.381560Z","updated_at":"2026-01-30T16:15:05.424645Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-01-30T16:15:05.424645Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-01-30T16:15:07.765950Z","region":"fr-par"}'
+        content_length: 568
+        body: '{"id":"1157fe98-a66f-4fbc-803c-30a07685869e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-sign-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-03T15:28:19.410788Z","updated_at":"2026-07-03T15:28:22.228189Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.523205Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-03T15:28:22.228188Z","protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "538"
+                - "568"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 30 Jan 2026 16:15:07 GMT
+                - Fri, 03 Jul 2026 15:28:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - 039452a4-3acb-456c-9e10-5d3c4ec70a66
+                - d6e0d42b-eb83-48e4-83d2-848273969167
         status: 200 OK
         code: 200
-        duration: 86.796432ms
+        duration: 47.090089ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -796,26 +796,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/d56237fa-e1c3-40e1-ba83-41dddfacae31
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8353536d-27ba-4e9d-bcf7-4d29355a1a29
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 455
-        body: '{"id":"d56237fa-e1c3-40e1-ba83-41dddfacae31","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-sign-secret","status":"ready","created_at":"2026-01-30T16:15:05.262533Z","updated_at":"2026-01-30T16:15:05.262533Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-01-30T16:15:07.785039Z","key_id":null,"region":"fr-par"}'
+        body: '{"id":"8353536d-27ba-4e9d-bcf7-4d29355a1a29","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-sign-secret","status":"ready","created_at":"2026-07-03T15:28:18.835051Z","updated_at":"2026-07-03T15:28:22.227522Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-07-03T15:28:22.227522Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "455"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 30 Jan 2026 16:15:07 GMT
+                - Fri, 03 Jul 2026 15:28:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge03)
             X-Request-Id:
-                - a93da044-89eb-4ae8-ab18-eed84effbb0f
+                - 7b3eec99-49dc-46e7-9c89-b9d218476df2
         status: 200 OK
         code: 200
-        duration: 50.354328ms
+        duration: 35.594056ms

--- a/internal/services/secret/secret.go
+++ b/internal/services/secret/secret.go
@@ -14,6 +14,7 @@ import (
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/identity"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/locality/regional"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/services/account"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/transport"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/types"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/verify"
 )
@@ -217,7 +218,15 @@ func ResourceSecretCreate(ctx context.Context, d *schema.ResourceData, m any) di
 		}
 	}
 
-	secretResponse, err := api.CreateSecret(secretCreateRequest, scw.WithContext(ctx))
+	var secretResponse *secret.Secret
+
+	err = transport.RetryOn403(ctx, func() error {
+		var err error
+
+		secretResponse, err = api.CreateSecret(secretCreateRequest, scw.WithContext(ctx))
+
+		return err
+	})
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -236,10 +245,13 @@ func ResourceSecretRead(ctx context.Context, d *schema.ResourceData, m any) diag
 		return diag.FromErr(err)
 	}
 
-	secretResponse, err := api.GetSecret(&secret.GetSecretRequest{
-		Region:   region,
-		SecretID: id,
-	}, scw.WithContext(ctx))
+	// Retry on 404 to handle eventual consistency issues
+	secretResponse, err := transport.RetryOn404(ctx, func(ctx context.Context) (*secret.Secret, error) {
+		return api.GetSecret(&secret.GetSecretRequest{
+			Region:   region,
+			SecretID: id,
+		}, scw.WithContext(ctx))
+	})
 	if err != nil {
 		if httperrors.Is404(err) {
 			d.SetId("")
@@ -254,10 +266,13 @@ func ResourceSecretRead(ctx context.Context, d *schema.ResourceData, m any) diag
 		_ = d.Set("tags", types.FlattenSliceString(secretResponse.Tags))
 	}
 
-	versionsResponse, err := api.ListSecretVersions(&secret.ListSecretVersionsRequest{
-		Region:   region,
-		SecretID: id,
-	}, scw.WithAllPages(), scw.WithContext(ctx))
+	// Retry on 404 to handle eventual consistency issues
+	versionsResponse, err := transport.RetryOn404(ctx, func(ctx context.Context) (*secret.ListSecretVersionsResponse, error) {
+		return api.ListSecretVersions(&secret.ListSecretVersionsRequest{
+			Region:   region,
+			SecretID: id,
+		}, scw.WithAllPages(), scw.WithContext(ctx))
+	})
 	if err != nil {
 		if httperrors.Is404(err) {
 			d.SetId("")
@@ -343,10 +358,12 @@ func ResourceSecretDelete(ctx context.Context, d *schema.ResourceData, m any) di
 		return diag.FromErr(err)
 	}
 
-	err = api.DeleteSecret(&secret.DeleteSecretRequest{
-		Region:   region,
-		SecretID: id,
-	}, scw.WithContext(ctx))
+	err = transport.RetryOn403(ctx, func() error {
+		return api.DeleteSecret(&secret.DeleteSecretRequest{
+			Region:   region,
+			SecretID: id,
+		}, scw.WithContext(ctx))
+	})
 	if err != nil && !httperrors.Is404(err) {
 		return diag.FromErr(err)
 	}

--- a/internal/services/secret/testdata/data-source-secret-basic.cassette.yaml
+++ b/internal/services/secret/testdata/data-source-secret-basic.cassette.yaml
@@ -13,7 +13,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets
         method: POST
       response:
@@ -21,21 +21,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 476
-        body: '{"id":"21025838-d5b7-42ed-84e9-60935778dc39","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-06-24T09:38:48.111189Z","updated_at":"2026-06-24T09:38:48.111189Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"9d4fd472-4b01-4a96-bb62-83712549262f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-07-03T15:27:54.781102Z","updated_at":"2026-07-03T15:27:54.781102Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "476"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
+                - Fri, 03 Jul 2026 15:27:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 375887a8-9fc8-4613-8916-615f9ec23cb5
+                - 0580b60e-bff6-45a7-9fd2-c91c7b897df4
         status: 200 OK
         code: 200
-        duration: 183.755569ms
+        duration: 525.516973ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -45,29 +45,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/21025838-d5b7-42ed-84e9-60935778dc39
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9d4fd472-4b01-4a96-bb62-83712549262f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 476
-        body: '{"id":"21025838-d5b7-42ed-84e9-60935778dc39","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-06-24T09:38:48.111189Z","updated_at":"2026-06-24T09:38:48.111189Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"9d4fd472-4b01-4a96-bb62-83712549262f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-07-03T15:27:54.781102Z","updated_at":"2026-07-03T15:27:54.781102Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "476"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
+                - Fri, 03 Jul 2026 15:27:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 0da2a7f0-7367-4a51-94fc-2cd08d95cb49
+                - 0899fd58-5c0b-4f5b-aaa8-627899a868de
         status: 200 OK
         code: 200
-        duration: 30.446609ms
+        duration: 200.369675ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -80,8 +80,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/21025838-d5b7-42ed-84e9-60935778dc39/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9d4fd472-4b01-4a96-bb62-83712549262f/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -95,82 +95,15 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
+                - Fri, 03 Jul 2026 15:27:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 178b278c-95c2-4ba8-a272-0c72f694fc54
+                - 27afb068-c188-4a21-9bd2-70d04a5ff342
         status: 200 OK
         code: 200
-        duration: 32.122725ms
+        duration: 57.009378ms
     - id: 3
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/21025838-d5b7-42ed-84e9-60935778dc39
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 476
-        body: '{"id":"21025838-d5b7-42ed-84e9-60935778dc39","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-06-24T09:38:48.111189Z","updated_at":"2026-06-24T09:38:48.111189Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "476"
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
-            X-Request-Id:
-                - cd16581a-26a9-48d6-a6f2-dee2d3608af4
-        status: 200 OK
-        code: 200
-        duration: 18.665223ms
-    - id: 4
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        form:
-            page:
-                - "1"
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/21025838-d5b7-42ed-84e9-60935778dc39/versions?page=1
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 31
-        body: '{"versions":[],"total_count":0}'
-        headers:
-            Content-Length:
-                - "31"
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
-            X-Request-Id:
-                - f9b56eb0-6c2d-4888-bcdc-71f54da67dc9
-        status: 200 OK
-        code: 200
-        duration: 53.02446ms
-    - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -190,7 +123,7 @@ interactions:
                 - unknown_type
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets?name=scalewayDataSourceSecretBasic&order_by=name_asc&project_id=105bdce1-64c0-48ab-899d-868455867ecf&scheduled_for_deletion=false&type=unknown_type
         method: GET
       response:
@@ -198,21 +131,88 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 506
-        body: '{"secrets":[{"id":"21025838-d5b7-42ed-84e9-60935778dc39","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-06-24T09:38:48.111189Z","updated_at":"2026-06-24T09:38:48.111189Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}],"total_count":1}'
+        body: '{"secrets":[{"id":"9d4fd472-4b01-4a96-bb62-83712549262f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-07-03T15:27:54.781102Z","updated_at":"2026-07-03T15:27:54.781102Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "506"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
+                - Fri, 03 Jul 2026 15:27:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 8ae74b3f-5a42-447b-8578-c5973339ec46
+                - 9cedda87-8543-41eb-be1e-3acbc7737c00
         status: 200 OK
         code: 200
-        duration: 100.676402ms
+        duration: 144.633498ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9d4fd472-4b01-4a96-bb62-83712549262f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 476
+        body: '{"id":"9d4fd472-4b01-4a96-bb62-83712549262f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-07-03T15:27:54.781102Z","updated_at":"2026-07-03T15:27:54.781102Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "476"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:27:55 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 0c12e9f3-47f6-40fb-9405-56de427077f9
+        status: 200 OK
+        code: 200
+        duration: 144.6823ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9d4fd472-4b01-4a96-bb62-83712549262f/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 31
+        body: '{"versions":[],"total_count":0}'
+        headers:
+            Content-Length:
+                - "31"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:27:55 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 7d0de4b9-5f7d-45f5-912f-50a623f24893
+        status: 200 OK
+        code: 200
+        duration: 31.114511ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -222,29 +222,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/21025838-d5b7-42ed-84e9-60935778dc39
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9d4fd472-4b01-4a96-bb62-83712549262f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 476
-        body: '{"id":"21025838-d5b7-42ed-84e9-60935778dc39","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-06-24T09:38:48.111189Z","updated_at":"2026-06-24T09:38:48.111189Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"9d4fd472-4b01-4a96-bb62-83712549262f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-07-03T15:27:54.781102Z","updated_at":"2026-07-03T15:27:54.781102Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "476"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
+                - Fri, 03 Jul 2026 15:27:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - b30ee1a1-a255-4b0d-80cc-60960d23a922
+                - e0f29f5f-b946-4ede-b67c-fbcb10fa7ed6
         status: 200 OK
         code: 200
-        duration: 22.237718ms
+        duration: 31.130711ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -257,8 +257,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/21025838-d5b7-42ed-84e9-60935778dc39/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9d4fd472-4b01-4a96-bb62-83712549262f/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -272,14 +272,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
+                - Fri, 03 Jul 2026 15:27:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - eea3435d-c33d-4e35-9e5e-47a9003505e6
+                - 6d22ebbd-d77c-442b-a685-aeecb4b2c237
         status: 200 OK
         code: 200
-        duration: 19.514684ms
+        duration: 33.888371ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -289,29 +289,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/21025838-d5b7-42ed-84e9-60935778dc39
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9d4fd472-4b01-4a96-bb62-83712549262f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 476
-        body: '{"id":"21025838-d5b7-42ed-84e9-60935778dc39","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-06-24T09:38:48.111189Z","updated_at":"2026-06-24T09:38:48.111189Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"9d4fd472-4b01-4a96-bb62-83712549262f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-07-03T15:27:54.781102Z","updated_at":"2026-07-03T15:27:54.781102Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "476"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
+                - Fri, 03 Jul 2026 15:27:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 6eb5b77c-d5e1-4642-b90a-6f6e324c3f75
+                - db62077f-7caf-40b0-8519-b2d339d07e21
         status: 200 OK
         code: 200
-        duration: 21.746196ms
+        duration: 40.517753ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -321,29 +321,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/21025838-d5b7-42ed-84e9-60935778dc39
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9d4fd472-4b01-4a96-bb62-83712549262f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 476
-        body: '{"id":"21025838-d5b7-42ed-84e9-60935778dc39","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-06-24T09:38:48.111189Z","updated_at":"2026-06-24T09:38:48.111189Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"9d4fd472-4b01-4a96-bb62-83712549262f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-07-03T15:27:54.781102Z","updated_at":"2026-07-03T15:27:54.781102Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "476"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
+                - Fri, 03 Jul 2026 15:27:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 79fb289e-3c03-4b53-80e8-80d73370ce1a
+                - 55a160f2-8545-411e-9b76-92ca5357445d
         status: 200 OK
         code: 200
-        duration: 17.744778ms
+        duration: 36.453679ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -353,65 +353,30 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/21025838-d5b7-42ed-84e9-60935778dc39
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9d4fd472-4b01-4a96-bb62-83712549262f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 476
-        body: '{"id":"21025838-d5b7-42ed-84e9-60935778dc39","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-06-24T09:38:48.111189Z","updated_at":"2026-06-24T09:38:48.111189Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"9d4fd472-4b01-4a96-bb62-83712549262f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-07-03T15:27:54.781102Z","updated_at":"2026-07-03T15:27:54.781102Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "476"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
+                - Fri, 03 Jul 2026 15:27:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - fe6f4bbc-5b3e-4b11-9828-8771b53a6ea1
+                - 401998df-bf2e-49f7-b58d-08e6102ef6ab
         status: 200 OK
         code: 200
-        duration: 27.19461ms
+        duration: 32.074975ms
     - id: 11
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        form:
-            page:
-                - "1"
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/21025838-d5b7-42ed-84e9-60935778dc39/versions?page=1
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 31
-        body: '{"versions":[],"total_count":0}'
-        headers:
-            Content-Length:
-                - "31"
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
-            X-Request-Id:
-                - d2d59748-cbfb-45ad-a44b-e0bb8d040c36
-        status: 200 OK
-        code: 200
-        duration: 18.06399ms
-    - id: 12
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -431,7 +396,7 @@ interactions:
                 - unknown_type
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets?name=scalewayDataSourceSecretBasic&order_by=name_asc&project_id=105bdce1-64c0-48ab-899d-868455867ecf&scheduled_for_deletion=false&type=unknown_type
         method: GET
       response:
@@ -439,21 +404,56 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 506
-        body: '{"secrets":[{"id":"21025838-d5b7-42ed-84e9-60935778dc39","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-06-24T09:38:48.111189Z","updated_at":"2026-06-24T09:38:48.111189Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}],"total_count":1}'
+        body: '{"secrets":[{"id":"9d4fd472-4b01-4a96-bb62-83712549262f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-07-03T15:27:54.781102Z","updated_at":"2026-07-03T15:27:54.781102Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "506"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
+                - Fri, 03 Jul 2026 15:27:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 6fab9d61-881a-472a-8e5b-b9c4c9f591f9
+                - 8040e5bf-6ab3-4498-8870-8918f17f1475
         status: 200 OK
         code: 200
-        duration: 114.872962ms
+        duration: 38.848778ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9d4fd472-4b01-4a96-bb62-83712549262f/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 31
+        body: '{"versions":[],"total_count":0}'
+        headers:
+            Content-Length:
+                - "31"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:27:55 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 302780bc-fb46-48e0-ba87-8caa70d0d34a
+        status: 200 OK
+        code: 200
+        duration: 29.604335ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -463,29 +463,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/21025838-d5b7-42ed-84e9-60935778dc39
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9d4fd472-4b01-4a96-bb62-83712549262f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 476
-        body: '{"id":"21025838-d5b7-42ed-84e9-60935778dc39","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-06-24T09:38:48.111189Z","updated_at":"2026-06-24T09:38:48.111189Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"9d4fd472-4b01-4a96-bb62-83712549262f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-07-03T15:27:54.781102Z","updated_at":"2026-07-03T15:27:54.781102Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "476"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
+                - Fri, 03 Jul 2026 15:27:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 39a94e84-7bd2-476d-9ae5-194872808c68
+                - ba45957d-f05e-4c18-b32c-7c9fe4c9ef38
         status: 200 OK
         code: 200
-        duration: 15.844581ms
+        duration: 32.478684ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -498,8 +498,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/21025838-d5b7-42ed-84e9-60935778dc39/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9d4fd472-4b01-4a96-bb62-83712549262f/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -513,14 +513,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
+                - Fri, 03 Jul 2026 15:27:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 7f58ae0a-8193-423a-b7c1-e9b917380e9f
+                - bd9d6763-85be-4105-90b5-35cc64d99c4e
         status: 200 OK
         code: 200
-        duration: 23.134399ms
+        duration: 132.447881ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -530,29 +530,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/21025838-d5b7-42ed-84e9-60935778dc39
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9d4fd472-4b01-4a96-bb62-83712549262f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 476
-        body: '{"id":"21025838-d5b7-42ed-84e9-60935778dc39","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-06-24T09:38:48.111189Z","updated_at":"2026-06-24T09:38:48.111189Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"9d4fd472-4b01-4a96-bb62-83712549262f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-07-03T15:27:54.781102Z","updated_at":"2026-07-03T15:27:54.781102Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "476"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
+                - Fri, 03 Jul 2026 15:27:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 877ea185-a9a9-43f6-b932-d6539ef229c8
+                - b51b89e2-f6e3-4d19-9c28-bcf06244e1b6
         status: 200 OK
         code: 200
-        duration: 21.659039ms
+        duration: 102.289095ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -565,8 +565,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/21025838-d5b7-42ed-84e9-60935778dc39/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9d4fd472-4b01-4a96-bb62-83712549262f/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -580,14 +580,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
+                - Fri, 03 Jul 2026 15:27:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 197bfa75-4fcb-4207-bf84-1acff974a1bd
+                - 68eb809e-f455-462f-80a9-01dda34a81fc
         status: 200 OK
         code: 200
-        duration: 25.147752ms
+        duration: 60.386641ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -597,30 +597,65 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/21025838-d5b7-42ed-84e9-60935778dc39
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9d4fd472-4b01-4a96-bb62-83712549262f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 476
-        body: '{"id":"21025838-d5b7-42ed-84e9-60935778dc39","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-06-24T09:38:48.111189Z","updated_at":"2026-06-24T09:38:48.111189Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"9d4fd472-4b01-4a96-bb62-83712549262f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-07-03T15:27:54.781102Z","updated_at":"2026-07-03T15:27:54.781102Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "476"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
+                - Fri, 03 Jul 2026 15:27:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - c8d3d639-cf05-4fb0-aae1-ac6ac12061a0
+                - b3ac0370-ed66-4deb-9720-c8ba8f596dfd
         status: 200 OK
         code: 200
-        duration: 17.97501ms
+        duration: 35.363712ms
     - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9d4fd472-4b01-4a96-bb62-83712549262f/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 31
+        body: '{"versions":[],"total_count":0}'
+        headers:
+            Content-Length:
+                - "31"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:27:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 0627d20e-b51f-4461-844d-0925627b9488
+        status: 200 OK
+        code: 200
+        duration: 93.58176ms
+    - id: 19
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -640,7 +675,7 @@ interactions:
                 - unknown_type
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets?name=scalewayDataSourceSecretBasic&order_by=name_asc&project_id=105bdce1-64c0-48ab-899d-868455867ecf&scheduled_for_deletion=false&type=unknown_type
         method: GET
       response:
@@ -648,53 +683,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 506
-        body: '{"secrets":[{"id":"21025838-d5b7-42ed-84e9-60935778dc39","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-06-24T09:38:48.111189Z","updated_at":"2026-06-24T09:38:48.111189Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}],"total_count":1}'
+        body: '{"secrets":[{"id":"9d4fd472-4b01-4a96-bb62-83712549262f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-07-03T15:27:54.781102Z","updated_at":"2026-07-03T15:27:54.781102Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "506"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
+                - Fri, 03 Jul 2026 15:27:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 752a76b8-0e9b-4007-8a6b-f3dcbba056da
+                - 21c6b7fa-325d-406c-abbf-9ccf075e56de
         status: 200 OK
         code: 200
-        duration: 21.997978ms
-    - id: 19
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/21025838-d5b7-42ed-84e9-60935778dc39
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 476
-        body: '{"id":"21025838-d5b7-42ed-84e9-60935778dc39","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-06-24T09:38:48.111189Z","updated_at":"2026-06-24T09:38:48.111189Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "476"
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
-            X-Request-Id:
-                - ed25c1e5-3ae3-4429-ace7-03121b361fe9
-        status: 200 OK
-        code: 200
-        duration: 20.273911ms
+        duration: 129.372925ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -702,34 +705,31 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: api.scaleway.com
-        form:
-            page:
-                - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/21025838-d5b7-42ed-84e9-60935778dc39/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9d4fd472-4b01-4a96-bb62-83712549262f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 31
-        body: '{"versions":[],"total_count":0}'
+        content_length: 476
+        body: '{"id":"9d4fd472-4b01-4a96-bb62-83712549262f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-07-03T15:27:54.781102Z","updated_at":"2026-07-03T15:27:54.781102Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "31"
+                - "476"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
+                - Fri, 03 Jul 2026 15:27:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - f5afb466-8d96-4598-a90e-a52e3fd6699a
+                - 4ea1c3df-1cf8-408c-81d8-d3ecd9035cdf
         status: 200 OK
         code: 200
-        duration: 25.248846ms
+        duration: 34.53231ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -742,8 +742,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/21025838-d5b7-42ed-84e9-60935778dc39/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9d4fd472-4b01-4a96-bb62-83712549262f/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -757,14 +757,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
+                - Fri, 03 Jul 2026 15:27:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 9773dc21-3199-408f-8092-1b647dbc34b0
+                - 5dd0924d-2606-470c-9264-cec224a2acf7
         status: 200 OK
         code: 200
-        duration: 18.723065ms
+        duration: 39.278345ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -774,8 +774,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/21025838-d5b7-42ed-84e9-60935778dc39
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9d4fd472-4b01-4a96-bb62-83712549262f
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -787,14 +787,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:49 GMT
+                - Fri, 03 Jul 2026 15:27:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 73957af3-18ee-4380-bce5-0446a93f1e77
+                - b0b50c0f-ed08-417d-babf-37c39d075ea1
         status: 204 No Content
         code: 204
-        duration: 116.486688ms
+        duration: 128.449681ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -804,29 +804,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/21025838-d5b7-42ed-84e9-60935778dc39
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9d4fd472-4b01-4a96-bb62-83712549262f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 501
-        body: '{"id":"21025838-d5b7-42ed-84e9-60935778dc39","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-06-24T09:38:48.111189Z","updated_at":"2026-06-24T09:38:49.401742Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-06-24T09:38:49.401742Z","key_id":null,"region":"fr-par"}'
+        body: '{"id":"9d4fd472-4b01-4a96-bb62-83712549262f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-07-03T15:27:54.781102Z","updated_at":"2026-07-03T15:27:57.155222Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-07-03T15:27:57.155222Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "501"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:49 GMT
+                - Fri, 03 Jul 2026 15:27:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - eb49f218-aada-41e6-8f9a-71ab9c37b4f6
+                - 20451a13-7db7-4044-bf73-0185df02b841
         status: 200 OK
         code: 200
-        duration: 36.16976ms
+        duration: 35.325661ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -836,29 +836,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/21025838-d5b7-42ed-84e9-60935778dc39
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9d4fd472-4b01-4a96-bb62-83712549262f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 501
-        body: '{"id":"21025838-d5b7-42ed-84e9-60935778dc39","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-06-24T09:38:48.111189Z","updated_at":"2026-06-24T09:38:49.401742Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-06-24T09:38:49.401742Z","key_id":null,"region":"fr-par"}'
+        body: '{"id":"9d4fd472-4b01-4a96-bb62-83712549262f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-07-03T15:27:54.781102Z","updated_at":"2026-07-03T15:27:57.155222Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-07-03T15:27:57.155222Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "501"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:49 GMT
+                - Fri, 03 Jul 2026 15:27:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 9fa650e5-4bd4-4658-a4a3-f59cb208b350
+                - a01997e2-6925-4e81-9b89-000c2a70e582
         status: 200 OK
         code: 200
-        duration: 18.597964ms
+        duration: 802.501953ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -868,26 +868,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/21025838-d5b7-42ed-84e9-60935778dc39
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9d4fd472-4b01-4a96-bb62-83712549262f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 501
-        body: '{"id":"21025838-d5b7-42ed-84e9-60935778dc39","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-06-24T09:38:48.111189Z","updated_at":"2026-06-24T09:38:49.401742Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-06-24T09:38:49.401742Z","key_id":null,"region":"fr-par"}'
+        body: '{"id":"9d4fd472-4b01-4a96-bb62-83712549262f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-07-03T15:27:54.781102Z","updated_at":"2026-07-03T15:27:57.155222Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-07-03T15:27:57.155222Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "501"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:49 GMT
+                - Fri, 03 Jul 2026 15:27:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 5579f9a3-811d-4ac4-afb8-d3a8a9fcbb8d
+                - db746c13-e401-4afb-b83a-2683a0e9acf9
         status: 200 OK
         code: 200
-        duration: 32.051017ms
+        duration: 333.061114ms

--- a/internal/services/secret/testdata/data-source-secret-no-versions.cassette.yaml
+++ b/internal/services/secret/testdata/data-source-secret-no-versions.cassette.yaml
@@ -13,7 +13,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets
         method: POST
       response:
@@ -21,21 +21,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 437
-        body: '{"id":"6c1598c9-6f70-40b6-bfd2-3ef5ac0afc08","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-no-versions","status":"ready","created_at":"2026-06-24T09:38:48.150599Z","updated_at":"2026-06-24T09:38:48.150599Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"3d0b6f6c-1ebf-4558-b675-b93f7038c53b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-no-versions","status":"ready","created_at":"2026-07-03T15:27:54.670466Z","updated_at":"2026-07-03T15:27:54.670466Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "437"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
+                - Fri, 03 Jul 2026 15:27:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - bcc8570d-28ba-49d0-8f5e-fcdbaeb8d2d2
+                - 8968db46-e446-4d7b-96c8-fc5216a2bc46
         status: 200 OK
         code: 200
-        duration: 212.507737ms
+        duration: 353.657899ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -45,29 +45,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6c1598c9-6f70-40b6-bfd2-3ef5ac0afc08
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3d0b6f6c-1ebf-4558-b675-b93f7038c53b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 437
-        body: '{"id":"6c1598c9-6f70-40b6-bfd2-3ef5ac0afc08","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-no-versions","status":"ready","created_at":"2026-06-24T09:38:48.150599Z","updated_at":"2026-06-24T09:38:48.150599Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"3d0b6f6c-1ebf-4558-b675-b93f7038c53b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-no-versions","status":"ready","created_at":"2026-07-03T15:27:54.670466Z","updated_at":"2026-07-03T15:27:54.670466Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "437"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
+                - Fri, 03 Jul 2026 15:27:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 1f850779-4e58-4a4f-8641-62a4dbdd123a
+                - ef33e646-1107-4cd7-b006-acde119efa21
         status: 200 OK
         code: 200
-        duration: 26.669592ms
+        duration: 95.718824ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -80,8 +80,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6c1598c9-6f70-40b6-bfd2-3ef5ac0afc08/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3d0b6f6c-1ebf-4558-b675-b93f7038c53b/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -95,14 +95,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
+                - Fri, 03 Jul 2026 15:27:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 0c265801-6459-4043-8354-e5da0cf8d92c
+                - 149e4815-6c0c-45fc-963a-b0192e60cd12
         status: 200 OK
         code: 200
-        duration: 24.5941ms
+        duration: 95.163842ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -112,29 +112,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6c1598c9-6f70-40b6-bfd2-3ef5ac0afc08
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3d0b6f6c-1ebf-4558-b675-b93f7038c53b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 437
-        body: '{"id":"6c1598c9-6f70-40b6-bfd2-3ef5ac0afc08","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-no-versions","status":"ready","created_at":"2026-06-24T09:38:48.150599Z","updated_at":"2026-06-24T09:38:48.150599Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"3d0b6f6c-1ebf-4558-b675-b93f7038c53b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-no-versions","status":"ready","created_at":"2026-07-03T15:27:54.670466Z","updated_at":"2026-07-03T15:27:54.670466Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "437"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
+                - Fri, 03 Jul 2026 15:27:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 98d6811f-db76-48e3-ad97-90fda5191c1a
+                - 527d59cb-1cad-4d97-8883-b03ef4b2e2fa
         status: 200 OK
         code: 200
-        duration: 21.755052ms
+        duration: 38.680392ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -147,8 +147,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6c1598c9-6f70-40b6-bfd2-3ef5ac0afc08/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3d0b6f6c-1ebf-4558-b675-b93f7038c53b/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -162,14 +162,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
+                - Fri, 03 Jul 2026 15:27:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 21f06f25-d1ff-4e07-b3c1-669f059bf58e
+                - 5b5b5b02-b1f1-4b4c-b7c9-1eb92bce7996
         status: 200 OK
         code: 200
-        duration: 38.036993ms
+        duration: 50.518667ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -179,29 +179,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6c1598c9-6f70-40b6-bfd2-3ef5ac0afc08
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3d0b6f6c-1ebf-4558-b675-b93f7038c53b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 437
-        body: '{"id":"6c1598c9-6f70-40b6-bfd2-3ef5ac0afc08","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-no-versions","status":"ready","created_at":"2026-06-24T09:38:48.150599Z","updated_at":"2026-06-24T09:38:48.150599Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"3d0b6f6c-1ebf-4558-b675-b93f7038c53b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-no-versions","status":"ready","created_at":"2026-07-03T15:27:54.670466Z","updated_at":"2026-07-03T15:27:54.670466Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "437"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
+                - Fri, 03 Jul 2026 15:27:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 11b517d0-f285-4d32-8d67-f24e46fe70eb
+                - 22f156b0-7da4-411a-8e34-0b661f08ef4c
         status: 200 OK
         code: 200
-        duration: 33.442017ms
+        duration: 102.063932ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -214,8 +214,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6c1598c9-6f70-40b6-bfd2-3ef5ac0afc08/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3d0b6f6c-1ebf-4558-b675-b93f7038c53b/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -229,14 +229,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
+                - Fri, 03 Jul 2026 15:27:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 12f029d5-8de4-4a07-be87-0b3531658850
+                - facba00f-7d49-4a6b-bdce-ec45348a8379
         status: 200 OK
         code: 200
-        duration: 20.666023ms
+        duration: 51.893038ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -246,29 +246,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6c1598c9-6f70-40b6-bfd2-3ef5ac0afc08
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3d0b6f6c-1ebf-4558-b675-b93f7038c53b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 437
-        body: '{"id":"6c1598c9-6f70-40b6-bfd2-3ef5ac0afc08","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-no-versions","status":"ready","created_at":"2026-06-24T09:38:48.150599Z","updated_at":"2026-06-24T09:38:48.150599Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"3d0b6f6c-1ebf-4558-b675-b93f7038c53b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-no-versions","status":"ready","created_at":"2026-07-03T15:27:54.670466Z","updated_at":"2026-07-03T15:27:54.670466Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "437"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
+                - Fri, 03 Jul 2026 15:27:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 087e1b4a-ac5f-468e-8449-a089c2dda4e7
+                - 823c3913-ce68-48d5-8888-5699a8d38c80
         status: 200 OK
         code: 200
-        duration: 21.44635ms
+        duration: 48.682588ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -281,8 +281,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6c1598c9-6f70-40b6-bfd2-3ef5ac0afc08/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3d0b6f6c-1ebf-4558-b675-b93f7038c53b/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -296,14 +296,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
+                - Fri, 03 Jul 2026 15:27:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 7d9b17a5-2703-4971-b17c-edfb6defef11
+                - a9429e48-5096-4e64-9f6a-c83356b9c822
         status: 200 OK
         code: 200
-        duration: 22.632336ms
+        duration: 40.834287ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -313,29 +313,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6c1598c9-6f70-40b6-bfd2-3ef5ac0afc08
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3d0b6f6c-1ebf-4558-b675-b93f7038c53b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 437
-        body: '{"id":"6c1598c9-6f70-40b6-bfd2-3ef5ac0afc08","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-no-versions","status":"ready","created_at":"2026-06-24T09:38:48.150599Z","updated_at":"2026-06-24T09:38:48.150599Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"3d0b6f6c-1ebf-4558-b675-b93f7038c53b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-no-versions","status":"ready","created_at":"2026-07-03T15:27:54.670466Z","updated_at":"2026-07-03T15:27:54.670466Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "437"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
+                - Fri, 03 Jul 2026 15:27:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - d76d65f0-742e-41af-9100-77cdfcac8653
+                - 21de58fe-da0f-44ef-a17b-811dc7714d43
         status: 200 OK
         code: 200
-        duration: 17.093788ms
+        duration: 133.331411ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -348,8 +348,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6c1598c9-6f70-40b6-bfd2-3ef5ac0afc08/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3d0b6f6c-1ebf-4558-b675-b93f7038c53b/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -363,14 +363,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
+                - Fri, 03 Jul 2026 15:27:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 9b6bdf97-256f-4886-9f8a-a6671065157d
+                - 005eeed5-d900-4282-be1a-16f34fb4cd79
         status: 200 OK
         code: 200
-        duration: 23.85469ms
+        duration: 33.539276ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -380,8 +380,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6c1598c9-6f70-40b6-bfd2-3ef5ac0afc08
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3d0b6f6c-1ebf-4558-b675-b93f7038c53b
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -393,14 +393,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:49 GMT
+                - Fri, 03 Jul 2026 15:27:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - ba993348-1620-484f-98d4-8ce1e5bc0f56
+                - a5b377f8-4587-47a4-b443-55c6599b4926
         status: 204 No Content
         code: 204
-        duration: 122.248924ms
+        duration: 143.519756ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -410,29 +410,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6c1598c9-6f70-40b6-bfd2-3ef5ac0afc08
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3d0b6f6c-1ebf-4558-b675-b93f7038c53b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 462
-        body: '{"id":"6c1598c9-6f70-40b6-bfd2-3ef5ac0afc08","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-no-versions","status":"ready","created_at":"2026-06-24T09:38:48.150599Z","updated_at":"2026-06-24T09:38:49.161416Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-06-24T09:38:49.161416Z","key_id":null,"region":"fr-par"}'
+        body: '{"id":"3d0b6f6c-1ebf-4558-b675-b93f7038c53b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-no-versions","status":"ready","created_at":"2026-07-03T15:27:54.670466Z","updated_at":"2026-07-03T15:27:56.519336Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-07-03T15:27:56.519336Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "462"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:49 GMT
+                - Fri, 03 Jul 2026 15:27:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 3486be5e-e92e-4485-ae37-dcadaa5792fe
+                - 0e7283d0-02fc-45a0-9a2e-ee24e82aaa62
         status: 200 OK
         code: 200
-        duration: 22.216948ms
+        duration: 48.865973ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -442,26 +442,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6c1598c9-6f70-40b6-bfd2-3ef5ac0afc08
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3d0b6f6c-1ebf-4558-b675-b93f7038c53b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 462
-        body: '{"id":"6c1598c9-6f70-40b6-bfd2-3ef5ac0afc08","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-no-versions","status":"ready","created_at":"2026-06-24T09:38:48.150599Z","updated_at":"2026-06-24T09:38:49.161416Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-06-24T09:38:49.161416Z","key_id":null,"region":"fr-par"}'
+        body: '{"id":"3d0b6f6c-1ebf-4558-b675-b93f7038c53b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-no-versions","status":"ready","created_at":"2026-07-03T15:27:54.670466Z","updated_at":"2026-07-03T15:27:56.519336Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-07-03T15:27:56.519336Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "462"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:49 GMT
+                - Fri, 03 Jul 2026 15:27:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 37fad687-bc67-4f70-9de7-71c9722c8731
+                - 3d89fe09-32c3-4747-9ec1-4860ce0140cf
         status: 200 OK
         code: 200
-        duration: 35.397969ms
+        duration: 32.395287ms

--- a/internal/services/secret/testdata/data-source-secret-path.cassette.yaml
+++ b/internal/services/secret/testdata/data-source-secret-path.cassette.yaml
@@ -13,7 +13,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets
         method: POST
       response:
@@ -21,21 +21,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 457
-        body: '{"id":"192e7723-09ec-4a4a-b9e5-36f3954969fb","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-ds-path","status":"ready","created_at":"2026-06-24T09:38:48.185097Z","updated_at":"2026-06-24T09:38:48.185097Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-ds-path-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"5e7b5c82-1166-4d86-9b54-20224776fed6","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-ds-path","status":"ready","created_at":"2026-07-03T15:28:02.378730Z","updated_at":"2026-07-03T15:28:02.378730Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-ds-path-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "457"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - d75bd8b9-7a4b-48ad-acde-88ff2b2cfb32
+                - 07213925-c500-4a93-9aca-33b93b8b2989
         status: 200 OK
         code: 200
-        duration: 254.059484ms
+        duration: 112.194571ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -45,29 +45,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/192e7723-09ec-4a4a-b9e5-36f3954969fb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5e7b5c82-1166-4d86-9b54-20224776fed6
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 457
-        body: '{"id":"192e7723-09ec-4a4a-b9e5-36f3954969fb","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-ds-path","status":"ready","created_at":"2026-06-24T09:38:48.185097Z","updated_at":"2026-06-24T09:38:48.185097Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-ds-path-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"5e7b5c82-1166-4d86-9b54-20224776fed6","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-ds-path","status":"ready","created_at":"2026-07-03T15:28:02.378730Z","updated_at":"2026-07-03T15:28:02.378730Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-ds-path-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "457"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - a3f83096-6924-4259-8114-db2af13091d9
+                - 36c68361-0e8f-4bf0-acd9-92818e8ae740
         status: 200 OK
         code: 200
-        duration: 37.204376ms
+        duration: 59.791864ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -80,8 +80,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/192e7723-09ec-4a4a-b9e5-36f3954969fb/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5e7b5c82-1166-4d86-9b54-20224776fed6/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -95,14 +95,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 6a322542-1dc4-4ab1-a7d2-91f6debc6591
+                - c99bdb02-6756-4622-8eb8-c1ebe61c511c
         status: 200 OK
         code: 200
-        duration: 20.949367ms
+        duration: 53.734237ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -125,7 +125,7 @@ interactions:
                 - unknown_type
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets?name=test-secret-ds-path&order_by=name_asc&path=%2Ftest-secret-ds-path-path&project_id=105bdce1-64c0-48ab-899d-868455867ecf&scheduled_for_deletion=false&type=unknown_type
         method: GET
       response:
@@ -133,21 +133,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 487
-        body: '{"secrets":[{"id":"192e7723-09ec-4a4a-b9e5-36f3954969fb","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-ds-path","status":"ready","created_at":"2026-06-24T09:38:48.185097Z","updated_at":"2026-06-24T09:38:48.185097Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-ds-path-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}],"total_count":1}'
+        body: '{"secrets":[{"id":"5e7b5c82-1166-4d86-9b54-20224776fed6","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-ds-path","status":"ready","created_at":"2026-07-03T15:28:02.378730Z","updated_at":"2026-07-03T15:28:02.378730Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-ds-path-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "487"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 328f0f24-1c55-4306-9cf1-102491a8af56
+                - 165278e8-f988-46f7-956b-7a80d7a2e306
         status: 200 OK
         code: 200
-        duration: 36.905522ms
+        duration: 40.841972ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -157,29 +157,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/192e7723-09ec-4a4a-b9e5-36f3954969fb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5e7b5c82-1166-4d86-9b54-20224776fed6
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 457
-        body: '{"id":"192e7723-09ec-4a4a-b9e5-36f3954969fb","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-ds-path","status":"ready","created_at":"2026-06-24T09:38:48.185097Z","updated_at":"2026-06-24T09:38:48.185097Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-ds-path-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"5e7b5c82-1166-4d86-9b54-20224776fed6","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-ds-path","status":"ready","created_at":"2026-07-03T15:28:02.378730Z","updated_at":"2026-07-03T15:28:02.378730Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-ds-path-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "457"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 577eddf2-66b3-49ff-aa96-3502c51d31a2
+                - ec41d9ae-ffdb-4d1d-b631-f80d61200269
         status: 200 OK
         code: 200
-        duration: 32.445655ms
+        duration: 32.209227ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -192,8 +192,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/192e7723-09ec-4a4a-b9e5-36f3954969fb/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5e7b5c82-1166-4d86-9b54-20224776fed6/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -207,14 +207,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 96297c5e-ae16-4dd4-b466-171fd6d82659
+                - 9242b0e8-f245-4447-a610-94a96d4734e0
         status: 200 OK
         code: 200
-        duration: 31.736003ms
+        duration: 38.767306ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -224,29 +224,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/192e7723-09ec-4a4a-b9e5-36f3954969fb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5e7b5c82-1166-4d86-9b54-20224776fed6
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 457
-        body: '{"id":"192e7723-09ec-4a4a-b9e5-36f3954969fb","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-ds-path","status":"ready","created_at":"2026-06-24T09:38:48.185097Z","updated_at":"2026-06-24T09:38:48.185097Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-ds-path-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"5e7b5c82-1166-4d86-9b54-20224776fed6","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-ds-path","status":"ready","created_at":"2026-07-03T15:28:02.378730Z","updated_at":"2026-07-03T15:28:02.378730Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-ds-path-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "457"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 6b821e68-885a-4f83-b164-98754b547a9c
+                - b1ea2349-b477-400d-a595-4371bfaf5525
         status: 200 OK
         code: 200
-        duration: 19.885635ms
+        duration: 43.573703ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -269,7 +269,7 @@ interactions:
                 - unknown_type
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets?name=test-secret-ds-path&order_by=name_asc&path=%2Ftest-secret-ds-path-path&project_id=105bdce1-64c0-48ab-899d-868455867ecf&scheduled_for_deletion=false&type=unknown_type
         method: GET
       response:
@@ -277,21 +277,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 487
-        body: '{"secrets":[{"id":"192e7723-09ec-4a4a-b9e5-36f3954969fb","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-ds-path","status":"ready","created_at":"2026-06-24T09:38:48.185097Z","updated_at":"2026-06-24T09:38:48.185097Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-ds-path-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}],"total_count":1}'
+        body: '{"secrets":[{"id":"5e7b5c82-1166-4d86-9b54-20224776fed6","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-ds-path","status":"ready","created_at":"2026-07-03T15:28:02.378730Z","updated_at":"2026-07-03T15:28:02.378730Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-ds-path-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "487"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 30a0411b-d5d2-4b1c-a68b-0ae44a9454e9
+                - e42e467f-19f4-4f79-82c2-6f33663f2ff1
         status: 200 OK
         code: 200
-        duration: 19.931714ms
+        duration: 119.726317ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -301,29 +301,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/192e7723-09ec-4a4a-b9e5-36f3954969fb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5e7b5c82-1166-4d86-9b54-20224776fed6
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 457
-        body: '{"id":"192e7723-09ec-4a4a-b9e5-36f3954969fb","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-ds-path","status":"ready","created_at":"2026-06-24T09:38:48.185097Z","updated_at":"2026-06-24T09:38:48.185097Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-ds-path-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"5e7b5c82-1166-4d86-9b54-20224776fed6","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-ds-path","status":"ready","created_at":"2026-07-03T15:28:02.378730Z","updated_at":"2026-07-03T15:28:02.378730Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-ds-path-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "457"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - a6aa8a7b-145a-41e0-8af2-90b26a5349a4
+                - cb262671-ce2a-4b2d-8bdf-4861142a142d
         status: 200 OK
         code: 200
-        duration: 23.81771ms
+        duration: 40.527541ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -336,8 +336,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/192e7723-09ec-4a4a-b9e5-36f3954969fb/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5e7b5c82-1166-4d86-9b54-20224776fed6/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -351,14 +351,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 75a81085-e5af-44a6-b750-31b4a10ba4d1
+                - b8471313-b2c8-4c81-8e96-e3f7802b5518
         status: 200 OK
         code: 200
-        duration: 18.612593ms
+        duration: 47.03823ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -368,29 +368,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/192e7723-09ec-4a4a-b9e5-36f3954969fb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5e7b5c82-1166-4d86-9b54-20224776fed6
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 457
-        body: '{"id":"192e7723-09ec-4a4a-b9e5-36f3954969fb","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-ds-path","status":"ready","created_at":"2026-06-24T09:38:48.185097Z","updated_at":"2026-06-24T09:38:48.185097Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-ds-path-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"5e7b5c82-1166-4d86-9b54-20224776fed6","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-ds-path","status":"ready","created_at":"2026-07-03T15:28:02.378730Z","updated_at":"2026-07-03T15:28:02.378730Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-ds-path-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "457"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 069b14ba-e98f-4672-86b5-3160101652b0
+                - 4286d399-d916-49a0-8dcf-5592c9e197ba
         status: 200 OK
         code: 200
-        duration: 18.699811ms
+        duration: 69.886465ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -403,8 +403,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/192e7723-09ec-4a4a-b9e5-36f3954969fb/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5e7b5c82-1166-4d86-9b54-20224776fed6/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -418,14 +418,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 083421c8-09bf-4367-b418-92a5fcf4f906
+                - 7066c8c5-cd50-4588-b508-dd1e09e36404
         status: 200 OK
         code: 200
-        duration: 23.876643ms
+        duration: 50.727589ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -448,7 +448,7 @@ interactions:
                 - unknown_type
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets?name=test-secret-ds-path&order_by=name_asc&path=%2Ftest-secret-ds-path-path&project_id=105bdce1-64c0-48ab-899d-868455867ecf&scheduled_for_deletion=false&type=unknown_type
         method: GET
       response:
@@ -456,21 +456,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 487
-        body: '{"secrets":[{"id":"192e7723-09ec-4a4a-b9e5-36f3954969fb","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-ds-path","status":"ready","created_at":"2026-06-24T09:38:48.185097Z","updated_at":"2026-06-24T09:38:48.185097Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-ds-path-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}],"total_count":1}'
+        body: '{"secrets":[{"id":"5e7b5c82-1166-4d86-9b54-20224776fed6","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-ds-path","status":"ready","created_at":"2026-07-03T15:28:02.378730Z","updated_at":"2026-07-03T15:28:02.378730Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-ds-path-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "487"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 31863ee9-58f5-4d43-8ccb-52292f415fb3
+                - 232536e5-a55e-490b-8ae0-ad20fe2509fd
         status: 200 OK
         code: 200
-        duration: 18.062888ms
+        duration: 43.913852ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -480,29 +480,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/192e7723-09ec-4a4a-b9e5-36f3954969fb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5e7b5c82-1166-4d86-9b54-20224776fed6
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 457
-        body: '{"id":"192e7723-09ec-4a4a-b9e5-36f3954969fb","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-ds-path","status":"ready","created_at":"2026-06-24T09:38:48.185097Z","updated_at":"2026-06-24T09:38:48.185097Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-ds-path-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"5e7b5c82-1166-4d86-9b54-20224776fed6","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-ds-path","status":"ready","created_at":"2026-07-03T15:28:02.378730Z","updated_at":"2026-07-03T15:28:02.378730Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-ds-path-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "457"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 30d1f53a-92d3-4ff4-9de0-135db28b59a4
+                - 2e19dd8c-aa9a-4657-9da7-9fd1986c2636
         status: 200 OK
         code: 200
-        duration: 21.338664ms
+        duration: 34.252375ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -515,8 +515,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/192e7723-09ec-4a4a-b9e5-36f3954969fb/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5e7b5c82-1166-4d86-9b54-20224776fed6/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -530,14 +530,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - e4737f68-867e-4864-b2c8-464f74f40e3c
+                - 25de46ae-4768-4c18-8c76-6eab7daef8e4
         status: 200 OK
         code: 200
-        duration: 25.818158ms
+        duration: 42.770474ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -547,8 +547,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/192e7723-09ec-4a4a-b9e5-36f3954969fb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5e7b5c82-1166-4d86-9b54-20224776fed6
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -560,14 +560,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:49 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - e4b4806a-1bf5-46b7-898b-aff8cd5b640c
+                - 395d2ffd-f29a-4b92-be07-bf3547f75bd3
         status: 204 No Content
         code: 204
-        duration: 126.53657ms
+        duration: 60.559807ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -577,29 +577,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/192e7723-09ec-4a4a-b9e5-36f3954969fb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5e7b5c82-1166-4d86-9b54-20224776fed6
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 482
-        body: '{"id":"192e7723-09ec-4a4a-b9e5-36f3954969fb","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-ds-path","status":"ready","created_at":"2026-06-24T09:38:48.185097Z","updated_at":"2026-06-24T09:38:49.347276Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-ds-path-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-06-24T09:38:49.347276Z","key_id":null,"region":"fr-par"}'
+        body: '{"id":"5e7b5c82-1166-4d86-9b54-20224776fed6","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-ds-path","status":"ready","created_at":"2026-07-03T15:28:02.378730Z","updated_at":"2026-07-03T15:28:04.504823Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-ds-path-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-07-03T15:28:04.504823Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "482"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:49 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 7d44f9f6-54fd-400d-9e51-5a0ee4255adf
+                - 63b9ed6b-6711-402f-a76d-40d02537cf0a
         status: 200 OK
         code: 200
-        duration: 29.064116ms
+        duration: 47.27817ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -609,26 +609,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/192e7723-09ec-4a4a-b9e5-36f3954969fb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5e7b5c82-1166-4d86-9b54-20224776fed6
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 482
-        body: '{"id":"192e7723-09ec-4a4a-b9e5-36f3954969fb","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-ds-path","status":"ready","created_at":"2026-06-24T09:38:48.185097Z","updated_at":"2026-06-24T09:38:49.347276Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-ds-path-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-06-24T09:38:49.347276Z","key_id":null,"region":"fr-par"}'
+        body: '{"id":"5e7b5c82-1166-4d86-9b54-20224776fed6","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-ds-path","status":"ready","created_at":"2026-07-03T15:28:02.378730Z","updated_at":"2026-07-03T15:28:04.504823Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-ds-path-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-07-03T15:28:04.504823Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "482"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:49 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 5856ee4d-cd4d-477a-99c9-d6e470eec8b6
+                - 4e244713-4932-4201-bd96-86c9ab328906
         status: 200 OK
         code: 200
-        duration: 19.252961ms
+        duration: 37.942646ms

--- a/internal/services/secret/testdata/data-source-secret-version-basic.cassette.yaml
+++ b/internal/services/secret/testdata/data-source-secret-version-basic.cassette.yaml
@@ -13,7 +13,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets
         method: POST
       response:
@@ -21,21 +21,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 493
-        body: '{"id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"dataSourceSecretVersionBasic","status":"ready","created_at":"2026-06-04T09:49:12.322216Z","updated_at":"2026-06-04T09:49:12.322216Z","tags":["devtools","provider","terraform"],"version_count":0,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"a2869384-3f17-46f5-8824-11b0bc94470f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"dataSourceSecretVersionBasic","status":"ready","created_at":"2026-07-03T15:27:54.696393Z","updated_at":"2026-07-03T15:27:54.696393Z","tags":["devtools","provider","terraform"],"version_count":0,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "493"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:12 GMT
+                - Fri, 03 Jul 2026 15:27:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 757297ca-3b8b-4ac7-9690-d52f9c885f00
+                - 081a2b66-fbd6-4d8d-b27b-ca114b68b516
         status: 200 OK
         code: 200
-        duration: 243.688024ms
+        duration: 342.716739ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -45,29 +45,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 493
-        body: '{"id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"dataSourceSecretVersionBasic","status":"ready","created_at":"2026-06-04T09:49:12.322216Z","updated_at":"2026-06-04T09:49:12.322216Z","tags":["devtools","provider","terraform"],"version_count":0,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"a2869384-3f17-46f5-8824-11b0bc94470f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"dataSourceSecretVersionBasic","status":"ready","created_at":"2026-07-03T15:27:54.696393Z","updated_at":"2026-07-03T15:27:54.696393Z","tags":["devtools","provider","terraform"],"version_count":0,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "493"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:12 GMT
+                - Fri, 03 Jul 2026 15:27:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - e2ef8081-cddd-45f8-a18c-5cf17d0e6b20
+                - 8ea17b11-548e-442f-9ffb-1757d9f0eab3
         status: 200 OK
         code: 200
-        duration: 117.030739ms
+        duration: 168.228405ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -80,8 +80,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -95,14 +95,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:12 GMT
+                - Fri, 03 Jul 2026 15:27:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - c2d6e265-b888-4e02-9e58-7f6d8a6fc062
+                - 4a46f91d-d635-420a-aaf5-4e97b7032458
         status: 200 OK
         code: 200
-        duration: 88.331124ms
+        duration: 44.234764ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -115,29 +115,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","status":"enabled","created_at":"2026-06-04T09:49:13.014569Z","updated_at":"2026-06-04T09:49:13.014569Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","status":"enabled","created_at":"2026-07-03T15:27:55.395862Z","updated_at":"2026-07-03T15:27:55.395862Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:13 GMT
+                - Fri, 03 Jul 2026 15:27:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - bcaf1e45-d057-4236-b850-e989d9205b30
+                - c82d440d-a7b2-49ce-a6f3-2e9faa0430ab
         status: 200 OK
         code: 200
-        duration: 468.202149ms
+        duration: 563.187409ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -147,29 +147,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","status":"enabled","created_at":"2026-06-04T09:49:13.014569Z","updated_at":"2026-06-04T09:49:13.014569Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","status":"enabled","created_at":"2026-07-03T15:27:55.395862Z","updated_at":"2026-07-03T15:27:55.395862Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:13 GMT
+                - Fri, 03 Jul 2026 15:27:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 32caae90-7423-40fd-9f7d-88c4ea0d8c18
+                - aab5179c-7e7f-47f2-99d3-4f9bd056c032
         status: 200 OK
         code: 200
-        duration: 77.38888ms
+        duration: 96.293593ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -179,29 +179,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 493
-        body: '{"id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"dataSourceSecretVersionBasic","status":"ready","created_at":"2026-06-04T09:49:12.322216Z","updated_at":"2026-06-04T09:49:12.322216Z","tags":["devtools","provider","terraform"],"version_count":1,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"a2869384-3f17-46f5-8824-11b0bc94470f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"dataSourceSecretVersionBasic","status":"ready","created_at":"2026-07-03T15:27:54.696393Z","updated_at":"2026-07-03T15:27:54.696393Z","tags":["devtools","provider","terraform"],"version_count":1,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "493"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:13 GMT
+                - Fri, 03 Jul 2026 15:27:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - f60d85dc-6367-4ea5-898b-61d303947c34
+                - 4e3ec1f7-c8f8-4b41-baa5-dcfc180005b3
         status: 200 OK
         code: 200
-        duration: 33.504864ms
+        duration: 83.736178ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -214,29 +214,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 333
-        body: '{"versions":[{"revision":1,"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","status":"enabled","created_at":"2026-06-04T09:49:13.014569Z","updated_at":"2026-06-04T09:49:13.014569Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        body: '{"versions":[{"revision":1,"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","status":"enabled","created_at":"2026-07-03T15:27:55.395862Z","updated_at":"2026-07-03T15:27:55.395862Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "333"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:13 GMT
+                - Fri, 03 Jul 2026 15:27:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - dd09eaf0-88fa-46e5-bcdf-5d9eb1448f86
+                - b0432b5e-c883-498c-a76c-b68a3fb61578
         status: 200 OK
         code: 200
-        duration: 33.5829ms
+        duration: 55.356193ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -246,29 +246,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","status":"enabled","created_at":"2026-06-04T09:49:13.014569Z","updated_at":"2026-06-04T09:49:13.014569Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","status":"enabled","created_at":"2026-07-03T15:27:55.395862Z","updated_at":"2026-07-03T15:27:55.395862Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:13 GMT
+                - Fri, 03 Jul 2026 15:27:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 7a004e55-6b68-4a6d-b52a-557653821c36
+                - 78d811ef-2507-4463-a5ae-2cdf5765005f
         status: 200 OK
         code: 200
-        duration: 89.862961ms
+        duration: 103.03203ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -278,29 +278,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 493
-        body: '{"id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"dataSourceSecretVersionBasic","status":"ready","created_at":"2026-06-04T09:49:12.322216Z","updated_at":"2026-06-04T09:49:12.322216Z","tags":["devtools","provider","terraform"],"version_count":1,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"a2869384-3f17-46f5-8824-11b0bc94470f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"dataSourceSecretVersionBasic","status":"ready","created_at":"2026-07-03T15:27:54.696393Z","updated_at":"2026-07-03T15:27:54.696393Z","tags":["devtools","provider","terraform"],"version_count":1,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "493"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:13 GMT
+                - Fri, 03 Jul 2026 15:27:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - de4a968c-b8cb-428b-bcdc-4e472dee7f95
+                - 08b03a8b-45f7-4de5-b645-1b4df1aa41b4
         status: 200 OK
         code: 200
-        duration: 74.030489ms
+        duration: 41.792357ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -313,29 +313,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 333
-        body: '{"versions":[{"revision":1,"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","status":"enabled","created_at":"2026-06-04T09:49:13.014569Z","updated_at":"2026-06-04T09:49:13.014569Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        body: '{"versions":[{"revision":1,"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","status":"enabled","created_at":"2026-07-03T15:27:55.395862Z","updated_at":"2026-07-03T15:27:55.395862Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "333"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:13 GMT
+                - Fri, 03 Jul 2026 15:27:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 77bb14ca-4270-46e5-b56e-d3a4bf04bafd
+                - 1a20c1b6-972d-4274-8d78-59faf0790686
         status: 200 OK
         code: 200
-        duration: 38.525564ms
+        duration: 31.060229ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -345,29 +345,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","status":"enabled","created_at":"2026-06-04T09:49:13.014569Z","updated_at":"2026-06-04T09:49:13.014569Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","status":"enabled","created_at":"2026-07-03T15:27:55.395862Z","updated_at":"2026-07-03T15:27:55.395862Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:14 GMT
+                - Fri, 03 Jul 2026 15:27:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 1c57b956-a806-42f8-8359-2eb9f9d994ef
+                - 9c3c7261-ca09-4ef2-b30e-95bf7546591e
         status: 200 OK
         code: 200
-        duration: 38.7693ms
+        duration: 113.84004ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -380,29 +380,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":2,"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","status":"enabled","created_at":"2026-06-04T09:49:14.390180Z","updated_at":"2026-06-04T09:49:14.390180Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":2,"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","status":"enabled","created_at":"2026-07-03T15:27:57.360463Z","updated_at":"2026-07-03T15:27:57.360463Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:14 GMT
+                - Fri, 03 Jul 2026 15:27:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - c22a63bc-ca8e-41c1-a64e-5f6773b2c4a1
+                - 44141d71-3abf-4618-ad9a-76374b78f1bb
         status: 200 OK
         code: 200
-        duration: 195.094199ms
+        duration: 946.158988ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -412,29 +412,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":2,"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","status":"enabled","created_at":"2026-06-04T09:49:14.390180Z","updated_at":"2026-06-04T09:49:14.390180Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":2,"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","status":"enabled","created_at":"2026-07-03T15:27:57.360463Z","updated_at":"2026-07-03T15:27:57.360463Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:14 GMT
+                - Fri, 03 Jul 2026 15:27:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 29b538c1-b826-4b39-9aed-52a94a629034
+                - 239d203a-a026-4030-aff1-cbaae91f368a
         status: 200 OK
         code: 200
-        duration: 80.159464ms
+        duration: 332.920078ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -444,29 +444,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 493
-        body: '{"id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"dataSourceSecretVersionBasic","status":"ready","created_at":"2026-06-04T09:49:12.322216Z","updated_at":"2026-06-04T09:49:12.322216Z","tags":["devtools","provider","terraform"],"version_count":2,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"a2869384-3f17-46f5-8824-11b0bc94470f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"dataSourceSecretVersionBasic","status":"ready","created_at":"2026-07-03T15:27:54.696393Z","updated_at":"2026-07-03T15:27:54.696393Z","tags":["devtools","provider","terraform"],"version_count":2,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "493"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:14 GMT
+                - Fri, 03 Jul 2026 15:27:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 8a4bb5b8-590c-4c18-8170-ddd09fd60d14
+                - d425602e-196a-4928-bac9-4a45e9fda50c
         status: 200 OK
         code: 200
-        duration: 38.028075ms
+        duration: 36.975018ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -479,29 +479,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 637
-        body: '{"versions":[{"revision":2,"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","status":"enabled","created_at":"2026-06-04T09:49:14.390180Z","updated_at":"2026-06-04T09:49:14.390180Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","status":"enabled","created_at":"2026-06-04T09:49:13.014569Z","updated_at":"2026-06-04T09:49:13.014569Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":2}'
+        body: '{"versions":[{"revision":2,"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","status":"enabled","created_at":"2026-07-03T15:27:57.360463Z","updated_at":"2026-07-03T15:27:57.360463Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","status":"enabled","created_at":"2026-07-03T15:27:55.395862Z","updated_at":"2026-07-03T15:27:55.395862Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":2}'
         headers:
             Content-Length:
                 - "637"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:14 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 147bfdf0-f7d4-40e7-b1df-8487ca7ac179
+                - 19ebfca6-f0dd-4f19-b0bb-b33d78707f62
         status: 200 OK
         code: 200
-        duration: 39.422262ms
+        duration: 47.909716ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -511,29 +511,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 303
-        body: '{"revision":1,"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","status":"enabled","created_at":"2026-06-04T09:49:13.014569Z","updated_at":"2026-06-04T09:49:13.014569Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","status":"enabled","created_at":"2026-07-03T15:27:55.395862Z","updated_at":"2026-07-03T15:27:55.395862Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "303"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:15 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 841d06af-4c05-430f-8c14-8888ab8b3104
+                - 770791e5-ef20-4806-8ed3-9639cb66ec9f
         status: 200 OK
         code: 200
-        duration: 86.333211ms
+        duration: 43.549717ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -543,29 +543,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":2,"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","status":"enabled","created_at":"2026-06-04T09:49:14.390180Z","updated_at":"2026-06-04T09:49:14.390180Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":2,"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","status":"enabled","created_at":"2026-07-03T15:27:57.360463Z","updated_at":"2026-07-03T15:27:57.360463Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:15 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 362f3e36-fc91-4f0e-90ec-91b9aaf473b4
+                - c26ab12f-ffcd-4e50-8188-73213497c891
         status: 200 OK
         code: 200
-        duration: 40.150725ms
+        duration: 40.714592ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -575,29 +575,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 493
-        body: '{"id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"dataSourceSecretVersionBasic","status":"ready","created_at":"2026-06-04T09:49:12.322216Z","updated_at":"2026-06-04T09:49:12.322216Z","tags":["devtools","provider","terraform"],"version_count":2,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"a2869384-3f17-46f5-8824-11b0bc94470f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"dataSourceSecretVersionBasic","status":"ready","created_at":"2026-07-03T15:27:54.696393Z","updated_at":"2026-07-03T15:27:54.696393Z","tags":["devtools","provider","terraform"],"version_count":2,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "493"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:15 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 301191d9-154e-4308-9eaa-3406f92f571b
+                - 108b1e0e-a4f9-4303-8c3e-32a04f7d67c2
         status: 200 OK
         code: 200
-        duration: 101.091506ms
+        duration: 54.782024ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -610,29 +610,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 637
-        body: '{"versions":[{"revision":2,"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","status":"enabled","created_at":"2026-06-04T09:49:14.390180Z","updated_at":"2026-06-04T09:49:14.390180Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","status":"enabled","created_at":"2026-06-04T09:49:13.014569Z","updated_at":"2026-06-04T09:49:13.014569Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":2}'
+        body: '{"versions":[{"revision":2,"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","status":"enabled","created_at":"2026-07-03T15:27:57.360463Z","updated_at":"2026-07-03T15:27:57.360463Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","status":"enabled","created_at":"2026-07-03T15:27:55.395862Z","updated_at":"2026-07-03T15:27:55.395862Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":2}'
         headers:
             Content-Length:
                 - "637"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:15 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 401a8539-62a4-4ff8-a435-70610282940d
+                - 1086352d-fbec-4d3a-a655-75aa15e36eb7
         status: 200 OK
         code: 200
-        duration: 39.891391ms
+        duration: 54.134989ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -642,29 +642,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 303
-        body: '{"revision":1,"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","status":"enabled","created_at":"2026-06-04T09:49:13.014569Z","updated_at":"2026-06-04T09:49:13.014569Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","status":"enabled","created_at":"2026-07-03T15:27:55.395862Z","updated_at":"2026-07-03T15:27:55.395862Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "303"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:15 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - eb1e5e64-3de1-46ea-9de7-b1f3f66f76e9
+                - ee5ba626-5995-4b51-bfa1-6272359a2d28
         status: 200 OK
         code: 200
-        duration: 36.151055ms
+        duration: 37.751106ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -674,29 +674,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":2,"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","status":"enabled","created_at":"2026-06-04T09:49:14.390180Z","updated_at":"2026-06-04T09:49:14.390180Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":2,"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","status":"enabled","created_at":"2026-07-03T15:27:57.360463Z","updated_at":"2026-07-03T15:27:57.360463Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:15 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 75525523-91e9-48c1-967c-a507df741c61
+                - d0235b0c-24f5-4387-ae72-9ab8a5a050c2
         status: 200 OK
         code: 200
-        duration: 37.06273ms
+        duration: 45.764808ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -706,29 +706,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions/2/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 133
-        body: '{"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","revision":2,"data":"bXlfc3VwZXJfc2VjcmV0X3Yy","data_crc32":null,"type":"opaque"}'
+        body: '{"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","revision":1,"data":"bXlfc3VwZXJfc2VjcmV0X3Yx","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
                 - "133"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:15 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - f9b2d3dd-7165-46d4-b610-8d1c9b6ed2f6
+                - 1d42f382-9554-4fb8-95ec-d1aec58cdbc4
         status: 200 OK
         code: 200
-        duration: 111.190975ms
+        duration: 120.821884ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -738,29 +738,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions/latest/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions/latest/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 133
-        body: '{"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","revision":2,"data":"bXlfc3VwZXJfc2VjcmV0X3Yy","data_crc32":null,"type":"opaque"}'
+        body: '{"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","revision":2,"data":"bXlfc3VwZXJfc2VjcmV0X3Yy","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
                 - "133"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:15 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 501a8980-f76d-4429-85e4-319f63c2d648
+                - 8d5d0b54-2aad-461e-a115-d0dd80476848
         status: 200 OK
         code: 200
-        duration: 128.655309ms
+        duration: 124.049136ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -770,29 +770,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions/1/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions/2/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 133
-        body: '{"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","revision":1,"data":"bXlfc3VwZXJfc2VjcmV0X3Yx","data_crc32":null,"type":"opaque"}'
+        body: '{"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","revision":2,"data":"bXlfc3VwZXJfc2VjcmV0X3Yy","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
                 - "133"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:15 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 6664d50e-888e-4889-a9a3-769aa8e76022
+                - 5c7b8617-77ec-4dab-ba54-7c1909843d9e
         status: 200 OK
         code: 200
-        duration: 128.80536ms
+        duration: 131.139052ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -802,29 +802,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 303
-        body: '{"revision":1,"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","status":"enabled","created_at":"2026-06-04T09:49:13.014569Z","updated_at":"2026-06-04T09:49:13.014569Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 302
+        body: '{"revision":2,"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","status":"enabled","created_at":"2026-07-03T15:27:57.360463Z","updated_at":"2026-07-03T15:27:57.360463Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "303"
+                - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:15 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 2ebdbb64-3936-421d-8528-2e23eaae7a08
+                - 94e20824-a35e-4e9b-a9c3-eda1a28c3ca7
         status: 200 OK
         code: 200
-        duration: 35.013778ms
+        duration: 33.255562ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -834,29 +834,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":2,"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","status":"enabled","created_at":"2026-06-04T09:49:14.390180Z","updated_at":"2026-06-04T09:49:14.390180Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":2,"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","status":"enabled","created_at":"2026-07-03T15:27:57.360463Z","updated_at":"2026-07-03T15:27:57.360463Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:15 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 9cc58f2b-1905-4699-9a81-a079bd18e168
+                - 7debce42-3c19-4f5b-a070-8a601c244906
         status: 200 OK
         code: 200
-        duration: 97.098517ms
+        duration: 39.045067ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -866,29 +866,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 302
-        body: '{"revision":2,"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","status":"enabled","created_at":"2026-06-04T09:49:14.390180Z","updated_at":"2026-06-04T09:49:14.390180Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 303
+        body: '{"revision":1,"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","status":"enabled","created_at":"2026-07-03T15:27:55.395862Z","updated_at":"2026-07-03T15:27:55.395862Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "302"
+                - "303"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:15 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - d75bcda9-621c-45f4-b8b3-d27a7519919e
+                - 108e8f68-b257-4607-ace7-e9bb00a2f8b2
         status: 200 OK
         code: 200
-        duration: 80.046986ms
+        duration: 49.168862ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -898,29 +898,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 303
-        body: '{"revision":1,"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","status":"enabled","created_at":"2026-06-04T09:49:13.014569Z","updated_at":"2026-06-04T09:49:13.014569Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","status":"enabled","created_at":"2026-07-03T15:27:55.395862Z","updated_at":"2026-07-03T15:27:55.395862Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "303"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:15 GMT
+                - Fri, 03 Jul 2026 15:28:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - a450bc50-2ce7-4ec8-be8d-7787aac586bb
+                - 71b1fd1b-5e3d-43b4-bddd-bcb89dff34fa
         status: 200 OK
         code: 200
-        duration: 31.535403ms
+        duration: 67.762135ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -930,29 +930,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":2,"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","status":"enabled","created_at":"2026-06-04T09:49:14.390180Z","updated_at":"2026-06-04T09:49:14.390180Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":2,"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","status":"enabled","created_at":"2026-07-03T15:27:57.360463Z","updated_at":"2026-07-03T15:27:57.360463Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:15 GMT
+                - Fri, 03 Jul 2026 15:28:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 9de0c564-a420-45c9-a366-fe84ed9cb515
+                - 32e09721-a513-439a-98e2-a7501b49445f
         status: 200 OK
         code: 200
-        duration: 38.167737ms
+        duration: 74.764347ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -962,29 +962,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions/2/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 133
-        body: '{"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","revision":2,"data":"bXlfc3VwZXJfc2VjcmV0X3Yy","data_crc32":null,"type":"opaque"}'
+        body: '{"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","revision":1,"data":"bXlfc3VwZXJfc2VjcmV0X3Yx","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
                 - "133"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:16 GMT
+                - Fri, 03 Jul 2026 15:28:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 513963cb-0826-44c9-bc6a-20e187e426d5
+                - cea459d3-057e-463b-b7da-befec7cd7240
         status: 200 OK
         code: 200
-        duration: 40.717236ms
+        duration: 39.439507ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -994,29 +994,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions/latest/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions/2/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 133
-        body: '{"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","revision":2,"data":"bXlfc3VwZXJfc2VjcmV0X3Yy","data_crc32":null,"type":"opaque"}'
+        body: '{"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","revision":2,"data":"bXlfc3VwZXJfc2VjcmV0X3Yy","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
                 - "133"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:16 GMT
+                - Fri, 03 Jul 2026 15:28:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 61210c89-bb62-4046-bf28-d074f28070c5
+                - 90bbbbc3-34ce-42d2-be80-1970d2d76d9a
         status: 200 OK
         code: 200
-        duration: 42.231959ms
+        duration: 39.127782ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1026,29 +1026,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":2,"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","status":"enabled","created_at":"2026-06-04T09:49:14.390180Z","updated_at":"2026-06-04T09:49:14.390180Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":2,"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","status":"enabled","created_at":"2026-07-03T15:27:57.360463Z","updated_at":"2026-07-03T15:27:57.360463Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:16 GMT
+                - Fri, 03 Jul 2026 15:28:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - d72bd7a7-fcd1-4199-97b0-b98864b4ab69
+                - d28f7166-96e8-402a-988c-491ebba97281
         status: 200 OK
         code: 200
-        duration: 42.427364ms
+        duration: 49.608828ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1058,29 +1058,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions/1/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 133
-        body: '{"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","revision":1,"data":"bXlfc3VwZXJfc2VjcmV0X3Yx","data_crc32":null,"type":"opaque"}'
+        content_length: 303
+        body: '{"revision":1,"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","status":"enabled","created_at":"2026-07-03T15:27:55.395862Z","updated_at":"2026-07-03T15:27:55.395862Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "133"
+                - "303"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:16 GMT
+                - Fri, 03 Jul 2026 15:28:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 6167648a-2c66-4b9c-8a64-0debbed0c978
+                - a6279086-056a-4ad4-9fd2-f26cdc299fb1
         status: 200 OK
         code: 200
-        duration: 121.633409ms
+        duration: 49.436104ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1090,29 +1090,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions/latest/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 302
-        body: '{"revision":2,"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","status":"enabled","created_at":"2026-06-04T09:49:14.390180Z","updated_at":"2026-06-04T09:49:14.390180Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 133
+        body: '{"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","revision":2,"data":"bXlfc3VwZXJfc2VjcmV0X3Yy","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "302"
+                - "133"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:16 GMT
+                - Fri, 03 Jul 2026 15:28:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 487e48e3-8fff-45be-ae53-05136a3cac24
+                - d6a38bc5-eb97-44a7-aee6-42104bd52d1b
         status: 200 OK
         code: 200
-        duration: 85.260468ms
+        duration: 148.896045ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1122,29 +1122,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 303
-        body: '{"revision":1,"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","status":"enabled","created_at":"2026-06-04T09:49:13.014569Z","updated_at":"2026-06-04T09:49:13.014569Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 302
+        body: '{"revision":2,"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","status":"enabled","created_at":"2026-07-03T15:27:57.360463Z","updated_at":"2026-07-03T15:27:57.360463Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "303"
+                - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:16 GMT
+                - Fri, 03 Jul 2026 15:28:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 6103818d-2d9b-47c2-8f81-7dd36ad4a836
+                - e84cec64-d90c-4a23-a6c7-52e64a4b7eb7
         status: 200 OK
         code: 200
-        duration: 35.675676ms
+        duration: 46.675468ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1154,29 +1154,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 493
-        body: '{"id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"dataSourceSecretVersionBasic","status":"ready","created_at":"2026-06-04T09:49:12.322216Z","updated_at":"2026-06-04T09:49:12.322216Z","tags":["devtools","provider","terraform"],"version_count":2,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"a2869384-3f17-46f5-8824-11b0bc94470f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"dataSourceSecretVersionBasic","status":"ready","created_at":"2026-07-03T15:27:54.696393Z","updated_at":"2026-07-03T15:27:54.696393Z","tags":["devtools","provider","terraform"],"version_count":2,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "493"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:16 GMT
+                - Fri, 03 Jul 2026 15:28:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - bb505db3-3b80-423b-8291-b55bb9c6ee9e
+                - b98aa4e4-2944-453d-bad8-e08372e8c31c
         status: 200 OK
         code: 200
-        duration: 33.091994ms
+        duration: 35.391515ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1189,29 +1189,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 637
-        body: '{"versions":[{"revision":2,"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","status":"enabled","created_at":"2026-06-04T09:49:14.390180Z","updated_at":"2026-06-04T09:49:14.390180Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","status":"enabled","created_at":"2026-06-04T09:49:13.014569Z","updated_at":"2026-06-04T09:49:13.014569Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":2}'
+        body: '{"versions":[{"revision":2,"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","status":"enabled","created_at":"2026-07-03T15:27:57.360463Z","updated_at":"2026-07-03T15:27:57.360463Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","status":"enabled","created_at":"2026-07-03T15:27:55.395862Z","updated_at":"2026-07-03T15:27:55.395862Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":2}'
         headers:
             Content-Length:
                 - "637"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:16 GMT
+                - Fri, 03 Jul 2026 15:28:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 5d63c910-9cff-4aa5-93b7-4cd265f3e8af
+                - 6095229b-2680-43c1-bed7-a753981fabf5
         status: 200 OK
         code: 200
-        duration: 99.455027ms
+        duration: 39.378373ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1221,29 +1221,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 303
-        body: '{"revision":1,"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","status":"enabled","created_at":"2026-06-04T09:49:13.014569Z","updated_at":"2026-06-04T09:49:13.014569Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","status":"enabled","created_at":"2026-07-03T15:27:55.395862Z","updated_at":"2026-07-03T15:27:55.395862Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "303"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:16 GMT
+                - Fri, 03 Jul 2026 15:28:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - f5671625-57e4-4400-b87f-1b12d930edbb
+                - 333bbed9-73f0-4721-9626-f4cfa4bb4300
         status: 200 OK
         code: 200
-        duration: 37.811642ms
+        duration: 51.684277ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1253,29 +1253,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions/latest/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions/latest/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 133
-        body: '{"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","revision":2,"data":"bXlfc3VwZXJfc2VjcmV0X3Yy","data_crc32":null,"type":"opaque"}'
+        body: '{"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","revision":2,"data":"bXlfc3VwZXJfc2VjcmV0X3Yy","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
                 - "133"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:16 GMT
+                - Fri, 03 Jul 2026 15:28:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - c1fc88ee-effc-426f-a0e7-e35a786537ad
+                - c9bd78f8-d433-43dc-bd9a-536d89d98db9
         status: 200 OK
         code: 200
-        duration: 49.698104ms
+        duration: 67.329372ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1285,29 +1285,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions/2/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions/2/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 133
-        body: '{"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","revision":2,"data":"bXlfc3VwZXJfc2VjcmV0X3Yy","data_crc32":null,"type":"opaque"}'
+        body: '{"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","revision":2,"data":"bXlfc3VwZXJfc2VjcmV0X3Yy","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
                 - "133"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:16 GMT
+                - Fri, 03 Jul 2026 15:28:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 38dd36d7-d8d5-4eb5-881e-1f2412285b20
+                - 54786443-6080-447f-8497-5abb3067f4d1
         status: 200 OK
         code: 200
-        duration: 49.938854ms
+        duration: 66.751837ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -1317,29 +1317,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":2,"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","status":"enabled","created_at":"2026-06-04T09:49:14.390180Z","updated_at":"2026-06-04T09:49:14.390180Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":2,"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","status":"enabled","created_at":"2026-07-03T15:27:57.360463Z","updated_at":"2026-07-03T15:27:57.360463Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:16 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 5e1ce76f-99a0-4190-bf75-db83c86a77e9
+                - e71174cf-e920-465c-99ed-0d6d69a790ff
         status: 200 OK
         code: 200
-        duration: 35.197662ms
+        duration: 35.486322ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -1349,29 +1349,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":2,"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","status":"enabled","created_at":"2026-06-04T09:49:14.390180Z","updated_at":"2026-06-04T09:49:14.390180Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":2,"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","status":"enabled","created_at":"2026-07-03T15:27:57.360463Z","updated_at":"2026-07-03T15:27:57.360463Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:16 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 7c35b2ed-92b4-4750-b02a-01e826267858
+                - 557c2fdd-c092-4db7-a068-2d59ca3154c3
         status: 200 OK
         code: 200
-        duration: 37.000164ms
+        duration: 41.03798ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -1381,29 +1381,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":2,"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","status":"enabled","created_at":"2026-06-04T09:49:14.390180Z","updated_at":"2026-06-04T09:49:14.390180Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":2,"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","status":"enabled","created_at":"2026-07-03T15:27:57.360463Z","updated_at":"2026-07-03T15:27:57.360463Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:16 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 51b83b7a-d0b7-4db3-951b-8fc1127d3568
+                - e6c393cd-7011-4eed-8ffe-a4526bd1ea54
         status: 200 OK
         code: 200
-        duration: 37.774001ms
+        duration: 41.765025ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -1413,29 +1413,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions/1/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 133
-        body: '{"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","revision":1,"data":"bXlfc3VwZXJfc2VjcmV0X3Yx","data_crc32":null,"type":"opaque"}'
+        body: '{"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","revision":1,"data":"bXlfc3VwZXJfc2VjcmV0X3Yx","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
                 - "133"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:16 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - cabd8b3b-0102-4a86-b951-3d0fee7f681c
+                - eef62810-51f9-4860-b744-1b03679fd87b
         status: 200 OK
         code: 200
-        duration: 98.513977ms
+        duration: 122.800932ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -1445,29 +1445,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 303
-        body: '{"revision":1,"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","status":"enabled","created_at":"2026-06-04T09:49:13.014569Z","updated_at":"2026-06-04T09:49:13.014569Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","status":"enabled","created_at":"2026-07-03T15:27:55.395862Z","updated_at":"2026-07-03T15:27:55.395862Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "303"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:16 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 5a013017-04f5-4030-b5df-9c71c5b8cd87
+                - 20d4d329-4478-4737-b7af-380688a8d80f
         status: 200 OK
         code: 200
-        duration: 34.192543ms
+        duration: 54.019082ms
     - id: 45
       request:
         proto: HTTP/1.1
@@ -1477,29 +1477,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 493
-        body: '{"id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"dataSourceSecretVersionBasic","status":"ready","created_at":"2026-06-04T09:49:12.322216Z","updated_at":"2026-06-04T09:49:12.322216Z","tags":["devtools","provider","terraform"],"version_count":2,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"a2869384-3f17-46f5-8824-11b0bc94470f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"dataSourceSecretVersionBasic","status":"ready","created_at":"2026-07-03T15:27:54.696393Z","updated_at":"2026-07-03T15:27:54.696393Z","tags":["devtools","provider","terraform"],"version_count":2,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "493"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:16 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - d629296c-1252-4ca5-8c2a-cd050b3973af
+                - 7641120c-22c1-4561-8560-0bbdf5e85c6d
         status: 200 OK
         code: 200
-        duration: 52.050964ms
+        duration: 37.143234ms
     - id: 46
       request:
         proto: HTTP/1.1
@@ -1512,29 +1512,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 637
-        body: '{"versions":[{"revision":2,"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","status":"enabled","created_at":"2026-06-04T09:49:14.390180Z","updated_at":"2026-06-04T09:49:14.390180Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","status":"enabled","created_at":"2026-06-04T09:49:13.014569Z","updated_at":"2026-06-04T09:49:13.014569Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":2}'
+        body: '{"versions":[{"revision":2,"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","status":"enabled","created_at":"2026-07-03T15:27:57.360463Z","updated_at":"2026-07-03T15:27:57.360463Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","status":"enabled","created_at":"2026-07-03T15:27:55.395862Z","updated_at":"2026-07-03T15:27:55.395862Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":2}'
         headers:
             Content-Length:
                 - "637"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:16 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 8b38ab66-5f6c-4f16-bf37-3c7e72d13bb4
+                - 6bcf408c-6a40-4254-b5f7-fc0741d5a315
         status: 200 OK
         code: 200
-        duration: 36.816551ms
+        duration: 52.097262ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -1544,29 +1544,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 303
-        body: '{"revision":1,"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","status":"enabled","created_at":"2026-06-04T09:49:13.014569Z","updated_at":"2026-06-04T09:49:13.014569Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","status":"enabled","created_at":"2026-07-03T15:27:55.395862Z","updated_at":"2026-07-03T15:27:55.395862Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "303"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:16 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 6b1732a1-a46e-42bc-9e59-ba9d849c938f
+                - 03879e24-e5a4-4052-8d99-c2a6d037bbaf
         status: 200 OK
         code: 200
-        duration: 35.157107ms
+        duration: 60.733904ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -1576,29 +1576,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":2,"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","status":"enabled","created_at":"2026-06-04T09:49:14.390180Z","updated_at":"2026-06-04T09:49:14.390180Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":2,"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","status":"enabled","created_at":"2026-07-03T15:27:57.360463Z","updated_at":"2026-07-03T15:27:57.360463Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:17 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 71ca2be3-5ec4-4bf5-9af7-eb69ed97209a
+                - 90667cd6-2567-43e9-8115-311f663b5813
         status: 200 OK
         code: 200
-        duration: 30.498234ms
+        duration: 46.968248ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -1611,29 +1611,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":3,"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","status":"enabled","created_at":"2026-06-04T09:49:17.362475Z","updated_at":"2026-06-04T09:49:17.362475Z","deleted_at":null,"description":"version3","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":3,"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","status":"enabled","created_at":"2026-07-03T15:28:02.189740Z","updated_at":"2026-07-03T15:28:02.189740Z","deleted_at":null,"description":"version3","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:17 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 66e34eb6-0777-42ac-a9b7-7a83b3bf82be
+                - fb7d68bd-89b3-4789-b09c-b8c02edb2e81
         status: 200 OK
         code: 200
-        duration: 158.736809ms
+        duration: 107.513659ms
     - id: 50
       request:
         proto: HTTP/1.1
@@ -1643,29 +1643,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions/3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions/3
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":3,"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","status":"enabled","created_at":"2026-06-04T09:49:17.362475Z","updated_at":"2026-06-04T09:49:17.362475Z","deleted_at":null,"description":"version3","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":3,"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","status":"enabled","created_at":"2026-07-03T15:28:02.189740Z","updated_at":"2026-07-03T15:28:02.189740Z","deleted_at":null,"description":"version3","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:17 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 9bb0abf5-aaa8-466c-89bc-5cac1e87ccef
+                - 174ab89b-b19e-4b8c-89f0-1649c14bcc0f
         status: 200 OK
         code: 200
-        duration: 33.826088ms
+        duration: 40.555244ms
     - id: 51
       request:
         proto: HTTP/1.1
@@ -1675,29 +1675,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions/3/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions/3/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 133
-        body: '{"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","revision":3,"data":"bXlfc3VwZXJfc2VjcmV0X3Yz","data_crc32":null,"type":"opaque"}'
+        body: '{"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","revision":3,"data":"bXlfc3VwZXJfc2VjcmV0X3Yz","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
                 - "133"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:17 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 7431e919-45ce-47fe-a929-1abea024d99e
+                - 42e85647-449a-4e0f-94ce-750d668e65cd
         status: 200 OK
         code: 200
-        duration: 120.315286ms
+        duration: 128.527077ms
     - id: 52
       request:
         proto: HTTP/1.1
@@ -1707,29 +1707,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions/3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions/3
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":3,"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","status":"enabled","created_at":"2026-06-04T09:49:17.362475Z","updated_at":"2026-06-04T09:49:17.362475Z","deleted_at":null,"description":"version3","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":3,"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","status":"enabled","created_at":"2026-07-03T15:28:02.189740Z","updated_at":"2026-07-03T15:28:02.189740Z","deleted_at":null,"description":"version3","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:17 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - ff9aca54-d1b3-4ff8-a207-ecec9aafc8b6
+                - cae85473-453f-42fa-9ab0-4531fb1ac83d
         status: 200 OK
         code: 200
-        duration: 83.436659ms
+        duration: 40.79339ms
     - id: 53
       request:
         proto: HTTP/1.1
@@ -1739,29 +1739,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions/3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions/3
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":3,"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","status":"enabled","created_at":"2026-06-04T09:49:17.362475Z","updated_at":"2026-06-04T09:49:17.362475Z","deleted_at":null,"description":"version3","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":3,"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","status":"enabled","created_at":"2026-07-03T15:28:02.189740Z","updated_at":"2026-07-03T15:28:02.189740Z","deleted_at":null,"description":"version3","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:17 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - bea75b68-c286-4654-9e03-c0625bedf085
+                - aa2485eb-2a29-43f7-abb2-493818ad8aee
         status: 200 OK
         code: 200
-        duration: 39.035722ms
+        duration: 67.992868ms
     - id: 54
       request:
         proto: HTTP/1.1
@@ -1771,29 +1771,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions/3/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions/3/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 133
-        body: '{"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","revision":3,"data":"bXlfc3VwZXJfc2VjcmV0X3Yz","data_crc32":null,"type":"opaque"}'
+        body: '{"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","revision":3,"data":"bXlfc3VwZXJfc2VjcmV0X3Yz","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
                 - "133"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:17 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 77399329-c2b4-4a50-9d65-aace4badb13c
+                - db8d20dd-b4d1-4b7c-bed5-790d7c783f5f
         status: 200 OK
         code: 200
-        duration: 47.058176ms
+        duration: 57.544794ms
     - id: 55
       request:
         proto: HTTP/1.1
@@ -1803,29 +1803,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions/3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions/3
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":3,"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","status":"enabled","created_at":"2026-06-04T09:49:17.362475Z","updated_at":"2026-06-04T09:49:17.362475Z","deleted_at":null,"description":"version3","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":3,"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","status":"enabled","created_at":"2026-07-03T15:28:02.189740Z","updated_at":"2026-07-03T15:28:02.189740Z","deleted_at":null,"description":"version3","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:17 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - c3b66956-2033-45e2-98a1-cba8f4546606
+                - 9d1b6ed6-46fd-478d-afa9-330915119e80
         status: 200 OK
         code: 200
-        duration: 36.883548ms
+        duration: 49.117726ms
     - id: 56
       request:
         proto: HTTP/1.1
@@ -1835,29 +1835,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 493
-        body: '{"id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"dataSourceSecretVersionBasic","status":"ready","created_at":"2026-06-04T09:49:12.322216Z","updated_at":"2026-06-04T09:49:12.322216Z","tags":["devtools","provider","terraform"],"version_count":3,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"a2869384-3f17-46f5-8824-11b0bc94470f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"dataSourceSecretVersionBasic","status":"ready","created_at":"2026-07-03T15:27:54.696393Z","updated_at":"2026-07-03T15:27:54.696393Z","tags":["devtools","provider","terraform"],"version_count":3,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "493"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:18 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - ce03b985-72f8-4f1b-b9d2-491df9deab75
+                - f4f2ea7e-a62a-4884-a2b6-cc9f7b45c068
         status: 200 OK
         code: 200
-        duration: 46.237523ms
+        duration: 33.420502ms
     - id: 57
       request:
         proto: HTTP/1.1
@@ -1870,29 +1870,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 941
-        body: '{"versions":[{"revision":3,"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","status":"enabled","created_at":"2026-06-04T09:49:17.362475Z","updated_at":"2026-06-04T09:49:17.362475Z","deleted_at":null,"description":"version3","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":2,"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","status":"enabled","created_at":"2026-06-04T09:49:14.390180Z","updated_at":"2026-06-04T09:49:14.390180Z","deleted_at":null,"description":"version2","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","status":"enabled","created_at":"2026-06-04T09:49:13.014569Z","updated_at":"2026-06-04T09:49:13.014569Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":3}'
+        body: '{"versions":[{"revision":3,"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","status":"enabled","created_at":"2026-07-03T15:28:02.189740Z","updated_at":"2026-07-03T15:28:02.189740Z","deleted_at":null,"description":"version3","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":2,"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","status":"enabled","created_at":"2026-07-03T15:27:57.360463Z","updated_at":"2026-07-03T15:27:57.360463Z","deleted_at":null,"description":"version2","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","status":"enabled","created_at":"2026-07-03T15:27:55.395862Z","updated_at":"2026-07-03T15:27:55.395862Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":3}'
         headers:
             Content-Length:
                 - "941"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:18 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 3970ad81-1035-40fc-8db3-6e800ed1ec3a
+                - 7c0e4f86-4b41-40be-badd-68ee373b79c8
         status: 200 OK
         code: 200
-        duration: 33.423686ms
+        duration: 34.491394ms
     - id: 58
       request:
         proto: HTTP/1.1
@@ -1902,29 +1902,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 303
-        body: '{"revision":1,"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","status":"enabled","created_at":"2026-06-04T09:49:13.014569Z","updated_at":"2026-06-04T09:49:13.014569Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","status":"enabled","created_at":"2026-07-03T15:27:55.395862Z","updated_at":"2026-07-03T15:27:55.395862Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "303"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:18 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - e4db04f3-16ad-4096-8777-be0b542129e2
+                - f7cf76a1-a45d-4e6b-bc2a-986ed6e326af
         status: 200 OK
         code: 200
-        duration: 39.913615ms
+        duration: 30.394879ms
     - id: 59
       request:
         proto: HTTP/1.1
@@ -1934,29 +1934,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 303
-        body: '{"revision":2,"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","status":"enabled","created_at":"2026-06-04T09:49:14.390180Z","updated_at":"2026-06-04T09:49:14.390180Z","deleted_at":null,"description":"version2","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":2,"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","status":"enabled","created_at":"2026-07-03T15:27:57.360463Z","updated_at":"2026-07-03T15:27:57.360463Z","deleted_at":null,"description":"version2","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "303"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:18 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 9e276c3a-4403-4030-9000-bdc53b72a50e
+                - 4499a97d-be02-4e8d-9a94-f276acce8927
         status: 200 OK
         code: 200
-        duration: 33.740378ms
+        duration: 50.578199ms
     - id: 60
       request:
         proto: HTTP/1.1
@@ -1966,29 +1966,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions/3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions/3
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":3,"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","status":"enabled","created_at":"2026-06-04T09:49:17.362475Z","updated_at":"2026-06-04T09:49:17.362475Z","deleted_at":null,"description":"version3","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":3,"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","status":"enabled","created_at":"2026-07-03T15:28:02.189740Z","updated_at":"2026-07-03T15:28:02.189740Z","deleted_at":null,"description":"version3","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:18 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 33a48369-3a35-4ce4-8759-bf01d6fd4ae7
+                - efcf1466-7b09-4196-a4f9-6dac211c98d9
         status: 200 OK
         code: 200
-        duration: 38.321588ms
+        duration: 38.815696ms
     - id: 61
       request:
         proto: HTTP/1.1
@@ -1998,29 +1998,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions/3/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions/3/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 133
-        body: '{"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","revision":3,"data":"bXlfc3VwZXJfc2VjcmV0X3Yz","data_crc32":null,"type":"opaque"}'
+        body: '{"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","revision":3,"data":"bXlfc3VwZXJfc2VjcmV0X3Yz","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
                 - "133"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:18 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 7fa6ad91-6a17-4bb0-83fb-d5b4d11fbd79
+                - 4ffce351-0bfa-43cf-ad93-b343ae44b93d
         status: 200 OK
         code: 200
-        duration: 37.891824ms
+        duration: 47.519073ms
     - id: 62
       request:
         proto: HTTP/1.1
@@ -2030,29 +2030,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions/3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions/3
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":3,"secret_id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","status":"enabled","created_at":"2026-06-04T09:49:17.362475Z","updated_at":"2026-06-04T09:49:17.362475Z","deleted_at":null,"description":"version3","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":3,"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","status":"enabled","created_at":"2026-07-03T15:28:02.189740Z","updated_at":"2026-07-03T15:28:02.189740Z","deleted_at":null,"description":"version3","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:18 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 87a2d4ca-f729-4e56-996e-ca89135dfaa8
+                - 99d2d260-6af6-45a1-88cd-2fac3a730d7c
         status: 200 OK
         code: 200
-        duration: 46.27339ms
+        duration: 42.550441ms
     - id: 63
       request:
         proto: HTTP/1.1
@@ -2062,8 +2062,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions/3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions/3
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2075,14 +2075,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:18 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 91804e3a-59db-49e8-ab7f-32aab608fc9b
+                - 7af39c7b-8327-4235-8177-7538b9e4a4da
         status: 204 No Content
         code: 204
-        duration: 120.346367ms
+        duration: 136.595061ms
     - id: 64
       request:
         proto: HTTP/1.1
@@ -2092,8 +2092,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions/2
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2105,14 +2105,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:19 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 8cac5d76-c998-4250-98db-e912b6b5324a
+                - 398570e9-f1a8-43d1-b778-ec8628f8f441
         status: 204 No Content
         code: 204
-        duration: 54.166784ms
+        duration: 74.436962ms
     - id: 65
       request:
         proto: HTTP/1.1
@@ -2122,8 +2122,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions/1
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2135,14 +2135,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:19 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 8dcbd9d6-922a-48d9-bc80-0ab79ce613cb
+                - 96e57d55-e8d2-42e1-bb56-6bae8b75cf3f
         status: 204 No Content
         code: 204
-        duration: 58.368885ms
+        duration: 126.763535ms
     - id: 66
       request:
         proto: HTTP/1.1
@@ -2152,8 +2152,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2165,14 +2165,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:19 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - ce1f5470-99e4-4ff0-be51-8517ebefb95d
+                - a9a3173b-de0b-4911-9e90-ef1230db0de1
         status: 204 No Content
         code: 204
-        duration: 119.75809ms
+        duration: 54.882744ms
     - id: 67
       request:
         proto: HTTP/1.1
@@ -2182,26 +2182,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 518
-        body: '{"id":"8b2711e5-dd2d-4f14-9cfa-b9254ec83ebf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"dataSourceSecretVersionBasic","status":"ready","created_at":"2026-06-04T09:49:12.322216Z","updated_at":"2026-06-04T09:49:12.322216Z","tags":["devtools","provider","terraform"],"version_count":3,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-06-04T09:49:19.181573Z","key_id":null,"region":"fr-par"}'
+        body: '{"id":"a2869384-3f17-46f5-8824-11b0bc94470f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"dataSourceSecretVersionBasic","status":"ready","created_at":"2026-07-03T15:27:54.696393Z","updated_at":"2026-07-03T15:28:04.673636Z","tags":["devtools","provider","terraform"],"version_count":3,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-07-03T15:28:04.673636Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "518"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:19 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 25fb4cb4-6752-4f07-a62c-b38d70ede1ff
+                - 0ad7afbb-ed5d-4c33-a7c9-ffe6967c91ea
         status: 200 OK
         code: 200
-        duration: 76.221096ms
+        duration: 73.917185ms

--- a/internal/services/secret/testdata/data-source-secret-version-by-name-secret.cassette.yaml
+++ b/internal/services/secret/testdata/data-source-secret-version-by-name-secret.cassette.yaml
@@ -13,7 +13,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets
         method: POST
       response:
@@ -21,21 +21,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 474
-        body: '{"id":"9c8b93e9-ea1d-441e-a7fc-7376cdb29a09","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"dsSecretVersionByNameSecret","status":"ready","created_at":"2026-06-04T09:49:12.350327Z","updated_at":"2026-06-04T09:49:12.350327Z","tags":["devtools","provider","terraform"],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"c02805ba-64eb-435b-80fb-74fd55caad1c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"dsSecretVersionByNameSecret","status":"ready","created_at":"2026-07-03T15:28:04.271187Z","updated_at":"2026-07-03T15:28:04.271187Z","tags":["devtools","provider","terraform"],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "474"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:12 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 164c7758-e839-4425-b1ac-2975a9e6b403
+                - 5ba55394-42db-4dc4-8452-5e89ab250d1c
         status: 200 OK
         code: 200
-        duration: 278.449598ms
+        duration: 108.136749ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -45,29 +45,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9c8b93e9-ea1d-441e-a7fc-7376cdb29a09
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c02805ba-64eb-435b-80fb-74fd55caad1c
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 474
-        body: '{"id":"9c8b93e9-ea1d-441e-a7fc-7376cdb29a09","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"dsSecretVersionByNameSecret","status":"ready","created_at":"2026-06-04T09:49:12.350327Z","updated_at":"2026-06-04T09:49:12.350327Z","tags":["devtools","provider","terraform"],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"c02805ba-64eb-435b-80fb-74fd55caad1c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"dsSecretVersionByNameSecret","status":"ready","created_at":"2026-07-03T15:28:04.271187Z","updated_at":"2026-07-03T15:28:04.271187Z","tags":["devtools","provider","terraform"],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "474"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:12 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 9f0f3632-5edf-44b4-83a6-d6b566218a8c
+                - 08d8d14f-8444-4393-aa4a-c3a1311d3614
         status: 200 OK
         code: 200
-        duration: 104.100036ms
+        duration: 35.606308ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -80,8 +80,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9c8b93e9-ea1d-441e-a7fc-7376cdb29a09/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c02805ba-64eb-435b-80fb-74fd55caad1c/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -95,14 +95,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:12 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - c3031136-ab83-4545-98f7-332d6db0ad34
+                - 1c120a35-471c-4dcc-918d-049593f49883
         status: 200 OK
         code: 200
-        duration: 92.136861ms
+        duration: 52.910951ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -115,29 +115,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9c8b93e9-ea1d-441e-a7fc-7376cdb29a09/versions
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c02805ba-64eb-435b-80fb-74fd55caad1c/versions
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"9c8b93e9-ea1d-441e-a7fc-7376cdb29a09","status":"enabled","created_at":"2026-06-04T09:49:12.913912Z","updated_at":"2026-06-04T09:49:12.913912Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"c02805ba-64eb-435b-80fb-74fd55caad1c","status":"enabled","created_at":"2026-07-03T15:28:04.760416Z","updated_at":"2026-07-03T15:28:04.760416Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:12 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 98bc0673-3b39-446d-ab66-5439249a2b94
+                - 65fa3090-1aa7-4495-b5d4-5565bccf6a96
         status: 200 OK
         code: 200
-        duration: 362.216054ms
+        duration: 398.202327ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -147,29 +147,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9c8b93e9-ea1d-441e-a7fc-7376cdb29a09/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c02805ba-64eb-435b-80fb-74fd55caad1c/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"9c8b93e9-ea1d-441e-a7fc-7376cdb29a09","status":"enabled","created_at":"2026-06-04T09:49:12.913912Z","updated_at":"2026-06-04T09:49:12.913912Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"c02805ba-64eb-435b-80fb-74fd55caad1c","status":"enabled","created_at":"2026-07-03T15:28:04.760416Z","updated_at":"2026-07-03T15:28:04.760416Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:12 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 9dcd591c-63fd-4f71-b067-a5c894c5d83b
+                - d510fc35-aca5-4389-9fac-052257133de5
         status: 200 OK
         code: 200
-        duration: 47.679955ms
+        duration: 36.244356ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -179,29 +179,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9c8b93e9-ea1d-441e-a7fc-7376cdb29a09
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c02805ba-64eb-435b-80fb-74fd55caad1c
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 474
-        body: '{"id":"9c8b93e9-ea1d-441e-a7fc-7376cdb29a09","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"dsSecretVersionByNameSecret","status":"ready","created_at":"2026-06-04T09:49:12.350327Z","updated_at":"2026-06-04T09:49:12.350327Z","tags":["devtools","provider","terraform"],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"c02805ba-64eb-435b-80fb-74fd55caad1c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"dsSecretVersionByNameSecret","status":"ready","created_at":"2026-07-03T15:28:04.271187Z","updated_at":"2026-07-03T15:28:04.271187Z","tags":["devtools","provider","terraform"],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "474"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:13 GMT
+                - Fri, 03 Jul 2026 15:28:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - e04c3045-1cb0-4a09-9773-a6a0911e5b56
+                - 627d63a0-810c-4554-bcbd-37fde0f9f3b2
         status: 200 OK
         code: 200
-        duration: 48.195099ms
+        duration: 45.495302ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -214,29 +214,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9c8b93e9-ea1d-441e-a7fc-7376cdb29a09/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c02805ba-64eb-435b-80fb-74fd55caad1c/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 333
-        body: '{"versions":[{"revision":1,"secret_id":"9c8b93e9-ea1d-441e-a7fc-7376cdb29a09","status":"enabled","created_at":"2026-06-04T09:49:12.913912Z","updated_at":"2026-06-04T09:49:12.913912Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        body: '{"versions":[{"revision":1,"secret_id":"c02805ba-64eb-435b-80fb-74fd55caad1c","status":"enabled","created_at":"2026-07-03T15:28:04.760416Z","updated_at":"2026-07-03T15:28:04.760416Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "333"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:13 GMT
+                - Fri, 03 Jul 2026 15:28:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - ff3bc930-9f73-4e51-a652-0523e0465af0
+                - 79b62eee-7676-4301-969c-33d55b50eabf
         status: 200 OK
         code: 200
-        duration: 36.243116ms
+        duration: 50.313652ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -246,29 +246,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9c8b93e9-ea1d-441e-a7fc-7376cdb29a09/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c02805ba-64eb-435b-80fb-74fd55caad1c/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"9c8b93e9-ea1d-441e-a7fc-7376cdb29a09","status":"enabled","created_at":"2026-06-04T09:49:12.913912Z","updated_at":"2026-06-04T09:49:12.913912Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"c02805ba-64eb-435b-80fb-74fd55caad1c","status":"enabled","created_at":"2026-07-03T15:28:04.760416Z","updated_at":"2026-07-03T15:28:04.760416Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:13 GMT
+                - Fri, 03 Jul 2026 15:28:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 3551ab51-4796-429c-a9a5-78868d2050e4
+                - a92a33ae-8421-458a-8ff9-fc10d88ec9a1
         status: 200 OK
         code: 200
-        duration: 52.956545ms
+        duration: 47.134761ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -278,29 +278,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9c8b93e9-ea1d-441e-a7fc-7376cdb29a09
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c02805ba-64eb-435b-80fb-74fd55caad1c
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 474
-        body: '{"id":"9c8b93e9-ea1d-441e-a7fc-7376cdb29a09","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"dsSecretVersionByNameSecret","status":"ready","created_at":"2026-06-04T09:49:12.350327Z","updated_at":"2026-06-04T09:49:12.350327Z","tags":["devtools","provider","terraform"],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"c02805ba-64eb-435b-80fb-74fd55caad1c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"dsSecretVersionByNameSecret","status":"ready","created_at":"2026-07-03T15:28:04.271187Z","updated_at":"2026-07-03T15:28:04.271187Z","tags":["devtools","provider","terraform"],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "474"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:13 GMT
+                - Fri, 03 Jul 2026 15:28:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 86ca8405-ae38-4262-994e-9b005b9707b3
+                - fde2b77c-37be-41b7-8bd9-67fc711bff1d
         status: 200 OK
         code: 200
-        duration: 32.240961ms
+        duration: 35.18669ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -313,29 +313,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9c8b93e9-ea1d-441e-a7fc-7376cdb29a09/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c02805ba-64eb-435b-80fb-74fd55caad1c/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 333
-        body: '{"versions":[{"revision":1,"secret_id":"9c8b93e9-ea1d-441e-a7fc-7376cdb29a09","status":"enabled","created_at":"2026-06-04T09:49:12.913912Z","updated_at":"2026-06-04T09:49:12.913912Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        body: '{"versions":[{"revision":1,"secret_id":"c02805ba-64eb-435b-80fb-74fd55caad1c","status":"enabled","created_at":"2026-07-03T15:28:04.760416Z","updated_at":"2026-07-03T15:28:04.760416Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "333"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:13 GMT
+                - Fri, 03 Jul 2026 15:28:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 4c84c432-e301-461f-b3a7-27dfed310adb
+                - 18d90d6f-2d82-4fd1-b90d-4310c249d6a0
         status: 200 OK
         code: 200
-        duration: 89.564532ms
+        duration: 37.893684ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -345,29 +345,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9c8b93e9-ea1d-441e-a7fc-7376cdb29a09/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c02805ba-64eb-435b-80fb-74fd55caad1c/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"9c8b93e9-ea1d-441e-a7fc-7376cdb29a09","status":"enabled","created_at":"2026-06-04T09:49:12.913912Z","updated_at":"2026-06-04T09:49:12.913912Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"c02805ba-64eb-435b-80fb-74fd55caad1c","status":"enabled","created_at":"2026-07-03T15:28:04.760416Z","updated_at":"2026-07-03T15:28:04.760416Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:13 GMT
+                - Fri, 03 Jul 2026 15:28:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - bf1b70cf-f51a-429a-a574-4c154ac66d2d
+                - 2911d21c-0c0e-440d-ab6c-63c8b1581330
         status: 200 OK
         code: 200
-        duration: 42.594825ms
+        duration: 48.386813ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -388,7 +388,7 @@ interactions:
                 - unknown_type
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets?name=dsSecretVersionByNameSecret&order_by=name_asc&project_id=105bdce1-64c0-48ab-899d-868455867ecf&scheduled_for_deletion=false&type=unknown_type
         method: GET
       response:
@@ -396,21 +396,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 504
-        body: '{"secrets":[{"id":"9c8b93e9-ea1d-441e-a7fc-7376cdb29a09","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"dsSecretVersionByNameSecret","status":"ready","created_at":"2026-06-04T09:49:12.350327Z","updated_at":"2026-06-04T09:49:12.350327Z","tags":["devtools","provider","terraform"],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}],"total_count":1}'
+        body: '{"secrets":[{"id":"c02805ba-64eb-435b-80fb-74fd55caad1c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"dsSecretVersionByNameSecret","status":"ready","created_at":"2026-07-03T15:28:04.271187Z","updated_at":"2026-07-03T15:28:04.271187Z","tags":["devtools","provider","terraform"],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "504"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:13 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 939606b5-07cb-4acc-b08b-fb364728b420
+                - 579a0707-cb3a-4001-af0b-e5fe39c56879
         status: 200 OK
         code: 200
-        duration: 87.958719ms
+        duration: 51.352172ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -431,7 +431,7 @@ interactions:
                 - unknown_type
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets?name=dsSecretVersionByNameSecret&order_by=name_asc&project_id=105bdce1-64c0-48ab-899d-868455867ecf&scheduled_for_deletion=false&type=unknown_type
         method: GET
       response:
@@ -439,21 +439,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 504
-        body: '{"secrets":[{"id":"9c8b93e9-ea1d-441e-a7fc-7376cdb29a09","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"dsSecretVersionByNameSecret","status":"ready","created_at":"2026-06-04T09:49:12.350327Z","updated_at":"2026-06-04T09:49:12.350327Z","tags":["devtools","provider","terraform"],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}],"total_count":1}'
+        body: '{"secrets":[{"id":"c02805ba-64eb-435b-80fb-74fd55caad1c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"dsSecretVersionByNameSecret","status":"ready","created_at":"2026-07-03T15:28:04.271187Z","updated_at":"2026-07-03T15:28:04.271187Z","tags":["devtools","provider","terraform"],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "504"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:13 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 18a95f96-da59-4ec3-baf8-8b51c4c33afb
+                - 9f83430c-0ea6-4264-85e1-d02bd1e49e89
         status: 200 OK
         code: 200
-        duration: 98.141044ms
+        duration: 57.502355ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -463,29 +463,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9c8b93e9-ea1d-441e-a7fc-7376cdb29a09/versions/latest/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c02805ba-64eb-435b-80fb-74fd55caad1c/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 133
-        body: '{"secret_id":"9c8b93e9-ea1d-441e-a7fc-7376cdb29a09","revision":1,"data":"bXlfc3VwZXJfc2VjcmV0X3Yx","data_crc32":null,"type":"opaque"}'
+        body: '{"secret_id":"c02805ba-64eb-435b-80fb-74fd55caad1c","revision":1,"data":"bXlfc3VwZXJfc2VjcmV0X3Yx","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
                 - "133"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:14 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 1b0bac3f-2caf-4ca8-90e9-fa734bf6920d
+                - 81f70f2f-bb6c-4df7-84fc-5043a1005e7a
         status: 200 OK
         code: 200
-        duration: 79.104772ms
+        duration: 126.858163ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -495,29 +495,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9c8b93e9-ea1d-441e-a7fc-7376cdb29a09/versions/1/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c02805ba-64eb-435b-80fb-74fd55caad1c/versions/latest/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 133
-        body: '{"secret_id":"9c8b93e9-ea1d-441e-a7fc-7376cdb29a09","revision":1,"data":"bXlfc3VwZXJfc2VjcmV0X3Yx","data_crc32":null,"type":"opaque"}'
+        body: '{"secret_id":"c02805ba-64eb-435b-80fb-74fd55caad1c","revision":1,"data":"bXlfc3VwZXJfc2VjcmV0X3Yx","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
                 - "133"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:14 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 83b73474-c5d8-4910-a034-2c80c46968a4
+                - 514cfd3f-5b73-4985-b46c-7b9da9caf701
         status: 200 OK
         code: 200
-        duration: 69.126108ms
+        duration: 128.514454ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -527,29 +527,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9c8b93e9-ea1d-441e-a7fc-7376cdb29a09/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c02805ba-64eb-435b-80fb-74fd55caad1c/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"9c8b93e9-ea1d-441e-a7fc-7376cdb29a09","status":"enabled","created_at":"2026-06-04T09:49:12.913912Z","updated_at":"2026-06-04T09:49:12.913912Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"c02805ba-64eb-435b-80fb-74fd55caad1c","status":"enabled","created_at":"2026-07-03T15:28:04.760416Z","updated_at":"2026-07-03T15:28:04.760416Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:14 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 48f53114-bbe4-4065-a240-271515ed5571
+                - 19452841-0e0d-4b00-977b-863b1fe5421e
         status: 200 OK
         code: 200
-        duration: 34.387746ms
+        duration: 42.153495ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -559,29 +559,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9c8b93e9-ea1d-441e-a7fc-7376cdb29a09/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c02805ba-64eb-435b-80fb-74fd55caad1c/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"9c8b93e9-ea1d-441e-a7fc-7376cdb29a09","status":"enabled","created_at":"2026-06-04T09:49:12.913912Z","updated_at":"2026-06-04T09:49:12.913912Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"c02805ba-64eb-435b-80fb-74fd55caad1c","status":"enabled","created_at":"2026-07-03T15:28:04.760416Z","updated_at":"2026-07-03T15:28:04.760416Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:14 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - f037225f-8d59-4f08-8268-733bcea505e5
+                - 4d925273-900e-4ce0-8488-af9e6ca574ca
         status: 200 OK
         code: 200
-        duration: 34.376295ms
+        duration: 63.054032ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -591,29 +591,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9c8b93e9-ea1d-441e-a7fc-7376cdb29a09/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c02805ba-64eb-435b-80fb-74fd55caad1c/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"9c8b93e9-ea1d-441e-a7fc-7376cdb29a09","status":"enabled","created_at":"2026-06-04T09:49:12.913912Z","updated_at":"2026-06-04T09:49:12.913912Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"c02805ba-64eb-435b-80fb-74fd55caad1c","status":"enabled","created_at":"2026-07-03T15:28:04.760416Z","updated_at":"2026-07-03T15:28:04.760416Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:14 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - b11455c9-3922-40f4-9622-81668b809e5c
+                - 8c543b0c-127f-4d6d-8519-90681d2297e7
         status: 200 OK
         code: 200
-        duration: 34.978361ms
+        duration: 60.689311ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -634,7 +634,7 @@ interactions:
                 - unknown_type
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets?name=dsSecretVersionByNameSecret&order_by=name_asc&project_id=105bdce1-64c0-48ab-899d-868455867ecf&scheduled_for_deletion=false&type=unknown_type
         method: GET
       response:
@@ -642,21 +642,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 504
-        body: '{"secrets":[{"id":"9c8b93e9-ea1d-441e-a7fc-7376cdb29a09","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"dsSecretVersionByNameSecret","status":"ready","created_at":"2026-06-04T09:49:12.350327Z","updated_at":"2026-06-04T09:49:12.350327Z","tags":["devtools","provider","terraform"],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}],"total_count":1}'
+        body: '{"secrets":[{"id":"c02805ba-64eb-435b-80fb-74fd55caad1c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"dsSecretVersionByNameSecret","status":"ready","created_at":"2026-07-03T15:28:04.271187Z","updated_at":"2026-07-03T15:28:04.271187Z","tags":["devtools","provider","terraform"],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "504"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:14 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - e2fb06ec-26dd-421a-8d34-d415813904a0
+                - 13b0b135-2029-470d-b35c-974b27c9800e
         status: 200 OK
         code: 200
-        duration: 37.190057ms
+        duration: 40.90473ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -677,7 +677,7 @@ interactions:
                 - unknown_type
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets?name=dsSecretVersionByNameSecret&order_by=name_asc&project_id=105bdce1-64c0-48ab-899d-868455867ecf&scheduled_for_deletion=false&type=unknown_type
         method: GET
       response:
@@ -685,21 +685,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 504
-        body: '{"secrets":[{"id":"9c8b93e9-ea1d-441e-a7fc-7376cdb29a09","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"dsSecretVersionByNameSecret","status":"ready","created_at":"2026-06-04T09:49:12.350327Z","updated_at":"2026-06-04T09:49:12.350327Z","tags":["devtools","provider","terraform"],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}],"total_count":1}'
+        body: '{"secrets":[{"id":"c02805ba-64eb-435b-80fb-74fd55caad1c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"dsSecretVersionByNameSecret","status":"ready","created_at":"2026-07-03T15:28:04.271187Z","updated_at":"2026-07-03T15:28:04.271187Z","tags":["devtools","provider","terraform"],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "504"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:14 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - f5f5f39b-6608-4157-8550-5c62920b0aea
+                - c6b2114f-bbd5-4908-ae98-780b96bacf69
         status: 200 OK
         code: 200
-        duration: 85.04949ms
+        duration: 41.04318ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -709,29 +709,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9c8b93e9-ea1d-441e-a7fc-7376cdb29a09/versions/1/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c02805ba-64eb-435b-80fb-74fd55caad1c/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 133
-        body: '{"secret_id":"9c8b93e9-ea1d-441e-a7fc-7376cdb29a09","revision":1,"data":"bXlfc3VwZXJfc2VjcmV0X3Yx","data_crc32":null,"type":"opaque"}'
+        body: '{"secret_id":"c02805ba-64eb-435b-80fb-74fd55caad1c","revision":1,"data":"bXlfc3VwZXJfc2VjcmV0X3Yx","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
                 - "133"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:14 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 5849885f-5649-4208-9b79-b764c9a60495
+                - 72486a92-cfaa-4ad5-86e9-dfef736825ae
         status: 200 OK
         code: 200
-        duration: 34.783546ms
+        duration: 32.763398ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -741,29 +741,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9c8b93e9-ea1d-441e-a7fc-7376cdb29a09/versions/latest/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c02805ba-64eb-435b-80fb-74fd55caad1c/versions/latest/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 133
-        body: '{"secret_id":"9c8b93e9-ea1d-441e-a7fc-7376cdb29a09","revision":1,"data":"bXlfc3VwZXJfc2VjcmV0X3Yx","data_crc32":null,"type":"opaque"}'
+        body: '{"secret_id":"c02805ba-64eb-435b-80fb-74fd55caad1c","revision":1,"data":"bXlfc3VwZXJfc2VjcmV0X3Yx","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
                 - "133"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:14 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - a8f1bc34-8453-4f97-9b0d-8b86b43e3c9f
+                - 57f02006-23df-4a11-a214-a723355c5243
         status: 200 OK
         code: 200
-        duration: 124.534009ms
+        duration: 77.052936ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -773,29 +773,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9c8b93e9-ea1d-441e-a7fc-7376cdb29a09/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c02805ba-64eb-435b-80fb-74fd55caad1c/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"9c8b93e9-ea1d-441e-a7fc-7376cdb29a09","status":"enabled","created_at":"2026-06-04T09:49:12.913912Z","updated_at":"2026-06-04T09:49:12.913912Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"c02805ba-64eb-435b-80fb-74fd55caad1c","status":"enabled","created_at":"2026-07-03T15:28:04.760416Z","updated_at":"2026-07-03T15:28:04.760416Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:14 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - aa120c45-96a9-4a9b-a216-811cc34129b2
+                - ba7de73a-a289-47ac-8fae-7d4f46d9b75c
         status: 200 OK
         code: 200
-        duration: 46.492166ms
+        duration: 44.361212ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -805,29 +805,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9c8b93e9-ea1d-441e-a7fc-7376cdb29a09/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c02805ba-64eb-435b-80fb-74fd55caad1c/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"9c8b93e9-ea1d-441e-a7fc-7376cdb29a09","status":"enabled","created_at":"2026-06-04T09:49:12.913912Z","updated_at":"2026-06-04T09:49:12.913912Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"c02805ba-64eb-435b-80fb-74fd55caad1c","status":"enabled","created_at":"2026-07-03T15:28:04.760416Z","updated_at":"2026-07-03T15:28:04.760416Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:14 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 7bf32279-4081-430d-9963-00703291aef9
+                - e54c7b6e-0b76-448a-b056-4a3155345f16
         status: 200 OK
         code: 200
-        duration: 92.006402ms
+        duration: 43.820697ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -837,29 +837,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9c8b93e9-ea1d-441e-a7fc-7376cdb29a09
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c02805ba-64eb-435b-80fb-74fd55caad1c
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 474
-        body: '{"id":"9c8b93e9-ea1d-441e-a7fc-7376cdb29a09","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"dsSecretVersionByNameSecret","status":"ready","created_at":"2026-06-04T09:49:12.350327Z","updated_at":"2026-06-04T09:49:12.350327Z","tags":["devtools","provider","terraform"],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"c02805ba-64eb-435b-80fb-74fd55caad1c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"dsSecretVersionByNameSecret","status":"ready","created_at":"2026-07-03T15:28:04.271187Z","updated_at":"2026-07-03T15:28:04.271187Z","tags":["devtools","provider","terraform"],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "474"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:14 GMT
+                - Fri, 03 Jul 2026 15:28:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 98d0e97a-3c54-478e-9e99-4046bbc07cbe
+                - eb80378e-e611-40a8-a558-855d8bf90b92
         status: 200 OK
         code: 200
-        duration: 48.290649ms
+        duration: 48.189963ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -872,29 +872,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9c8b93e9-ea1d-441e-a7fc-7376cdb29a09/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c02805ba-64eb-435b-80fb-74fd55caad1c/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 333
-        body: '{"versions":[{"revision":1,"secret_id":"9c8b93e9-ea1d-441e-a7fc-7376cdb29a09","status":"enabled","created_at":"2026-06-04T09:49:12.913912Z","updated_at":"2026-06-04T09:49:12.913912Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        body: '{"versions":[{"revision":1,"secret_id":"c02805ba-64eb-435b-80fb-74fd55caad1c","status":"enabled","created_at":"2026-07-03T15:28:04.760416Z","updated_at":"2026-07-03T15:28:04.760416Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "333"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:15 GMT
+                - Fri, 03 Jul 2026 15:28:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - a3cb5471-255f-430e-8315-9ce4df262d0a
+                - b400f0bf-4920-429f-b5f6-375f99779459
         status: 200 OK
         code: 200
-        duration: 47.55793ms
+        duration: 42.920306ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -904,29 +904,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9c8b93e9-ea1d-441e-a7fc-7376cdb29a09/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c02805ba-64eb-435b-80fb-74fd55caad1c/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"9c8b93e9-ea1d-441e-a7fc-7376cdb29a09","status":"enabled","created_at":"2026-06-04T09:49:12.913912Z","updated_at":"2026-06-04T09:49:12.913912Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"c02805ba-64eb-435b-80fb-74fd55caad1c","status":"enabled","created_at":"2026-07-03T15:28:04.760416Z","updated_at":"2026-07-03T15:28:04.760416Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:15 GMT
+                - Fri, 03 Jul 2026 15:28:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 82f3ccdd-d3ce-48d8-951c-10dcd078d1ec
+                - 0764da76-d61d-4c79-8900-bb4b5e067558
         status: 200 OK
         code: 200
-        duration: 61.653814ms
+        duration: 41.57539ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -947,7 +947,7 @@ interactions:
                 - unknown_type
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets?name=dsSecretVersionByNameSecret&order_by=name_asc&project_id=105bdce1-64c0-48ab-899d-868455867ecf&scheduled_for_deletion=false&type=unknown_type
         method: GET
       response:
@@ -955,22 +955,86 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 504
-        body: '{"secrets":[{"id":"9c8b93e9-ea1d-441e-a7fc-7376cdb29a09","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"dsSecretVersionByNameSecret","status":"ready","created_at":"2026-06-04T09:49:12.350327Z","updated_at":"2026-06-04T09:49:12.350327Z","tags":["devtools","provider","terraform"],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}],"total_count":1}'
+        body: '{"secrets":[{"id":"c02805ba-64eb-435b-80fb-74fd55caad1c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"dsSecretVersionByNameSecret","status":"ready","created_at":"2026-07-03T15:28:04.271187Z","updated_at":"2026-07-03T15:28:04.271187Z","tags":["devtools","provider","terraform"],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "504"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:15 GMT
+                - Fri, 03 Jul 2026 15:28:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - fe50caa9-9b91-4df3-9646-ef624e848189
+                - 248a7881-5706-40ae-8f35-6eaf19a03603
         status: 200 OK
         code: 200
-        duration: 42.258158ms
+        duration: 44.583229ms
     - id: 28
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c02805ba-64eb-435b-80fb-74fd55caad1c/versions/latest/access
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 133
+        body: '{"secret_id":"c02805ba-64eb-435b-80fb-74fd55caad1c","revision":1,"data":"bXlfc3VwZXJfc2VjcmV0X3Yx","data_crc32":null,"type":"opaque"}'
+        headers:
+            Content-Length:
+                - "133"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:07 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 1e51427a-1d51-4146-8e5c-66236253ec6e
+        status: 200 OK
+        code: 200
+        duration: 42.446976ms
+    - id: 29
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c02805ba-64eb-435b-80fb-74fd55caad1c/versions/1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 302
+        body: '{"revision":1,"secret_id":"c02805ba-64eb-435b-80fb-74fd55caad1c","status":"enabled","created_at":"2026-07-03T15:28:04.760416Z","updated_at":"2026-07-03T15:28:04.760416Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "302"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:07 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 5be10dcd-705e-4071-b762-a814b4c4fd89
+        status: 200 OK
+        code: 200
+        duration: 39.055246ms
+    - id: 30
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -990,7 +1054,7 @@ interactions:
                 - unknown_type
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets?name=dsSecretVersionByNameSecret&order_by=name_asc&project_id=105bdce1-64c0-48ab-899d-868455867ecf&scheduled_for_deletion=false&type=unknown_type
         method: GET
       response:
@@ -998,85 +1062,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 504
-        body: '{"secrets":[{"id":"9c8b93e9-ea1d-441e-a7fc-7376cdb29a09","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"dsSecretVersionByNameSecret","status":"ready","created_at":"2026-06-04T09:49:12.350327Z","updated_at":"2026-06-04T09:49:12.350327Z","tags":["devtools","provider","terraform"],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}],"total_count":1}'
+        body: '{"secrets":[{"id":"c02805ba-64eb-435b-80fb-74fd55caad1c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"dsSecretVersionByNameSecret","status":"ready","created_at":"2026-07-03T15:28:04.271187Z","updated_at":"2026-07-03T15:28:04.271187Z","tags":["devtools","provider","terraform"],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "504"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:15 GMT
+                - Fri, 03 Jul 2026 15:28:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - ddc355b1-483e-4bb1-9c34-efc816f85430
+                - dbc51447-eb0c-424b-ae5f-e5788f48c782
         status: 200 OK
         code: 200
-        duration: 87.841443ms
-    - id: 29
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9c8b93e9-ea1d-441e-a7fc-7376cdb29a09/versions/1/access
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 133
-        body: '{"secret_id":"9c8b93e9-ea1d-441e-a7fc-7376cdb29a09","revision":1,"data":"bXlfc3VwZXJfc2VjcmV0X3Yx","data_crc32":null,"type":"opaque"}'
-        headers:
-            Content-Length:
-                - "133"
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 04 Jun 2026 09:49:15 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            X-Request-Id:
-                - b4350a15-0bed-4cb0-b542-4d88114e04b4
-        status: 200 OK
-        code: 200
-        duration: 83.104955ms
-    - id: 30
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9c8b93e9-ea1d-441e-a7fc-7376cdb29a09/versions/1
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 302
-        body: '{"revision":1,"secret_id":"9c8b93e9-ea1d-441e-a7fc-7376cdb29a09","status":"enabled","created_at":"2026-06-04T09:49:12.913912Z","updated_at":"2026-06-04T09:49:12.913912Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "302"
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 04 Jun 2026 09:49:15 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            X-Request-Id:
-                - b77882cd-57d9-4862-befa-c2d74377a6ac
-        status: 200 OK
-        code: 200
-        duration: 39.863749ms
+        duration: 132.884813ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1086,29 +1086,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9c8b93e9-ea1d-441e-a7fc-7376cdb29a09/versions/latest/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c02805ba-64eb-435b-80fb-74fd55caad1c/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 133
-        body: '{"secret_id":"9c8b93e9-ea1d-441e-a7fc-7376cdb29a09","revision":1,"data":"bXlfc3VwZXJfc2VjcmV0X3Yx","data_crc32":null,"type":"opaque"}'
+        body: '{"secret_id":"c02805ba-64eb-435b-80fb-74fd55caad1c","revision":1,"data":"bXlfc3VwZXJfc2VjcmV0X3Yx","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
                 - "133"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:15 GMT
+                - Fri, 03 Jul 2026 15:28:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 2bff2160-a5b7-4fc5-a277-6af3d4b80b9d
+                - c7e1cefd-5ecd-4a11-8b89-c101c4c89e84
         status: 200 OK
         code: 200
-        duration: 115.788113ms
+        duration: 44.874046ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1118,29 +1118,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9c8b93e9-ea1d-441e-a7fc-7376cdb29a09/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c02805ba-64eb-435b-80fb-74fd55caad1c/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"9c8b93e9-ea1d-441e-a7fc-7376cdb29a09","status":"enabled","created_at":"2026-06-04T09:49:12.913912Z","updated_at":"2026-06-04T09:49:12.913912Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"c02805ba-64eb-435b-80fb-74fd55caad1c","status":"enabled","created_at":"2026-07-03T15:28:04.760416Z","updated_at":"2026-07-03T15:28:04.760416Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:15 GMT
+                - Fri, 03 Jul 2026 15:28:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - bbf8fe9e-2771-4779-b708-541fc1699376
+                - 4eefbb72-e30d-4b7e-a8ae-39798de31808
         status: 200 OK
         code: 200
-        duration: 37.072519ms
+        duration: 31.812392ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1150,8 +1150,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9c8b93e9-ea1d-441e-a7fc-7376cdb29a09/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c02805ba-64eb-435b-80fb-74fd55caad1c/versions/1
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1163,14 +1163,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:15 GMT
+                - Fri, 03 Jul 2026 15:28:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - db5ee1ed-25e6-4a5e-836a-cfb5a09682c0
+                - db223431-19eb-45aa-9ad8-14d16c7e83a9
         status: 204 No Content
         code: 204
-        duration: 110.82421ms
+        duration: 62.518246ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1180,8 +1180,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9c8b93e9-ea1d-441e-a7fc-7376cdb29a09
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c02805ba-64eb-435b-80fb-74fd55caad1c
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1193,14 +1193,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:15 GMT
+                - Fri, 03 Jul 2026 15:28:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 8e218804-309a-4b38-a5e4-2b27b1e41737
+                - e395eb20-b634-4140-8a70-cfe8ed587637
         status: 204 No Content
         code: 204
-        duration: 101.937979ms
+        duration: 80.022654ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1210,26 +1210,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/9c8b93e9-ea1d-441e-a7fc-7376cdb29a09
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c02805ba-64eb-435b-80fb-74fd55caad1c
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 499
-        body: '{"id":"9c8b93e9-ea1d-441e-a7fc-7376cdb29a09","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"dsSecretVersionByNameSecret","status":"ready","created_at":"2026-06-04T09:49:12.350327Z","updated_at":"2026-06-04T09:49:12.350327Z","tags":["devtools","provider","terraform"],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-06-04T09:49:15.859524Z","key_id":null,"region":"fr-par"}'
+        body: '{"id":"c02805ba-64eb-435b-80fb-74fd55caad1c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"dsSecretVersionByNameSecret","status":"ready","created_at":"2026-07-03T15:28:04.271187Z","updated_at":"2026-07-03T15:28:07.911372Z","tags":["devtools","provider","terraform"],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-07-03T15:28:07.911372Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "499"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:15 GMT
+                - Fri, 03 Jul 2026 15:28:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - a532504d-1faa-4017-8021-21d5ac6e18c6
+                - 9df7200a-d1e1-448c-9c6c-7fd4a4ccb3ae
         status: 200 OK
         code: 200
-        duration: 90.90834ms
+        duration: 56.531811ms

--- a/internal/services/secret/testdata/data-source-secret-with-versions.cassette.yaml
+++ b/internal/services/secret/testdata/data-source-secret-with-versions.cassette.yaml
@@ -13,7 +13,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets
         method: POST
       response:
@@ -21,21 +21,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 454
-        body: '{"id":"b4b900f5-76ab-435e-81fe-efae7b2f8127","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-versions","status":"ready","created_at":"2026-06-24T09:38:48.050553Z","updated_at":"2026-06-24T09:38:48.050553Z","tags":[],"version_count":0,"description":"Secret with versions","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"692f14f6-be88-4147-af00-7948291dc422","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-versions","status":"ready","created_at":"2026-07-03T15:27:54.753741Z","updated_at":"2026-07-03T15:27:54.753741Z","tags":[],"version_count":0,"description":"Secret with versions","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "454"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
+                - Fri, 03 Jul 2026 15:27:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - a4437a58-45e6-4190-9013-28f9c0a08079
+                - 3409b750-4629-4f9d-9135-2b314ff799e5
         status: 200 OK
         code: 200
-        duration: 118.924084ms
+        duration: 426.595583ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -45,29 +45,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b4b900f5-76ab-435e-81fe-efae7b2f8127
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/692f14f6-be88-4147-af00-7948291dc422
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 454
-        body: '{"id":"b4b900f5-76ab-435e-81fe-efae7b2f8127","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-versions","status":"ready","created_at":"2026-06-24T09:38:48.050553Z","updated_at":"2026-06-24T09:38:48.050553Z","tags":[],"version_count":0,"description":"Secret with versions","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"692f14f6-be88-4147-af00-7948291dc422","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-versions","status":"ready","created_at":"2026-07-03T15:27:54.753741Z","updated_at":"2026-07-03T15:27:54.753741Z","tags":[],"version_count":0,"description":"Secret with versions","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "454"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
+                - Fri, 03 Jul 2026 15:27:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - b725f2b4-9127-4fac-9934-aa6d52b91c13
+                - 4ee44c5a-717b-4bb4-96cc-647dbffdeebd
         status: 200 OK
         code: 200
-        duration: 28.882238ms
+        duration: 117.427448ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -80,8 +80,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b4b900f5-76ab-435e-81fe-efae7b2f8127/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/692f14f6-be88-4147-af00-7948291dc422/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -95,14 +95,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
+                - Fri, 03 Jul 2026 15:27:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - e02f594b-628d-4862-81f2-8f5ce5d1adf8
+                - 005a3ea2-dcfd-48c9-a215-63fae68a80cb
         status: 200 OK
         code: 200
-        duration: 20.146045ms
+        duration: 189.66582ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -115,29 +115,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b4b900f5-76ab-435e-81fe-efae7b2f8127/versions
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/692f14f6-be88-4147-af00-7948291dc422/versions
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 294
-        body: '{"revision":1,"secret_id":"b4b900f5-76ab-435e-81fe-efae7b2f8127","status":"enabled","created_at":"2026-06-24T09:38:48.459695Z","updated_at":"2026-06-24T09:38:48.459695Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"692f14f6-be88-4147-af00-7948291dc422","status":"enabled","created_at":"2026-07-03T15:27:55.512791Z","updated_at":"2026-07-03T15:27:55.512791Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "294"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
+                - Fri, 03 Jul 2026 15:27:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - f7b50a48-534f-4fea-b7cb-ceb28d08d0e5
+                - b7307c5f-b059-4d38-a413-69592638f55c
         status: 200 OK
         code: 200
-        duration: 339.727137ms
+        duration: 443.660416ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -147,29 +147,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b4b900f5-76ab-435e-81fe-efae7b2f8127/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/692f14f6-be88-4147-af00-7948291dc422/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 294
-        body: '{"revision":1,"secret_id":"b4b900f5-76ab-435e-81fe-efae7b2f8127","status":"enabled","created_at":"2026-06-24T09:38:48.459695Z","updated_at":"2026-06-24T09:38:48.459695Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"692f14f6-be88-4147-af00-7948291dc422","status":"enabled","created_at":"2026-07-03T15:27:55.512791Z","updated_at":"2026-07-03T15:27:55.512791Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "294"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
+                - Fri, 03 Jul 2026 15:27:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 565abd20-f6b6-43e5-8fd3-bf16e12aedff
+                - b6d26dea-9693-4aba-80a0-1a17e5c748fd
         status: 200 OK
         code: 200
-        duration: 32.035588ms
+        duration: 33.946891ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -182,29 +182,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b4b900f5-76ab-435e-81fe-efae7b2f8127/versions
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/692f14f6-be88-4147-af00-7948291dc422/versions
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 294
-        body: '{"revision":2,"secret_id":"b4b900f5-76ab-435e-81fe-efae7b2f8127","status":"enabled","created_at":"2026-06-24T09:38:48.664475Z","updated_at":"2026-06-24T09:38:48.664475Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":2,"secret_id":"692f14f6-be88-4147-af00-7948291dc422","status":"enabled","created_at":"2026-07-03T15:27:55.767398Z","updated_at":"2026-07-03T15:27:55.767398Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "294"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
+                - Fri, 03 Jul 2026 15:27:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - f401ccaa-233f-4686-9a9f-b47d805e1be9
+                - f75220ca-6a79-43cf-b60f-db251a72bb00
         status: 200 OK
         code: 200
-        duration: 529.164648ms
+        duration: 706.404797ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -214,29 +214,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b4b900f5-76ab-435e-81fe-efae7b2f8127/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/692f14f6-be88-4147-af00-7948291dc422/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 294
-        body: '{"revision":2,"secret_id":"b4b900f5-76ab-435e-81fe-efae7b2f8127","status":"enabled","created_at":"2026-06-24T09:38:48.664475Z","updated_at":"2026-06-24T09:38:48.664475Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":2,"secret_id":"692f14f6-be88-4147-af00-7948291dc422","status":"enabled","created_at":"2026-07-03T15:27:55.767398Z","updated_at":"2026-07-03T15:27:55.767398Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "294"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
+                - Fri, 03 Jul 2026 15:27:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 5435b190-d483-49ca-9f5f-5ebdf8fe34f5
+                - d1818016-fcf1-4b3f-a59d-59727ee0006e
         status: 200 OK
         code: 200
-        duration: 18.180613ms
+        duration: 111.346437ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -246,29 +246,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b4b900f5-76ab-435e-81fe-efae7b2f8127
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/692f14f6-be88-4147-af00-7948291dc422
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 454
-        body: '{"id":"b4b900f5-76ab-435e-81fe-efae7b2f8127","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-versions","status":"ready","created_at":"2026-06-24T09:38:48.050553Z","updated_at":"2026-06-24T09:38:48.050553Z","tags":[],"version_count":2,"description":"Secret with versions","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"692f14f6-be88-4147-af00-7948291dc422","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-versions","status":"ready","created_at":"2026-07-03T15:27:54.753741Z","updated_at":"2026-07-03T15:27:54.753741Z","tags":[],"version_count":2,"description":"Secret with versions","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "454"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
+                - Fri, 03 Jul 2026 15:27:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 8a46d2ce-6d8a-4c56-b1e6-65c4d421a820
+                - 0c8e9688-2efa-4ec2-99f9-6ab8e6f8b07f
         status: 200 OK
         code: 200
-        duration: 14.692561ms
+        duration: 46.732876ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -281,29 +281,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b4b900f5-76ab-435e-81fe-efae7b2f8127/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/692f14f6-be88-4147-af00-7948291dc422/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 621
-        body: '{"versions":[{"revision":2,"secret_id":"b4b900f5-76ab-435e-81fe-efae7b2f8127","status":"enabled","created_at":"2026-06-24T09:38:48.664475Z","updated_at":"2026-06-24T09:38:48.664475Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"b4b900f5-76ab-435e-81fe-efae7b2f8127","status":"enabled","created_at":"2026-06-24T09:38:48.459695Z","updated_at":"2026-06-24T09:38:48.459695Z","deleted_at":null,"description":"","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":2}'
+        body: '{"versions":[{"revision":2,"secret_id":"692f14f6-be88-4147-af00-7948291dc422","status":"enabled","created_at":"2026-07-03T15:27:55.767398Z","updated_at":"2026-07-03T15:27:55.767398Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"692f14f6-be88-4147-af00-7948291dc422","status":"enabled","created_at":"2026-07-03T15:27:55.512791Z","updated_at":"2026-07-03T15:27:55.512791Z","deleted_at":null,"description":"","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":2}'
         headers:
             Content-Length:
                 - "621"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
+                - Fri, 03 Jul 2026 15:27:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 4ad4001d-954c-4d0c-80f4-89ab0afced08
+                - 1054ccb8-30ad-454e-a76d-1a90adfb64d5
         status: 200 OK
         code: 200
-        duration: 43.607161ms
+        duration: 43.323873ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -313,29 +313,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b4b900f5-76ab-435e-81fe-efae7b2f8127
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/692f14f6-be88-4147-af00-7948291dc422
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 454
-        body: '{"id":"b4b900f5-76ab-435e-81fe-efae7b2f8127","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-versions","status":"ready","created_at":"2026-06-24T09:38:48.050553Z","updated_at":"2026-06-24T09:38:48.050553Z","tags":[],"version_count":2,"description":"Secret with versions","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"692f14f6-be88-4147-af00-7948291dc422","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-versions","status":"ready","created_at":"2026-07-03T15:27:54.753741Z","updated_at":"2026-07-03T15:27:54.753741Z","tags":[],"version_count":2,"description":"Secret with versions","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "454"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:48 GMT
+                - Fri, 03 Jul 2026 15:27:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - b0995157-854e-4847-9126-85e0008cb603
+                - e9e50f91-4da7-4e5b-8932-d39ceb8ff40f
         status: 200 OK
         code: 200
-        duration: 22.828673ms
+        duration: 49.345743ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -345,29 +345,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b4b900f5-76ab-435e-81fe-efae7b2f8127
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/692f14f6-be88-4147-af00-7948291dc422
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 454
-        body: '{"id":"b4b900f5-76ab-435e-81fe-efae7b2f8127","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-versions","status":"ready","created_at":"2026-06-24T09:38:48.050553Z","updated_at":"2026-06-24T09:38:48.050553Z","tags":[],"version_count":2,"description":"Secret with versions","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"692f14f6-be88-4147-af00-7948291dc422","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-versions","status":"ready","created_at":"2026-07-03T15:27:54.753741Z","updated_at":"2026-07-03T15:27:54.753741Z","tags":[],"version_count":2,"description":"Secret with versions","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "454"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:49 GMT
+                - Fri, 03 Jul 2026 15:27:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - f844508e-5d6a-4db8-84a0-76c9190ab6de
+                - 443b6dda-5855-43ec-928f-08be5589ea9e
         status: 200 OK
         code: 200
-        duration: 24.32317ms
+        duration: 35.733216ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -380,29 +380,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b4b900f5-76ab-435e-81fe-efae7b2f8127/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/692f14f6-be88-4147-af00-7948291dc422/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 621
-        body: '{"versions":[{"revision":2,"secret_id":"b4b900f5-76ab-435e-81fe-efae7b2f8127","status":"enabled","created_at":"2026-06-24T09:38:48.664475Z","updated_at":"2026-06-24T09:38:48.664475Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"b4b900f5-76ab-435e-81fe-efae7b2f8127","status":"enabled","created_at":"2026-06-24T09:38:48.459695Z","updated_at":"2026-06-24T09:38:48.459695Z","deleted_at":null,"description":"","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":2}'
+        body: '{"versions":[{"revision":2,"secret_id":"692f14f6-be88-4147-af00-7948291dc422","status":"enabled","created_at":"2026-07-03T15:27:55.767398Z","updated_at":"2026-07-03T15:27:55.767398Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"692f14f6-be88-4147-af00-7948291dc422","status":"enabled","created_at":"2026-07-03T15:27:55.512791Z","updated_at":"2026-07-03T15:27:55.512791Z","deleted_at":null,"description":"","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":2}'
         headers:
             Content-Length:
                 - "621"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:49 GMT
+                - Fri, 03 Jul 2026 15:27:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 2d35ccad-18d6-4427-a399-e35646b927b3
+                - ede86bea-7383-47c8-917a-6ce69429562b
         status: 200 OK
         code: 200
-        duration: 28.853643ms
+        duration: 119.278074ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -412,29 +412,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b4b900f5-76ab-435e-81fe-efae7b2f8127
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/692f14f6-be88-4147-af00-7948291dc422
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 454
-        body: '{"id":"b4b900f5-76ab-435e-81fe-efae7b2f8127","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-versions","status":"ready","created_at":"2026-06-24T09:38:48.050553Z","updated_at":"2026-06-24T09:38:48.050553Z","tags":[],"version_count":2,"description":"Secret with versions","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"692f14f6-be88-4147-af00-7948291dc422","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-versions","status":"ready","created_at":"2026-07-03T15:27:54.753741Z","updated_at":"2026-07-03T15:27:54.753741Z","tags":[],"version_count":2,"description":"Secret with versions","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "454"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:49 GMT
+                - Fri, 03 Jul 2026 15:27:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - bafbb06f-7a9b-499b-b407-7e634946dc96
+                - 65d5958a-05a9-4f5a-91ad-205ba316606d
         status: 200 OK
         code: 200
-        duration: 32.73465ms
+        duration: 36.016538ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -447,29 +447,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b4b900f5-76ab-435e-81fe-efae7b2f8127/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/692f14f6-be88-4147-af00-7948291dc422/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 621
-        body: '{"versions":[{"revision":2,"secret_id":"b4b900f5-76ab-435e-81fe-efae7b2f8127","status":"enabled","created_at":"2026-06-24T09:38:48.664475Z","updated_at":"2026-06-24T09:38:48.664475Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"b4b900f5-76ab-435e-81fe-efae7b2f8127","status":"enabled","created_at":"2026-06-24T09:38:48.459695Z","updated_at":"2026-06-24T09:38:48.459695Z","deleted_at":null,"description":"","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":2}'
+        body: '{"versions":[{"revision":2,"secret_id":"692f14f6-be88-4147-af00-7948291dc422","status":"enabled","created_at":"2026-07-03T15:27:55.767398Z","updated_at":"2026-07-03T15:27:55.767398Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"692f14f6-be88-4147-af00-7948291dc422","status":"enabled","created_at":"2026-07-03T15:27:55.512791Z","updated_at":"2026-07-03T15:27:55.512791Z","deleted_at":null,"description":"","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":2}'
         headers:
             Content-Length:
                 - "621"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:49 GMT
+                - Fri, 03 Jul 2026 15:27:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - acbd4020-5be3-48ee-8c8b-ff6856e669e6
+                - 7f360d45-353e-49c5-a175-910e1b69ce2f
         status: 200 OK
         code: 200
-        duration: 27.636106ms
+        duration: 107.830653ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -479,29 +479,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b4b900f5-76ab-435e-81fe-efae7b2f8127/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/692f14f6-be88-4147-af00-7948291dc422/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 295
-        body: '{"revision":1,"secret_id":"b4b900f5-76ab-435e-81fe-efae7b2f8127","status":"enabled","created_at":"2026-06-24T09:38:48.459695Z","updated_at":"2026-06-24T09:38:48.459695Z","deleted_at":null,"description":"","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 294
+        body: '{"revision":2,"secret_id":"692f14f6-be88-4147-af00-7948291dc422","status":"enabled","created_at":"2026-07-03T15:27:55.767398Z","updated_at":"2026-07-03T15:27:55.767398Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "295"
+                - "294"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:49 GMT
+                - Fri, 03 Jul 2026 15:27:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - b8069daa-7c3a-408b-80ad-b9fe32629de8
+                - 9fc7f8af-5de0-42b8-9c5f-bc6ae65c0761
         status: 200 OK
         code: 200
-        duration: 22.968751ms
+        duration: 36.503473ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -511,29 +511,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b4b900f5-76ab-435e-81fe-efae7b2f8127/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/692f14f6-be88-4147-af00-7948291dc422/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 294
-        body: '{"revision":2,"secret_id":"b4b900f5-76ab-435e-81fe-efae7b2f8127","status":"enabled","created_at":"2026-06-24T09:38:48.664475Z","updated_at":"2026-06-24T09:38:48.664475Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 295
+        body: '{"revision":1,"secret_id":"692f14f6-be88-4147-af00-7948291dc422","status":"enabled","created_at":"2026-07-03T15:27:55.512791Z","updated_at":"2026-07-03T15:27:55.512791Z","deleted_at":null,"description":"","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "294"
+                - "295"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:49 GMT
+                - Fri, 03 Jul 2026 15:27:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 369e6ac5-c13b-4c34-af43-46d6905b52dc
+                - 6f268aa2-70b9-4397-9760-7b3c4113d5cf
         status: 200 OK
         code: 200
-        duration: 28.74291ms
+        duration: 41.482034ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -543,29 +543,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b4b900f5-76ab-435e-81fe-efae7b2f8127
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/692f14f6-be88-4147-af00-7948291dc422
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 454
-        body: '{"id":"b4b900f5-76ab-435e-81fe-efae7b2f8127","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-versions","status":"ready","created_at":"2026-06-24T09:38:48.050553Z","updated_at":"2026-06-24T09:38:48.050553Z","tags":[],"version_count":2,"description":"Secret with versions","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"692f14f6-be88-4147-af00-7948291dc422","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-versions","status":"ready","created_at":"2026-07-03T15:27:54.753741Z","updated_at":"2026-07-03T15:27:54.753741Z","tags":[],"version_count":2,"description":"Secret with versions","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "454"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:49 GMT
+                - Fri, 03 Jul 2026 15:27:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - bdf48957-41f3-44ca-92e6-9b1c4a4e2185
+                - 659c4407-6385-40a6-b0fc-c3482cba3e4e
         status: 200 OK
         code: 200
-        duration: 23.872074ms
+        duration: 47.149189ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -578,29 +578,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b4b900f5-76ab-435e-81fe-efae7b2f8127/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/692f14f6-be88-4147-af00-7948291dc422/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 621
-        body: '{"versions":[{"revision":2,"secret_id":"b4b900f5-76ab-435e-81fe-efae7b2f8127","status":"enabled","created_at":"2026-06-24T09:38:48.664475Z","updated_at":"2026-06-24T09:38:48.664475Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"b4b900f5-76ab-435e-81fe-efae7b2f8127","status":"enabled","created_at":"2026-06-24T09:38:48.459695Z","updated_at":"2026-06-24T09:38:48.459695Z","deleted_at":null,"description":"","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":2}'
+        body: '{"versions":[{"revision":2,"secret_id":"692f14f6-be88-4147-af00-7948291dc422","status":"enabled","created_at":"2026-07-03T15:27:55.767398Z","updated_at":"2026-07-03T15:27:55.767398Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"692f14f6-be88-4147-af00-7948291dc422","status":"enabled","created_at":"2026-07-03T15:27:55.512791Z","updated_at":"2026-07-03T15:27:55.512791Z","deleted_at":null,"description":"","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":2}'
         headers:
             Content-Length:
                 - "621"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:49 GMT
+                - Fri, 03 Jul 2026 15:27:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - a66d5149-61a4-4a11-8a74-7abe924d3499
+                - 40725e77-2631-4d1b-8b3f-2373672829fe
         status: 200 OK
         code: 200
-        duration: 26.944319ms
+        duration: 108.029486ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -610,8 +610,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b4b900f5-76ab-435e-81fe-efae7b2f8127/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/692f14f6-be88-4147-af00-7948291dc422/versions/2
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -623,14 +623,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:49 GMT
+                - Fri, 03 Jul 2026 15:27:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 05ea496b-9cc9-4043-a35b-734f90d40c21
+                - e89d9d54-c069-4ee0-a214-8767725825de
         status: 204 No Content
         code: 204
-        duration: 93.758989ms
+        duration: 921.731747ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -640,8 +640,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b4b900f5-76ab-435e-81fe-efae7b2f8127/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/692f14f6-be88-4147-af00-7948291dc422/versions/1
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -653,14 +653,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:49 GMT
+                - Fri, 03 Jul 2026 15:27:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 6e0a25a1-7623-4fc1-837a-bc7116c9084f
+                - e9846a9c-6832-4294-a23a-d43cb407754c
         status: 204 No Content
         code: 204
-        duration: 104.896178ms
+        duration: 929.916681ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -670,8 +670,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b4b900f5-76ab-435e-81fe-efae7b2f8127
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/692f14f6-be88-4147-af00-7948291dc422
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -683,14 +683,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:49 GMT
+                - Fri, 03 Jul 2026 15:27:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 2029b8c1-ffd9-441b-890c-b0a91b961963
+                - d712faa9-9b00-4c22-b458-a5e7642e0615
         status: 204 No Content
         code: 204
-        duration: 38.189956ms
+        duration: 57.259618ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -700,29 +700,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b4b900f5-76ab-435e-81fe-efae7b2f8127
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/692f14f6-be88-4147-af00-7948291dc422
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 479
-        body: '{"id":"b4b900f5-76ab-435e-81fe-efae7b2f8127","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-versions","status":"ready","created_at":"2026-06-24T09:38:48.050553Z","updated_at":"2026-06-24T09:38:49.769883Z","tags":[],"version_count":2,"description":"Secret with versions","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-06-24T09:38:49.769883Z","key_id":null,"region":"fr-par"}'
+        body: '{"id":"692f14f6-be88-4147-af00-7948291dc422","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-versions","status":"ready","created_at":"2026-07-03T15:27:54.753741Z","updated_at":"2026-07-03T15:27:58.501111Z","tags":[],"version_count":2,"description":"Secret with versions","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-07-03T15:27:58.501111Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "479"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:49 GMT
+                - Fri, 03 Jul 2026 15:27:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - ac8b0b98-2fff-47d6-abf6-7a696175e1c0
+                - 54a36f91-8dfe-4214-9e3d-2a4889218a57
         status: 200 OK
         code: 200
-        duration: 28.725166ms
+        duration: 53.940093ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -732,26 +732,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b4b900f5-76ab-435e-81fe-efae7b2f8127
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/692f14f6-be88-4147-af00-7948291dc422
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 479
-        body: '{"id":"b4b900f5-76ab-435e-81fe-efae7b2f8127","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-versions","status":"ready","created_at":"2026-06-24T09:38:48.050553Z","updated_at":"2026-06-24T09:38:49.769883Z","tags":[],"version_count":2,"description":"Secret with versions","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-06-24T09:38:49.769883Z","key_id":null,"region":"fr-par"}'
+        body: '{"id":"692f14f6-be88-4147-af00-7948291dc422","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-versions","status":"ready","created_at":"2026-07-03T15:27:54.753741Z","updated_at":"2026-07-03T15:27:58.501111Z","tags":[],"version_count":2,"description":"Secret with versions","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-07-03T15:27:58.501111Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "479"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:49 GMT
+                - Fri, 03 Jul 2026 15:27:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - e4cb3afb-6b24-4dc9-b027-b5160407c73a
+                - 0edc2668-0ef8-42c6-8b25-7b2fc84aa796
         status: 200 OK
         code: 200
-        duration: 27.663559ms
+        duration: 54.077081ms

--- a/internal/services/secret/testdata/ephemeral-resource-secret-version-basic.cassette.yaml
+++ b/internal/services/secret/testdata/ephemeral-resource-secret-version-basic.cassette.yaml
@@ -13,29 +13,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 511
-        body: '{"id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"ephemeralSecretVersionBasic", "status":"ready", "created_at":"2026-02-03T16:00:54.600551Z", "updated_at":"2026-02-03T16:00:54.600551Z", "tags":["devtools", "provider", "terraform"], "version_count":0, "description":"secret description", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}'
+        content_length: 492
+        body: '{"id":"c393aa9c-26fc-4726-af24-e17eb380fea4","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"ephemeralSecretVersionBasic","status":"ready","created_at":"2026-07-03T15:28:04.247068Z","updated_at":"2026-07-03T15:28:04.247068Z","tags":["devtools","provider","terraform"],"version_count":0,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "511"
+                - "492"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:54 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - a9eaf842-18a4-4693-a5f2-197750520806
+                - 67bc05a6-c756-4285-a87a-5e8b74400ac5
         status: 200 OK
         code: 200
-        duration: 264.850874ms
+        duration: 116.713329ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -45,29 +45,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 511
-        body: '{"id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"ephemeralSecretVersionBasic", "status":"ready", "created_at":"2026-02-03T16:00:54.600551Z", "updated_at":"2026-02-03T16:00:54.600551Z", "tags":["devtools", "provider", "terraform"], "version_count":0, "description":"secret description", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}'
+        content_length: 492
+        body: '{"id":"c393aa9c-26fc-4726-af24-e17eb380fea4","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"ephemeralSecretVersionBasic","status":"ready","created_at":"2026-07-03T15:28:04.247068Z","updated_at":"2026-07-03T15:28:04.247068Z","tags":["devtools","provider","terraform"],"version_count":0,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "511"
+                - "492"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:54 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 3cb28302-4222-49c1-849a-de1200cf3e1a
+                - d3b0e13e-ba06-4bbe-a8a9-936e0683d003
         status: 200 OK
         code: 200
-        duration: 85.265651ms
+        duration: 48.147473ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -80,29 +80,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 32
-        body: '{"versions":[], "total_count":0}'
+        content_length: 31
+        body: '{"versions":[],"total_count":0}'
         headers:
             Content-Length:
-                - "32"
+                - "31"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:54 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - c5baae01-a140-4283-baf6-39412a447faf
+                - ab440f3f-7021-4ae4-b4fa-b62d0fb54819
         status: 200 OK
         code: 200
-        duration: 111.161066ms
+        duration: 55.749222ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -115,29 +115,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 312
-        body: '{"revision":1, "secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "status":"enabled", "created_at":"2026-02-03T16:00:55.221005Z", "updated_at":"2026-02-03T16:00:55.221005Z", "deleted_at":null, "description":"version1", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 302
+        body: '{"revision":1,"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","status":"enabled","created_at":"2026-07-03T15:28:04.634400Z","updated_at":"2026-07-03T15:28:04.634400Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "312"
+                - "302"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:55 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 8c99c4ac-4d57-43ef-be60-6a51d233baf4
+                - 743d7fd6-b960-4c4e-9726-73c118ca88b2
         status: 200 OK
         code: 200
-        duration: 427.697545ms
+        duration: 268.616793ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -147,94 +147,30 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 312
-        body: '{"revision":1, "secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "status":"enabled", "created_at":"2026-02-03T16:00:55.221005Z", "updated_at":"2026-02-03T16:00:55.221005Z", "deleted_at":null, "description":"version1", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 302
+        body: '{"revision":1,"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","status":"enabled","created_at":"2026-07-03T15:28:04.634400Z","updated_at":"2026-07-03T15:28:04.634400Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "312"
+                - "302"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:55 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 3b67d5a3-267a-44f4-98ad-18136fb51d80
+                - b3cfa7a8-00cf-4d50-8fdb-eea247f7d580
         status: 200 OK
         code: 200
-        duration: 46.072315ms
+        duration: 36.222405ms
     - id: 5
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions/1/access
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 137
-        body: '{"secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "revision":1, "data":"bXlfc3VwZXJfc2VjcmV0X3Yx", "data_crc32":null, "type":"opaque"}'
-        headers:
-            Content-Length:
-                - "137"
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 03 Feb 2026 16:00:55 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            X-Request-Id:
-                - 95a05b9b-c320-40b5-8dea-408a7831283c
-        status: 200 OK
-        code: 200
-        duration: 144.362722ms
-    - id: 6
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions/1
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 312
-        body: '{"revision":1, "secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "status":"enabled", "created_at":"2026-02-03T16:00:55.221005Z", "updated_at":"2026-02-03T16:00:55.221005Z", "deleted_at":null, "description":"version1", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "312"
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 03 Feb 2026 16:00:55 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            X-Request-Id:
-                - 0262a057-0a30-4347-91f7-469f991c8985
-        status: 200 OK
-        code: 200
-        duration: 35.724225ms
-    - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -246,29 +182,93 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 312
-        body: '{"revision":2, "secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "status":"enabled", "created_at":"2026-02-03T16:00:55.479663Z", "updated_at":"2026-02-03T16:00:55.479663Z", "deleted_at":null, "description":"version2", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 302
+        body: '{"revision":2,"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","status":"enabled","created_at":"2026-07-03T15:28:04.843543Z","updated_at":"2026-07-03T15:28:04.843543Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "312"
+                - "302"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:55 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 1e3e985d-bc56-474d-9f44-6523edadb89a
+                - 8819acc8-098e-40e7-96ef-f1cad5f41795
         status: 200 OK
         code: 200
-        duration: 193.953809ms
+        duration: 163.065459ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions/1/access
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 133
+        body: '{"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","revision":1,"data":"bXlfc3VwZXJfc2VjcmV0X3Yx","data_crc32":null,"type":"opaque"}'
+        headers:
+            Content-Length:
+                - "133"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - f8654f55-3a7f-4c17-bb31-7aff7343cf3f
+        status: 200 OK
+        code: 200
+        duration: 192.650668ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions/2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 302
+        body: '{"revision":2,"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","status":"enabled","created_at":"2026-07-03T15:28:04.843543Z","updated_at":"2026-07-03T15:28:04.843543Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "302"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 2fd280d6-4477-4bed-b77b-a69c23ebf683
+        status: 200 OK
+        code: 200
+        duration: 39.947672ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -278,30 +278,126 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 312
-        body: '{"revision":2, "secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "status":"enabled", "created_at":"2026-02-03T16:00:55.479663Z", "updated_at":"2026-02-03T16:00:55.479663Z", "deleted_at":null, "description":"version2", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 303
+        body: '{"revision":1,"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","status":"enabled","created_at":"2026-07-03T15:28:04.634400Z","updated_at":"2026-07-03T15:28:04.634400Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "312"
+                - "303"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:55 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 595cdd6f-e31a-47ca-9c88-b51d4536cf13
+                - 372a0f6c-c646-48d1-8a0d-5b5f3692cda1
         status: 200 OK
         code: 200
-        duration: 104.337148ms
+        duration: 60.472453ms
     - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions/2/access
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 133
+        body: '{"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","revision":2,"data":"bXlfc3VwZXJfc2VjcmV0X3Yy","data_crc32":null,"type":"opaque"}'
+        headers:
+            Content-Length:
+                - "133"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 0c5f426a-68c5-48c8-9dae-a1ae58730eb2
+        status: 200 OK
+        code: 200
+        duration: 54.941545ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions/2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 302
+        body: '{"revision":2,"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","status":"enabled","created_at":"2026-07-03T15:28:04.843543Z","updated_at":"2026-07-03T15:28:04.843543Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "302"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - f3fd5d29-71c5-48c4-8b9f-da2163717360
+        status: 200 OK
+        code: 200
+        duration: 45.415712ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions/latest/access
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 133
+        body: '{"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","revision":2,"data":"bXlfc3VwZXJfc2VjcmV0X3Yy","data_crc32":null,"type":"opaque"}'
+        headers:
+            Content-Length:
+                - "133"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 9000db78-eba1-49dd-802f-9bbac062efb9
+        status: 200 OK
+        code: 200
+        duration: 128.797666ms
+    - id: 12
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -313,125 +409,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 327
-        body: '{"revision":3, "secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "status":"enabled", "created_at":"2026-02-03T16:00:55.603810Z", "updated_at":"2026-02-03T16:00:55.603810Z", "deleted_at":null, "description":"version1_from_ephemeral", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 317
+        body: '{"revision":3,"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","status":"enabled","created_at":"2026-07-03T15:28:05.035400Z","updated_at":"2026-07-03T15:28:05.035400Z","deleted_at":null,"description":"version1_from_ephemeral","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "327"
+                - "317"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:55 GMT
+                - Fri, 03 Jul 2026 15:28:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - d140f8e7-ef73-4df5-ac93-d8af29741aa0
+                - 40ccb33b-dbc7-4da7-9973-4b5263a0f4ee
         status: 200 OK
         code: 200
-        duration: 145.461317ms
-    - id: 10
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions/3
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 327
-        body: '{"revision":3, "secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "status":"enabled", "created_at":"2026-02-03T16:00:55.603810Z", "updated_at":"2026-02-03T16:00:55.603810Z", "deleted_at":null, "description":"version1_from_ephemeral", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "327"
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 03 Feb 2026 16:00:55 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            X-Request-Id:
-                - fd38119b-b325-4517-b010-ab6d4f59e13e
-        status: 200 OK
-        code: 200
-        duration: 36.665051ms
-    - id: 11
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions/latest/access
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 137
-        body: '{"secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "revision":3, "data":"bXlfc3VwZXJfc2VjcmV0X3Yx", "data_crc32":null, "type":"opaque"}'
-        headers:
-            Content-Length:
-                - "137"
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 03 Feb 2026 16:00:55 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            X-Request-Id:
-                - 5a9898ef-ae57-4944-87e2-3959ac21cef5
-        status: 200 OK
-        code: 200
-        duration: 104.727712ms
-    - id: 12
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions/3/access
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 137
-        body: '{"secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "revision":3, "data":"bXlfc3VwZXJfc2VjcmV0X3Yx", "data_crc32":null, "type":"opaque"}'
-        headers:
-            Content-Length:
-                - "137"
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 03 Feb 2026 16:00:55 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            X-Request-Id:
-                - 316f3bb5-3733-4495-95ff-68f6b58895dc
-        status: 200 OK
-        code: 200
-        duration: 50.155324ms
+        duration: 97.998106ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -441,29 +441,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions/2/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 137
-        body: '{"secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "revision":2, "data":"bXlfc3VwZXJfc2VjcmV0X3Yy", "data_crc32":null, "type":"opaque"}'
+        content_length: 303
+        body: '{"revision":2,"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","status":"enabled","created_at":"2026-07-03T15:28:04.843543Z","updated_at":"2026-07-03T15:28:04.843543Z","deleted_at":null,"description":"version2","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "137"
+                - "303"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:55 GMT
+                - Fri, 03 Jul 2026 15:28:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 9e531abe-437b-42e2-aed7-ebd53b7c125d
+                - db2613b4-f62e-4796-8492-ce01c967064e
         status: 200 OK
         code: 200
-        duration: 136.94307ms
+        duration: 31.999814ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -473,29 +473,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions/3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions/3
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 327
-        body: '{"revision":3, "secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "status":"enabled", "created_at":"2026-02-03T16:00:55.603810Z", "updated_at":"2026-02-03T16:00:55.603810Z", "deleted_at":null, "description":"version1_from_ephemeral", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 317
+        body: '{"revision":3,"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","status":"enabled","created_at":"2026-07-03T15:28:05.035400Z","updated_at":"2026-07-03T15:28:05.035400Z","deleted_at":null,"description":"version1_from_ephemeral","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "327"
+                - "317"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:55 GMT
+                - Fri, 03 Jul 2026 15:28:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - b028dc90-368e-4cbf-b329-f7abb0e672b2
+                - da42f692-a62b-4f7f-aa99-1d35fc88362e
         status: 200 OK
         code: 200
-        duration: 49.278765ms
+        duration: 34.099417ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -505,29 +505,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions/3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions/3/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 327
-        body: '{"revision":3, "secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "status":"enabled", "created_at":"2026-02-03T16:00:55.603810Z", "updated_at":"2026-02-03T16:00:55.603810Z", "deleted_at":null, "description":"version1_from_ephemeral", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 133
+        body: '{"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","revision":3,"data":"bXlfc3VwZXJfc2VjcmV0X3Yx","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "327"
+                - "133"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:55 GMT
+                - Fri, 03 Jul 2026 15:28:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - e80b443c-4da8-45f1-88f3-36696578b2bf
+                - 4da33e48-6348-4fed-b826-ff3eb4f0b5c6
         status: 200 OK
         code: 200
-        duration: 42.906796ms
+        duration: 46.986653ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -537,29 +537,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions/3
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 313
-        body: '{"revision":2, "secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "status":"enabled", "created_at":"2026-02-03T16:00:55.479663Z", "updated_at":"2026-02-03T16:00:55.479663Z", "deleted_at":null, "description":"version2", "latest":false, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 317
+        body: '{"revision":3,"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","status":"enabled","created_at":"2026-07-03T15:28:05.035400Z","updated_at":"2026-07-03T15:28:05.035400Z","deleted_at":null,"description":"version1_from_ephemeral","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "313"
+                - "317"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:55 GMT
+                - Fri, 03 Jul 2026 15:28:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - b2c7e9fa-36b0-473d-bae2-a74f4ea15107
+                - 7f9a0c21-ca68-4cb1-8c25-38a6e4ac28c7
         status: 200 OK
         code: 200
-        duration: 40.532107ms
+        duration: 37.824384ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -572,29 +572,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 327
-        body: '{"revision":4, "secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "status":"enabled", "created_at":"2026-02-03T16:00:55.931802Z", "updated_at":"2026-02-03T16:00:55.931802Z", "deleted_at":null, "description":"version2_from_ephemeral", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 317
+        body: '{"revision":4,"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","status":"enabled","created_at":"2026-07-03T15:28:05.197066Z","updated_at":"2026-07-03T15:28:05.197066Z","deleted_at":null,"description":"version2_from_ephemeral","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "327"
+                - "317"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:55 GMT
+                - Fri, 03 Jul 2026 15:28:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 19f3aa60-607d-4f6b-8986-0e96e6c23e37
+                - 30bb623b-fab4-4607-96a5-28d92a3889b9
         status: 200 OK
         code: 200
-        duration: 263.856703ms
+        duration: 120.848525ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -604,29 +604,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions/4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions/4
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 327
-        body: '{"revision":4, "secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "status":"enabled", "created_at":"2026-02-03T16:00:55.931802Z", "updated_at":"2026-02-03T16:00:55.931802Z", "deleted_at":null, "description":"version2_from_ephemeral", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 317
+        body: '{"revision":4,"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","status":"enabled","created_at":"2026-07-03T15:28:05.197066Z","updated_at":"2026-07-03T15:28:05.197066Z","deleted_at":null,"description":"version2_from_ephemeral","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "327"
+                - "317"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:56 GMT
+                - Fri, 03 Jul 2026 15:28:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - ee16fb63-4a1b-436f-9cf0-f4367ce64489
+                - a90f0005-013e-46cf-8e6d-2a1a7d465c7e
         status: 200 OK
         code: 200
-        duration: 48.578494ms
+        duration: 39.607724ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -636,29 +636,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions/4/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions/4/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 137
-        body: '{"secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "revision":4, "data":"bXlfc3VwZXJfc2VjcmV0X3Yy", "data_crc32":null, "type":"opaque"}'
+        content_length: 133
+        body: '{"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","revision":4,"data":"bXlfc3VwZXJfc2VjcmV0X3Yy","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "137"
+                - "133"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:56 GMT
+                - Fri, 03 Jul 2026 15:28:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - c736ceb3-73ba-4fae-a9c9-0949a7b6bcb9
+                - e2212b7c-3648-44b1-84ef-d539957a4d1f
         status: 200 OK
         code: 200
-        duration: 50.267198ms
+        duration: 45.383422ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -668,29 +668,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions/4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions/4
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 327
-        body: '{"revision":4, "secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "status":"enabled", "created_at":"2026-02-03T16:00:55.931802Z", "updated_at":"2026-02-03T16:00:55.931802Z", "deleted_at":null, "description":"version2_from_ephemeral", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 317
+        body: '{"revision":4,"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","status":"enabled","created_at":"2026-07-03T15:28:05.197066Z","updated_at":"2026-07-03T15:28:05.197066Z","deleted_at":null,"description":"version2_from_ephemeral","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "327"
+                - "317"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:56 GMT
+                - Fri, 03 Jul 2026 15:28:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - d9dc7d5b-85fb-4098-a7c4-85879a51615e
+                - c1e757e9-0f99-4b81-b7e6-4fd6d0f1daae
         status: 200 OK
         code: 200
-        duration: 39.226061ms
+        duration: 37.867314ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -703,29 +703,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 327
-        body: '{"revision":5, "secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "status":"enabled", "created_at":"2026-02-03T16:00:56.324155Z", "updated_at":"2026-02-03T16:00:56.324155Z", "deleted_at":null, "description":"version2_from_ephemeral", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 317
+        body: '{"revision":5,"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","status":"enabled","created_at":"2026-07-03T15:28:05.343319Z","updated_at":"2026-07-03T15:28:05.343319Z","deleted_at":null,"description":"version2_from_ephemeral","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "327"
+                - "317"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:56 GMT
+                - Fri, 03 Jul 2026 15:28:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 793f62fb-3d30-497e-b959-b8d226fb00b6
+                - 9d9dfd48-1470-4f66-ab2c-5ec7988887bc
         status: 200 OK
         code: 200
-        duration: 308.448273ms
+        duration: 88.381163ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -735,29 +735,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions/5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions/5
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 327
-        body: '{"revision":5, "secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "status":"enabled", "created_at":"2026-02-03T16:00:56.324155Z", "updated_at":"2026-02-03T16:00:56.324155Z", "deleted_at":null, "description":"version2_from_ephemeral", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 317
+        body: '{"revision":5,"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","status":"enabled","created_at":"2026-07-03T15:28:05.343319Z","updated_at":"2026-07-03T15:28:05.343319Z","deleted_at":null,"description":"version2_from_ephemeral","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "327"
+                - "317"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:56 GMT
+                - Fri, 03 Jul 2026 15:28:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 63b9c48d-ba33-4ebc-8faa-85fc9c7e726e
+                - 46e71b59-16e7-4b52-9ea4-cfea21c47f35
         status: 200 OK
         code: 200
-        duration: 36.370833ms
+        duration: 51.417786ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -767,29 +767,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions/5/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions/5/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 137
-        body: '{"secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "revision":5, "data":"bXlfc3VwZXJfc2VjcmV0X3Yy", "data_crc32":null, "type":"opaque"}'
+        content_length: 133
+        body: '{"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","revision":5,"data":"bXlfc3VwZXJfc2VjcmV0X3Yy","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "137"
+                - "133"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:56 GMT
+                - Fri, 03 Jul 2026 15:28:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 9939c979-8376-45f4-9fd1-fb8b5fbcb48f
+                - a7855c77-d782-4a85-a9f2-693ec2486f82
         status: 200 OK
         code: 200
-        duration: 110.761648ms
+        duration: 52.226906ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -799,29 +799,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions/5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions/5
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 327
-        body: '{"revision":5, "secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "status":"enabled", "created_at":"2026-02-03T16:00:56.324155Z", "updated_at":"2026-02-03T16:00:56.324155Z", "deleted_at":null, "description":"version2_from_ephemeral", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 317
+        body: '{"revision":5,"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","status":"enabled","created_at":"2026-07-03T15:28:05.343319Z","updated_at":"2026-07-03T15:28:05.343319Z","deleted_at":null,"description":"version2_from_ephemeral","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "327"
+                - "317"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:56 GMT
+                - Fri, 03 Jul 2026 15:28:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 4adda4cc-2bc8-4859-a0a2-364281d9007f
+                - c3a10e59-947a-42ad-8cd2-6bc856858b2b
         status: 200 OK
         code: 200
-        duration: 211.422059ms
+        duration: 40.934896ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -831,29 +831,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 313
-        body: '{"revision":1, "secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "status":"enabled", "created_at":"2026-02-03T16:00:55.221005Z", "updated_at":"2026-02-03T16:00:55.221005Z", "deleted_at":null, "description":"version1", "latest":false, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 303
+        body: '{"revision":1,"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","status":"enabled","created_at":"2026-07-03T15:28:04.634400Z","updated_at":"2026-07-03T15:28:04.634400Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "313"
+                - "303"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:56 GMT
+                - Fri, 03 Jul 2026 15:28:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - a88cef0c-4d53-47b8-9504-cb64aa116e13
+                - c5d20793-09bf-461c-9d0a-2c16c67e3363
         status: 200 OK
         code: 200
-        duration: 94.094422ms
+        duration: 38.740886ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -863,29 +863,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 313
-        body: '{"revision":2, "secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "status":"enabled", "created_at":"2026-02-03T16:00:55.479663Z", "updated_at":"2026-02-03T16:00:55.479663Z", "deleted_at":null, "description":"version2", "latest":false, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 303
+        body: '{"revision":2,"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","status":"enabled","created_at":"2026-07-03T15:28:04.843543Z","updated_at":"2026-07-03T15:28:04.843543Z","deleted_at":null,"description":"version2","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "313"
+                - "303"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:56 GMT
+                - Fri, 03 Jul 2026 15:28:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 9c461f9a-e4f4-4e3b-b58a-ab27de05e51b
+                - 346db121-f060-4aa7-8d82-bffa6ae8d4b6
         status: 200 OK
         code: 200
-        duration: 37.253563ms
+        duration: 36.488154ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -895,29 +895,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions/2/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 137
-        body: '{"secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "revision":2, "data":"bXlfc3VwZXJfc2VjcmV0X3Yy", "data_crc32":null, "type":"opaque"}'
+        content_length: 133
+        body: '{"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","revision":1,"data":"bXlfc3VwZXJfc2VjcmV0X3Yx","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "137"
+                - "133"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:57 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - bb3e8752-fc46-409b-b6fe-27f04f06e604
+                - 134c0873-5497-4656-93a6-d9c290907722
         status: 200 OK
         code: 200
-        duration: 58.392128ms
+        duration: 49.237541ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -927,29 +927,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions/latest/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions/latest/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 137
-        body: '{"secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "revision":5, "data":"bXlfc3VwZXJfc2VjcmV0X3Yy", "data_crc32":null, "type":"opaque"}'
+        content_length: 133
+        body: '{"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","revision":5,"data":"bXlfc3VwZXJfc2VjcmV0X3Yy","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "137"
+                - "133"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:57 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - c5408201-8ae4-451e-8be7-af00f4ffb67d
+                - e66338ee-dc44-47d3-9940-428d16c27c02
         status: 200 OK
         code: 200
-        duration: 79.910609ms
+        duration: 51.985141ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -959,29 +959,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions/1/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 137
-        body: '{"secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "revision":1, "data":"bXlfc3VwZXJfc2VjcmV0X3Yx", "data_crc32":null, "type":"opaque"}'
+        content_length: 303
+        body: '{"revision":1,"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","status":"enabled","created_at":"2026-07-03T15:28:04.634400Z","updated_at":"2026-07-03T15:28:04.634400Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "137"
+                - "303"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:57 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 19ab8651-bf9c-47bd-baf9-e171e0638262
+                - 56d97563-81e5-4998-8031-834a7e2bcec1
         status: 200 OK
         code: 200
-        duration: 94.036098ms
+        duration: 40.673856ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -991,29 +991,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions/5
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 313
-        body: '{"revision":1, "secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "status":"enabled", "created_at":"2026-02-03T16:00:55.221005Z", "updated_at":"2026-02-03T16:00:55.221005Z", "deleted_at":null, "description":"version1", "latest":false, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 317
+        body: '{"revision":5,"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","status":"enabled","created_at":"2026-07-03T15:28:05.343319Z","updated_at":"2026-07-03T15:28:05.343319Z","deleted_at":null,"description":"version2_from_ephemeral","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "313"
+                - "317"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:57 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - e4d3016e-f685-4aae-982e-0258388c1cae
+                - 002f0433-0de4-40d7-b4e8-f752e6a23463
         status: 200 OK
         code: 200
-        duration: 37.282386ms
+        duration: 60.908752ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1023,29 +1023,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions/2/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 313
-        body: '{"revision":2, "secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "status":"enabled", "created_at":"2026-02-03T16:00:55.479663Z", "updated_at":"2026-02-03T16:00:55.479663Z", "deleted_at":null, "description":"version2", "latest":false, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 133
+        body: '{"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","revision":2,"data":"bXlfc3VwZXJfc2VjcmV0X3Yy","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "313"
+                - "133"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:57 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 00785cfb-908e-44b2-a0e6-489575d5b199
+                - 9a473dfa-af52-4f36-8b16-e5737b82e83d
         status: 200 OK
         code: 200
-        duration: 74.963781ms
+        duration: 115.496743ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1055,29 +1055,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions/5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 327
-        body: '{"revision":5, "secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "status":"enabled", "created_at":"2026-02-03T16:00:56.324155Z", "updated_at":"2026-02-03T16:00:56.324155Z", "deleted_at":null, "description":"version2_from_ephemeral", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 303
+        body: '{"revision":2,"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","status":"enabled","created_at":"2026-07-03T15:28:04.843543Z","updated_at":"2026-07-03T15:28:04.843543Z","deleted_at":null,"description":"version2","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "327"
+                - "303"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:57 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 081b53bf-b39f-4ea9-b2cf-823d63567ea6
+                - 3553d2a8-e8a5-4fa5-a35e-ea58b408ca4a
         status: 200 OK
         code: 200
-        duration: 88.230586ms
+        duration: 35.606738ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1087,29 +1087,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions/3/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions/4/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 137
-        body: '{"secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "revision":3, "data":"bXlfc3VwZXJfc2VjcmV0X3Yx", "data_crc32":null, "type":"opaque"}'
+        content_length: 133
+        body: '{"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","revision":4,"data":"bXlfc3VwZXJfc2VjcmV0X3Yy","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "137"
+                - "133"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:57 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 2d211712-898f-490f-a1c0-3a032d7905b7
+                - 81e30bc6-cb2a-46d9-b949-a499e7aa0083
         status: 200 OK
         code: 200
-        duration: 50.026232ms
+        duration: 60.513891ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1119,29 +1119,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions/4/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions/5/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 137
-        body: '{"secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "revision":4, "data":"bXlfc3VwZXJfc2VjcmV0X3Yy", "data_crc32":null, "type":"opaque"}'
+        content_length: 133
+        body: '{"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","revision":5,"data":"bXlfc3VwZXJfc2VjcmV0X3Yy","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "137"
+                - "133"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:57 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 2e2aba94-77c4-44fc-a369-fe8aeae1d7e6
+                - 175f8bf5-b2e7-4101-b698-6f346be9b4be
         status: 200 OK
         code: 200
-        duration: 65.899394ms
+        duration: 64.865074ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1151,29 +1151,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions/5/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions/3/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 137
-        body: '{"secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "revision":5, "data":"bXlfc3VwZXJfc2VjcmV0X3Yy", "data_crc32":null, "type":"opaque"}'
+        content_length: 133
+        body: '{"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","revision":3,"data":"bXlfc3VwZXJfc2VjcmV0X3Yx","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "137"
+                - "133"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:57 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 79f7663d-d9e0-41a2-ac5d-624ba5bef9d1
+                - 1d4a57da-117f-4e64-bdb0-c9248fcc345f
         status: 200 OK
         code: 200
-        duration: 65.431008ms
+        duration: 135.721421ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1183,29 +1183,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions/3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions/4
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 328
-        body: '{"revision":3, "secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "status":"enabled", "created_at":"2026-02-03T16:00:55.603810Z", "updated_at":"2026-02-03T16:00:55.603810Z", "deleted_at":null, "description":"version1_from_ephemeral", "latest":false, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 318
+        body: '{"revision":4,"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","status":"enabled","created_at":"2026-07-03T15:28:05.197066Z","updated_at":"2026-07-03T15:28:05.197066Z","deleted_at":null,"description":"version2_from_ephemeral","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "328"
+                - "318"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:57 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 9e9cd2be-02c3-428c-a041-6d603635cbb8
+                - 7894184f-0506-4de1-9a04-d0d635fc5ad9
         status: 200 OK
         code: 200
-        duration: 36.06968ms
+        duration: 44.404703ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1215,29 +1215,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions/4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions/5
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 328
-        body: '{"revision":4, "secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "status":"enabled", "created_at":"2026-02-03T16:00:55.931802Z", "updated_at":"2026-02-03T16:00:55.931802Z", "deleted_at":null, "description":"version2_from_ephemeral", "latest":false, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 317
+        body: '{"revision":5,"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","status":"enabled","created_at":"2026-07-03T15:28:05.343319Z","updated_at":"2026-07-03T15:28:05.343319Z","deleted_at":null,"description":"version2_from_ephemeral","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "328"
+                - "317"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:57 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 3d866de7-52c7-43ce-94e3-639235f8d076
+                - e0333e41-b222-4c45-b619-c2915bc34695
         status: 200 OK
         code: 200
-        duration: 37.276245ms
+        duration: 37.827681ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1247,29 +1247,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions/5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions/3
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 327
-        body: '{"revision":5, "secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "status":"enabled", "created_at":"2026-02-03T16:00:56.324155Z", "updated_at":"2026-02-03T16:00:56.324155Z", "deleted_at":null, "description":"version2_from_ephemeral", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 318
+        body: '{"revision":3,"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","status":"enabled","created_at":"2026-07-03T15:28:05.035400Z","updated_at":"2026-07-03T15:28:05.035400Z","deleted_at":null,"description":"version1_from_ephemeral","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "327"
+                - "318"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:57 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - d7b20a1e-96a4-4ee8-b148-9254e4dd884d
+                - 93cbfbf2-d48b-45ba-8af8-e080d5154fb9
         status: 200 OK
         code: 200
-        duration: 39.423363ms
+        duration: 33.227831ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1279,29 +1279,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 511
-        body: '{"id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"ephemeralSecretVersionBasic", "status":"ready", "created_at":"2026-02-03T16:00:54.600551Z", "updated_at":"2026-02-03T16:00:54.600551Z", "tags":["devtools", "provider", "terraform"], "version_count":5, "description":"secret description", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}'
+        content_length: 492
+        body: '{"id":"c393aa9c-26fc-4726-af24-e17eb380fea4","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"ephemeralSecretVersionBasic","status":"ready","created_at":"2026-07-03T15:28:04.247068Z","updated_at":"2026-07-03T15:28:04.247068Z","tags":["devtools","provider","terraform"],"version_count":5,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "511"
+                - "492"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:57 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 33f45c2f-4a94-4cf0-a045-b39873cdaea0
+                - 8e6b8f42-fc12-4169-bfa8-2ef9a5b7662e
         status: 200 OK
         code: 200
-        duration: 34.956379ms
+        duration: 40.3192ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -1314,29 +1314,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 1649
-        body: '{"versions":[{"revision":5, "secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "status":"enabled", "created_at":"2026-02-03T16:00:56.324155Z", "updated_at":"2026-02-03T16:00:56.324155Z", "deleted_at":null, "description":"version2_from_ephemeral", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}, {"revision":4, "secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "status":"enabled", "created_at":"2026-02-03T16:00:55.931802Z", "updated_at":"2026-02-03T16:00:55.931802Z", "deleted_at":null, "description":"version2_from_ephemeral", "latest":false, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}, {"revision":3, "secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "status":"enabled", "created_at":"2026-02-03T16:00:55.603810Z", "updated_at":"2026-02-03T16:00:55.603810Z", "deleted_at":null, "description":"version1_from_ephemeral", "latest":false, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}, {"revision":2, "secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "status":"enabled", "created_at":"2026-02-03T16:00:55.479663Z", "updated_at":"2026-02-03T16:00:55.479663Z", "deleted_at":null, "description":"version2", "latest":false, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}, {"revision":1, "secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "status":"enabled", "created_at":"2026-02-03T16:00:55.221005Z", "updated_at":"2026-02-03T16:00:55.221005Z", "deleted_at":null, "description":"version1", "latest":false, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}], "total_count":5}'
+        content_length: 1594
+        body: '{"versions":[{"revision":5,"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","status":"enabled","created_at":"2026-07-03T15:28:05.343319Z","updated_at":"2026-07-03T15:28:05.343319Z","deleted_at":null,"description":"version2_from_ephemeral","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":4,"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","status":"enabled","created_at":"2026-07-03T15:28:05.197066Z","updated_at":"2026-07-03T15:28:05.197066Z","deleted_at":null,"description":"version2_from_ephemeral","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":3,"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","status":"enabled","created_at":"2026-07-03T15:28:05.035400Z","updated_at":"2026-07-03T15:28:05.035400Z","deleted_at":null,"description":"version1_from_ephemeral","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":2,"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","status":"enabled","created_at":"2026-07-03T15:28:04.843543Z","updated_at":"2026-07-03T15:28:04.843543Z","deleted_at":null,"description":"version2","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","status":"enabled","created_at":"2026-07-03T15:28:04.634400Z","updated_at":"2026-07-03T15:28:04.634400Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":5}'
         headers:
             Content-Length:
-                - "1649"
+                - "1594"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:57 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 0c89ee94-b4fd-4ac7-b1ef-4e4d223cb84e
+                - 53af55b0-b1c4-4186-b5e6-f70ec0ae8849
         status: 200 OK
         code: 200
-        duration: 52.797251ms
+        duration: 42.903114ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -1346,29 +1346,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 313
-        body: '{"revision":1, "secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "status":"enabled", "created_at":"2026-02-03T16:00:55.221005Z", "updated_at":"2026-02-03T16:00:55.221005Z", "deleted_at":null, "description":"version1", "latest":false, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 303
+        body: '{"revision":1,"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","status":"enabled","created_at":"2026-07-03T15:28:04.634400Z","updated_at":"2026-07-03T15:28:04.634400Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "313"
+                - "303"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:57 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 6ca6e2f2-c3b5-494a-b7fc-4036361283c6
+                - 46ae96a1-2c5f-4d42-a49c-8a58dde16004
         status: 200 OK
         code: 200
-        duration: 40.984161ms
+        duration: 49.942645ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -1378,29 +1378,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 313
-        body: '{"revision":2, "secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "status":"enabled", "created_at":"2026-02-03T16:00:55.479663Z", "updated_at":"2026-02-03T16:00:55.479663Z", "deleted_at":null, "description":"version2", "latest":false, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 133
+        body: '{"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","revision":1,"data":"bXlfc3VwZXJfc2VjcmV0X3Yx","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "313"
+                - "133"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:57 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - d70b55b2-d268-41c4-9c0f-e2762eaf5f45
+                - 041d06e8-859c-46a2-841c-a04d9cfd2cf0
         status: 200 OK
         code: 200
-        duration: 44.148901ms
+        duration: 42.511557ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -1410,29 +1410,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions/1/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 137
-        body: '{"secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "revision":1, "data":"bXlfc3VwZXJfc2VjcmV0X3Yx", "data_crc32":null, "type":"opaque"}'
+        content_length: 303
+        body: '{"revision":2,"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","status":"enabled","created_at":"2026-07-03T15:28:04.843543Z","updated_at":"2026-07-03T15:28:04.843543Z","deleted_at":null,"description":"version2","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "137"
+                - "303"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:57 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - faadddc7-2bff-4c0c-b190-2f33c09702b6
+                - 32e2c06a-2bb8-4558-9477-758e87f5525c
         status: 200 OK
         code: 200
-        duration: 52.675989ms
+        duration: 46.503626ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -1442,29 +1442,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 313
-        body: '{"revision":1, "secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "status":"enabled", "created_at":"2026-02-03T16:00:55.221005Z", "updated_at":"2026-02-03T16:00:55.221005Z", "deleted_at":null, "description":"version1", "latest":false, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 303
+        body: '{"revision":1,"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","status":"enabled","created_at":"2026-07-03T15:28:04.634400Z","updated_at":"2026-07-03T15:28:04.634400Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "313"
+                - "303"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:57 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - e737cb08-5a63-47c5-9dfb-64c7bb0a3cff
+                - 64600bfe-d04b-4c32-bf9e-877b808d2c4d
         status: 200 OK
         code: 200
-        duration: 38.581242ms
+        duration: 34.812386ms
     - id: 45
       request:
         proto: HTTP/1.1
@@ -1474,29 +1474,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions/latest/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions/2/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 137
-        body: '{"secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "revision":5, "data":"bXlfc3VwZXJfc2VjcmV0X3Yy", "data_crc32":null, "type":"opaque"}'
+        content_length: 133
+        body: '{"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","revision":2,"data":"bXlfc3VwZXJfc2VjcmV0X3Yy","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "137"
+                - "133"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:57 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - d1b1cb77-24a5-4834-bd6e-6c6968ad8c7e
+                - 93ffb06e-4e7b-4be9-916f-9fe81e68f524
         status: 200 OK
         code: 200
-        duration: 49.23964ms
+        duration: 38.866762ms
     - id: 46
       request:
         proto: HTTP/1.1
@@ -1506,29 +1506,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions/2/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions/latest/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 137
-        body: '{"secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "revision":2, "data":"bXlfc3VwZXJfc2VjcmV0X3Yy", "data_crc32":null, "type":"opaque"}'
+        content_length: 133
+        body: '{"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","revision":5,"data":"bXlfc3VwZXJfc2VjcmV0X3Yy","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "137"
+                - "133"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:57 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - bccee8fd-c35c-47e7-aab8-497cf2551192
+                - c476ea9a-b673-4b23-a5f3-fff98da27b6a
         status: 200 OK
         code: 200
-        duration: 49.037331ms
+        duration: 39.80799ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -1538,29 +1538,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions/3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions/3
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 328
-        body: '{"revision":3, "secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "status":"enabled", "created_at":"2026-02-03T16:00:55.603810Z", "updated_at":"2026-02-03T16:00:55.603810Z", "deleted_at":null, "description":"version1_from_ephemeral", "latest":false, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 318
+        body: '{"revision":3,"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","status":"enabled","created_at":"2026-07-03T15:28:05.035400Z","updated_at":"2026-07-03T15:28:05.035400Z","deleted_at":null,"description":"version1_from_ephemeral","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "328"
+                - "318"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:57 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 3fa3372e-8a6e-4b14-bf4a-5eb28b4d89bf
+                - 03dfc169-6dc1-4f18-ae9d-427c61887390
         status: 200 OK
         code: 200
-        duration: 41.618623ms
+        duration: 45.106041ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -1570,29 +1570,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 313
-        body: '{"revision":2, "secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "status":"enabled", "created_at":"2026-02-03T16:00:55.479663Z", "updated_at":"2026-02-03T16:00:55.479663Z", "deleted_at":null, "description":"version2", "latest":false, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 303
+        body: '{"revision":2,"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","status":"enabled","created_at":"2026-07-03T15:28:04.843543Z","updated_at":"2026-07-03T15:28:04.843543Z","deleted_at":null,"description":"version2","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "313"
+                - "303"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:57 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - f636a452-549f-401a-8af1-ae2f4201c14f
+                - 4e00c471-97e8-492b-9a24-4ef802a0e54f
         status: 200 OK
         code: 200
-        duration: 41.678609ms
+        duration: 41.09118ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -1602,29 +1602,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions/5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions/5
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 327
-        body: '{"revision":5, "secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "status":"enabled", "created_at":"2026-02-03T16:00:56.324155Z", "updated_at":"2026-02-03T16:00:56.324155Z", "deleted_at":null, "description":"version2_from_ephemeral", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 317
+        body: '{"revision":5,"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","status":"enabled","created_at":"2026-07-03T15:28:05.343319Z","updated_at":"2026-07-03T15:28:05.343319Z","deleted_at":null,"description":"version2_from_ephemeral","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "327"
+                - "317"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:57 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - bd9a0563-2774-42d2-bbdb-2125b3b8aa09
+                - f4219cc9-9e4d-4bb9-85ab-58d81abfeff1
         status: 200 OK
         code: 200
-        duration: 41.67029ms
+        duration: 43.200382ms
     - id: 50
       request:
         proto: HTTP/1.1
@@ -1634,29 +1634,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions/4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions/4
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 328
-        body: '{"revision":4, "secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "status":"enabled", "created_at":"2026-02-03T16:00:55.931802Z", "updated_at":"2026-02-03T16:00:55.931802Z", "deleted_at":null, "description":"version2_from_ephemeral", "latest":false, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 318
+        body: '{"revision":4,"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","status":"enabled","created_at":"2026-07-03T15:28:05.197066Z","updated_at":"2026-07-03T15:28:05.197066Z","deleted_at":null,"description":"version2_from_ephemeral","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "328"
+                - "318"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:57 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 9f9203c3-e362-4546-9f55-f0e5e38ebd11
+                - ddbbb14e-8f8e-4837-986a-3476b40c4f16
         status: 200 OK
         code: 200
-        duration: 97.383819ms
+        duration: 34.541368ms
     - id: 51
       request:
         proto: HTTP/1.1
@@ -1666,29 +1666,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions/3/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions/3/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 137
-        body: '{"secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "revision":3, "data":"bXlfc3VwZXJfc2VjcmV0X3Yx", "data_crc32":null, "type":"opaque"}'
+        content_length: 133
+        body: '{"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","revision":3,"data":"bXlfc3VwZXJfc2VjcmV0X3Yx","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "137"
+                - "133"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:57 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - e4203cb4-8bd7-4084-9933-c7633630930f
+                - dd48aba9-930a-464b-bb72-79374e64e645
         status: 200 OK
         code: 200
-        duration: 100.113824ms
+        duration: 46.01572ms
     - id: 52
       request:
         proto: HTTP/1.1
@@ -1698,29 +1698,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions/3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions/3
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 328
-        body: '{"revision":3, "secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "status":"enabled", "created_at":"2026-02-03T16:00:55.603810Z", "updated_at":"2026-02-03T16:00:55.603810Z", "deleted_at":null, "description":"version1_from_ephemeral", "latest":false, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 318
+        body: '{"revision":3,"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","status":"enabled","created_at":"2026-07-03T15:28:05.035400Z","updated_at":"2026-07-03T15:28:05.035400Z","deleted_at":null,"description":"version1_from_ephemeral","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "328"
+                - "318"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:57 GMT
+                - Fri, 03 Jul 2026 15:28:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - d6df9dc2-ca74-4176-935b-6088c76c4776
+                - 2288bf8b-e4fc-4e40-ab66-674d6e26a4de
         status: 200 OK
         code: 200
-        duration: 42.99011ms
+        duration: 33.18471ms
     - id: 53
       request:
         proto: HTTP/1.1
@@ -1730,29 +1730,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions/5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions/5
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 327
-        body: '{"revision":5, "secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "status":"enabled", "created_at":"2026-02-03T16:00:56.324155Z", "updated_at":"2026-02-03T16:00:56.324155Z", "deleted_at":null, "description":"version2_from_ephemeral", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 317
+        body: '{"revision":5,"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","status":"enabled","created_at":"2026-07-03T15:28:05.343319Z","updated_at":"2026-07-03T15:28:05.343319Z","deleted_at":null,"description":"version2_from_ephemeral","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "327"
+                - "317"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:57 GMT
+                - Fri, 03 Jul 2026 15:28:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - cb13bd08-404c-4eac-8416-6a4d991e8568
+                - 4b6d9d97-4dff-47ea-964e-f0b0d7912194
         status: 200 OK
         code: 200
-        duration: 40.406864ms
+        duration: 44.954556ms
     - id: 54
       request:
         proto: HTTP/1.1
@@ -1762,29 +1762,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions/4/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions/4/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 137
-        body: '{"secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "revision":4, "data":"bXlfc3VwZXJfc2VjcmV0X3Yy", "data_crc32":null, "type":"opaque"}'
+        content_length: 133
+        body: '{"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","revision":4,"data":"bXlfc3VwZXJfc2VjcmV0X3Yy","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "137"
+                - "133"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:57 GMT
+                - Fri, 03 Jul 2026 15:28:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - f44e561f-7c4c-48b5-8471-ad091f62ab16
+                - 62f1074f-5fc8-43bc-98bf-e0bb74522998
         status: 200 OK
         code: 200
-        duration: 48.964855ms
+        duration: 47.020386ms
     - id: 55
       request:
         proto: HTTP/1.1
@@ -1794,29 +1794,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions/4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions/5/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 328
-        body: '{"revision":4, "secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "status":"enabled", "created_at":"2026-02-03T16:00:55.931802Z", "updated_at":"2026-02-03T16:00:55.931802Z", "deleted_at":null, "description":"version2_from_ephemeral", "latest":false, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 133
+        body: '{"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","revision":5,"data":"bXlfc3VwZXJfc2VjcmV0X3Yy","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "328"
+                - "133"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:57 GMT
+                - Fri, 03 Jul 2026 15:28:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 9c548598-cdb1-4cce-9e6b-37d416927dee
+                - 20753cb5-614d-4aaa-9006-404906cca26e
         status: 200 OK
         code: 200
-        duration: 44.31227ms
+        duration: 50.483531ms
     - id: 56
       request:
         proto: HTTP/1.1
@@ -1826,29 +1826,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions/5/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions/4
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 137
-        body: '{"secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "revision":5, "data":"bXlfc3VwZXJfc2VjcmV0X3Yy", "data_crc32":null, "type":"opaque"}'
+        content_length: 318
+        body: '{"revision":4,"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","status":"enabled","created_at":"2026-07-03T15:28:05.197066Z","updated_at":"2026-07-03T15:28:05.197066Z","deleted_at":null,"description":"version2_from_ephemeral","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "137"
+                - "318"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:57 GMT
+                - Fri, 03 Jul 2026 15:28:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - e5ce031c-a443-49d5-8535-74c9de4bd293
+                - 0572200c-9c5e-4122-9e3e-1d591eed7c97
         status: 200 OK
         code: 200
-        duration: 55.251873ms
+        duration: 58.883819ms
     - id: 57
       request:
         proto: HTTP/1.1
@@ -1858,29 +1858,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions/5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions/5
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 327
-        body: '{"revision":5, "secret_id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "status":"enabled", "created_at":"2026-02-03T16:00:56.324155Z", "updated_at":"2026-02-03T16:00:56.324155Z", "deleted_at":null, "description":"version2_from_ephemeral", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 317
+        body: '{"revision":5,"secret_id":"c393aa9c-26fc-4726-af24-e17eb380fea4","status":"enabled","created_at":"2026-07-03T15:28:05.343319Z","updated_at":"2026-07-03T15:28:05.343319Z","deleted_at":null,"description":"version2_from_ephemeral","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "327"
+                - "317"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:58 GMT
+                - Fri, 03 Jul 2026 15:28:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 258c1cad-e359-4ad4-a1c2-af2249788ae8
+                - 759df9b1-ca92-4190-be15-9eeb431019f8
         status: 200 OK
         code: 200
-        duration: 35.953484ms
+        duration: 48.080348ms
     - id: 58
       request:
         proto: HTTP/1.1
@@ -1890,8 +1890,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions/5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions/5
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1903,14 +1903,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:58 GMT
+                - Fri, 03 Jul 2026 15:28:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 65cd6b18-8622-4532-8927-f2ccb2d40fe3
+                - af5495ae-a4e7-42b9-af73-e081d42b988c
         status: 204 No Content
         code: 204
-        duration: 103.165492ms
+        duration: 64.849835ms
     - id: 59
       request:
         proto: HTTP/1.1
@@ -1920,8 +1920,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions/4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions/4
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1933,14 +1933,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:58 GMT
+                - Fri, 03 Jul 2026 15:28:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 84f2b3e3-2140-4a26-b9f4-e8b8b3d1b340
+                - 0586e121-d467-46b2-863d-de3dc0946442
         status: 204 No Content
         code: 204
-        duration: 163.838253ms
+        duration: 81.129683ms
     - id: 60
       request:
         proto: HTTP/1.1
@@ -1950,8 +1950,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions/3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions/2
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1963,14 +1963,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:58 GMT
+                - Fri, 03 Jul 2026 15:28:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 8d201f0e-eb0e-4762-957e-e03d1a442b03
+                - fccdecc5-5684-4ab8-9880-da0576e479e7
         status: 204 No Content
         code: 204
-        duration: 102.157794ms
+        duration: 59.500628ms
     - id: 61
       request:
         proto: HTTP/1.1
@@ -1980,8 +1980,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions/3
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1993,14 +1993,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:58 GMT
+                - Fri, 03 Jul 2026 15:28:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 40061d46-9dd0-4e20-8962-72d8a1692017
+                - 7aa67696-d7ea-4f93-bf59-b55a7332e1b5
         status: 204 No Content
         code: 204
-        duration: 118.411142ms
+        duration: 79.326065ms
     - id: 62
       request:
         proto: HTTP/1.1
@@ -2010,8 +2010,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4/versions/1
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2023,14 +2023,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:58 GMT
+                - Fri, 03 Jul 2026 15:28:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - b621a067-9be1-4170-9c6e-019ba0b9db33
+                - 48647dd8-b01c-49fb-b506-14f927afffcf
         status: 204 No Content
         code: 204
-        duration: 62.164108ms
+        duration: 61.266425ms
     - id: 63
       request:
         proto: HTTP/1.1
@@ -2040,8 +2040,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2053,14 +2053,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:58 GMT
+                - Fri, 03 Jul 2026 15:28:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - ffbd638a-4052-4d88-b610-eec477b6d18a
+                - 853d3e11-8b22-4202-ba43-1ddc999a6fe3
         status: 204 No Content
         code: 204
-        duration: 60.195481ms
+        duration: 52.53254ms
     - id: 64
       request:
         proto: HTTP/1.1
@@ -2070,26 +2070,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/986fbf50-ae44-4c88-b5af-79a80a0c1fa8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c393aa9c-26fc-4726-af24-e17eb380fea4
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 536
-        body: '{"id":"986fbf50-ae44-4c88-b5af-79a80a0c1fa8", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"ephemeralSecretVersionBasic", "status":"ready", "created_at":"2026-02-03T16:00:54.600551Z", "updated_at":"2026-02-03T16:00:54.600551Z", "tags":["devtools", "provider", "terraform"], "version_count":5, "description":"secret description", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":"2026-02-03T16:00:58.750817Z", "key_id":null, "region":"fr-par"}'
+        content_length: 517
+        body: '{"id":"c393aa9c-26fc-4726-af24-e17eb380fea4","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"ephemeralSecretVersionBasic","status":"ready","created_at":"2026-07-03T15:28:04.247068Z","updated_at":"2026-07-03T15:28:07.839062Z","tags":["devtools","provider","terraform"],"version_count":5,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-07-03T15:28:07.839062Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "536"
+                - "517"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:00:58 GMT
+                - Fri, 03 Jul 2026 15:28:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 40015db1-c135-4bcd-a0e8-06550d39f571
+                - 7141e197-8938-4dd1-ae26-3a67a3297469
         status: 200 OK
         code: 200
-        duration: 37.808979ms
+        duration: 53.168364ms

--- a/internal/services/secret/testdata/ephemeral-resource-secret-version-by-name-secret.cassette.yaml
+++ b/internal/services/secret/testdata/ephemeral-resource-secret-version-by-name-secret.cassette.yaml
@@ -13,29 +13,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 493
-        body: '{"id":"5da358e6-5214-4b7c-95ae-7ceae22a7da4", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"erSecretVersionByNameSecret", "status":"ready", "created_at":"2026-02-03T16:01:39.879166Z", "updated_at":"2026-02-03T16:01:39.879166Z", "tags":["devtools", "provider", "terraform"], "version_count":0, "description":"", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}'
+        content_length: 474
+        body: '{"id":"caedd6aa-562d-40dd-a2d7-3273a1e0beee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"erSecretVersionByNameSecret","status":"ready","created_at":"2026-07-03T15:28:00.703451Z","updated_at":"2026-07-03T15:28:00.703451Z","tags":["devtools","provider","terraform"],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "493"
+                - "474"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:01:39 GMT
+                - Fri, 03 Jul 2026 15:28:00 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 4781a657-c11b-4ce9-8ca0-eacb7740c2d1
+                - 77588978-ff62-4d25-b2d1-bebbcd2793fb
         status: 200 OK
         code: 200
-        duration: 296.298332ms
+        duration: 100.771815ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -45,29 +45,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5da358e6-5214-4b7c-95ae-7ceae22a7da4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/caedd6aa-562d-40dd-a2d7-3273a1e0beee
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 493
-        body: '{"id":"5da358e6-5214-4b7c-95ae-7ceae22a7da4", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"erSecretVersionByNameSecret", "status":"ready", "created_at":"2026-02-03T16:01:39.879166Z", "updated_at":"2026-02-03T16:01:39.879166Z", "tags":["devtools", "provider", "terraform"], "version_count":0, "description":"", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}'
+        content_length: 474
+        body: '{"id":"caedd6aa-562d-40dd-a2d7-3273a1e0beee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"erSecretVersionByNameSecret","status":"ready","created_at":"2026-07-03T15:28:00.703451Z","updated_at":"2026-07-03T15:28:00.703451Z","tags":["devtools","provider","terraform"],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "493"
+                - "474"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:01:40 GMT
+                - Fri, 03 Jul 2026 15:28:00 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 14a48c5e-5823-4b28-b6b5-8ecf44b08c74
+                - b9bcbe8c-b9e1-460d-9e45-55dc14f30642
         status: 200 OK
         code: 200
-        duration: 106.430417ms
+        duration: 54.625501ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -80,29 +80,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5da358e6-5214-4b7c-95ae-7ceae22a7da4/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/caedd6aa-562d-40dd-a2d7-3273a1e0beee/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 32
-        body: '{"versions":[], "total_count":0}'
+        content_length: 31
+        body: '{"versions":[],"total_count":0}'
         headers:
             Content-Length:
-                - "32"
+                - "31"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:01:40 GMT
+                - Fri, 03 Jul 2026 15:28:00 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 6d4d7363-d442-4709-8e92-33cf6bc68ed7
+                - 8e38054d-6077-49eb-b416-bd8f1dd3188a
         status: 200 OK
         code: 200
-        duration: 87.169555ms
+        duration: 60.835224ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -115,29 +115,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5da358e6-5214-4b7c-95ae-7ceae22a7da4/versions
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/caedd6aa-562d-40dd-a2d7-3273a1e0beee/versions
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 312
-        body: '{"revision":1, "secret_id":"5da358e6-5214-4b7c-95ae-7ceae22a7da4", "status":"enabled", "created_at":"2026-02-03T16:01:40.502261Z", "updated_at":"2026-02-03T16:01:40.502261Z", "deleted_at":null, "description":"version1", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 302
+        body: '{"revision":1,"secret_id":"caedd6aa-562d-40dd-a2d7-3273a1e0beee","status":"enabled","created_at":"2026-07-03T15:28:01.105720Z","updated_at":"2026-07-03T15:28:01.105720Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "312"
+                - "302"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:01:40 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - d60dbcc4-3b84-4edf-8fcd-939792c27c59
+                - cd5b6339-32d3-4106-a674-0685d92c1122
         status: 200 OK
         code: 200
-        duration: 416.764824ms
+        duration: 281.12208ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -147,29 +147,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5da358e6-5214-4b7c-95ae-7ceae22a7da4/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/caedd6aa-562d-40dd-a2d7-3273a1e0beee/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 312
-        body: '{"revision":1, "secret_id":"5da358e6-5214-4b7c-95ae-7ceae22a7da4", "status":"enabled", "created_at":"2026-02-03T16:01:40.502261Z", "updated_at":"2026-02-03T16:01:40.502261Z", "deleted_at":null, "description":"version1", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 302
+        body: '{"revision":1,"secret_id":"caedd6aa-562d-40dd-a2d7-3273a1e0beee","status":"enabled","created_at":"2026-07-03T15:28:01.105720Z","updated_at":"2026-07-03T15:28:01.105720Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "312"
+                - "302"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:01:40 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 23e6e783-3b02-4d23-a864-c54a6cccf3f7
+                - ffe5e0c5-fbb3-44f7-8f7b-04ad0fbec5bf
         status: 200 OK
         code: 200
-        duration: 86.68615ms
+        duration: 45.793883ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -190,29 +190,29 @@ interactions:
                 - unknown_type
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets?name=erSecretVersionByNameSecret&order_by=name_asc&project_id=105bdce1-64c0-48ab-899d-868455867ecf&scheduled_for_deletion=false&type=unknown_type
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 524
-        body: '{"secrets":[{"id":"5da358e6-5214-4b7c-95ae-7ceae22a7da4", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"erSecretVersionByNameSecret", "status":"ready", "created_at":"2026-02-03T16:01:39.879166Z", "updated_at":"2026-02-03T16:01:39.879166Z", "tags":["devtools", "provider", "terraform"], "version_count":1, "description":"", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}], "total_count":1}'
+        content_length: 504
+        body: '{"secrets":[{"id":"caedd6aa-562d-40dd-a2d7-3273a1e0beee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"erSecretVersionByNameSecret","status":"ready","created_at":"2026-07-03T15:28:00.703451Z","updated_at":"2026-07-03T15:28:00.703451Z","tags":["devtools","provider","terraform"],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
-                - "524"
+                - "504"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:01:40 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - a1df84ec-2c08-4647-9615-dc3d19c31046
+                - bb070461-687d-4f18-91a4-40441b609fa1
         status: 200 OK
         code: 200
-        duration: 81.16698ms
+        duration: 124.506175ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -233,29 +233,29 @@ interactions:
                 - unknown_type
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets?name=erSecretVersionByNameSecret&order_by=name_asc&project_id=105bdce1-64c0-48ab-899d-868455867ecf&scheduled_for_deletion=false&type=unknown_type
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 524
-        body: '{"secrets":[{"id":"5da358e6-5214-4b7c-95ae-7ceae22a7da4", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"erSecretVersionByNameSecret", "status":"ready", "created_at":"2026-02-03T16:01:39.879166Z", "updated_at":"2026-02-03T16:01:39.879166Z", "tags":["devtools", "provider", "terraform"], "version_count":1, "description":"", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}], "total_count":1}'
+        content_length: 504
+        body: '{"secrets":[{"id":"caedd6aa-562d-40dd-a2d7-3273a1e0beee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"erSecretVersionByNameSecret","status":"ready","created_at":"2026-07-03T15:28:00.703451Z","updated_at":"2026-07-03T15:28:00.703451Z","tags":["devtools","provider","terraform"],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
-                - "524"
+                - "504"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:01:40 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 815d5adb-94d8-46cf-882f-603ae4b9dd63
+                - f8a39d2b-a66f-4ea3-8d08-b0c7ffc4aaef
         status: 200 OK
         code: 200
-        duration: 83.333597ms
+        duration: 143.370638ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -265,29 +265,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5da358e6-5214-4b7c-95ae-7ceae22a7da4/versions/latest/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/caedd6aa-562d-40dd-a2d7-3273a1e0beee/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 137
-        body: '{"secret_id":"5da358e6-5214-4b7c-95ae-7ceae22a7da4", "revision":1, "data":"bXlfc3VwZXJfc2VjcmV0X3Yx", "data_crc32":null, "type":"opaque"}'
+        content_length: 133
+        body: '{"secret_id":"caedd6aa-562d-40dd-a2d7-3273a1e0beee","revision":1,"data":"bXlfc3VwZXJfc2VjcmV0X3Yx","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "137"
+                - "133"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:01:40 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - bcd807ec-047d-45be-a4a5-97b85176cc35
+                - 8d9109ec-fc84-4c79-a7e3-e9aa4eac4c82
         status: 200 OK
         code: 200
-        duration: 208.051991ms
+        duration: 161.919968ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -297,29 +297,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5da358e6-5214-4b7c-95ae-7ceae22a7da4/versions/1/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/caedd6aa-562d-40dd-a2d7-3273a1e0beee/versions/latest/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 137
-        body: '{"secret_id":"5da358e6-5214-4b7c-95ae-7ceae22a7da4", "revision":1, "data":"bXlfc3VwZXJfc2VjcmV0X3Yx", "data_crc32":null, "type":"opaque"}'
+        content_length: 133
+        body: '{"secret_id":"caedd6aa-562d-40dd-a2d7-3273a1e0beee","revision":1,"data":"bXlfc3VwZXJfc2VjcmV0X3Yx","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "137"
+                - "133"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:01:40 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - ee0f1ce0-0678-4657-8afe-064b847c8c2a
+                - 12456afb-3203-44c5-945c-73f564403840
         status: 200 OK
         code: 200
-        duration: 205.955599ms
+        duration: 156.922602ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -329,29 +329,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5da358e6-5214-4b7c-95ae-7ceae22a7da4/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/caedd6aa-562d-40dd-a2d7-3273a1e0beee/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 312
-        body: '{"revision":1, "secret_id":"5da358e6-5214-4b7c-95ae-7ceae22a7da4", "status":"enabled", "created_at":"2026-02-03T16:01:40.502261Z", "updated_at":"2026-02-03T16:01:40.502261Z", "deleted_at":null, "description":"version1", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 302
+        body: '{"revision":1,"secret_id":"caedd6aa-562d-40dd-a2d7-3273a1e0beee","status":"enabled","created_at":"2026-07-03T15:28:01.105720Z","updated_at":"2026-07-03T15:28:01.105720Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "312"
+                - "302"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:01:40 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 31e9ecdb-0b70-48c8-b0c8-ed46d9a08105
+                - 70420469-2904-4353-9d8f-a4279e125e49
         status: 200 OK
         code: 200
-        duration: 46.154325ms
+        duration: 34.75523ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -361,29 +361,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5da358e6-5214-4b7c-95ae-7ceae22a7da4/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/caedd6aa-562d-40dd-a2d7-3273a1e0beee/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 312
-        body: '{"revision":1, "secret_id":"5da358e6-5214-4b7c-95ae-7ceae22a7da4", "status":"enabled", "created_at":"2026-02-03T16:01:40.502261Z", "updated_at":"2026-02-03T16:01:40.502261Z", "deleted_at":null, "description":"version1", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 302
+        body: '{"revision":1,"secret_id":"caedd6aa-562d-40dd-a2d7-3273a1e0beee","status":"enabled","created_at":"2026-07-03T15:28:01.105720Z","updated_at":"2026-07-03T15:28:01.105720Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "312"
+                - "302"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:01:41 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 6d43c201-e594-440f-b7ef-175f5181f174
+                - ac5d74ee-4368-4ff0-ad34-7bae6ebd679f
         status: 200 OK
         code: 200
-        duration: 107.935061ms
+        duration: 43.977351ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -396,62 +396,30 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5da358e6-5214-4b7c-95ae-7ceae22a7da4/versions
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/caedd6aa-562d-40dd-a2d7-3273a1e0beee/versions
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 327
-        body: '{"revision":2, "secret_id":"5da358e6-5214-4b7c-95ae-7ceae22a7da4", "status":"enabled", "created_at":"2026-02-03T16:01:41.112688Z", "updated_at":"2026-02-03T16:01:41.112688Z", "deleted_at":null, "description":"version1_from_ephemeral", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 317
+        body: '{"revision":2,"secret_id":"caedd6aa-562d-40dd-a2d7-3273a1e0beee","status":"enabled","created_at":"2026-07-03T15:28:01.594979Z","updated_at":"2026-07-03T15:28:01.594979Z","deleted_at":null,"description":"version1_from_ephemeral","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "327"
+                - "317"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:01:41 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - b09fa865-a0ff-4e18-8fd2-650b016b7518
+                - aae529fa-8fda-4120-96e2-eb00ed19cd81
         status: 200 OK
         code: 200
-        duration: 181.288113ms
+        duration: 94.327561ms
     - id: 12
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5da358e6-5214-4b7c-95ae-7ceae22a7da4/versions/2
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 327
-        body: '{"revision":2, "secret_id":"5da358e6-5214-4b7c-95ae-7ceae22a7da4", "status":"enabled", "created_at":"2026-02-03T16:01:41.112688Z", "updated_at":"2026-02-03T16:01:41.112688Z", "deleted_at":null, "description":"version1_from_ephemeral", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "327"
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 03 Feb 2026 16:01:41 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            X-Request-Id:
-                - a1269225-032d-4b63-9957-06dfc0358b0a
-        status: 200 OK
-        code: 200
-        duration: 34.583401ms
-    - id: 13
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -463,29 +431,61 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5da358e6-5214-4b7c-95ae-7ceae22a7da4/versions
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/caedd6aa-562d-40dd-a2d7-3273a1e0beee/versions
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 326
-        body: '{"revision":3, "secret_id":"5da358e6-5214-4b7c-95ae-7ceae22a7da4", "status":"enabled", "created_at":"2026-02-03T16:01:41.164988Z", "updated_at":"2026-02-03T16:01:41.164988Z", "deleted_at":null, "description":"by_name_from_ephemeral", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 316
+        body: '{"revision":3,"secret_id":"caedd6aa-562d-40dd-a2d7-3273a1e0beee","status":"enabled","created_at":"2026-07-03T15:28:01.638457Z","updated_at":"2026-07-03T15:28:01.638457Z","deleted_at":null,"description":"by_name_from_ephemeral","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "326"
+                - "316"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:01:41 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - aaaaabd3-36e6-44a2-bf34-cb2a273dbf82
+                - 294e742a-ab82-4fab-b4b2-d794206dd7f9
         status: 200 OK
         code: 200
-        duration: 163.906161ms
+        duration: 104.433102ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/caedd6aa-562d-40dd-a2d7-3273a1e0beee/versions/2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 318
+        body: '{"revision":2,"secret_id":"caedd6aa-562d-40dd-a2d7-3273a1e0beee","status":"enabled","created_at":"2026-07-03T15:28:01.594979Z","updated_at":"2026-07-03T15:28:01.594979Z","deleted_at":null,"description":"version1_from_ephemeral","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "318"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:01 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 2cebba74-596f-4447-8e3d-4e6058079ecb
+        status: 200 OK
+        code: 200
+        duration: 75.286638ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -495,29 +495,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5da358e6-5214-4b7c-95ae-7ceae22a7da4/versions/3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/caedd6aa-562d-40dd-a2d7-3273a1e0beee/versions/3
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 326
-        body: '{"revision":3, "secret_id":"5da358e6-5214-4b7c-95ae-7ceae22a7da4", "status":"enabled", "created_at":"2026-02-03T16:01:41.164988Z", "updated_at":"2026-02-03T16:01:41.164988Z", "deleted_at":null, "description":"by_name_from_ephemeral", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 316
+        body: '{"revision":3,"secret_id":"caedd6aa-562d-40dd-a2d7-3273a1e0beee","status":"enabled","created_at":"2026-07-03T15:28:01.638457Z","updated_at":"2026-07-03T15:28:01.638457Z","deleted_at":null,"description":"by_name_from_ephemeral","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "326"
+                - "316"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:01:41 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 8adf640d-d8db-4a73-9eda-aebf3ef8bcaf
+                - 60a916f2-d000-46bb-8e1e-8c7fa5690e6c
         status: 200 OK
         code: 200
-        duration: 38.705765ms
+        duration: 37.731881ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -527,29 +527,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5da358e6-5214-4b7c-95ae-7ceae22a7da4/versions/2/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/caedd6aa-562d-40dd-a2d7-3273a1e0beee/versions/3/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 137
-        body: '{"secret_id":"5da358e6-5214-4b7c-95ae-7ceae22a7da4", "revision":2, "data":"bXlfc3VwZXJfc2VjcmV0X3Yx", "data_crc32":null, "type":"opaque"}'
+        content_length: 133
+        body: '{"secret_id":"caedd6aa-562d-40dd-a2d7-3273a1e0beee","revision":3,"data":"bXlfc3VwZXJfc2VjcmV0X3Yx","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "137"
+                - "133"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:01:41 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 4640c518-9091-4fbe-8238-e35d151fe5ed
+                - 3d420bd6-d26e-40c7-a515-ee1c8e8a917a
         status: 200 OK
         code: 200
-        duration: 56.202985ms
+        duration: 32.953676ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -559,29 +559,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5da358e6-5214-4b7c-95ae-7ceae22a7da4/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/caedd6aa-562d-40dd-a2d7-3273a1e0beee/versions/3
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 328
-        body: '{"revision":2, "secret_id":"5da358e6-5214-4b7c-95ae-7ceae22a7da4", "status":"enabled", "created_at":"2026-02-03T16:01:41.112688Z", "updated_at":"2026-02-03T16:01:41.112688Z", "deleted_at":null, "description":"version1_from_ephemeral", "latest":false, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 316
+        body: '{"revision":3,"secret_id":"caedd6aa-562d-40dd-a2d7-3273a1e0beee","status":"enabled","created_at":"2026-07-03T15:28:01.638457Z","updated_at":"2026-07-03T15:28:01.638457Z","deleted_at":null,"description":"by_name_from_ephemeral","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "328"
+                - "316"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:01:41 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - b5d95c94-7146-446e-8dfb-a64976bbf8a9
+                - 2eddced1-2e6f-40d3-8023-fba190528204
         status: 200 OK
         code: 200
-        duration: 75.668751ms
+        duration: 34.764596ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -591,29 +591,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5da358e6-5214-4b7c-95ae-7ceae22a7da4/versions/3/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/caedd6aa-562d-40dd-a2d7-3273a1e0beee/versions/2/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 137
-        body: '{"secret_id":"5da358e6-5214-4b7c-95ae-7ceae22a7da4", "revision":3, "data":"bXlfc3VwZXJfc2VjcmV0X3Yx", "data_crc32":null, "type":"opaque"}'
+        content_length: 133
+        body: '{"secret_id":"caedd6aa-562d-40dd-a2d7-3273a1e0beee","revision":2,"data":"bXlfc3VwZXJfc2VjcmV0X3Yx","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "137"
+                - "133"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:01:41 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 27d34a89-ed20-4d9d-bddf-ec0a2b0a3b14
+                - 7c9fb585-d320-49c6-a3f5-d4542797abac
         status: 200 OK
         code: 200
-        duration: 107.778986ms
+        duration: 165.057831ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -623,29 +623,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5da358e6-5214-4b7c-95ae-7ceae22a7da4/versions/3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/caedd6aa-562d-40dd-a2d7-3273a1e0beee/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 326
-        body: '{"revision":3, "secret_id":"5da358e6-5214-4b7c-95ae-7ceae22a7da4", "status":"enabled", "created_at":"2026-02-03T16:01:41.164988Z", "updated_at":"2026-02-03T16:01:41.164988Z", "deleted_at":null, "description":"by_name_from_ephemeral", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 318
+        body: '{"revision":2,"secret_id":"caedd6aa-562d-40dd-a2d7-3273a1e0beee","status":"enabled","created_at":"2026-07-03T15:28:01.594979Z","updated_at":"2026-07-03T15:28:01.594979Z","deleted_at":null,"description":"version1_from_ephemeral","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "326"
+                - "318"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:01:41 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - f20c6cd9-09be-4bf2-9424-3fe4fcbc4af5
+                - 83230444-2e6e-459d-8be8-5c8df458b33a
         status: 200 OK
         code: 200
-        duration: 77.363467ms
+        duration: 75.665539ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -655,29 +655,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5da358e6-5214-4b7c-95ae-7ceae22a7da4/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/caedd6aa-562d-40dd-a2d7-3273a1e0beee/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 328
-        body: '{"revision":2, "secret_id":"5da358e6-5214-4b7c-95ae-7ceae22a7da4", "status":"enabled", "created_at":"2026-02-03T16:01:41.112688Z", "updated_at":"2026-02-03T16:01:41.112688Z", "deleted_at":null, "description":"version1_from_ephemeral", "latest":false, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 318
+        body: '{"revision":2,"secret_id":"caedd6aa-562d-40dd-a2d7-3273a1e0beee","status":"enabled","created_at":"2026-07-03T15:28:01.594979Z","updated_at":"2026-07-03T15:28:01.594979Z","deleted_at":null,"description":"version1_from_ephemeral","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "328"
+                - "318"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:01:41 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - f6791a20-adff-48cf-983a-c5508d5f3dcb
+                - 054f7ad9-c962-47b6-ba97-e6c9f8c0496f
         status: 200 OK
         code: 200
-        duration: 37.264256ms
+        duration: 51.974452ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -687,29 +687,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5da358e6-5214-4b7c-95ae-7ceae22a7da4/versions/3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/caedd6aa-562d-40dd-a2d7-3273a1e0beee/versions/3
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 326
-        body: '{"revision":3, "secret_id":"5da358e6-5214-4b7c-95ae-7ceae22a7da4", "status":"enabled", "created_at":"2026-02-03T16:01:41.164988Z", "updated_at":"2026-02-03T16:01:41.164988Z", "deleted_at":null, "description":"by_name_from_ephemeral", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 316
+        body: '{"revision":3,"secret_id":"caedd6aa-562d-40dd-a2d7-3273a1e0beee","status":"enabled","created_at":"2026-07-03T15:28:01.638457Z","updated_at":"2026-07-03T15:28:01.638457Z","deleted_at":null,"description":"by_name_from_ephemeral","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "326"
+                - "316"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:01:41 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 5963a1dc-9dd5-43a5-9887-a251abd63a26
+                - d4a63539-f753-48d6-a7c4-3681ac4b3b26
         status: 200 OK
         code: 200
-        duration: 36.660529ms
+        duration: 59.753943ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -730,29 +730,29 @@ interactions:
                 - unknown_type
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets?name=erSecretVersionByNameSecret&order_by=name_asc&project_id=105bdce1-64c0-48ab-899d-868455867ecf&scheduled_for_deletion=false&type=unknown_type
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 524
-        body: '{"secrets":[{"id":"5da358e6-5214-4b7c-95ae-7ceae22a7da4", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"erSecretVersionByNameSecret", "status":"ready", "created_at":"2026-02-03T16:01:39.879166Z", "updated_at":"2026-02-03T16:01:39.879166Z", "tags":["devtools", "provider", "terraform"], "version_count":3, "description":"", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}], "total_count":1}'
+        content_length: 504
+        body: '{"secrets":[{"id":"caedd6aa-562d-40dd-a2d7-3273a1e0beee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"erSecretVersionByNameSecret","status":"ready","created_at":"2026-07-03T15:28:00.703451Z","updated_at":"2026-07-03T15:28:00.703451Z","tags":["devtools","provider","terraform"],"version_count":3,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
-                - "524"
+                - "504"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:01:41 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - cafbf829-26f8-4cfb-85ca-9b06572406ba
+                - 0629f9b7-8590-4716-b98b-4e5f3d4b39d4
         status: 200 OK
         code: 200
-        duration: 36.883871ms
+        duration: 37.739915ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -773,29 +773,29 @@ interactions:
                 - unknown_type
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets?name=erSecretVersionByNameSecret&order_by=name_asc&project_id=105bdce1-64c0-48ab-899d-868455867ecf&scheduled_for_deletion=false&type=unknown_type
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 524
-        body: '{"secrets":[{"id":"5da358e6-5214-4b7c-95ae-7ceae22a7da4", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"erSecretVersionByNameSecret", "status":"ready", "created_at":"2026-02-03T16:01:39.879166Z", "updated_at":"2026-02-03T16:01:39.879166Z", "tags":["devtools", "provider", "terraform"], "version_count":3, "description":"", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}], "total_count":1}'
+        content_length: 504
+        body: '{"secrets":[{"id":"caedd6aa-562d-40dd-a2d7-3273a1e0beee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"erSecretVersionByNameSecret","status":"ready","created_at":"2026-07-03T15:28:00.703451Z","updated_at":"2026-07-03T15:28:00.703451Z","tags":["devtools","provider","terraform"],"version_count":3,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
-                - "524"
+                - "504"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:01:41 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 6776ecd9-062f-46d5-8ba1-c89ae0c8f5d0
+                - fd72766a-c6fa-41df-be60-17095401f747
         status: 200 OK
         code: 200
-        duration: 47.966428ms
+        duration: 103.138381ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -805,29 +805,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5da358e6-5214-4b7c-95ae-7ceae22a7da4/versions/latest/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/caedd6aa-562d-40dd-a2d7-3273a1e0beee/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 137
-        body: '{"secret_id":"5da358e6-5214-4b7c-95ae-7ceae22a7da4", "revision":3, "data":"bXlfc3VwZXJfc2VjcmV0X3Yx", "data_crc32":null, "type":"opaque"}'
+        content_length: 133
+        body: '{"secret_id":"caedd6aa-562d-40dd-a2d7-3273a1e0beee","revision":1,"data":"bXlfc3VwZXJfc2VjcmV0X3Yx","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "137"
+                - "133"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:01:41 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 7ee9f834-260c-4d6c-b728-aab5b48aed4b
+                - 5d3e2c3e-35cb-4e86-a952-5b6daa3c0a87
         status: 200 OK
         code: 200
-        duration: 52.061788ms
+        duration: 114.453914ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -837,29 +837,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5da358e6-5214-4b7c-95ae-7ceae22a7da4/versions/1/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/caedd6aa-562d-40dd-a2d7-3273a1e0beee/versions/latest/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 137
-        body: '{"secret_id":"5da358e6-5214-4b7c-95ae-7ceae22a7da4", "revision":1, "data":"bXlfc3VwZXJfc2VjcmV0X3Yx", "data_crc32":null, "type":"opaque"}'
+        content_length: 133
+        body: '{"secret_id":"caedd6aa-562d-40dd-a2d7-3273a1e0beee","revision":3,"data":"bXlfc3VwZXJfc2VjcmV0X3Yx","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "137"
+                - "133"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:01:41 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - a17a10d7-f874-4047-86a0-653b4994d73a
+                - 2b45db32-2dae-45d4-a9cb-f4a069254b04
         status: 200 OK
         code: 200
-        duration: 45.868262ms
+        duration: 50.949777ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -869,29 +869,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5da358e6-5214-4b7c-95ae-7ceae22a7da4/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/caedd6aa-562d-40dd-a2d7-3273a1e0beee/versions/3
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 313
-        body: '{"revision":1, "secret_id":"5da358e6-5214-4b7c-95ae-7ceae22a7da4", "status":"enabled", "created_at":"2026-02-03T16:01:40.502261Z", "updated_at":"2026-02-03T16:01:40.502261Z", "deleted_at":null, "description":"version1", "latest":false, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 316
+        body: '{"revision":3,"secret_id":"caedd6aa-562d-40dd-a2d7-3273a1e0beee","status":"enabled","created_at":"2026-07-03T15:28:01.638457Z","updated_at":"2026-07-03T15:28:01.638457Z","deleted_at":null,"description":"by_name_from_ephemeral","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "313"
+                - "316"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:01:41 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - baf19f69-a414-4f03-8b83-c41b796386d7
+                - b85d9535-d5ac-4c1c-882a-45cee1cc7c2e
         status: 200 OK
         code: 200
-        duration: 43.521305ms
+        duration: 50.149434ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -901,29 +901,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5da358e6-5214-4b7c-95ae-7ceae22a7da4/versions/3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/caedd6aa-562d-40dd-a2d7-3273a1e0beee/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 326
-        body: '{"revision":3, "secret_id":"5da358e6-5214-4b7c-95ae-7ceae22a7da4", "status":"enabled", "created_at":"2026-02-03T16:01:41.164988Z", "updated_at":"2026-02-03T16:01:41.164988Z", "deleted_at":null, "description":"by_name_from_ephemeral", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 303
+        body: '{"revision":1,"secret_id":"caedd6aa-562d-40dd-a2d7-3273a1e0beee","status":"enabled","created_at":"2026-07-03T15:28:01.105720Z","updated_at":"2026-07-03T15:28:01.105720Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "326"
+                - "303"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:01:41 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 6a71891f-421b-45e8-80f4-8caeb3dd3a42
+                - aa7ed2aa-7e9e-4393-86a4-20d6fa6d1105
         status: 200 OK
         code: 200
-        duration: 51.40378ms
+        duration: 50.705448ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -933,29 +933,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5da358e6-5214-4b7c-95ae-7ceae22a7da4/versions/2/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/caedd6aa-562d-40dd-a2d7-3273a1e0beee/versions/2/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 137
-        body: '{"secret_id":"5da358e6-5214-4b7c-95ae-7ceae22a7da4", "revision":2, "data":"bXlfc3VwZXJfc2VjcmV0X3Yx", "data_crc32":null, "type":"opaque"}'
+        content_length: 133
+        body: '{"secret_id":"caedd6aa-562d-40dd-a2d7-3273a1e0beee","revision":2,"data":"bXlfc3VwZXJfc2VjcmV0X3Yx","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "137"
+                - "133"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:01:41 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 9702cff8-1e4f-47c3-b2ef-b2f4d39ad694
+                - 23c4b7ff-a7ad-452d-a966-46adae879829
         status: 200 OK
         code: 200
-        duration: 55.09591ms
+        duration: 44.070446ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -965,29 +965,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5da358e6-5214-4b7c-95ae-7ceae22a7da4/versions/3/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/caedd6aa-562d-40dd-a2d7-3273a1e0beee/versions/3/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 137
-        body: '{"secret_id":"5da358e6-5214-4b7c-95ae-7ceae22a7da4", "revision":3, "data":"bXlfc3VwZXJfc2VjcmV0X3Yx", "data_crc32":null, "type":"opaque"}'
+        content_length: 133
+        body: '{"secret_id":"caedd6aa-562d-40dd-a2d7-3273a1e0beee","revision":3,"data":"bXlfc3VwZXJfc2VjcmV0X3Yx","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "137"
+                - "133"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:01:41 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 966e9b9c-df12-437a-8f23-4c3bcdc9729d
+                - 9f7c6ed0-5dcf-440a-a2e8-c0353e9b2e5c
         status: 200 OK
         code: 200
-        duration: 66.232928ms
+        duration: 45.806476ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -997,29 +997,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5da358e6-5214-4b7c-95ae-7ceae22a7da4/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/caedd6aa-562d-40dd-a2d7-3273a1e0beee/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 328
-        body: '{"revision":2, "secret_id":"5da358e6-5214-4b7c-95ae-7ceae22a7da4", "status":"enabled", "created_at":"2026-02-03T16:01:41.112688Z", "updated_at":"2026-02-03T16:01:41.112688Z", "deleted_at":null, "description":"version1_from_ephemeral", "latest":false, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 318
+        body: '{"revision":2,"secret_id":"caedd6aa-562d-40dd-a2d7-3273a1e0beee","status":"enabled","created_at":"2026-07-03T15:28:01.594979Z","updated_at":"2026-07-03T15:28:01.594979Z","deleted_at":null,"description":"version1_from_ephemeral","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "328"
+                - "318"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:01:41 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - e954d985-7cb1-4766-a3ca-63509a070b7d
+                - df79132a-5eb1-4c8f-ba8d-a5ef060e6760
         status: 200 OK
         code: 200
-        duration: 38.096788ms
+        duration: 36.17147ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1029,29 +1029,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5da358e6-5214-4b7c-95ae-7ceae22a7da4/versions/3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/caedd6aa-562d-40dd-a2d7-3273a1e0beee/versions/3
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 326
-        body: '{"revision":3, "secret_id":"5da358e6-5214-4b7c-95ae-7ceae22a7da4", "status":"enabled", "created_at":"2026-02-03T16:01:41.164988Z", "updated_at":"2026-02-03T16:01:41.164988Z", "deleted_at":null, "description":"by_name_from_ephemeral", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 316
+        body: '{"revision":3,"secret_id":"caedd6aa-562d-40dd-a2d7-3273a1e0beee","status":"enabled","created_at":"2026-07-03T15:28:01.638457Z","updated_at":"2026-07-03T15:28:01.638457Z","deleted_at":null,"description":"by_name_from_ephemeral","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "326"
+                - "316"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:01:41 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 00309812-cd94-4665-aba0-61f538298530
+                - d03ef935-6f01-4366-8c1f-abf325468f40
         status: 200 OK
         code: 200
-        duration: 37.341446ms
+        duration: 51.741223ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1061,29 +1061,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5da358e6-5214-4b7c-95ae-7ceae22a7da4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/caedd6aa-562d-40dd-a2d7-3273a1e0beee
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 493
-        body: '{"id":"5da358e6-5214-4b7c-95ae-7ceae22a7da4", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"erSecretVersionByNameSecret", "status":"ready", "created_at":"2026-02-03T16:01:39.879166Z", "updated_at":"2026-02-03T16:01:39.879166Z", "tags":["devtools", "provider", "terraform"], "version_count":3, "description":"", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}'
+        content_length: 474
+        body: '{"id":"caedd6aa-562d-40dd-a2d7-3273a1e0beee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"erSecretVersionByNameSecret","status":"ready","created_at":"2026-07-03T15:28:00.703451Z","updated_at":"2026-07-03T15:28:00.703451Z","tags":["devtools","provider","terraform"],"version_count":3,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "493"
+                - "474"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:01:42 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 2c5029a6-2902-4a53-b415-625531ebecfe
+                - 21f8c6ee-0285-4c1f-ad70-16e321d4a4da
         status: 200 OK
         code: 200
-        duration: 43.620743ms
+        duration: 31.301853ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1096,29 +1096,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5da358e6-5214-4b7c-95ae-7ceae22a7da4/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/caedd6aa-562d-40dd-a2d7-3273a1e0beee/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 1003
-        body: '{"versions":[{"revision":3, "secret_id":"5da358e6-5214-4b7c-95ae-7ceae22a7da4", "status":"enabled", "created_at":"2026-02-03T16:01:41.164988Z", "updated_at":"2026-02-03T16:01:41.164988Z", "deleted_at":null, "description":"by_name_from_ephemeral", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}, {"revision":2, "secret_id":"5da358e6-5214-4b7c-95ae-7ceae22a7da4", "status":"enabled", "created_at":"2026-02-03T16:01:41.112688Z", "updated_at":"2026-02-03T16:01:41.112688Z", "deleted_at":null, "description":"version1_from_ephemeral", "latest":false, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}, {"revision":1, "secret_id":"5da358e6-5214-4b7c-95ae-7ceae22a7da4", "status":"enabled", "created_at":"2026-02-03T16:01:40.502261Z", "updated_at":"2026-02-03T16:01:40.502261Z", "deleted_at":null, "description":"version1", "latest":false, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}], "total_count":3}'
+        content_length: 970
+        body: '{"versions":[{"revision":3,"secret_id":"caedd6aa-562d-40dd-a2d7-3273a1e0beee","status":"enabled","created_at":"2026-07-03T15:28:01.638457Z","updated_at":"2026-07-03T15:28:01.638457Z","deleted_at":null,"description":"by_name_from_ephemeral","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":2,"secret_id":"caedd6aa-562d-40dd-a2d7-3273a1e0beee","status":"enabled","created_at":"2026-07-03T15:28:01.594979Z","updated_at":"2026-07-03T15:28:01.594979Z","deleted_at":null,"description":"version1_from_ephemeral","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"caedd6aa-562d-40dd-a2d7-3273a1e0beee","status":"enabled","created_at":"2026-07-03T15:28:01.105720Z","updated_at":"2026-07-03T15:28:01.105720Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":3}'
         headers:
             Content-Length:
-                - "1003"
+                - "970"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:01:42 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 7dc7b11e-4a6f-454d-a8ba-2ed9240d5d4a
+                - cf030f4b-3558-44d9-9f85-59241698fbe9
         status: 200 OK
         code: 200
-        duration: 53.273558ms
+        duration: 43.73231ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1128,29 +1128,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5da358e6-5214-4b7c-95ae-7ceae22a7da4/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/caedd6aa-562d-40dd-a2d7-3273a1e0beee/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 313
-        body: '{"revision":1, "secret_id":"5da358e6-5214-4b7c-95ae-7ceae22a7da4", "status":"enabled", "created_at":"2026-02-03T16:01:40.502261Z", "updated_at":"2026-02-03T16:01:40.502261Z", "deleted_at":null, "description":"version1", "latest":false, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 303
+        body: '{"revision":1,"secret_id":"caedd6aa-562d-40dd-a2d7-3273a1e0beee","status":"enabled","created_at":"2026-07-03T15:28:01.105720Z","updated_at":"2026-07-03T15:28:01.105720Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "313"
+                - "303"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:01:42 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 45213c16-73e2-4c03-aea2-188126c1a6be
+                - 69d51240-2481-4e24-b19b-481ff343effa
         status: 200 OK
         code: 200
-        duration: 31.542186ms
+        duration: 44.023979ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1171,29 +1171,29 @@ interactions:
                 - unknown_type
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets?name=erSecretVersionByNameSecret&order_by=name_asc&project_id=105bdce1-64c0-48ab-899d-868455867ecf&scheduled_for_deletion=false&type=unknown_type
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 524
-        body: '{"secrets":[{"id":"5da358e6-5214-4b7c-95ae-7ceae22a7da4", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"erSecretVersionByNameSecret", "status":"ready", "created_at":"2026-02-03T16:01:39.879166Z", "updated_at":"2026-02-03T16:01:39.879166Z", "tags":["devtools", "provider", "terraform"], "version_count":3, "description":"", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}], "total_count":1}'
+        content_length: 504
+        body: '{"secrets":[{"id":"caedd6aa-562d-40dd-a2d7-3273a1e0beee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"erSecretVersionByNameSecret","status":"ready","created_at":"2026-07-03T15:28:00.703451Z","updated_at":"2026-07-03T15:28:00.703451Z","tags":["devtools","provider","terraform"],"version_count":3,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
-                - "524"
+                - "504"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:01:42 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 48640cc1-4bb8-46ab-8358-2f6e7aefd51f
+                - 2bbacdd7-2209-4ef9-b7bb-1bb1b0d55747
         status: 200 OK
         code: 200
-        duration: 59.994313ms
+        duration: 41.054441ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1214,29 +1214,29 @@ interactions:
                 - unknown_type
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets?name=erSecretVersionByNameSecret&order_by=name_asc&project_id=105bdce1-64c0-48ab-899d-868455867ecf&scheduled_for_deletion=false&type=unknown_type
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 524
-        body: '{"secrets":[{"id":"5da358e6-5214-4b7c-95ae-7ceae22a7da4", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"erSecretVersionByNameSecret", "status":"ready", "created_at":"2026-02-03T16:01:39.879166Z", "updated_at":"2026-02-03T16:01:39.879166Z", "tags":["devtools", "provider", "terraform"], "version_count":3, "description":"", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}], "total_count":1}'
+        content_length: 504
+        body: '{"secrets":[{"id":"caedd6aa-562d-40dd-a2d7-3273a1e0beee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"erSecretVersionByNameSecret","status":"ready","created_at":"2026-07-03T15:28:00.703451Z","updated_at":"2026-07-03T15:28:00.703451Z","tags":["devtools","provider","terraform"],"version_count":3,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
-                - "524"
+                - "504"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:01:42 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - b85dce48-7f90-4d3d-93db-3dbc53b7d661
+                - de4c1518-caf0-43c4-864e-074f472f6c88
         status: 200 OK
         code: 200
-        duration: 88.651387ms
+        duration: 41.001712ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1246,29 +1246,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5da358e6-5214-4b7c-95ae-7ceae22a7da4/versions/1/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/caedd6aa-562d-40dd-a2d7-3273a1e0beee/versions/latest/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 137
-        body: '{"secret_id":"5da358e6-5214-4b7c-95ae-7ceae22a7da4", "revision":1, "data":"bXlfc3VwZXJfc2VjcmV0X3Yx", "data_crc32":null, "type":"opaque"}'
+        content_length: 133
+        body: '{"secret_id":"caedd6aa-562d-40dd-a2d7-3273a1e0beee","revision":3,"data":"bXlfc3VwZXJfc2VjcmV0X3Yx","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "137"
+                - "133"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:01:42 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - d9e035ad-8411-45fb-8802-625d26c72342
+                - 8c716dd0-2e82-476d-b35d-ccb43608f57e
         status: 200 OK
         code: 200
-        duration: 129.357357ms
+        duration: 35.752142ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1278,29 +1278,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5da358e6-5214-4b7c-95ae-7ceae22a7da4/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/caedd6aa-562d-40dd-a2d7-3273a1e0beee/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 313
-        body: '{"revision":1, "secret_id":"5da358e6-5214-4b7c-95ae-7ceae22a7da4", "status":"enabled", "created_at":"2026-02-03T16:01:40.502261Z", "updated_at":"2026-02-03T16:01:40.502261Z", "deleted_at":null, "description":"version1", "latest":false, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 133
+        body: '{"secret_id":"caedd6aa-562d-40dd-a2d7-3273a1e0beee","revision":1,"data":"bXlfc3VwZXJfc2VjcmV0X3Yx","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "313"
+                - "133"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:01:42 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 8e216ec1-2e32-4c65-8b4f-5b6fd65d586c
+                - fe529d99-c8e7-4a0d-9ee6-91f75e78ec3a
         status: 200 OK
         code: 200
-        duration: 42.147264ms
+        duration: 40.973659ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1310,29 +1310,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5da358e6-5214-4b7c-95ae-7ceae22a7da4/versions/latest/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/caedd6aa-562d-40dd-a2d7-3273a1e0beee/versions/3
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 137
-        body: '{"secret_id":"5da358e6-5214-4b7c-95ae-7ceae22a7da4", "revision":3, "data":"bXlfc3VwZXJfc2VjcmV0X3Yx", "data_crc32":null, "type":"opaque"}'
+        content_length: 316
+        body: '{"revision":3,"secret_id":"caedd6aa-562d-40dd-a2d7-3273a1e0beee","status":"enabled","created_at":"2026-07-03T15:28:01.638457Z","updated_at":"2026-07-03T15:28:01.638457Z","deleted_at":null,"description":"by_name_from_ephemeral","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "137"
+                - "316"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:01:42 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 8cdd9651-a9bd-4406-b746-617f3f8d16ff
+                - 1d70e6c7-1abe-4960-b4f1-c1fd65250457
         status: 200 OK
         code: 200
-        duration: 152.554532ms
+        duration: 37.954238ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1342,29 +1342,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5da358e6-5214-4b7c-95ae-7ceae22a7da4/versions/3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/caedd6aa-562d-40dd-a2d7-3273a1e0beee/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 326
-        body: '{"revision":3, "secret_id":"5da358e6-5214-4b7c-95ae-7ceae22a7da4", "status":"enabled", "created_at":"2026-02-03T16:01:41.164988Z", "updated_at":"2026-02-03T16:01:41.164988Z", "deleted_at":null, "description":"by_name_from_ephemeral", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 303
+        body: '{"revision":1,"secret_id":"caedd6aa-562d-40dd-a2d7-3273a1e0beee","status":"enabled","created_at":"2026-07-03T15:28:01.105720Z","updated_at":"2026-07-03T15:28:01.105720Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "326"
+                - "303"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:01:42 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 68287390-a5c4-47d4-9aa8-73587b991c55
+                - 3615f9d6-51f5-4a6d-ba61-51c474775d1c
         status: 200 OK
         code: 200
-        duration: 116.504493ms
+        duration: 51.213312ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -1374,29 +1374,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5da358e6-5214-4b7c-95ae-7ceae22a7da4/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/caedd6aa-562d-40dd-a2d7-3273a1e0beee/versions/3
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 328
-        body: '{"revision":2, "secret_id":"5da358e6-5214-4b7c-95ae-7ceae22a7da4", "status":"enabled", "created_at":"2026-02-03T16:01:41.112688Z", "updated_at":"2026-02-03T16:01:41.112688Z", "deleted_at":null, "description":"version1_from_ephemeral", "latest":false, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 316
+        body: '{"revision":3,"secret_id":"caedd6aa-562d-40dd-a2d7-3273a1e0beee","status":"enabled","created_at":"2026-07-03T15:28:01.638457Z","updated_at":"2026-07-03T15:28:01.638457Z","deleted_at":null,"description":"by_name_from_ephemeral","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "328"
+                - "316"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:01:42 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 7c4623e0-7ba4-4426-b396-3c7d841f3e00
+                - 35515f09-e4c7-41a1-ba25-0aadf9414bb4
         status: 200 OK
         code: 200
-        duration: 121.757324ms
+        duration: 35.111108ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -1406,29 +1406,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5da358e6-5214-4b7c-95ae-7ceae22a7da4/versions/3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/caedd6aa-562d-40dd-a2d7-3273a1e0beee/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 326
-        body: '{"revision":3, "secret_id":"5da358e6-5214-4b7c-95ae-7ceae22a7da4", "status":"enabled", "created_at":"2026-02-03T16:01:41.164988Z", "updated_at":"2026-02-03T16:01:41.164988Z", "deleted_at":null, "description":"by_name_from_ephemeral", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 318
+        body: '{"revision":2,"secret_id":"caedd6aa-562d-40dd-a2d7-3273a1e0beee","status":"enabled","created_at":"2026-07-03T15:28:01.594979Z","updated_at":"2026-07-03T15:28:01.594979Z","deleted_at":null,"description":"version1_from_ephemeral","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "326"
+                - "318"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:01:42 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 60ab7a08-fa66-4e7f-a6d8-276c86703045
+                - 3b02435c-8319-4c49-b589-b0fe90047ce2
         status: 200 OK
         code: 200
-        duration: 46.382126ms
+        duration: 35.012853ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -1438,29 +1438,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5da358e6-5214-4b7c-95ae-7ceae22a7da4/versions/2/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/caedd6aa-562d-40dd-a2d7-3273a1e0beee/versions/3/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 137
-        body: '{"secret_id":"5da358e6-5214-4b7c-95ae-7ceae22a7da4", "revision":2, "data":"bXlfc3VwZXJfc2VjcmV0X3Yx", "data_crc32":null, "type":"opaque"}'
+        content_length: 133
+        body: '{"secret_id":"caedd6aa-562d-40dd-a2d7-3273a1e0beee","revision":3,"data":"bXlfc3VwZXJfc2VjcmV0X3Yx","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "137"
+                - "133"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:01:42 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 8ba24171-4202-417b-bd63-1b96e58df70c
+                - 05b05eab-0234-4249-a8c9-5407fadc9522
         status: 200 OK
         code: 200
-        duration: 54.827774ms
+        duration: 43.126313ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -1470,29 +1470,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5da358e6-5214-4b7c-95ae-7ceae22a7da4/versions/3/access
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/caedd6aa-562d-40dd-a2d7-3273a1e0beee/versions/2/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 137
-        body: '{"secret_id":"5da358e6-5214-4b7c-95ae-7ceae22a7da4", "revision":3, "data":"bXlfc3VwZXJfc2VjcmV0X3Yx", "data_crc32":null, "type":"opaque"}'
+        content_length: 133
+        body: '{"secret_id":"caedd6aa-562d-40dd-a2d7-3273a1e0beee","revision":2,"data":"bXlfc3VwZXJfc2VjcmV0X3Yx","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "137"
+                - "133"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:01:42 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 2391e153-cd5a-45ee-91d3-4f03b22edc55
+                - 1bf25813-ee50-489a-b2f1-06eaf65f115f
         status: 200 OK
         code: 200
-        duration: 91.869728ms
+        duration: 40.644391ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -1502,29 +1502,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5da358e6-5214-4b7c-95ae-7ceae22a7da4/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/caedd6aa-562d-40dd-a2d7-3273a1e0beee/versions/3
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 328
-        body: '{"revision":2, "secret_id":"5da358e6-5214-4b7c-95ae-7ceae22a7da4", "status":"enabled", "created_at":"2026-02-03T16:01:41.112688Z", "updated_at":"2026-02-03T16:01:41.112688Z", "deleted_at":null, "description":"version1_from_ephemeral", "latest":false, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 316
+        body: '{"revision":3,"secret_id":"caedd6aa-562d-40dd-a2d7-3273a1e0beee","status":"enabled","created_at":"2026-07-03T15:28:01.638457Z","updated_at":"2026-07-03T15:28:01.638457Z","deleted_at":null,"description":"by_name_from_ephemeral","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "328"
+                - "316"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:01:42 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 1c424521-619d-4e5a-9943-73f973bc39eb
+                - d23e2d88-551d-4097-be9d-ac8747943d19
         status: 200 OK
         code: 200
-        duration: 86.180493ms
+        duration: 41.198352ms
     - id: 45
       request:
         proto: HTTP/1.1
@@ -1534,29 +1534,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5da358e6-5214-4b7c-95ae-7ceae22a7da4/versions/3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/caedd6aa-562d-40dd-a2d7-3273a1e0beee/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 326
-        body: '{"revision":3, "secret_id":"5da358e6-5214-4b7c-95ae-7ceae22a7da4", "status":"enabled", "created_at":"2026-02-03T16:01:41.164988Z", "updated_at":"2026-02-03T16:01:41.164988Z", "deleted_at":null, "description":"by_name_from_ephemeral", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 318
+        body: '{"revision":2,"secret_id":"caedd6aa-562d-40dd-a2d7-3273a1e0beee","status":"enabled","created_at":"2026-07-03T15:28:01.594979Z","updated_at":"2026-07-03T15:28:01.594979Z","deleted_at":null,"description":"version1_from_ephemeral","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "326"
+                - "318"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:01:42 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 85b77064-33c9-4b0b-bba6-66d1d4794d20
+                - 32291728-5b90-47a5-bf6a-ae4356915c94
         status: 200 OK
         code: 200
-        duration: 41.247752ms
+        duration: 40.795826ms
     - id: 46
       request:
         proto: HTTP/1.1
@@ -1566,8 +1566,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5da358e6-5214-4b7c-95ae-7ceae22a7da4/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/caedd6aa-562d-40dd-a2d7-3273a1e0beee/versions/2
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1579,14 +1579,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:01:43 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 1c26aa7c-5b6a-436f-8cf4-507b9b9e2a52
+                - 840b3f51-46c4-474b-9d51-ae51cc1e01f7
         status: 204 No Content
         code: 204
-        duration: 164.584159ms
+        duration: 61.655245ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -1596,8 +1596,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5da358e6-5214-4b7c-95ae-7ceae22a7da4/versions/3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/caedd6aa-562d-40dd-a2d7-3273a1e0beee/versions/3
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1609,14 +1609,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:01:43 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 67b93e49-c7fa-4932-b5f3-e768e0c6899f
+                - 4a15ec0d-3a8f-4c82-b510-725ba41cdcdf
         status: 204 No Content
         code: 204
-        duration: 164.677023ms
+        duration: 156.563767ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -1626,8 +1626,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5da358e6-5214-4b7c-95ae-7ceae22a7da4/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/caedd6aa-562d-40dd-a2d7-3273a1e0beee/versions/1
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1639,14 +1639,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:01:43 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - bb7089f4-bab4-439d-a4d4-9ad9aba7b931
+                - fbcad685-59ce-4f05-81f5-19c40f87ba32
         status: 204 No Content
         code: 204
-        duration: 111.219177ms
+        duration: 68.46255ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -1656,8 +1656,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5da358e6-5214-4b7c-95ae-7ceae22a7da4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/caedd6aa-562d-40dd-a2d7-3273a1e0beee
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1669,14 +1669,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:01:43 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 8c4af75e-dfea-4662-a8f1-93f54a1cb14b
+                - 94f3dea7-34b7-44e2-b264-ecbe5cc4747a
         status: 204 No Content
         code: 204
-        duration: 80.60154ms
+        duration: 71.324937ms
     - id: 50
       request:
         proto: HTTP/1.1
@@ -1686,26 +1686,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5da358e6-5214-4b7c-95ae-7ceae22a7da4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/caedd6aa-562d-40dd-a2d7-3273a1e0beee
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 518
-        body: '{"id":"5da358e6-5214-4b7c-95ae-7ceae22a7da4", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"erSecretVersionByNameSecret", "status":"ready", "created_at":"2026-02-03T16:01:39.879166Z", "updated_at":"2026-02-03T16:01:39.879166Z", "tags":["devtools", "provider", "terraform"], "version_count":3, "description":"", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":"2026-02-03T16:01:43.311804Z", "key_id":null, "region":"fr-par"}'
+        content_length: 499
+        body: '{"id":"caedd6aa-562d-40dd-a2d7-3273a1e0beee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"erSecretVersionByNameSecret","status":"ready","created_at":"2026-07-03T15:28:00.703451Z","updated_at":"2026-07-03T15:28:04.505834Z","tags":["devtools","provider","terraform"],"version_count":3,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-07-03T15:28:04.505834Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "518"
+                - "499"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 16:01:43 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - dd72c3e0-0a63-459b-904b-3ffeed2570f7
+                - 889d869f-51d6-4b2a-93ad-8c108c9fb220
         status: 200 OK
         code: 200
-        duration: 45.881976ms
+        duration: 46.92128ms

--- a/internal/services/secret/testdata/list-secret-versions-all-secrets.cassette.yaml
+++ b/internal/services/secret/testdata/list-secret-versions-all-secrets.cassette.yaml
@@ -13,7 +13,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets
         method: POST
       response:
@@ -21,21 +21,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 439
-        body: '{"id":"8aa68a52-b2ec-491b-83e4-090c6d905729","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-version-all-1","status":"ready","created_at":"2026-06-04T09:49:33.714643Z","updated_at":"2026-06-04T09:49:33.714643Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"695f8a21-f14a-4506-8103-7d37eef09227","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-version-all-1","status":"ready","created_at":"2026-07-03T15:27:57.376047Z","updated_at":"2026-07-03T15:27:57.376047Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "439"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:33 GMT
+                - Fri, 03 Jul 2026 15:27:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - c6c53776-a43e-4b5a-a476-a43b7a38877b
+                - c7cf9510-86d7-4795-8238-4bb85e1a4b90
         status: 200 OK
         code: 200
-        duration: 209.702748ms
+        duration: 1.089616688s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -45,29 +45,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8aa68a52-b2ec-491b-83e4-090c6d905729
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/695f8a21-f14a-4506-8103-7d37eef09227
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 439
-        body: '{"id":"8aa68a52-b2ec-491b-83e4-090c6d905729","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-version-all-1","status":"ready","created_at":"2026-06-04T09:49:33.714643Z","updated_at":"2026-06-04T09:49:33.714643Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"695f8a21-f14a-4506-8103-7d37eef09227","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-version-all-1","status":"ready","created_at":"2026-07-03T15:27:57.376047Z","updated_at":"2026-07-03T15:27:57.376047Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "439"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:33 GMT
+                - Fri, 03 Jul 2026 15:27:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 2a7fd8c2-f64f-49f1-9e2c-fbb7ab832b3e
+                - 60072dc1-3b9e-45db-ab88-17c3e168a102
         status: 200 OK
         code: 200
-        duration: 47.736723ms
+        duration: 47.785503ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -80,8 +80,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8aa68a52-b2ec-491b-83e4-090c6d905729/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/695f8a21-f14a-4506-8103-7d37eef09227/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -95,14 +95,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:33 GMT
+                - Fri, 03 Jul 2026 15:27:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 1b1caa84-fbd7-40b5-86b1-2f5916522806
+                - ef7cce1f-d851-48e4-92d0-bc7cc18e33af
         status: 200 OK
         code: 200
-        duration: 50.196314ms
+        duration: 54.458507ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -115,29 +115,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8aa68a52-b2ec-491b-83e4-090c6d905729/versions
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/695f8a21-f14a-4506-8103-7d37eef09227/versions
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 294
-        body: '{"revision":1,"secret_id":"8aa68a52-b2ec-491b-83e4-090c6d905729","status":"enabled","created_at":"2026-06-04T09:49:34.262686Z","updated_at":"2026-06-04T09:49:34.262686Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"695f8a21-f14a-4506-8103-7d37eef09227","status":"enabled","created_at":"2026-07-03T15:27:58.780042Z","updated_at":"2026-07-03T15:27:58.780042Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "294"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:34 GMT
+                - Fri, 03 Jul 2026 15:27:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 33025053-4c66-4666-a017-f653c245167f
+                - 80c8e49f-17c2-4ec4-88e7-e0c6e299fc9f
         status: 200 OK
         code: 200
-        duration: 453.366995ms
+        duration: 375.909264ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -147,29 +147,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8aa68a52-b2ec-491b-83e4-090c6d905729/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/695f8a21-f14a-4506-8103-7d37eef09227/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 294
-        body: '{"revision":1,"secret_id":"8aa68a52-b2ec-491b-83e4-090c6d905729","status":"enabled","created_at":"2026-06-04T09:49:34.262686Z","updated_at":"2026-06-04T09:49:34.262686Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"695f8a21-f14a-4506-8103-7d37eef09227","status":"enabled","created_at":"2026-07-03T15:27:58.780042Z","updated_at":"2026-07-03T15:27:58.780042Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "294"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:34 GMT
+                - Fri, 03 Jul 2026 15:27:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - a0f3ab3f-a587-45e8-986b-52bcd1cccc3c
+                - d71bb07b-4581-48a8-8ba2-7dee8b9e9421
         status: 200 OK
         code: 200
-        duration: 49.942019ms
+        duration: 40.63346ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -179,29 +179,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8aa68a52-b2ec-491b-83e4-090c6d905729
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/695f8a21-f14a-4506-8103-7d37eef09227
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 439
-        body: '{"id":"8aa68a52-b2ec-491b-83e4-090c6d905729","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-version-all-1","status":"ready","created_at":"2026-06-04T09:49:33.714643Z","updated_at":"2026-06-04T09:49:33.714643Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"695f8a21-f14a-4506-8103-7d37eef09227","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-version-all-1","status":"ready","created_at":"2026-07-03T15:27:57.376047Z","updated_at":"2026-07-03T15:27:57.376047Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "439"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:34 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 6876a03f-e5cc-41ab-8cef-fce4cb496b24
+                - 83ca1931-3de4-465f-84e4-62750ee06565
         status: 200 OK
         code: 200
-        duration: 38.178292ms
+        duration: 50.494882ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -214,29 +214,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8aa68a52-b2ec-491b-83e4-090c6d905729/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/695f8a21-f14a-4506-8103-7d37eef09227/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 325
-        body: '{"versions":[{"revision":1,"secret_id":"8aa68a52-b2ec-491b-83e4-090c6d905729","status":"enabled","created_at":"2026-06-04T09:49:34.262686Z","updated_at":"2026-06-04T09:49:34.262686Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        body: '{"versions":[{"revision":1,"secret_id":"695f8a21-f14a-4506-8103-7d37eef09227","status":"enabled","created_at":"2026-07-03T15:27:58.780042Z","updated_at":"2026-07-03T15:27:58.780042Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "325"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:34 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 8fcf6c15-f287-4719-91a3-8d6d50a32903
+                - 9af3ec4b-94c2-41dc-b4d0-9a266ff18ec9
         status: 200 OK
         code: 200
-        duration: 80.665005ms
+        duration: 60.8062ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -246,29 +246,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8aa68a52-b2ec-491b-83e4-090c6d905729/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/695f8a21-f14a-4506-8103-7d37eef09227/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 294
-        body: '{"revision":1,"secret_id":"8aa68a52-b2ec-491b-83e4-090c6d905729","status":"enabled","created_at":"2026-06-04T09:49:34.262686Z","updated_at":"2026-06-04T09:49:34.262686Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"695f8a21-f14a-4506-8103-7d37eef09227","status":"enabled","created_at":"2026-07-03T15:27:58.780042Z","updated_at":"2026-07-03T15:27:58.780042Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "294"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:34 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 5edb87ae-ab63-4011-b39f-2b0168a00b76
+                - 49e3920f-0cd2-4d7a-8c50-87816f14166b
         status: 200 OK
         code: 200
-        duration: 44.576983ms
+        duration: 48.690534ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -278,29 +278,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8aa68a52-b2ec-491b-83e4-090c6d905729
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/695f8a21-f14a-4506-8103-7d37eef09227
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 439
-        body: '{"id":"8aa68a52-b2ec-491b-83e4-090c6d905729","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-version-all-1","status":"ready","created_at":"2026-06-04T09:49:33.714643Z","updated_at":"2026-06-04T09:49:33.714643Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"695f8a21-f14a-4506-8103-7d37eef09227","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-version-all-1","status":"ready","created_at":"2026-07-03T15:27:57.376047Z","updated_at":"2026-07-03T15:27:57.376047Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "439"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:35 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - b2f07891-19ac-4b69-9d0c-82e7d0d1b281
+                - b40cd2b2-2d50-4d67-8b53-fecc45c6f337
         status: 200 OK
         code: 200
-        duration: 50.284431ms
+        duration: 35.115215ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -313,29 +313,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8aa68a52-b2ec-491b-83e4-090c6d905729/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/695f8a21-f14a-4506-8103-7d37eef09227/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 325
-        body: '{"versions":[{"revision":1,"secret_id":"8aa68a52-b2ec-491b-83e4-090c6d905729","status":"enabled","created_at":"2026-06-04T09:49:34.262686Z","updated_at":"2026-06-04T09:49:34.262686Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        body: '{"versions":[{"revision":1,"secret_id":"695f8a21-f14a-4506-8103-7d37eef09227","status":"enabled","created_at":"2026-07-03T15:27:58.780042Z","updated_at":"2026-07-03T15:27:58.780042Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "325"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:35 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 57747643-f441-49e4-b42d-795664d2278f
+                - 81e78b73-3b3e-4ede-9ab1-534ed4dce5d1
         status: 200 OK
         code: 200
-        duration: 71.762591ms
+        duration: 53.401542ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -345,29 +345,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8aa68a52-b2ec-491b-83e4-090c6d905729/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/695f8a21-f14a-4506-8103-7d37eef09227/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 294
-        body: '{"revision":1,"secret_id":"8aa68a52-b2ec-491b-83e4-090c6d905729","status":"enabled","created_at":"2026-06-04T09:49:34.262686Z","updated_at":"2026-06-04T09:49:34.262686Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"695f8a21-f14a-4506-8103-7d37eef09227","status":"enabled","created_at":"2026-07-03T15:27:58.780042Z","updated_at":"2026-07-03T15:27:58.780042Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "294"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:35 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 4cba214d-cc9e-41fb-9863-4922165f278c
+                - 13285ba1-621f-4318-908a-768869acf665
         status: 200 OK
         code: 200
-        duration: 44.914004ms
+        duration: 34.339017ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -380,7 +380,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets
         method: POST
       response:
@@ -388,21 +388,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 439
-        body: '{"id":"30ba3bf0-c5d4-43aa-89dc-6d396835182f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-version-all-2","status":"ready","created_at":"2026-06-04T09:49:35.461289Z","updated_at":"2026-06-04T09:49:35.461289Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"02bbcfdd-6da4-45da-8614-c7c930289009","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-version-all-2","status":"ready","created_at":"2026-07-03T15:28:00.318708Z","updated_at":"2026-07-03T15:28:00.318708Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "439"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:35 GMT
+                - Fri, 03 Jul 2026 15:28:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 7721fd0b-b8df-4c03-a69c-2dc50a638e45
+                - e923e3ea-f459-46ed-b197-8b627fb32621
         status: 200 OK
         code: 200
-        duration: 100.651546ms
+        duration: 82.077613ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -412,29 +412,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/30ba3bf0-c5d4-43aa-89dc-6d396835182f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/02bbcfdd-6da4-45da-8614-c7c930289009
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 439
-        body: '{"id":"30ba3bf0-c5d4-43aa-89dc-6d396835182f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-version-all-2","status":"ready","created_at":"2026-06-04T09:49:35.461289Z","updated_at":"2026-06-04T09:49:35.461289Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"02bbcfdd-6da4-45da-8614-c7c930289009","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-version-all-2","status":"ready","created_at":"2026-07-03T15:28:00.318708Z","updated_at":"2026-07-03T15:28:00.318708Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "439"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:35 GMT
+                - Fri, 03 Jul 2026 15:28:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - b41bff57-bd39-4f79-acaa-977c951ec30b
+                - 6be5d0ce-2fa8-4284-a062-cc84ead8fa2c
         status: 200 OK
         code: 200
-        duration: 52.84445ms
+        duration: 51.769015ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -447,8 +447,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/30ba3bf0-c5d4-43aa-89dc-6d396835182f/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/02bbcfdd-6da4-45da-8614-c7c930289009/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -462,14 +462,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:35 GMT
+                - Fri, 03 Jul 2026 15:28:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 6a3b77d2-41a8-4d8b-a8cb-7518d57d3ede
+                - b369f6a6-09f5-4878-a307-12355279443a
         status: 200 OK
         code: 200
-        duration: 63.974391ms
+        duration: 57.177224ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -482,29 +482,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/30ba3bf0-c5d4-43aa-89dc-6d396835182f/versions
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/02bbcfdd-6da4-45da-8614-c7c930289009/versions
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 294
-        body: '{"revision":1,"secret_id":"30ba3bf0-c5d4-43aa-89dc-6d396835182f","status":"enabled","created_at":"2026-06-04T09:49:35.835238Z","updated_at":"2026-06-04T09:49:35.835238Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"02bbcfdd-6da4-45da-8614-c7c930289009","status":"enabled","created_at":"2026-07-03T15:28:00.813553Z","updated_at":"2026-07-03T15:28:00.813553Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "294"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:35 GMT
+                - Fri, 03 Jul 2026 15:28:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 7f0343b5-c989-4f7a-9a60-15a374a976c9
+                - 6d1e94be-116a-4191-91f2-75cdda9d602e
         status: 200 OK
         code: 200
-        duration: 242.692894ms
+        duration: 383.767905ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -514,29 +514,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/30ba3bf0-c5d4-43aa-89dc-6d396835182f/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/02bbcfdd-6da4-45da-8614-c7c930289009/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 294
-        body: '{"revision":1,"secret_id":"30ba3bf0-c5d4-43aa-89dc-6d396835182f","status":"enabled","created_at":"2026-06-04T09:49:35.835238Z","updated_at":"2026-06-04T09:49:35.835238Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"02bbcfdd-6da4-45da-8614-c7c930289009","status":"enabled","created_at":"2026-07-03T15:28:00.813553Z","updated_at":"2026-07-03T15:28:00.813553Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "294"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:35 GMT
+                - Fri, 03 Jul 2026 15:28:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 44d3ef41-b7ec-4f32-88b4-32bf6e220ffb
+                - be68eae8-c0e5-4f3b-b104-10608f92eb32
         status: 200 OK
         code: 200
-        duration: 40.498744ms
+        duration: 54.600453ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -546,29 +546,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/30ba3bf0-c5d4-43aa-89dc-6d396835182f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/02bbcfdd-6da4-45da-8614-c7c930289009
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 439
-        body: '{"id":"30ba3bf0-c5d4-43aa-89dc-6d396835182f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-version-all-2","status":"ready","created_at":"2026-06-04T09:49:35.461289Z","updated_at":"2026-06-04T09:49:35.461289Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"02bbcfdd-6da4-45da-8614-c7c930289009","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-version-all-2","status":"ready","created_at":"2026-07-03T15:28:00.318708Z","updated_at":"2026-07-03T15:28:00.318708Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "439"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:36 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 460813e0-3120-479b-a173-4d15cdb57387
+                - adbe3613-da14-459d-9415-05d7e3e1ba58
         status: 200 OK
         code: 200
-        duration: 52.770674ms
+        duration: 38.792402ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -578,29 +578,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8aa68a52-b2ec-491b-83e4-090c6d905729
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/695f8a21-f14a-4506-8103-7d37eef09227
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 439
-        body: '{"id":"8aa68a52-b2ec-491b-83e4-090c6d905729","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-version-all-1","status":"ready","created_at":"2026-06-04T09:49:33.714643Z","updated_at":"2026-06-04T09:49:33.714643Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"695f8a21-f14a-4506-8103-7d37eef09227","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-version-all-1","status":"ready","created_at":"2026-07-03T15:27:57.376047Z","updated_at":"2026-07-03T15:27:57.376047Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "439"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:36 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 7cc7ec85-fe8c-46ff-913a-113d78d43080
+                - 958b56b2-a9b9-437e-9219-def3a1858822
         status: 200 OK
         code: 200
-        duration: 58.660332ms
+        duration: 45.580632ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -613,29 +613,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/30ba3bf0-c5d4-43aa-89dc-6d396835182f/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/02bbcfdd-6da4-45da-8614-c7c930289009/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 325
-        body: '{"versions":[{"revision":1,"secret_id":"30ba3bf0-c5d4-43aa-89dc-6d396835182f","status":"enabled","created_at":"2026-06-04T09:49:35.835238Z","updated_at":"2026-06-04T09:49:35.835238Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        body: '{"versions":[{"revision":1,"secret_id":"02bbcfdd-6da4-45da-8614-c7c930289009","status":"enabled","created_at":"2026-07-03T15:28:00.813553Z","updated_at":"2026-07-03T15:28:00.813553Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "325"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:36 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - a7b5df2a-3e81-4a58-b697-e8d719024eec
+                - a3759e8d-59e4-4e45-a4d5-dce5d0f774a6
         status: 200 OK
         code: 200
-        duration: 39.529472ms
+        duration: 65.420156ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -648,29 +648,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8aa68a52-b2ec-491b-83e4-090c6d905729/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/695f8a21-f14a-4506-8103-7d37eef09227/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 325
-        body: '{"versions":[{"revision":1,"secret_id":"8aa68a52-b2ec-491b-83e4-090c6d905729","status":"enabled","created_at":"2026-06-04T09:49:34.262686Z","updated_at":"2026-06-04T09:49:34.262686Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        body: '{"versions":[{"revision":1,"secret_id":"695f8a21-f14a-4506-8103-7d37eef09227","status":"enabled","created_at":"2026-07-03T15:27:58.780042Z","updated_at":"2026-07-03T15:27:58.780042Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "325"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:36 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - be59fe23-5135-486a-94ba-fbe70ffea9de
+                - 47779024-aa25-4012-8da1-c037e2622596
         status: 200 OK
         code: 200
-        duration: 63.47032ms
+        duration: 57.798971ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -680,29 +680,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/30ba3bf0-c5d4-43aa-89dc-6d396835182f/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/02bbcfdd-6da4-45da-8614-c7c930289009/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 294
-        body: '{"revision":1,"secret_id":"30ba3bf0-c5d4-43aa-89dc-6d396835182f","status":"enabled","created_at":"2026-06-04T09:49:35.835238Z","updated_at":"2026-06-04T09:49:35.835238Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"02bbcfdd-6da4-45da-8614-c7c930289009","status":"enabled","created_at":"2026-07-03T15:28:00.813553Z","updated_at":"2026-07-03T15:28:00.813553Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "294"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:36 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - f9655c88-a18f-4c92-a319-dfccaa390c79
+                - df5fa6ad-406a-45a2-b2c2-76e306131b1d
         status: 200 OK
         code: 200
-        duration: 33.492598ms
+        duration: 40.906263ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -712,29 +712,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8aa68a52-b2ec-491b-83e4-090c6d905729/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/695f8a21-f14a-4506-8103-7d37eef09227/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 294
-        body: '{"revision":1,"secret_id":"8aa68a52-b2ec-491b-83e4-090c6d905729","status":"enabled","created_at":"2026-06-04T09:49:34.262686Z","updated_at":"2026-06-04T09:49:34.262686Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"695f8a21-f14a-4506-8103-7d37eef09227","status":"enabled","created_at":"2026-07-03T15:27:58.780042Z","updated_at":"2026-07-03T15:27:58.780042Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "294"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:36 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - e7fc1653-c030-482b-9be7-36a880493f33
+                - 04b9ed47-7548-4a28-a7a1-ca935f3d0344
         status: 200 OK
         code: 200
-        duration: 60.313213ms
+        duration: 50.329772ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -755,29 +755,29 @@ interactions:
                 - unknown_type
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets?order_by=name_asc&page=1&project_id=105bdce1-64c0-48ab-899d-868455867ecf&scheduled_for_deletion=false&type=unknown_type
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 2220
-        body: '{"secrets":[{"id":"2c4667fd-76d8-4205-b60b-efc0cd3ce15f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-multi-1","status":"ready","created_at":"2026-06-04T09:49:33.744869Z","updated_at":"2026-06-04T09:49:33.744869Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"cbfa0f8d-5515-4516-9d3c-7a53761312b9","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-multi-2","status":"ready","created_at":"2026-06-04T09:49:35.223211Z","updated_at":"2026-06-04T09:49:35.223211Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"8aa68a52-b2ec-491b-83e4-090c6d905729","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-version-all-1","status":"ready","created_at":"2026-06-04T09:49:33.714643Z","updated_at":"2026-06-04T09:49:33.714643Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"30ba3bf0-c5d4-43aa-89dc-6d396835182f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-version-all-2","status":"ready","created_at":"2026-06-04T09:49:35.461289Z","updated_at":"2026-06-04T09:49:35.461289Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"a115f047-311a-483b-a194-eec3276d00d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-version-filter-1","status":"ready","created_at":"2026-06-04T09:49:33.690641Z","updated_at":"2026-06-04T09:49:33.690641Z","tags":[],"version_count":2,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}],"total_count":6}'
+        content_length: 18295
+        body: '{"secrets":[{"id":"40cb655e-0b83-4cba-8de5-ed05b59bbf6e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"connection_08d6273a-c2b5-46e5-b354-3fe4c0479914","status":"ready","created_at":"2026-06-16T03:39:38.598272Z","updated_at":"2026-06-16T03:39:38.598272Z","tags":["S2S VPN"],"version_count":1,"description":"Generated by Scaleway","managed":false,"type":"opaque","protected":true,"path":"/s2s_vpn","ephemeral_policy":null,"used_by":["s2s_vpn"],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"1eb6c146-1818-452b-b826-a8e4621b99d8","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"connection_2218b908-d9a5-44b7-8c09-68a460b916c1","status":"ready","created_at":"2026-06-30T03:03:53.867704Z","updated_at":"2026-06-30T03:03:53.867704Z","tags":["S2S VPN"],"version_count":1,"description":"Generated by Scaleway","managed":false,"type":"opaque","protected":true,"path":"/s2s_vpn","ephemeral_policy":null,"used_by":["s2s_vpn"],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"0cda53cf-8fee-4e91-b213-8a2b694d6f59","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"connection_28bd4354-390f-49e4-80af-05bf69ec081c","status":"ready","created_at":"2026-06-13T03:00:04.370651Z","updated_at":"2026-06-13T03:00:04.370651Z","tags":["S2S VPN"],"version_count":1,"description":"Generated by Scaleway","managed":false,"type":"opaque","protected":true,"path":"/s2s_vpn","ephemeral_policy":null,"used_by":["s2s_vpn"],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"6565cc4a-8b55-4f35-8169-a8a2eff35aac","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"connection_2f4a7c59-b5e2-485a-a443-5ac94ab7bf52","status":"ready","created_at":"2026-06-23T02:54:56.356466Z","updated_at":"2026-06-23T02:54:56.356466Z","tags":["S2S VPN"],"version_count":1,"description":"Generated by Scaleway","managed":false,"type":"opaque","protected":true,"path":"/s2s_vpn","ephemeral_policy":null,"used_by":["s2s_vpn"],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"932f9b5d-10f2-4d45-8e89-88bd6fb5b415","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"connection_38db8a48-71b2-4da0-a0f1-ac4ca533fad6","status":"ready","created_at":"2026-06-10T02:55:49.355268Z","updated_at":"2026-06-10T02:55:49.355268Z","tags":["S2S VPN"],"version_count":1,"description":"Generated by Scaleway","managed":false,"type":"opaque","protected":true,"path":"/s2s_vpn","ephemeral_policy":null,"used_by":["s2s_vpn"],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"03a5e79f-e5d8-46b4-9d78-4b012a4960f8","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"connection_3a323e68-069a-4c54-b729-d70c1f5dc749","status":"ready","created_at":"2026-06-09T02:47:26.614803Z","updated_at":"2026-06-09T02:47:26.614803Z","tags":["S2S VPN"],"version_count":1,"description":"Generated by Scaleway","managed":false,"type":"opaque","protected":true,"path":"/s2s_vpn","ephemeral_policy":null,"used_by":["s2s_vpn"],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"b051d579-0885-4d53-b335-43090b05c930","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"connection_4ef585a5-b8e7-45ba-a98f-82437b07f860","status":"ready","created_at":"2026-06-07T03:30:50.371185Z","updated_at":"2026-06-07T03:30:50.371185Z","tags":["S2S VPN"],"version_count":1,"description":"Generated by Scaleway","managed":false,"type":"opaque","protected":true,"path":"/s2s_vpn","ephemeral_policy":null,"used_by":["s2s_vpn"],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"f17b0b58-d687-48c6-ace5-1b3edff8b7fd","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"connection_5a276b66-5f6c-4104-9e2d-4453f934da3f","status":"ready","created_at":"2026-06-15T03:42:24.708279Z","updated_at":"2026-06-15T03:42:24.708279Z","tags":["S2S VPN"],"version_count":1,"description":"Generated by Scaleway","managed":false,"type":"opaque","protected":true,"path":"/s2s_vpn","ephemeral_policy":null,"used_by":["s2s_vpn"],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"eb9e6f63-703e-407b-aaf5-211287c2c8d1","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"connection_5c577157-6841-4a76-a264-f31292b60af0","status":"ready","created_at":"2026-06-11T03:34:53.359914Z","updated_at":"2026-06-11T03:34:53.359914Z","tags":["S2S VPN"],"version_count":1,"description":"Generated by Scaleway","managed":false,"type":"opaque","protected":true,"path":"/s2s_vpn","ephemeral_policy":null,"used_by":["s2s_vpn"],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"71fcf44c-86b2-4efc-8a06-56d3ff907d16","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"connection_609879df-0176-499b-b792-b60cb848b535","status":"ready","created_at":"2026-06-28T02:57:22.343631Z","updated_at":"2026-06-28T02:57:22.343631Z","tags":["S2S VPN"],"version_count":1,"description":"Generated by Scaleway","managed":false,"type":"opaque","protected":true,"path":"/s2s_vpn","ephemeral_policy":null,"used_by":["s2s_vpn"],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"935e292f-3075-4a76-9270-5fede1a9d84c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"connection_61246285-fec6-48a0-a472-2c283079c1cb","status":"ready","created_at":"2026-06-27T02:42:57.828042Z","updated_at":"2026-06-27T02:42:57.828042Z","tags":["S2S VPN"],"version_count":1,"description":"Generated by Scaleway","managed":false,"type":"opaque","protected":true,"path":"/s2s_vpn","ephemeral_policy":null,"used_by":["s2s_vpn"],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"60158ec5-ca94-45ee-8de2-9b1d4f74e9e0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"connection_67777f4e-f46e-4474-ac8a-6a628db42fb0","status":"ready","created_at":"2026-06-08T03:38:49.349096Z","updated_at":"2026-06-08T03:38:49.349096Z","tags":["S2S VPN"],"version_count":1,"description":"Generated by Scaleway","managed":false,"type":"opaque","protected":true,"path":"/s2s_vpn","ephemeral_policy":null,"used_by":["s2s_vpn"],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"f04c6727-cc01-4883-b3c2-7977ec93c412","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"connection_6abf2567-64e9-4db7-9d26-861cf31761a3","status":"ready","created_at":"2026-06-17T03:41:09.832399Z","updated_at":"2026-06-17T03:41:09.832399Z","tags":["S2S VPN"],"version_count":1,"description":"Generated by Scaleway","managed":false,"type":"opaque","protected":true,"path":"/s2s_vpn","ephemeral_policy":null,"used_by":["s2s_vpn"],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"69e8cdc3-e1d1-44df-9d60-38efcfaa5599","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"connection_7642b0ed-2468-4b9f-b360-1954814c5abe","status":"ready","created_at":"2026-07-03T02:44:04.981824Z","updated_at":"2026-07-03T02:44:04.981824Z","tags":["S2S VPN"],"version_count":1,"description":"Generated by Scaleway","managed":false,"type":"opaque","protected":true,"path":"/s2s_vpn","ephemeral_policy":null,"used_by":["s2s_vpn"],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"cf003fb7-b3ab-4784-881d-d5ac9108d88e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"connection_816b8ad4-15e0-491c-b2d1-b951119feb06","status":"ready","created_at":"2026-07-01T02:58:58.984933Z","updated_at":"2026-07-01T02:58:58.984933Z","tags":["S2S VPN"],"version_count":1,"description":"Generated by Scaleway","managed":false,"type":"opaque","protected":true,"path":"/s2s_vpn","ephemeral_policy":null,"used_by":["s2s_vpn"],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"2051831a-b6a9-4342-aac3-75676ab86fb6","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"connection_9327b21d-6975-4771-b2f5-7f208bcd9c58","status":"ready","created_at":"2026-06-12T03:29:22.193932Z","updated_at":"2026-06-12T03:29:22.193932Z","tags":["S2S VPN"],"version_count":1,"description":"Generated by Scaleway","managed":false,"type":"opaque","protected":true,"path":"/s2s_vpn","ephemeral_policy":null,"used_by":["s2s_vpn"],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"b85dc0f7-3f60-4680-9548-6f317b30b91c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"connection_99f1556f-fe16-4d9e-86d6-e58a2754fc74","status":"ready","created_at":"2026-06-25T02:52:24.034368Z","updated_at":"2026-06-25T02:52:24.034368Z","tags":["S2S VPN"],"version_count":1,"description":"Generated by Scaleway","managed":false,"type":"opaque","protected":true,"path":"/s2s_vpn","ephemeral_policy":null,"used_by":["s2s_vpn"],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"cf90ef51-4870-474f-82f1-7524e12e6e14","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"connection_a0b68f59-3041-4dc9-b44e-ff04519300f7","status":"ready","created_at":"2026-06-29T03:04:43.735589Z","updated_at":"2026-06-29T03:04:43.735589Z","tags":["S2S VPN"],"version_count":1,"description":"Generated by Scaleway","managed":false,"type":"opaque","protected":true,"path":"/s2s_vpn","ephemeral_policy":null,"used_by":["s2s_vpn"],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"36ed51b8-d388-42f7-bec2-3d5be6d0bf69","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"connection_b43308f8-116b-4d75-929f-09cc3c1500ef","status":"ready","created_at":"2026-06-14T03:34:12.810033Z","updated_at":"2026-06-14T03:34:12.810033Z","tags":["S2S VPN"],"version_count":1,"description":"Generated by Scaleway","managed":false,"type":"opaque","protected":true,"path":"/s2s_vpn","ephemeral_policy":null,"used_by":["s2s_vpn"],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"e8f8a3c7-2ea6-46a9-a627-1ca88d9391f3","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"connection_ba0f7ebc-bb17-4656-ba62-04dc5d7f7928","status":"ready","created_at":"2026-06-24T02:51:41.970106Z","updated_at":"2026-06-24T02:51:41.970106Z","tags":["S2S VPN"],"version_count":1,"description":"Generated by Scaleway","managed":false,"type":"opaque","protected":true,"path":"/s2s_vpn","ephemeral_policy":null,"used_by":["s2s_vpn"],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"4eba51ea-465a-4af0-b701-4f2b16e2ccbc","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"connection_bec5dbc9-809d-4a84-807f-266b9f521a17","status":"ready","created_at":"2026-06-26T02:59:26.822728Z","updated_at":"2026-06-26T02:59:26.822728Z","tags":["S2S VPN"],"version_count":1,"description":"Generated by Scaleway","managed":false,"type":"opaque","protected":true,"path":"/s2s_vpn","ephemeral_policy":null,"used_by":["s2s_vpn"],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"f07b7fe0-2825-4575-8e05-327c8975c5df","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"connection_c3dc67eb-bf73-47cb-ab52-5d450de73dff","status":"ready","created_at":"2026-06-06T02:43:45.366752Z","updated_at":"2026-06-06T02:43:45.366752Z","tags":["S2S VPN"],"version_count":1,"description":"Generated by Scaleway","managed":false,"type":"opaque","protected":true,"path":"/s2s_vpn","ephemeral_policy":null,"used_by":["s2s_vpn"],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"a5db1324-1270-4e43-9391-d1db13528db0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"connection_d878de1e-4248-434c-827f-add38f0d7de4","status":"ready","created_at":"2026-06-23T02:53:55.162445Z","updated_at":"2026-06-23T02:53:55.162445Z","tags":["S2S VPN"],"version_count":1,"description":"Generated by Scaleway","managed":false,"type":"opaque","protected":true,"path":"/s2s_vpn","ephemeral_policy":null,"used_by":["s2s_vpn"],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"e3e583f3-49bc-455c-8de9-af902f679cb8","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"connection_e28fa068-9beb-4de5-b358-bc2e746ce25b","status":"ready","created_at":"2026-06-24T02:52:29.661712Z","updated_at":"2026-06-24T02:52:29.661712Z","tags":["S2S VPN"],"version_count":1,"description":"Generated by Scaleway","managed":false,"type":"opaque","protected":true,"path":"/s2s_vpn","ephemeral_policy":null,"used_by":["s2s_vpn"],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"32e4fa9a-2007-4928-8b7e-a56603c988b7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"connection_f175e613-0952-4a51-9148-b8a7b3a7fc5a","status":"ready","created_at":"2026-06-05T02:56:25.887171Z","updated_at":"2026-06-05T02:56:25.887171Z","tags":["S2S VPN"],"version_count":1,"description":"Generated by Scaleway","managed":false,"type":"opaque","protected":true,"path":"/s2s_vpn","ephemeral_policy":null,"used_by":["s2s_vpn"],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"debe451d-dc87-49c1-b272-be84929d6b27","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"connection_fe011434-8c96-45c1-bbf2-55cb66f7748f","status":"ready","created_at":"2026-07-02T02:54:07.800400Z","updated_at":"2026-07-02T02:54:07.800400Z","tags":["S2S VPN"],"version_count":1,"description":"Generated by Scaleway","managed":false,"type":"opaque","protected":true,"path":"/s2s_vpn","ephemeral_policy":null,"used_by":["s2s_vpn"],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"a2869384-3f17-46f5-8824-11b0bc94470f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"dataSourceSecretVersionBasic","status":"ready","created_at":"2026-07-03T15:27:54.696393Z","updated_at":"2026-07-03T15:27:54.696393Z","tags":["devtools","provider","terraform"],"version_count":3,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"caedd6aa-562d-40dd-a2d7-3273a1e0beee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"erSecretVersionByNameSecret","status":"ready","created_at":"2026-07-03T15:28:00.703451Z","updated_at":"2026-07-03T15:28:00.703451Z","tags":["devtools","provider","terraform"],"version_count":3,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"842d724a-1e9c-4017-ac08-6bf83cab4c64","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretVersionNameBasic","status":"ready","created_at":"2026-07-03T15:27:59.863920Z","updated_at":"2026-07-03T15:27:59.863920Z","tags":["devtools","provider","terraform"],"version_count":1,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"e52321be-7d3f-4417-8fb7-4d3c11c9790f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretVersionNameDataWO","status":"ready","created_at":"2026-07-03T15:27:59.801664Z","updated_at":"2026-07-03T15:27:59.801664Z","tags":["devtools","provider","terraform"],"version_count":1,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"646cb095-08ab-467f-aa7f-0cce3b822253","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretVersionNameDataWOB","status":"ready","created_at":"2026-07-03T15:27:59.827262Z","updated_at":"2026-07-03T15:27:59.827262Z","tags":["devtools","provider","terraform"],"version_count":1,"description":"secret descriptionB","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"950b1fc8-caea-478e-bdc7-30dc2ed6f05d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-multi-1","status":"ready","created_at":"2026-07-03T15:28:00.513850Z","updated_at":"2026-07-03T15:28:00.513850Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"41d5d749-aaab-4503-8ae3-c593c4846010","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-07-03T15:27:54.644460Z","updated_at":"2026-07-03T15:28:01.714669Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"695f8a21-f14a-4506-8103-7d37eef09227","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-version-all-1","status":"ready","created_at":"2026-07-03T15:27:57.376047Z","updated_at":"2026-07-03T15:27:57.376047Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"02bbcfdd-6da4-45da-8614-c7c930289009","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-version-all-2","status":"ready","created_at":"2026-07-03T15:28:00.318708Z","updated_at":"2026-07-03T15:28:00.318708Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"0f40b082-1dfe-4fa7-81f3-09477bd5cfb4","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-version-filter-1","status":"ready","created_at":"2026-07-03T15:28:01.237720Z","updated_at":"2026-07-03T15:28:01.237720Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"d023fa93-eb36-44b5-91b8-13b998e2e630","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-tests-edge-dns-wildcard-cert","status":"ready","created_at":"2026-06-26T09:32:44.780706Z","updated_at":"2026-06-26T09:32:44.780706Z","tags":[],"version_count":1,"description":"","managed":false,"type":"certificate","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}],"total_count":37}'
         headers:
             Content-Length:
-                - "2220"
+                - "18295"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:36 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 5b91008f-c278-45ff-b024-1c9b250f43cd
+                - 1afca4f5-5ee7-4a70-92e2-974257040115
         status: 200 OK
         code: 200
-        duration: 92.51097ms
+        duration: 138.427031ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -786,41 +786,33 @@ interactions:
         content_length: 0
         host: api.scaleway.com
         form:
-            order_by:
-                - name_asc
             page:
-                - "2"
-            project_id:
-                - 105bdce1-64c0-48ab-899d-868455867ecf
-            scheduled_for_deletion:
-                - "false"
-            type:
-                - unknown_type
+                - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets?order_by=name_asc&page=2&project_id=105bdce1-64c0-48ab-899d-868455867ecf&scheduled_for_deletion=false&type=unknown_type
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/932f9b5d-10f2-4d45-8e89-88bd6fb5b415/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 30
-        body: '{"secrets":[],"total_count":3}'
+        content_length: 325
+        body: '{"versions":[{"revision":1,"secret_id":"932f9b5d-10f2-4d45-8e89-88bd6fb5b415","status":"enabled","created_at":"2026-06-10T02:55:49.693748Z","updated_at":"2026-06-10T02:55:49.693748Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
-                - "30"
+                - "325"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:36 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 7f6fc6c3-c9b1-474d-a985-0ea40a6bad53
+                - 85b42215-8951-415d-80ce-6b85ad330f9d
         status: 200 OK
         code: 200
-        duration: 87.360604ms
+        duration: 56.251274ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -833,29 +825,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/2c4667fd-76d8-4205-b60b-efc0cd3ce15f/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/935e292f-3075-4a76-9270-5fede1a9d84c/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 365
-        body: '{"versions":[{"revision":1,"secret_id":"2c4667fd-76d8-4205-b60b-efc0cd3ce15f","status":"scheduled_for_deletion","created_at":"2026-06-04T09:49:34.091013Z","updated_at":"2026-06-04T09:49:34.091013Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":"2026-06-04T09:49:36.812399Z","region":"fr-par"}],"total_count":1}'
+        content_length: 325
+        body: '{"versions":[{"revision":1,"secret_id":"935e292f-3075-4a76-9270-5fede1a9d84c","status":"enabled","created_at":"2026-06-27T02:42:58.169125Z","updated_at":"2026-06-27T02:42:58.169125Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
-                - "365"
+                - "325"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:36 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 286fa9c4-8f5d-4a19-a012-6e686bf22aad
+                - 4ffa3d3b-c24a-425b-bc94-bdaaa4caf6a0
         status: 200 OK
         code: 200
-        duration: 43.661151ms
+        duration: 56.398792ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -868,29 +860,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a115f047-311a-483b-a194-eec3276d00d7/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/0cda53cf-8fee-4e91-b213-8a2b694d6f59/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 621
-        body: '{"versions":[{"revision":2,"secret_id":"a115f047-311a-483b-a194-eec3276d00d7","status":"enabled","created_at":"2026-06-04T09:49:35.434602Z","updated_at":"2026-06-04T09:49:35.434602Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"a115f047-311a-483b-a194-eec3276d00d7","status":"enabled","created_at":"2026-06-04T09:49:34.181599Z","updated_at":"2026-06-04T09:49:34.181599Z","deleted_at":null,"description":"","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":2}'
+        content_length: 325
+        body: '{"versions":[{"revision":1,"secret_id":"0cda53cf-8fee-4e91-b213-8a2b694d6f59","status":"enabled","created_at":"2026-06-13T03:00:04.864353Z","updated_at":"2026-06-13T03:00:04.864353Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
-                - "621"
+                - "325"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:36 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 61ce8540-e4d2-4deb-a3ae-c7ea1bc22283
+                - ff38fc2b-5240-4869-8c84-ad00ddde388d
         status: 200 OK
         code: 200
-        duration: 43.622799ms
+        duration: 56.7227ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -903,29 +895,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8aa68a52-b2ec-491b-83e4-090c6d905729/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/71fcf44c-86b2-4efc-8a06-56d3ff907d16/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 325
-        body: '{"versions":[{"revision":1,"secret_id":"8aa68a52-b2ec-491b-83e4-090c6d905729","status":"enabled","created_at":"2026-06-04T09:49:34.262686Z","updated_at":"2026-06-04T09:49:34.262686Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        body: '{"versions":[{"revision":1,"secret_id":"71fcf44c-86b2-4efc-8a06-56d3ff907d16","status":"enabled","created_at":"2026-06-28T02:57:22.758541Z","updated_at":"2026-06-28T02:57:22.758541Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "325"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:36 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 786bea92-c49f-4af7-9f7a-e0c2664ec680
+                - 66e9b07f-b703-4d07-a88c-77f48725df48
         status: 200 OK
         code: 200
-        duration: 44.642918ms
+        duration: 57.34562ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -938,29 +930,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/cbfa0f8d-5515-4516-9d3c-7a53761312b9/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/03a5e79f-e5d8-46b4-9d78-4b012a4960f8/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 365
-        body: '{"versions":[{"revision":1,"secret_id":"cbfa0f8d-5515-4516-9d3c-7a53761312b9","status":"scheduled_for_deletion","created_at":"2026-06-04T09:49:35.601163Z","updated_at":"2026-06-04T09:49:35.601163Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":"2026-06-04T09:49:36.762359Z","region":"fr-par"}],"total_count":1}'
+        content_length: 325
+        body: '{"versions":[{"revision":1,"secret_id":"03a5e79f-e5d8-46b4-9d78-4b012a4960f8","status":"enabled","created_at":"2026-06-09T02:47:26.973361Z","updated_at":"2026-06-09T02:47:26.973361Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
-                - "365"
+                - "325"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:36 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 48bc1fdf-c4a1-42d9-a3b1-ec1ced3c7b94
+                - a8f10536-c216-43f7-8635-d6d67eba8b45
         status: 200 OK
         code: 200
-        duration: 56.762811ms
+        duration: 59.966633ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -973,29 +965,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/30ba3bf0-c5d4-43aa-89dc-6d396835182f/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/eb9e6f63-703e-407b-aaf5-211287c2c8d1/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 325
-        body: '{"versions":[{"revision":1,"secret_id":"30ba3bf0-c5d4-43aa-89dc-6d396835182f","status":"enabled","created_at":"2026-06-04T09:49:35.835238Z","updated_at":"2026-06-04T09:49:35.835238Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        body: '{"versions":[{"revision":1,"secret_id":"eb9e6f63-703e-407b-aaf5-211287c2c8d1","status":"enabled","created_at":"2026-06-11T03:34:53.678718Z","updated_at":"2026-06-11T03:34:53.678718Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "325"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:36 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - cc70450d-0667-4070-b1ea-6fded490dcae
+                - c33a5ff1-13b7-4ac8-b18e-915b330c959a
         status: 200 OK
         code: 200
-        duration: 56.952898ms
+        duration: 60.965348ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1003,29 +995,34 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: api.scaleway.com
+        form:
+            page:
+                - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8aa68a52-b2ec-491b-83e4-090c6d905729/versions/1
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b051d579-0885-4d53-b335-43090b05c930/versions?page=1
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 0
-        body: ""
+        content_length: 325
+        body: '{"versions":[{"revision":1,"secret_id":"b051d579-0885-4d53-b335-43090b05c930","status":"enabled","created_at":"2026-06-07T03:30:50.929410Z","updated_at":"2026-06-07T03:30:50.929410Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
         headers:
+            Content-Length:
+                - "325"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:37 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 39f7b781-742c-4cf3-ae55-8984f5254b7a
-        status: 204 No Content
-        code: 204
-        duration: 69.286222ms
+                - 2c6706ba-5e5d-4ce5-bf4a-f4a6f25ee5d0
+        status: 200 OK
+        code: 200
+        duration: 61.056109ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1033,29 +1030,34 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: api.scaleway.com
+        form:
+            page:
+                - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/30ba3bf0-c5d4-43aa-89dc-6d396835182f/versions/1
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1eb6c146-1818-452b-b826-a8e4621b99d8/versions?page=1
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 0
-        body: ""
+        content_length: 325
+        body: '{"versions":[{"revision":1,"secret_id":"1eb6c146-1818-452b-b826-a8e4621b99d8","status":"enabled","created_at":"2026-06-30T03:03:54.284949Z","updated_at":"2026-06-30T03:03:54.284949Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
         headers:
+            Content-Length:
+                - "325"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:37 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 018fde0f-8484-4221-aa4a-b8bb4aa876ec
-        status: 204 No Content
-        code: 204
-        duration: 72.327922ms
+                - 3f864e81-086d-4f8c-a763-f80a4274b897
+        status: 200 OK
+        code: 200
+        duration: 61.074795ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1063,29 +1065,34 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: api.scaleway.com
+        form:
+            page:
+                - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/30ba3bf0-c5d4-43aa-89dc-6d396835182f
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/60158ec5-ca94-45ee-8de2-9b1d4f74e9e0/versions?page=1
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 0
-        body: ""
+        content_length: 325
+        body: '{"versions":[{"revision":1,"secret_id":"60158ec5-ca94-45ee-8de2-9b1d4f74e9e0","status":"enabled","created_at":"2026-06-08T03:38:49.688569Z","updated_at":"2026-06-08T03:38:49.688569Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
         headers:
+            Content-Length:
+                - "325"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:37 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - f41fe405-6b8f-4ef8-b17e-aa98c75899d2
-        status: 204 No Content
-        code: 204
-        duration: 69.547591ms
+                - bf2482dd-66d7-4d85-a087-00abfa252104
+        status: 200 OK
+        code: 200
+        duration: 60.990756ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1093,10 +1100,990 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: api.scaleway.com
+        form:
+            page:
+                - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8aa68a52-b2ec-491b-83e4-090c6d905729
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6565cc4a-8b55-4f35-8169-a8a2eff35aac/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 325
+        body: '{"versions":[{"revision":1,"secret_id":"6565cc4a-8b55-4f35-8169-a8a2eff35aac","status":"enabled","created_at":"2026-06-23T02:54:56.786263Z","updated_at":"2026-06-23T02:54:56.786263Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "325"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 605c1c79-9067-4f24-8f2b-09d9caba321f
+        status: 200 OK
+        code: 200
+        duration: 65.835606ms
+    - id: 33
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f17b0b58-d687-48c6-ace5-1b3edff8b7fd/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 325
+        body: '{"versions":[{"revision":1,"secret_id":"f17b0b58-d687-48c6-ace5-1b3edff8b7fd","status":"enabled","created_at":"2026-06-15T03:42:25.129596Z","updated_at":"2026-06-15T03:42:25.129596Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "325"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - e078429a-1f3f-4302-9f21-e5e336a286bf
+        status: 200 OK
+        code: 200
+        duration: 67.574793ms
+    - id: 34
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/40cb655e-0b83-4cba-8de5-ed05b59bbf6e/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 325
+        body: '{"versions":[{"revision":1,"secret_id":"40cb655e-0b83-4cba-8de5-ed05b59bbf6e","status":"enabled","created_at":"2026-06-16T03:39:38.993051Z","updated_at":"2026-06-16T03:39:38.993051Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "325"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 9e27d068-f171-48bd-ba03-1e78a50303ff
+        status: 200 OK
+        code: 200
+        duration: 67.469355ms
+    - id: 35
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/cf003fb7-b3ab-4784-881d-d5ac9108d88e/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 325
+        body: '{"versions":[{"revision":1,"secret_id":"cf003fb7-b3ab-4784-881d-d5ac9108d88e","status":"enabled","created_at":"2026-07-01T02:58:59.408321Z","updated_at":"2026-07-01T02:58:59.408321Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "325"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 74a34751-16a3-4207-be4b-6dd004cfb5a4
+        status: 200 OK
+        code: 200
+        duration: 54.654586ms
+    - id: 36
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e8f8a3c7-2ea6-46a9-a627-1ca88d9391f3/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 325
+        body: '{"versions":[{"revision":1,"secret_id":"e8f8a3c7-2ea6-46a9-a627-1ca88d9391f3","status":"enabled","created_at":"2026-06-24T02:51:42.379208Z","updated_at":"2026-06-24T02:51:42.379208Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "325"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 8f8d6db0-6257-4969-9bff-4a435419e1fa
+        status: 200 OK
+        code: 200
+        duration: 57.10604ms
+    - id: 37
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/cf90ef51-4870-474f-82f1-7524e12e6e14/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 325
+        body: '{"versions":[{"revision":1,"secret_id":"cf90ef51-4870-474f-82f1-7524e12e6e14","status":"enabled","created_at":"2026-06-29T03:04:44.158226Z","updated_at":"2026-06-29T03:04:44.158226Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "325"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 04c41c94-6919-4947-9ac4-f0dba8c31031
+        status: 200 OK
+        code: 200
+        duration: 57.188595ms
+    - id: 38
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b85dc0f7-3f60-4680-9548-6f317b30b91c/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 325
+        body: '{"versions":[{"revision":1,"secret_id":"b85dc0f7-3f60-4680-9548-6f317b30b91c","status":"enabled","created_at":"2026-06-25T02:52:24.426179Z","updated_at":"2026-06-25T02:52:24.426179Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "325"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 2cc28b6c-1c3b-458f-a7d4-716ec451ec60
+        status: 200 OK
+        code: 200
+        duration: 58.133079ms
+    - id: 39
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/2051831a-b6a9-4342-aac3-75676ab86fb6/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 325
+        body: '{"versions":[{"revision":1,"secret_id":"2051831a-b6a9-4342-aac3-75676ab86fb6","status":"enabled","created_at":"2026-06-12T03:29:22.591486Z","updated_at":"2026-06-12T03:29:22.591486Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "325"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - de7f225e-ae86-48eb-b4e8-9e9584b7c60e
+        status: 200 OK
+        code: 200
+        duration: 60.389056ms
+    - id: 40
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/4eba51ea-465a-4af0-b701-4f2b16e2ccbc/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 325
+        body: '{"versions":[{"revision":1,"secret_id":"4eba51ea-465a-4af0-b701-4f2b16e2ccbc","status":"enabled","created_at":"2026-06-26T02:59:27.204906Z","updated_at":"2026-06-26T02:59:27.204906Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "325"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - b626e72b-a791-4c3f-b310-59d601642d12
+        status: 200 OK
+        code: 200
+        duration: 58.204503ms
+    - id: 41
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/36ed51b8-d388-42f7-bec2-3d5be6d0bf69/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 325
+        body: '{"versions":[{"revision":1,"secret_id":"36ed51b8-d388-42f7-bec2-3d5be6d0bf69","status":"enabled","created_at":"2026-06-14T03:34:13.212588Z","updated_at":"2026-06-14T03:34:13.212588Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "325"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 18df6455-64f4-416d-82be-18a5ee7a55bc
+        status: 200 OK
+        code: 200
+        duration: 58.290205ms
+    - id: 42
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a5db1324-1270-4e43-9391-d1db13528db0/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 325
+        body: '{"versions":[{"revision":1,"secret_id":"a5db1324-1270-4e43-9391-d1db13528db0","status":"enabled","created_at":"2026-06-23T02:53:55.605657Z","updated_at":"2026-06-23T02:53:55.605657Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "325"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - d6ddd23b-bbf1-4544-8c62-34a1ffd079bc
+        status: 200 OK
+        code: 200
+        duration: 51.804262ms
+    - id: 43
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f07b7fe0-2825-4575-8e05-327c8975c5df/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 325
+        body: '{"versions":[{"revision":1,"secret_id":"f07b7fe0-2825-4575-8e05-327c8975c5df","status":"enabled","created_at":"2026-06-06T02:43:45.706106Z","updated_at":"2026-06-06T02:43:45.706106Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "325"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - d4047f33-46d7-4b78-845c-449524b859ea
+        status: 200 OK
+        code: 200
+        duration: 55.73283ms
+    - id: 44
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/69e8cdc3-e1d1-44df-9d60-38efcfaa5599/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 325
+        body: '{"versions":[{"revision":1,"secret_id":"69e8cdc3-e1d1-44df-9d60-38efcfaa5599","status":"enabled","created_at":"2026-07-03T02:44:05.466701Z","updated_at":"2026-07-03T02:44:05.466701Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "325"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - be663bc6-b1b5-443d-aff0-8b19422f5717
+        status: 200 OK
+        code: 200
+        duration: 64.665949ms
+    - id: 45
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f04c6727-cc01-4883-b3c2-7977ec93c412/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 325
+        body: '{"versions":[{"revision":1,"secret_id":"f04c6727-cc01-4883-b3c2-7977ec93c412","status":"enabled","created_at":"2026-06-17T03:41:10.220274Z","updated_at":"2026-06-17T03:41:10.220274Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "325"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 63208df2-0587-49ae-8256-2b2eaa73c59a
+        status: 200 OK
+        code: 200
+        duration: 69.853583ms
+    - id: 46
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e3e583f3-49bc-455c-8de9-af902f679cb8/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 325
+        body: '{"versions":[{"revision":1,"secret_id":"e3e583f3-49bc-455c-8de9-af902f679cb8","status":"enabled","created_at":"2026-06-24T02:52:30.037014Z","updated_at":"2026-06-24T02:52:30.037014Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "325"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 3e125209-62bf-481a-b854-4ead79978a2d
+        status: 200 OK
+        code: 200
+        duration: 68.278715ms
+    - id: 47
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/950b1fc8-caea-478e-bdc7-30dc2ed6f05d/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 325
+        body: '{"versions":[{"revision":1,"secret_id":"950b1fc8-caea-478e-bdc7-30dc2ed6f05d","status":"enabled","created_at":"2026-07-03T15:28:00.965072Z","updated_at":"2026-07-03T15:28:00.965072Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "325"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 04ec1582-7d0d-4eff-8957-c2064a179a23
+        status: 200 OK
+        code: 200
+        duration: 44.314544ms
+    - id: 48
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/695f8a21-f14a-4506-8103-7d37eef09227/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 325
+        body: '{"versions":[{"revision":1,"secret_id":"695f8a21-f14a-4506-8103-7d37eef09227","status":"enabled","created_at":"2026-07-03T15:27:58.780042Z","updated_at":"2026-07-03T15:27:58.780042Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "325"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - e78a434d-9883-41f6-995d-5ad69049294e
+        status: 200 OK
+        code: 200
+        duration: 43.821358ms
+    - id: 49
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/caedd6aa-562d-40dd-a2d7-3273a1e0beee/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 970
+        body: '{"versions":[{"revision":3,"secret_id":"caedd6aa-562d-40dd-a2d7-3273a1e0beee","status":"enabled","created_at":"2026-07-03T15:28:01.638457Z","updated_at":"2026-07-03T15:28:01.638457Z","deleted_at":null,"description":"by_name_from_ephemeral","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":2,"secret_id":"caedd6aa-562d-40dd-a2d7-3273a1e0beee","status":"enabled","created_at":"2026-07-03T15:28:01.594979Z","updated_at":"2026-07-03T15:28:01.594979Z","deleted_at":null,"description":"version1_from_ephemeral","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"caedd6aa-562d-40dd-a2d7-3273a1e0beee","status":"enabled","created_at":"2026-07-03T15:28:01.105720Z","updated_at":"2026-07-03T15:28:01.105720Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":3}'
+        headers:
+            Content-Length:
+                - "970"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 49529f50-5576-4bd3-bfb5-059be0027923
+        status: 200 OK
+        code: 200
+        duration: 46.89949ms
+    - id: 50
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/646cb095-08ab-467f-aa7f-0cce3b822253/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 384
+        body: '{"versions":[{"revision":1,"secret_id":"646cb095-08ab-467f-aa7f-0cce3b822253","status":"scheduled_for_deletion","created_at":"2026-07-03T15:28:00.241314Z","updated_at":"2026-07-03T15:28:00.241314Z","deleted_at":null,"description":"secret descriptionB","latest":true,"ephemeral_properties":null,"deletion_requested_at":"2026-07-03T15:28:02.387345Z","region":"fr-par"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "384"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 89c3713d-dd0f-46e8-a7e7-816964c8a1ff
+        status: 200 OK
+        code: 200
+        duration: 51.262033ms
+    - id: 51
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/41d5d749-aaab-4503-8ae3-c593c4846010/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 31
+        body: '{"versions":[],"total_count":0}'
+        headers:
+            Content-Length:
+                - "31"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - d89a0407-bc8a-4c12-97b8-aab6692e0d73
+        status: 200 OK
+        code: 200
+        duration: 49.241708ms
+    - id: 52
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/842d724a-1e9c-4017-ac08-6bf83cab4c64/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 351
+        body: '{"versions":[{"revision":1,"secret_id":"842d724a-1e9c-4017-ac08-6bf83cab4c64","status":"enabled","created_at":"2026-07-03T15:28:00.329374Z","updated_at":"2026-07-03T15:28:02.406879Z","deleted_at":null,"description":"secret version description","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "351"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 8000cd08-b14a-4266-a078-a6213b0c6e1e
+        status: 200 OK
+        code: 200
+        duration: 52.848813ms
+    - id: 53
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a2869384-3f17-46f5-8824-11b0bc94470f/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 941
+        body: '{"versions":[{"revision":3,"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","status":"enabled","created_at":"2026-07-03T15:28:02.189740Z","updated_at":"2026-07-03T15:28:02.189740Z","deleted_at":null,"description":"version3","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":2,"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","status":"enabled","created_at":"2026-07-03T15:27:57.360463Z","updated_at":"2026-07-03T15:27:57.360463Z","deleted_at":null,"description":"version2","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"a2869384-3f17-46f5-8824-11b0bc94470f","status":"enabled","created_at":"2026-07-03T15:27:55.395862Z","updated_at":"2026-07-03T15:27:55.395862Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":3}'
+        headers:
+            Content-Length:
+                - "941"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 926d9714-47d3-4280-b18a-f5ff12a6ff1a
+        status: 200 OK
+        code: 200
+        duration: 52.560503ms
+    - id: 54
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/32e4fa9a-2007-4928-8b7e-a56603c988b7/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 325
+        body: '{"versions":[{"revision":1,"secret_id":"32e4fa9a-2007-4928-8b7e-a56603c988b7","status":"enabled","created_at":"2026-06-05T02:56:26.209348Z","updated_at":"2026-06-05T02:56:26.209348Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "325"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 224fa900-ab12-4f7e-86bc-86f0cad6deb4
+        status: 200 OK
+        code: 200
+        duration: 59.263422ms
+    - id: 55
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e52321be-7d3f-4417-8fb7-4d3c11c9790f/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 343
+        body: '{"versions":[{"revision":1,"secret_id":"e52321be-7d3f-4417-8fb7-4d3c11c9790f","status":"enabled","created_at":"2026-07-03T15:28:00.438195Z","updated_at":"2026-07-03T15:28:00.438195Z","deleted_at":null,"description":"secret description","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "343"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - de16c49f-cb18-4198-bbce-d787c33a8565
+        status: 200 OK
+        code: 200
+        duration: 57.046307ms
+    - id: 56
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/0f40b082-1dfe-4fa7-81f3-09477bd5cfb4/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 325
+        body: '{"versions":[{"revision":1,"secret_id":"0f40b082-1dfe-4fa7-81f3-09477bd5cfb4","status":"enabled","created_at":"2026-07-03T15:28:01.633314Z","updated_at":"2026-07-03T15:28:01.633314Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "325"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 8c8e8ba5-7ade-44d3-855e-e3be05e142f3
+        status: 200 OK
+        code: 200
+        duration: 43.411418ms
+    - id: 57
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/debe451d-dc87-49c1-b272-be84929d6b27/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 325
+        body: '{"versions":[{"revision":1,"secret_id":"debe451d-dc87-49c1-b272-be84929d6b27","status":"enabled","created_at":"2026-07-02T02:54:08.203922Z","updated_at":"2026-07-02T02:54:08.203922Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "325"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - fce80774-287a-48c3-bdda-560e3c40a008
+        status: 200 OK
+        code: 200
+        duration: 63.462208ms
+    - id: 58
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/02bbcfdd-6da4-45da-8614-c7c930289009/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 325
+        body: '{"versions":[{"revision":1,"secret_id":"02bbcfdd-6da4-45da-8614-c7c930289009","status":"enabled","created_at":"2026-07-03T15:28:00.813553Z","updated_at":"2026-07-03T15:28:00.813553Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "325"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - a13aae77-bde6-462e-821c-330b81124fe3
+        status: 200 OK
+        code: 200
+        duration: 54.858208ms
+    - id: 59
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/d023fa93-eb36-44b5-91b8-13b998e2e630/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 325
+        body: '{"versions":[{"revision":1,"secret_id":"d023fa93-eb36-44b5-91b8-13b998e2e630","status":"enabled","created_at":"2026-06-26T09:32:45.202219Z","updated_at":"2026-06-26T09:32:45.202219Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "325"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - dd848214-0484-4c4c-b454-cb143eba9d80
+        status: 200 OK
+        code: 200
+        duration: 48.095766ms
+    - id: 60
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/695f8a21-f14a-4506-8103-7d37eef09227/versions/1
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1108,15 +2095,15 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:37 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - d6f59c57-90a4-411d-b6f1-be46f5dd62d9
+                - e17b540e-3c14-461f-8ee6-f1dd6a006cdb
         status: 204 No Content
         code: 204
-        duration: 124.210184ms
-    - id: 33
+        duration: 69.998174ms
+    - id: 61
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1125,30 +2112,28 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8aa68a52-b2ec-491b-83e4-090c6d905729
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/02bbcfdd-6da4-45da-8614-c7c930289009/versions/1
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 464
-        body: '{"id":"8aa68a52-b2ec-491b-83e4-090c6d905729","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-version-all-1","status":"ready","created_at":"2026-06-04T09:49:33.714643Z","updated_at":"2026-06-04T09:49:33.714643Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-06-04T09:49:37.310360Z","key_id":null,"region":"fr-par"}'
+        content_length: 0
+        body: ""
         headers:
-            Content-Length:
-                - "464"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:37 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - b8ae941f-3fb4-49c3-b169-c04560d1fa2e
-        status: 200 OK
-        code: 200
-        duration: 49.051036ms
-    - id: 34
+                - 37051f94-6081-4214-b8c8-941ca809b601
+        status: 204 No Content
+        code: 204
+        duration: 149.988557ms
+    - id: 62
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1157,26 +2142,118 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/30ba3bf0-c5d4-43aa-89dc-6d396835182f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/695f8a21-f14a-4506-8103-7d37eef09227
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 6a64c1c5-072f-4c98-bd12-c326048de7e9
+        status: 204 No Content
+        code: 204
+        duration: 59.679063ms
+    - id: 63
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/02bbcfdd-6da4-45da-8614-c7c930289009
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 30c6fa78-3256-46c6-8f65-9698260e08f9
+        status: 204 No Content
+        code: 204
+        duration: 60.128036ms
+    - id: 64
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/695f8a21-f14a-4506-8103-7d37eef09227
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 464
-        body: '{"id":"30ba3bf0-c5d4-43aa-89dc-6d396835182f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-version-all-2","status":"ready","created_at":"2026-06-04T09:49:35.461289Z","updated_at":"2026-06-04T09:49:35.461289Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-06-04T09:49:37.258903Z","key_id":null,"region":"fr-par"}'
+        body: '{"id":"695f8a21-f14a-4506-8103-7d37eef09227","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-version-all-1","status":"ready","created_at":"2026-07-03T15:27:57.376047Z","updated_at":"2026-07-03T15:28:03.037271Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-07-03T15:28:03.037271Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "464"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:37 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - bc2221ca-4986-476a-afe6-719f6c89a9bd
+                - 1114c623-ce28-40f6-a3ae-1c581b3935d0
         status: 200 OK
         code: 200
-        duration: 50.990434ms
+        duration: 51.586724ms
+    - id: 65
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/02bbcfdd-6da4-45da-8614-c7c930289009
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 464
+        body: '{"id":"02bbcfdd-6da4-45da-8614-c7c930289009","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-version-all-2","status":"ready","created_at":"2026-07-03T15:28:00.318708Z","updated_at":"2026-07-03T15:28:03.115823Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-07-03T15:28:03.115823Z","key_id":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "464"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - dad20b12-38f5-4c14-a3ba-528cc685d121
+        status: 200 OK
+        code: 200
+        duration: 37.405366ms

--- a/internal/services/secret/testdata/list-secret-versions-basic.cassette.yaml
+++ b/internal/services/secret/testdata/list-secret-versions-basic.cassette.yaml
@@ -13,7 +13,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets
         method: POST
       response:
@@ -21,21 +21,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 440
-        body: '{"id":"1f6a5be7-2da1-4c1b-9ede-d90672cf090c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-version-list-1","status":"ready","created_at":"2026-06-04T09:49:33.773787Z","updated_at":"2026-06-04T09:49:33.773787Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"e741aacd-147e-4df3-9fed-6593ef0dd1d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-version-list-1","status":"ready","created_at":"2026-07-03T15:28:02.742049Z","updated_at":"2026-07-03T15:28:02.742049Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "440"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:33 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 21c38bd7-9d0e-4121-a565-44714cc103f1
+                - 9bf4976f-336b-48a8-a354-f4e10afd4b49
         status: 200 OK
         code: 200
-        duration: 275.032483ms
+        duration: 77.797073ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -45,29 +45,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1f6a5be7-2da1-4c1b-9ede-d90672cf090c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e741aacd-147e-4df3-9fed-6593ef0dd1d7
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 440
-        body: '{"id":"1f6a5be7-2da1-4c1b-9ede-d90672cf090c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-version-list-1","status":"ready","created_at":"2026-06-04T09:49:33.773787Z","updated_at":"2026-06-04T09:49:33.773787Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"e741aacd-147e-4df3-9fed-6593ef0dd1d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-version-list-1","status":"ready","created_at":"2026-07-03T15:28:02.742049Z","updated_at":"2026-07-03T15:28:02.742049Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "440"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:33 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 7abd8a29-8279-4495-ae37-15ae8cc59577
+                - 291d5b39-d64b-4c64-b8c3-f1a6592d860a
         status: 200 OK
         code: 200
-        duration: 45.519996ms
+        duration: 44.684919ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -80,8 +80,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1f6a5be7-2da1-4c1b-9ede-d90672cf090c/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e741aacd-147e-4df3-9fed-6593ef0dd1d7/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -95,14 +95,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:33 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 79ef3499-af98-4625-a8c8-01e06857e431
+                - 38c78ecb-1765-4d29-86e0-051c90a6f46a
         status: 200 OK
         code: 200
-        duration: 58.047251ms
+        duration: 62.795186ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -115,29 +115,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1f6a5be7-2da1-4c1b-9ede-d90672cf090c/versions
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e741aacd-147e-4df3-9fed-6593ef0dd1d7/versions
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 294
-        body: '{"revision":1,"secret_id":"1f6a5be7-2da1-4c1b-9ede-d90672cf090c","status":"enabled","created_at":"2026-06-04T09:49:34.337977Z","updated_at":"2026-06-04T09:49:34.337977Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"e741aacd-147e-4df3-9fed-6593ef0dd1d7","status":"enabled","created_at":"2026-07-03T15:28:03.201885Z","updated_at":"2026-07-03T15:28:03.201885Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "294"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:34 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - ab002b7b-d171-4f75-a792-50268b5513d9
+                - fd531985-d5cd-4265-a0d9-6919aae7983c
         status: 200 OK
         code: 200
-        duration: 459.208765ms
+        duration: 351.036407ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -147,29 +147,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1f6a5be7-2da1-4c1b-9ede-d90672cf090c/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e741aacd-147e-4df3-9fed-6593ef0dd1d7/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 294
-        body: '{"revision":1,"secret_id":"1f6a5be7-2da1-4c1b-9ede-d90672cf090c","status":"enabled","created_at":"2026-06-04T09:49:34.337977Z","updated_at":"2026-06-04T09:49:34.337977Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"e741aacd-147e-4df3-9fed-6593ef0dd1d7","status":"enabled","created_at":"2026-07-03T15:28:03.201885Z","updated_at":"2026-07-03T15:28:03.201885Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "294"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:34 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 7ed0e950-7d7f-4b17-abc6-407b9f85317f
+                - 1f6fc285-7609-4182-88ab-87f65acb1220
         status: 200 OK
         code: 200
-        duration: 43.801491ms
+        duration: 40.390333ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -179,29 +179,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1f6a5be7-2da1-4c1b-9ede-d90672cf090c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e741aacd-147e-4df3-9fed-6593ef0dd1d7
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 440
-        body: '{"id":"1f6a5be7-2da1-4c1b-9ede-d90672cf090c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-version-list-1","status":"ready","created_at":"2026-06-04T09:49:33.773787Z","updated_at":"2026-06-04T09:49:33.773787Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"e741aacd-147e-4df3-9fed-6593ef0dd1d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-version-list-1","status":"ready","created_at":"2026-07-03T15:28:02.742049Z","updated_at":"2026-07-03T15:28:02.742049Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "440"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:34 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - a967ea0c-5c81-4f6a-85dd-107154ad5f5b
+                - 54bc9df0-3da7-4be4-b64b-fb3af6ecf622
         status: 200 OK
         code: 200
-        duration: 40.258413ms
+        duration: 50.864517ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -214,29 +214,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1f6a5be7-2da1-4c1b-9ede-d90672cf090c/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e741aacd-147e-4df3-9fed-6593ef0dd1d7/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 325
-        body: '{"versions":[{"revision":1,"secret_id":"1f6a5be7-2da1-4c1b-9ede-d90672cf090c","status":"enabled","created_at":"2026-06-04T09:49:34.337977Z","updated_at":"2026-06-04T09:49:34.337977Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        body: '{"versions":[{"revision":1,"secret_id":"e741aacd-147e-4df3-9fed-6593ef0dd1d7","status":"enabled","created_at":"2026-07-03T15:28:03.201885Z","updated_at":"2026-07-03T15:28:03.201885Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "325"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:34 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 7371ed9f-bc66-4000-a04a-080c55a44a6d
+                - c7e53126-c428-4d4d-8bd1-c5b79c7321ac
         status: 200 OK
         code: 200
-        duration: 50.22583ms
+        duration: 63.321805ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -246,29 +246,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1f6a5be7-2da1-4c1b-9ede-d90672cf090c/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e741aacd-147e-4df3-9fed-6593ef0dd1d7/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 294
-        body: '{"revision":1,"secret_id":"1f6a5be7-2da1-4c1b-9ede-d90672cf090c","status":"enabled","created_at":"2026-06-04T09:49:34.337977Z","updated_at":"2026-06-04T09:49:34.337977Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"e741aacd-147e-4df3-9fed-6593ef0dd1d7","status":"enabled","created_at":"2026-07-03T15:28:03.201885Z","updated_at":"2026-07-03T15:28:03.201885Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "294"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:34 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 6ea204b1-a789-4d4b-9add-f3bbb129671d
+                - 28700970-9db4-45de-a9d4-cba45e50f32c
         status: 200 OK
         code: 200
-        duration: 40.041778ms
+        duration: 45.18564ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -278,29 +278,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1f6a5be7-2da1-4c1b-9ede-d90672cf090c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e741aacd-147e-4df3-9fed-6593ef0dd1d7
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 440
-        body: '{"id":"1f6a5be7-2da1-4c1b-9ede-d90672cf090c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-version-list-1","status":"ready","created_at":"2026-06-04T09:49:33.773787Z","updated_at":"2026-06-04T09:49:33.773787Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"e741aacd-147e-4df3-9fed-6593ef0dd1d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-version-list-1","status":"ready","created_at":"2026-07-03T15:28:02.742049Z","updated_at":"2026-07-03T15:28:02.742049Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "440"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:35 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - c6496661-50d5-43e0-ba64-ed1254762f2b
+                - 82e811da-16cb-48a1-a568-fb2db395a10a
         status: 200 OK
         code: 200
-        duration: 39.222616ms
+        duration: 49.836356ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -313,29 +313,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1f6a5be7-2da1-4c1b-9ede-d90672cf090c/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e741aacd-147e-4df3-9fed-6593ef0dd1d7/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 325
-        body: '{"versions":[{"revision":1,"secret_id":"1f6a5be7-2da1-4c1b-9ede-d90672cf090c","status":"enabled","created_at":"2026-06-04T09:49:34.337977Z","updated_at":"2026-06-04T09:49:34.337977Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        body: '{"versions":[{"revision":1,"secret_id":"e741aacd-147e-4df3-9fed-6593ef0dd1d7","status":"enabled","created_at":"2026-07-03T15:28:03.201885Z","updated_at":"2026-07-03T15:28:03.201885Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "325"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:35 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 409117eb-3965-49cb-9879-5776d424ab6e
+                - f8962810-ed44-40da-8a46-23d992b10177
         status: 200 OK
         code: 200
-        duration: 82.478038ms
+        duration: 47.297988ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -345,29 +345,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1f6a5be7-2da1-4c1b-9ede-d90672cf090c/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e741aacd-147e-4df3-9fed-6593ef0dd1d7/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 294
-        body: '{"revision":1,"secret_id":"1f6a5be7-2da1-4c1b-9ede-d90672cf090c","status":"enabled","created_at":"2026-06-04T09:49:34.337977Z","updated_at":"2026-06-04T09:49:34.337977Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"e741aacd-147e-4df3-9fed-6593ef0dd1d7","status":"enabled","created_at":"2026-07-03T15:28:03.201885Z","updated_at":"2026-07-03T15:28:03.201885Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "294"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:35 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 2a456728-2ae8-4ae6-a8c7-6ebe4a4371b1
+                - 1bece821-ec69-458a-8826-5bcfa28aacd6
         status: 200 OK
         code: 200
-        duration: 46.813608ms
+        duration: 36.911179ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -380,29 +380,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1f6a5be7-2da1-4c1b-9ede-d90672cf090c/versions
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e741aacd-147e-4df3-9fed-6593ef0dd1d7/versions
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 294
-        body: '{"revision":2,"secret_id":"1f6a5be7-2da1-4c1b-9ede-d90672cf090c","status":"enabled","created_at":"2026-06-04T09:49:35.570883Z","updated_at":"2026-06-04T09:49:35.570883Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":2,"secret_id":"e741aacd-147e-4df3-9fed-6593ef0dd1d7","status":"enabled","created_at":"2026-07-03T15:28:05.118256Z","updated_at":"2026-07-03T15:28:05.118256Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "294"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:35 GMT
+                - Fri, 03 Jul 2026 15:28:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 9e098a66-208e-4f49-ab24-2f7fa93fe298
+                - 8012342f-8383-4894-aa09-0bd6fed6a202
         status: 200 OK
         code: 200
-        duration: 199.807155ms
+        duration: 151.350626ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -412,29 +412,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1f6a5be7-2da1-4c1b-9ede-d90672cf090c/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e741aacd-147e-4df3-9fed-6593ef0dd1d7/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 294
-        body: '{"revision":2,"secret_id":"1f6a5be7-2da1-4c1b-9ede-d90672cf090c","status":"enabled","created_at":"2026-06-04T09:49:35.570883Z","updated_at":"2026-06-04T09:49:35.570883Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":2,"secret_id":"e741aacd-147e-4df3-9fed-6593ef0dd1d7","status":"enabled","created_at":"2026-07-03T15:28:05.118256Z","updated_at":"2026-07-03T15:28:05.118256Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "294"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:35 GMT
+                - Fri, 03 Jul 2026 15:28:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 53e8a614-a7ef-4c3b-8aea-5bdfecdf3863
+                - 97e6fb5e-7f52-464f-8d2f-bfc866cf5697
         status: 200 OK
         code: 200
-        duration: 44.743755ms
+        duration: 41.24025ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -444,29 +444,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1f6a5be7-2da1-4c1b-9ede-d90672cf090c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e741aacd-147e-4df3-9fed-6593ef0dd1d7
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 440
-        body: '{"id":"1f6a5be7-2da1-4c1b-9ede-d90672cf090c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-version-list-1","status":"ready","created_at":"2026-06-04T09:49:33.773787Z","updated_at":"2026-06-04T09:49:33.773787Z","tags":[],"version_count":2,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"e741aacd-147e-4df3-9fed-6593ef0dd1d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-version-list-1","status":"ready","created_at":"2026-07-03T15:28:02.742049Z","updated_at":"2026-07-03T15:28:02.742049Z","tags":[],"version_count":2,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "440"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:36 GMT
+                - Fri, 03 Jul 2026 15:28:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 96cb4212-8425-4cba-ad61-2bd7f8b8b7b2
+                - c91a2b7c-1fc6-4afa-b534-e8742078813e
         status: 200 OK
         code: 200
-        duration: 41.765995ms
+        duration: 41.520306ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -479,29 +479,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1f6a5be7-2da1-4c1b-9ede-d90672cf090c/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e741aacd-147e-4df3-9fed-6593ef0dd1d7/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 621
-        body: '{"versions":[{"revision":2,"secret_id":"1f6a5be7-2da1-4c1b-9ede-d90672cf090c","status":"enabled","created_at":"2026-06-04T09:49:35.570883Z","updated_at":"2026-06-04T09:49:35.570883Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"1f6a5be7-2da1-4c1b-9ede-d90672cf090c","status":"enabled","created_at":"2026-06-04T09:49:34.337977Z","updated_at":"2026-06-04T09:49:34.337977Z","deleted_at":null,"description":"","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":2}'
+        body: '{"versions":[{"revision":2,"secret_id":"e741aacd-147e-4df3-9fed-6593ef0dd1d7","status":"enabled","created_at":"2026-07-03T15:28:05.118256Z","updated_at":"2026-07-03T15:28:05.118256Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"e741aacd-147e-4df3-9fed-6593ef0dd1d7","status":"enabled","created_at":"2026-07-03T15:28:03.201885Z","updated_at":"2026-07-03T15:28:03.201885Z","deleted_at":null,"description":"","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":2}'
         headers:
             Content-Length:
                 - "621"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:36 GMT
+                - Fri, 03 Jul 2026 15:28:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - aa5a390f-9701-4683-9dd5-a7f611071b60
+                - be0d6799-97ff-467d-8fad-6b5824121106
         status: 200 OK
         code: 200
-        duration: 52.942264ms
+        duration: 71.342049ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -511,29 +511,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1f6a5be7-2da1-4c1b-9ede-d90672cf090c/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e741aacd-147e-4df3-9fed-6593ef0dd1d7/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 294
-        body: '{"revision":2,"secret_id":"1f6a5be7-2da1-4c1b-9ede-d90672cf090c","status":"enabled","created_at":"2026-06-04T09:49:35.570883Z","updated_at":"2026-06-04T09:49:35.570883Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":2,"secret_id":"e741aacd-147e-4df3-9fed-6593ef0dd1d7","status":"enabled","created_at":"2026-07-03T15:28:05.118256Z","updated_at":"2026-07-03T15:28:05.118256Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "294"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:36 GMT
+                - Fri, 03 Jul 2026 15:28:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - a3f35653-c769-45c0-afa9-b945044a2c08
+                - 7b39343a-3144-4912-8cd7-e78830b5b8fc
         status: 200 OK
         code: 200
-        duration: 33.485444ms
+        duration: 45.986715ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -543,29 +543,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1f6a5be7-2da1-4c1b-9ede-d90672cf090c/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e741aacd-147e-4df3-9fed-6593ef0dd1d7/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 295
-        body: '{"revision":1,"secret_id":"1f6a5be7-2da1-4c1b-9ede-d90672cf090c","status":"enabled","created_at":"2026-06-04T09:49:34.337977Z","updated_at":"2026-06-04T09:49:34.337977Z","deleted_at":null,"description":"","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"e741aacd-147e-4df3-9fed-6593ef0dd1d7","status":"enabled","created_at":"2026-07-03T15:28:03.201885Z","updated_at":"2026-07-03T15:28:03.201885Z","deleted_at":null,"description":"","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "295"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:36 GMT
+                - Fri, 03 Jul 2026 15:28:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 676dabeb-ae81-4f06-b755-0919c43a00dc
+                - a3d94475-008a-48f2-8a68-9abb02e89053
         status: 200 OK
         code: 200
-        duration: 46.58466ms
+        duration: 46.103514ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -578,29 +578,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1f6a5be7-2da1-4c1b-9ede-d90672cf090c/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e741aacd-147e-4df3-9fed-6593ef0dd1d7/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 621
-        body: '{"versions":[{"revision":2,"secret_id":"1f6a5be7-2da1-4c1b-9ede-d90672cf090c","status":"enabled","created_at":"2026-06-04T09:49:35.570883Z","updated_at":"2026-06-04T09:49:35.570883Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"1f6a5be7-2da1-4c1b-9ede-d90672cf090c","status":"enabled","created_at":"2026-06-04T09:49:34.337977Z","updated_at":"2026-06-04T09:49:34.337977Z","deleted_at":null,"description":"","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":2}'
+        body: '{"versions":[{"revision":2,"secret_id":"e741aacd-147e-4df3-9fed-6593ef0dd1d7","status":"enabled","created_at":"2026-07-03T15:28:05.118256Z","updated_at":"2026-07-03T15:28:05.118256Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"e741aacd-147e-4df3-9fed-6593ef0dd1d7","status":"enabled","created_at":"2026-07-03T15:28:03.201885Z","updated_at":"2026-07-03T15:28:03.201885Z","deleted_at":null,"description":"","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":2}'
         headers:
             Content-Length:
                 - "621"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:36 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 451b407f-f634-4e1e-a545-ec6413dc5b1f
+                - 28c00878-e64a-415e-b57b-11e81ea4c942
         status: 200 OK
         code: 200
-        duration: 54.161816ms
+        duration: 43.369859ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -610,8 +610,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1f6a5be7-2da1-4c1b-9ede-d90672cf090c/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e741aacd-147e-4df3-9fed-6593ef0dd1d7/versions/2
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -623,14 +623,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:36 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 0007ba32-dc8a-4e73-8157-c6ee81a18db7
+                - a2c3bd8f-c244-41da-9f97-fc889a4688dd
         status: 204 No Content
         code: 204
-        duration: 62.648362ms
+        duration: 90.587487ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -640,8 +640,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1f6a5be7-2da1-4c1b-9ede-d90672cf090c/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e741aacd-147e-4df3-9fed-6593ef0dd1d7/versions/1
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -653,14 +653,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:36 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 1a311809-520f-4e5d-baed-2def1d6dbd45
+                - 87edb8a1-04ac-4c0c-b071-e75dae3833d6
         status: 204 No Content
         code: 204
-        duration: 82.989477ms
+        duration: 96.714856ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -670,8 +670,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1f6a5be7-2da1-4c1b-9ede-d90672cf090c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e741aacd-147e-4df3-9fed-6593ef0dd1d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -683,14 +683,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:36 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 3dcd66db-626b-46b4-addf-45008fbd936f
+                - cddcdd91-99a4-4a06-bb0a-bff3ff8f5a01
         status: 204 No Content
         code: 204
-        duration: 67.822883ms
+        duration: 61.826186ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -700,26 +700,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1f6a5be7-2da1-4c1b-9ede-d90672cf090c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e741aacd-147e-4df3-9fed-6593ef0dd1d7
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 465
-        body: '{"id":"1f6a5be7-2da1-4c1b-9ede-d90672cf090c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-version-list-1","status":"ready","created_at":"2026-06-04T09:49:33.773787Z","updated_at":"2026-06-04T09:49:33.773787Z","tags":[],"version_count":2,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-06-04T09:49:36.764289Z","key_id":null,"region":"fr-par"}'
+        body: '{"id":"e741aacd-147e-4df3-9fed-6593ef0dd1d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-version-list-1","status":"ready","created_at":"2026-07-03T15:28:02.742049Z","updated_at":"2026-07-03T15:28:06.755462Z","tags":[],"version_count":2,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-07-03T15:28:06.755462Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "465"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:36 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 8ddc432e-341e-4b4a-8071-61428037c422
+                - b535128e-2674-46f5-a0fb-258efe4bea7c
         status: 200 OK
         code: 200
-        duration: 28.616676ms
+        duration: 59.626755ms

--- a/internal/services/secret/testdata/list-secret-versions-by-status.cassette.yaml
+++ b/internal/services/secret/testdata/list-secret-versions-by-status.cassette.yaml
@@ -13,7 +13,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets
         method: POST
       response:
@@ -21,21 +21,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 442
-        body: '{"id":"a115f047-311a-483b-a194-eec3276d00d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-version-filter-1","status":"ready","created_at":"2026-06-04T09:49:33.690641Z","updated_at":"2026-06-04T09:49:33.690641Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"0f40b082-1dfe-4fa7-81f3-09477bd5cfb4","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-version-filter-1","status":"ready","created_at":"2026-07-03T15:28:01.237720Z","updated_at":"2026-07-03T15:28:01.237720Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "442"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:33 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 2cf6f0eb-15bb-499a-b8f1-1612ea163618
+                - dadfd88f-4fe6-4d4f-a446-2a3e36e93c51
         status: 200 OK
         code: 200
-        duration: 192.504084ms
+        duration: 178.503916ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -45,29 +45,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a115f047-311a-483b-a194-eec3276d00d7
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/0f40b082-1dfe-4fa7-81f3-09477bd5cfb4
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 442
-        body: '{"id":"a115f047-311a-483b-a194-eec3276d00d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-version-filter-1","status":"ready","created_at":"2026-06-04T09:49:33.690641Z","updated_at":"2026-06-04T09:49:33.690641Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"0f40b082-1dfe-4fa7-81f3-09477bd5cfb4","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-version-filter-1","status":"ready","created_at":"2026-07-03T15:28:01.237720Z","updated_at":"2026-07-03T15:28:01.237720Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "442"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:33 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - d809e5a3-061c-4103-add6-dfeed546f42d
+                - 3a7217b8-e89e-4d79-82c6-ee5f332c835e
         status: 200 OK
         code: 200
-        duration: 48.632608ms
+        duration: 46.436038ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -80,8 +80,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a115f047-311a-483b-a194-eec3276d00d7/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/0f40b082-1dfe-4fa7-81f3-09477bd5cfb4/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -95,14 +95,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:33 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 9ae34d60-ab98-4b41-a707-5af06d6eb0c9
+                - 59ee6e41-6d78-4718-b5e2-5697f54b7dc3
         status: 200 OK
         code: 200
-        duration: 53.868343ms
+        duration: 46.282581ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -115,29 +115,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a115f047-311a-483b-a194-eec3276d00d7/versions
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/0f40b082-1dfe-4fa7-81f3-09477bd5cfb4/versions
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 294
-        body: '{"revision":1,"secret_id":"a115f047-311a-483b-a194-eec3276d00d7","status":"enabled","created_at":"2026-06-04T09:49:34.181599Z","updated_at":"2026-06-04T09:49:34.181599Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"0f40b082-1dfe-4fa7-81f3-09477bd5cfb4","status":"enabled","created_at":"2026-07-03T15:28:01.633314Z","updated_at":"2026-07-03T15:28:01.633314Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "294"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:34 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 2e040f13-b797-4398-82bb-642deec2c790
+                - 64c321bd-a18e-47f7-8edc-9216acaac144
         status: 200 OK
         code: 200
-        duration: 379.871733ms
+        duration: 291.541931ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -147,29 +147,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a115f047-311a-483b-a194-eec3276d00d7/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/0f40b082-1dfe-4fa7-81f3-09477bd5cfb4/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 294
-        body: '{"revision":1,"secret_id":"a115f047-311a-483b-a194-eec3276d00d7","status":"enabled","created_at":"2026-06-04T09:49:34.181599Z","updated_at":"2026-06-04T09:49:34.181599Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"0f40b082-1dfe-4fa7-81f3-09477bd5cfb4","status":"enabled","created_at":"2026-07-03T15:28:01.633314Z","updated_at":"2026-07-03T15:28:01.633314Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "294"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:34 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - e40902c3-6092-450d-a5a5-4561470f6302
+                - 251cad53-f7b4-4292-aaac-e25d5b5dbf52
         status: 200 OK
         code: 200
-        duration: 43.240212ms
+        duration: 45.275119ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -179,29 +179,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a115f047-311a-483b-a194-eec3276d00d7
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/0f40b082-1dfe-4fa7-81f3-09477bd5cfb4
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 442
-        body: '{"id":"a115f047-311a-483b-a194-eec3276d00d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-version-filter-1","status":"ready","created_at":"2026-06-04T09:49:33.690641Z","updated_at":"2026-06-04T09:49:33.690641Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"0f40b082-1dfe-4fa7-81f3-09477bd5cfb4","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-version-filter-1","status":"ready","created_at":"2026-07-03T15:28:01.237720Z","updated_at":"2026-07-03T15:28:01.237720Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "442"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:34 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 42320795-a10e-4783-8e6d-475050cde1c2
+                - 67ce38f2-b66d-4376-9e7b-997a5d6d61f8
         status: 200 OK
         code: 200
-        duration: 35.859004ms
+        duration: 49.307983ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -214,29 +214,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a115f047-311a-483b-a194-eec3276d00d7/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/0f40b082-1dfe-4fa7-81f3-09477bd5cfb4/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 325
-        body: '{"versions":[{"revision":1,"secret_id":"a115f047-311a-483b-a194-eec3276d00d7","status":"enabled","created_at":"2026-06-04T09:49:34.181599Z","updated_at":"2026-06-04T09:49:34.181599Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        body: '{"versions":[{"revision":1,"secret_id":"0f40b082-1dfe-4fa7-81f3-09477bd5cfb4","status":"enabled","created_at":"2026-07-03T15:28:01.633314Z","updated_at":"2026-07-03T15:28:01.633314Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "325"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:34 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 48044a15-68de-41a9-a680-99552a84d738
+                - 39d8aec0-0714-446a-b12a-258b3ad219d6
         status: 200 OK
         code: 200
-        duration: 63.201034ms
+        duration: 62.972378ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -246,29 +246,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a115f047-311a-483b-a194-eec3276d00d7/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/0f40b082-1dfe-4fa7-81f3-09477bd5cfb4/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 294
-        body: '{"revision":1,"secret_id":"a115f047-311a-483b-a194-eec3276d00d7","status":"enabled","created_at":"2026-06-04T09:49:34.181599Z","updated_at":"2026-06-04T09:49:34.181599Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"0f40b082-1dfe-4fa7-81f3-09477bd5cfb4","status":"enabled","created_at":"2026-07-03T15:28:01.633314Z","updated_at":"2026-07-03T15:28:01.633314Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "294"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:34 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - a6efa0b4-ebf6-4f31-b401-7a151d50cc4b
+                - 63ee27ac-5e73-4c27-afbd-d6e21aff9f60
         status: 200 OK
         code: 200
-        duration: 36.523226ms
+        duration: 47.714601ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -278,29 +278,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a115f047-311a-483b-a194-eec3276d00d7
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/0f40b082-1dfe-4fa7-81f3-09477bd5cfb4
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 442
-        body: '{"id":"a115f047-311a-483b-a194-eec3276d00d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-version-filter-1","status":"ready","created_at":"2026-06-04T09:49:33.690641Z","updated_at":"2026-06-04T09:49:33.690641Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"0f40b082-1dfe-4fa7-81f3-09477bd5cfb4","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-version-filter-1","status":"ready","created_at":"2026-07-03T15:28:01.237720Z","updated_at":"2026-07-03T15:28:01.237720Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "442"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:34 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - c791c040-73a1-4180-97e7-7148e15db769
+                - 2fc1450a-a404-4889-a113-4bc7005a35b7
         status: 200 OK
         code: 200
-        duration: 49.381511ms
+        duration: 35.988296ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -313,29 +313,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a115f047-311a-483b-a194-eec3276d00d7/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/0f40b082-1dfe-4fa7-81f3-09477bd5cfb4/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 325
-        body: '{"versions":[{"revision":1,"secret_id":"a115f047-311a-483b-a194-eec3276d00d7","status":"enabled","created_at":"2026-06-04T09:49:34.181599Z","updated_at":"2026-06-04T09:49:34.181599Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        body: '{"versions":[{"revision":1,"secret_id":"0f40b082-1dfe-4fa7-81f3-09477bd5cfb4","status":"enabled","created_at":"2026-07-03T15:28:01.633314Z","updated_at":"2026-07-03T15:28:01.633314Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "325"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:35 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 9e280d6d-96fb-4c6a-8861-687e4cd4780d
+                - 8a64f77e-bcc3-472e-a361-c62789c3e502
         status: 200 OK
         code: 200
-        duration: 47.270171ms
+        duration: 46.536939ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -345,29 +345,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a115f047-311a-483b-a194-eec3276d00d7/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/0f40b082-1dfe-4fa7-81f3-09477bd5cfb4/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 294
-        body: '{"revision":1,"secret_id":"a115f047-311a-483b-a194-eec3276d00d7","status":"enabled","created_at":"2026-06-04T09:49:34.181599Z","updated_at":"2026-06-04T09:49:34.181599Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"0f40b082-1dfe-4fa7-81f3-09477bd5cfb4","status":"enabled","created_at":"2026-07-03T15:28:01.633314Z","updated_at":"2026-07-03T15:28:01.633314Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "294"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:35 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 2b456b19-cb9f-4be4-9e5b-d3c1a792b6cf
+                - d60fd152-ae00-4186-ae74-59addb615127
         status: 200 OK
         code: 200
-        duration: 81.84315ms
+        duration: 58.114233ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -380,29 +380,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a115f047-311a-483b-a194-eec3276d00d7/versions
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/0f40b082-1dfe-4fa7-81f3-09477bd5cfb4/versions
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 294
-        body: '{"revision":2,"secret_id":"a115f047-311a-483b-a194-eec3276d00d7","status":"enabled","created_at":"2026-06-04T09:49:35.434602Z","updated_at":"2026-06-04T09:49:35.434602Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":2,"secret_id":"0f40b082-1dfe-4fa7-81f3-09477bd5cfb4","status":"enabled","created_at":"2026-07-03T15:28:03.288416Z","updated_at":"2026-07-03T15:28:03.288416Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "294"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:35 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - fd131ebd-1e0c-4bff-902e-226e487066c3
+                - 8ebedf8a-65f0-462d-ad7c-d02984b8a86a
         status: 200 OK
         code: 200
-        duration: 218.812209ms
+        duration: 88.130332ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -412,29 +412,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a115f047-311a-483b-a194-eec3276d00d7/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/0f40b082-1dfe-4fa7-81f3-09477bd5cfb4/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 294
-        body: '{"revision":2,"secret_id":"a115f047-311a-483b-a194-eec3276d00d7","status":"enabled","created_at":"2026-06-04T09:49:35.434602Z","updated_at":"2026-06-04T09:49:35.434602Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":2,"secret_id":"0f40b082-1dfe-4fa7-81f3-09477bd5cfb4","status":"enabled","created_at":"2026-07-03T15:28:03.288416Z","updated_at":"2026-07-03T15:28:03.288416Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "294"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:35 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - ee80b6c3-d941-4c2b-af54-bb698561df23
+                - bb7292a9-0d27-4a52-a486-de80ae7bc9d9
         status: 200 OK
         code: 200
-        duration: 42.228079ms
+        duration: 31.613438ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -444,29 +444,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a115f047-311a-483b-a194-eec3276d00d7
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/0f40b082-1dfe-4fa7-81f3-09477bd5cfb4
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 442
-        body: '{"id":"a115f047-311a-483b-a194-eec3276d00d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-version-filter-1","status":"ready","created_at":"2026-06-04T09:49:33.690641Z","updated_at":"2026-06-04T09:49:33.690641Z","tags":[],"version_count":2,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"0f40b082-1dfe-4fa7-81f3-09477bd5cfb4","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-version-filter-1","status":"ready","created_at":"2026-07-03T15:28:01.237720Z","updated_at":"2026-07-03T15:28:01.237720Z","tags":[],"version_count":2,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "442"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:35 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 777a8e02-b5d5-4d64-86b4-294b6f9cf28a
+                - 834e439c-7e4d-4298-91cb-ae72dca1a770
         status: 200 OK
         code: 200
-        duration: 41.152157ms
+        duration: 49.080836ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -479,29 +479,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a115f047-311a-483b-a194-eec3276d00d7/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/0f40b082-1dfe-4fa7-81f3-09477bd5cfb4/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 621
-        body: '{"versions":[{"revision":2,"secret_id":"a115f047-311a-483b-a194-eec3276d00d7","status":"enabled","created_at":"2026-06-04T09:49:35.434602Z","updated_at":"2026-06-04T09:49:35.434602Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"a115f047-311a-483b-a194-eec3276d00d7","status":"enabled","created_at":"2026-06-04T09:49:34.181599Z","updated_at":"2026-06-04T09:49:34.181599Z","deleted_at":null,"description":"","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":2}'
+        body: '{"versions":[{"revision":2,"secret_id":"0f40b082-1dfe-4fa7-81f3-09477bd5cfb4","status":"enabled","created_at":"2026-07-03T15:28:03.288416Z","updated_at":"2026-07-03T15:28:03.288416Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"0f40b082-1dfe-4fa7-81f3-09477bd5cfb4","status":"enabled","created_at":"2026-07-03T15:28:01.633314Z","updated_at":"2026-07-03T15:28:01.633314Z","deleted_at":null,"description":"","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":2}'
         headers:
             Content-Length:
                 - "621"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:35 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - cd51373d-5d15-4543-96ca-06cbccfa3abe
+                - d64c3ca9-f3bb-4324-bce0-befa480b8a5b
         status: 200 OK
         code: 200
-        duration: 41.631643ms
+        duration: 47.035194ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -511,29 +511,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a115f047-311a-483b-a194-eec3276d00d7/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/0f40b082-1dfe-4fa7-81f3-09477bd5cfb4/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 294
-        body: '{"revision":2,"secret_id":"a115f047-311a-483b-a194-eec3276d00d7","status":"enabled","created_at":"2026-06-04T09:49:35.434602Z","updated_at":"2026-06-04T09:49:35.434602Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 295
+        body: '{"revision":1,"secret_id":"0f40b082-1dfe-4fa7-81f3-09477bd5cfb4","status":"enabled","created_at":"2026-07-03T15:28:01.633314Z","updated_at":"2026-07-03T15:28:01.633314Z","deleted_at":null,"description":"","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "294"
+                - "295"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:35 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 16675ba7-b6f5-4cfd-9647-a01814d67678
+                - f25dbd8b-00a1-4a2a-bafa-aed91cbf438a
         status: 200 OK
         code: 200
-        duration: 39.242945ms
+        duration: 45.066347ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -543,29 +543,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a115f047-311a-483b-a194-eec3276d00d7/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/0f40b082-1dfe-4fa7-81f3-09477bd5cfb4/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 295
-        body: '{"revision":1,"secret_id":"a115f047-311a-483b-a194-eec3276d00d7","status":"enabled","created_at":"2026-06-04T09:49:34.181599Z","updated_at":"2026-06-04T09:49:34.181599Z","deleted_at":null,"description":"","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 294
+        body: '{"revision":2,"secret_id":"0f40b082-1dfe-4fa7-81f3-09477bd5cfb4","status":"enabled","created_at":"2026-07-03T15:28:03.288416Z","updated_at":"2026-07-03T15:28:03.288416Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "295"
+                - "294"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:35 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 93724a34-f41d-4f29-800f-7f8532126267
+                - 3184865f-086d-446b-8d3a-23e4c818c9a4
         status: 200 OK
         code: 200
-        duration: 39.979312ms
+        duration: 45.032062ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -575,29 +575,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a115f047-311a-483b-a194-eec3276d00d7
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/0f40b082-1dfe-4fa7-81f3-09477bd5cfb4
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 442
-        body: '{"id":"a115f047-311a-483b-a194-eec3276d00d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-version-filter-1","status":"ready","created_at":"2026-06-04T09:49:33.690641Z","updated_at":"2026-06-04T09:49:33.690641Z","tags":[],"version_count":2,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"0f40b082-1dfe-4fa7-81f3-09477bd5cfb4","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-version-filter-1","status":"ready","created_at":"2026-07-03T15:28:01.237720Z","updated_at":"2026-07-03T15:28:01.237720Z","tags":[],"version_count":2,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "442"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:36 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - b286d5ea-08c2-4a40-8480-17686fedb8b6
+                - d49d54bd-4938-45b5-95a5-8e12f43ce3d7
         status: 200 OK
         code: 200
-        duration: 47.589881ms
+        duration: 40.952439ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -610,29 +610,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a115f047-311a-483b-a194-eec3276d00d7/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/0f40b082-1dfe-4fa7-81f3-09477bd5cfb4/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 621
-        body: '{"versions":[{"revision":2,"secret_id":"a115f047-311a-483b-a194-eec3276d00d7","status":"enabled","created_at":"2026-06-04T09:49:35.434602Z","updated_at":"2026-06-04T09:49:35.434602Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"a115f047-311a-483b-a194-eec3276d00d7","status":"enabled","created_at":"2026-06-04T09:49:34.181599Z","updated_at":"2026-06-04T09:49:34.181599Z","deleted_at":null,"description":"","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":2}'
+        body: '{"versions":[{"revision":2,"secret_id":"0f40b082-1dfe-4fa7-81f3-09477bd5cfb4","status":"enabled","created_at":"2026-07-03T15:28:03.288416Z","updated_at":"2026-07-03T15:28:03.288416Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"0f40b082-1dfe-4fa7-81f3-09477bd5cfb4","status":"enabled","created_at":"2026-07-03T15:28:01.633314Z","updated_at":"2026-07-03T15:28:01.633314Z","deleted_at":null,"description":"","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":2}'
         headers:
             Content-Length:
                 - "621"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:36 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 9febe759-5a09-4ee3-be47-1c2af11aabe3
+                - c0503d1f-f947-4b82-ac96-60084d0d9f5f
         status: 200 OK
         code: 200
-        duration: 58.09313ms
+        duration: 59.255477ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -642,29 +642,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a115f047-311a-483b-a194-eec3276d00d7/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/0f40b082-1dfe-4fa7-81f3-09477bd5cfb4/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 294
-        body: '{"revision":2,"secret_id":"a115f047-311a-483b-a194-eec3276d00d7","status":"enabled","created_at":"2026-06-04T09:49:35.434602Z","updated_at":"2026-06-04T09:49:35.434602Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 295
+        body: '{"revision":1,"secret_id":"0f40b082-1dfe-4fa7-81f3-09477bd5cfb4","status":"enabled","created_at":"2026-07-03T15:28:01.633314Z","updated_at":"2026-07-03T15:28:01.633314Z","deleted_at":null,"description":"","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "294"
+                - "295"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:36 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 126b16a4-4342-474e-841c-c879cc0685c8
+                - 69bab392-357d-4133-a885-f1e7b2c23f1b
         status: 200 OK
         code: 200
-        duration: 38.356377ms
+        duration: 32.442776ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -674,29 +674,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a115f047-311a-483b-a194-eec3276d00d7/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/0f40b082-1dfe-4fa7-81f3-09477bd5cfb4/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 295
-        body: '{"revision":1,"secret_id":"a115f047-311a-483b-a194-eec3276d00d7","status":"enabled","created_at":"2026-06-04T09:49:34.181599Z","updated_at":"2026-06-04T09:49:34.181599Z","deleted_at":null,"description":"","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 294
+        body: '{"revision":2,"secret_id":"0f40b082-1dfe-4fa7-81f3-09477bd5cfb4","status":"enabled","created_at":"2026-07-03T15:28:03.288416Z","updated_at":"2026-07-03T15:28:03.288416Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "295"
+                - "294"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:36 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 8ee9911d-325a-41ce-bd73-400e3567d437
+                - c3cfdbdd-19f4-467c-a0a1-3fc73bdbb21b
         status: 200 OK
         code: 200
-        duration: 60.207556ms
+        duration: 35.431119ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -706,29 +706,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a115f047-311a-483b-a194-eec3276d00d7
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/0f40b082-1dfe-4fa7-81f3-09477bd5cfb4
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 442
-        body: '{"id":"a115f047-311a-483b-a194-eec3276d00d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-version-filter-1","status":"ready","created_at":"2026-06-04T09:49:33.690641Z","updated_at":"2026-06-04T09:49:33.690641Z","tags":[],"version_count":2,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"0f40b082-1dfe-4fa7-81f3-09477bd5cfb4","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-version-filter-1","status":"ready","created_at":"2026-07-03T15:28:01.237720Z","updated_at":"2026-07-03T15:28:01.237720Z","tags":[],"version_count":2,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "442"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:36 GMT
+                - Fri, 03 Jul 2026 15:28:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 83a690ef-69fe-4c2c-aeda-6ef03c4badcf
+                - 93bb14e6-7b94-49c7-ab9d-4970b4dce9ff
         status: 200 OK
         code: 200
-        duration: 32.801575ms
+        duration: 31.264042ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -741,29 +741,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a115f047-311a-483b-a194-eec3276d00d7/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/0f40b082-1dfe-4fa7-81f3-09477bd5cfb4/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 621
-        body: '{"versions":[{"revision":2,"secret_id":"a115f047-311a-483b-a194-eec3276d00d7","status":"enabled","created_at":"2026-06-04T09:49:35.434602Z","updated_at":"2026-06-04T09:49:35.434602Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"a115f047-311a-483b-a194-eec3276d00d7","status":"enabled","created_at":"2026-06-04T09:49:34.181599Z","updated_at":"2026-06-04T09:49:34.181599Z","deleted_at":null,"description":"","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":2}'
+        body: '{"versions":[{"revision":2,"secret_id":"0f40b082-1dfe-4fa7-81f3-09477bd5cfb4","status":"enabled","created_at":"2026-07-03T15:28:03.288416Z","updated_at":"2026-07-03T15:28:03.288416Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"0f40b082-1dfe-4fa7-81f3-09477bd5cfb4","status":"enabled","created_at":"2026-07-03T15:28:01.633314Z","updated_at":"2026-07-03T15:28:01.633314Z","deleted_at":null,"description":"","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":2}'
         headers:
             Content-Length:
                 - "621"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:36 GMT
+                - Fri, 03 Jul 2026 15:28:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 2311d1d6-dcc2-483e-ad14-598f8d5995c7
+                - 04ff3e8a-2159-4a3b-acc2-07b745ccc5d9
         status: 200 OK
         code: 200
-        duration: 37.764801ms
+        duration: 36.441697ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -773,29 +773,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a115f047-311a-483b-a194-eec3276d00d7/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/0f40b082-1dfe-4fa7-81f3-09477bd5cfb4/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 295
-        body: '{"revision":1,"secret_id":"a115f047-311a-483b-a194-eec3276d00d7","status":"enabled","created_at":"2026-06-04T09:49:34.181599Z","updated_at":"2026-06-04T09:49:34.181599Z","deleted_at":null,"description":"","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 294
+        body: '{"revision":2,"secret_id":"0f40b082-1dfe-4fa7-81f3-09477bd5cfb4","status":"enabled","created_at":"2026-07-03T15:28:03.288416Z","updated_at":"2026-07-03T15:28:03.288416Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "295"
+                - "294"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:36 GMT
+                - Fri, 03 Jul 2026 15:28:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - a02af332-01f6-4080-970a-a0652dbfc0b9
+                - 1c17ad70-78c8-4af2-9139-848287c8ec83
         status: 200 OK
         code: 200
-        duration: 35.834379ms
+        duration: 50.217302ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -805,29 +805,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a115f047-311a-483b-a194-eec3276d00d7/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/0f40b082-1dfe-4fa7-81f3-09477bd5cfb4/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 294
-        body: '{"revision":2,"secret_id":"a115f047-311a-483b-a194-eec3276d00d7","status":"enabled","created_at":"2026-06-04T09:49:35.434602Z","updated_at":"2026-06-04T09:49:35.434602Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 295
+        body: '{"revision":1,"secret_id":"0f40b082-1dfe-4fa7-81f3-09477bd5cfb4","status":"enabled","created_at":"2026-07-03T15:28:01.633314Z","updated_at":"2026-07-03T15:28:01.633314Z","deleted_at":null,"description":"","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "294"
+                - "295"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:36 GMT
+                - Fri, 03 Jul 2026 15:28:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 39e34533-7754-49c0-9ff8-df42210915c7
+                - 9af863db-0c26-4029-b70c-3230c7265a4e
         status: 200 OK
         code: 200
-        duration: 35.612143ms
+        duration: 60.85958ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -842,29 +842,29 @@ interactions:
                 - enabled
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a115f047-311a-483b-a194-eec3276d00d7/versions?page=1&status=enabled
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/0f40b082-1dfe-4fa7-81f3-09477bd5cfb4/versions?page=1&status=enabled
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 621
-        body: '{"versions":[{"revision":2,"secret_id":"a115f047-311a-483b-a194-eec3276d00d7","status":"enabled","created_at":"2026-06-04T09:49:35.434602Z","updated_at":"2026-06-04T09:49:35.434602Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"a115f047-311a-483b-a194-eec3276d00d7","status":"enabled","created_at":"2026-06-04T09:49:34.181599Z","updated_at":"2026-06-04T09:49:34.181599Z","deleted_at":null,"description":"","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":2}'
+        body: '{"versions":[{"revision":2,"secret_id":"0f40b082-1dfe-4fa7-81f3-09477bd5cfb4","status":"enabled","created_at":"2026-07-03T15:28:03.288416Z","updated_at":"2026-07-03T15:28:03.288416Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"0f40b082-1dfe-4fa7-81f3-09477bd5cfb4","status":"enabled","created_at":"2026-07-03T15:28:01.633314Z","updated_at":"2026-07-03T15:28:01.633314Z","deleted_at":null,"description":"","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":2}'
         headers:
             Content-Length:
                 - "621"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:37 GMT
+                - Fri, 03 Jul 2026 15:28:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - ba7759b7-efe3-44a7-aed0-2f4e35deb283
+                - e2e08f08-9678-4b57-8ac4-ab396899c6ec
         status: 200 OK
         code: 200
-        duration: 77.223792ms
+        duration: 47.612449ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -874,8 +874,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a115f047-311a-483b-a194-eec3276d00d7/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/0f40b082-1dfe-4fa7-81f3-09477bd5cfb4/versions/2
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -887,14 +887,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:37 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 327514ee-49eb-444d-b1e8-89c0a1355741
+                - 8645e2c9-60a4-40b2-ac8f-2bf484d1a774
         status: 204 No Content
         code: 204
-        duration: 118.012249ms
+        duration: 74.665491ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -904,8 +904,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a115f047-311a-483b-a194-eec3276d00d7/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/0f40b082-1dfe-4fa7-81f3-09477bd5cfb4/versions/1
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -917,14 +917,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:37 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 5b036aa9-2af1-412c-af55-a7c31d0fcae4
+                - 8966146a-82aa-42dd-8e58-8289469860fe
         status: 204 No Content
         code: 204
-        duration: 174.363733ms
+        duration: 90.873173ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -934,8 +934,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a115f047-311a-483b-a194-eec3276d00d7
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/0f40b082-1dfe-4fa7-81f3-09477bd5cfb4
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -947,14 +947,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:37 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - c40dc250-fa74-423e-af69-8b06ec35bcb2
+                - 41b3b0dc-3a3c-44a0-8e07-d0df1d7efd3d
         status: 204 No Content
         code: 204
-        duration: 79.107576ms
+        duration: 63.471145ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -964,26 +964,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a115f047-311a-483b-a194-eec3276d00d7
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/0f40b082-1dfe-4fa7-81f3-09477bd5cfb4
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 467
-        body: '{"id":"a115f047-311a-483b-a194-eec3276d00d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-version-filter-1","status":"ready","created_at":"2026-06-04T09:49:33.690641Z","updated_at":"2026-06-04T09:49:33.690641Z","tags":[],"version_count":2,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-06-04T09:49:37.604662Z","key_id":null,"region":"fr-par"}'
+        body: '{"id":"0f40b082-1dfe-4fa7-81f3-09477bd5cfb4","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-version-filter-1","status":"ready","created_at":"2026-07-03T15:28:01.237720Z","updated_at":"2026-07-03T15:28:06.508616Z","tags":[],"version_count":2,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-07-03T15:28:06.508616Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "467"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:37 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 817ef951-c0e0-42d6-a0d3-04c0034dd555
+                - 1dfa113d-b02f-4447-9230-501f0e94de9c
         status: 200 OK
         code: 200
-        duration: 55.106925ms
+        duration: 50.39805ms

--- a/internal/services/secret/testdata/list-secret-versions-multiple-secrets.cassette.yaml
+++ b/internal/services/secret/testdata/list-secret-versions-multiple-secrets.cassette.yaml
@@ -13,7 +13,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets
         method: POST
       response:
@@ -21,21 +21,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 433
-        body: '{"id":"2c4667fd-76d8-4205-b60b-efc0cd3ce15f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-multi-1","status":"ready","created_at":"2026-06-04T09:49:33.744869Z","updated_at":"2026-06-04T09:49:33.744869Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"950b1fc8-caea-478e-bdc7-30dc2ed6f05d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-multi-1","status":"ready","created_at":"2026-07-03T15:28:00.513850Z","updated_at":"2026-07-03T15:28:00.513850Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "433"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:33 GMT
+                - Fri, 03 Jul 2026 15:28:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - a3588d53-aa95-44a7-82c7-2efc764084f8
+                - 90eed3e3-31ae-4df7-91f4-76aa09a2762d
         status: 200 OK
         code: 200
-        duration: 244.664332ms
+        duration: 103.31365ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -45,29 +45,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/2c4667fd-76d8-4205-b60b-efc0cd3ce15f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/950b1fc8-caea-478e-bdc7-30dc2ed6f05d
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 433
-        body: '{"id":"2c4667fd-76d8-4205-b60b-efc0cd3ce15f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-multi-1","status":"ready","created_at":"2026-06-04T09:49:33.744869Z","updated_at":"2026-06-04T09:49:33.744869Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"950b1fc8-caea-478e-bdc7-30dc2ed6f05d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-multi-1","status":"ready","created_at":"2026-07-03T15:28:00.513850Z","updated_at":"2026-07-03T15:28:00.513850Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "433"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:33 GMT
+                - Fri, 03 Jul 2026 15:28:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 42f3b48a-c3ed-408e-b639-d0dea2be78e9
+                - 5d7bb34b-5b56-447e-b84c-db882cde6866
         status: 200 OK
         code: 200
-        duration: 51.096458ms
+        duration: 57.67068ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -80,8 +80,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/2c4667fd-76d8-4205-b60b-efc0cd3ce15f/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/950b1fc8-caea-478e-bdc7-30dc2ed6f05d/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -95,14 +95,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:33 GMT
+                - Fri, 03 Jul 2026 15:28:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 9f8e4379-56f1-4633-9321-f5917f7dd596
+                - a85a5681-1555-4d1a-a8ab-a6cf9c4e4003
         status: 200 OK
         code: 200
-        duration: 37.474885ms
+        duration: 43.357075ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -115,29 +115,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/2c4667fd-76d8-4205-b60b-efc0cd3ce15f/versions
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/950b1fc8-caea-478e-bdc7-30dc2ed6f05d/versions
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 294
-        body: '{"revision":1,"secret_id":"2c4667fd-76d8-4205-b60b-efc0cd3ce15f","status":"enabled","created_at":"2026-06-04T09:49:34.091013Z","updated_at":"2026-06-04T09:49:34.091013Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"950b1fc8-caea-478e-bdc7-30dc2ed6f05d","status":"enabled","created_at":"2026-07-03T15:28:00.965072Z","updated_at":"2026-07-03T15:28:00.965072Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "294"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:34 GMT
+                - Fri, 03 Jul 2026 15:28:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 80efa1ec-87fe-4d5b-af55-46239efeaf7a
+                - d00523f3-3eaa-43b4-aabb-3837e4bdf950
         status: 200 OK
         code: 200
-        duration: 256.895466ms
+        duration: 343.772042ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -147,29 +147,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/2c4667fd-76d8-4205-b60b-efc0cd3ce15f/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/950b1fc8-caea-478e-bdc7-30dc2ed6f05d/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 294
-        body: '{"revision":1,"secret_id":"2c4667fd-76d8-4205-b60b-efc0cd3ce15f","status":"enabled","created_at":"2026-06-04T09:49:34.091013Z","updated_at":"2026-06-04T09:49:34.091013Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"950b1fc8-caea-478e-bdc7-30dc2ed6f05d","status":"enabled","created_at":"2026-07-03T15:28:00.965072Z","updated_at":"2026-07-03T15:28:00.965072Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "294"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:34 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 0088075e-6acb-4be6-9d75-dbfd855c5469
+                - 0c5ffa87-ff66-4d53-ad82-18499145e9f0
         status: 200 OK
         code: 200
-        duration: 41.282981ms
+        duration: 44.059094ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -179,29 +179,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/2c4667fd-76d8-4205-b60b-efc0cd3ce15f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/950b1fc8-caea-478e-bdc7-30dc2ed6f05d
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 433
-        body: '{"id":"2c4667fd-76d8-4205-b60b-efc0cd3ce15f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-multi-1","status":"ready","created_at":"2026-06-04T09:49:33.744869Z","updated_at":"2026-06-04T09:49:33.744869Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"950b1fc8-caea-478e-bdc7-30dc2ed6f05d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-multi-1","status":"ready","created_at":"2026-07-03T15:28:00.513850Z","updated_at":"2026-07-03T15:28:00.513850Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "433"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:34 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 7dea9951-7631-4193-9115-cf050dc5941b
+                - 6b1de296-45fc-4be4-8846-8fca6f584d96
         status: 200 OK
         code: 200
-        duration: 34.501785ms
+        duration: 49.388955ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -214,29 +214,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/2c4667fd-76d8-4205-b60b-efc0cd3ce15f/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/950b1fc8-caea-478e-bdc7-30dc2ed6f05d/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 325
-        body: '{"versions":[{"revision":1,"secret_id":"2c4667fd-76d8-4205-b60b-efc0cd3ce15f","status":"enabled","created_at":"2026-06-04T09:49:34.091013Z","updated_at":"2026-06-04T09:49:34.091013Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        body: '{"versions":[{"revision":1,"secret_id":"950b1fc8-caea-478e-bdc7-30dc2ed6f05d","status":"enabled","created_at":"2026-07-03T15:28:00.965072Z","updated_at":"2026-07-03T15:28:00.965072Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "325"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:34 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - f956281a-eddb-413b-a723-dc44297cbe07
+                - 48e54782-f3de-4fdb-b370-6459f28cdfd2
         status: 200 OK
         code: 200
-        duration: 57.454143ms
+        duration: 57.437813ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -246,29 +246,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/2c4667fd-76d8-4205-b60b-efc0cd3ce15f/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/950b1fc8-caea-478e-bdc7-30dc2ed6f05d/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 294
-        body: '{"revision":1,"secret_id":"2c4667fd-76d8-4205-b60b-efc0cd3ce15f","status":"enabled","created_at":"2026-06-04T09:49:34.091013Z","updated_at":"2026-06-04T09:49:34.091013Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"950b1fc8-caea-478e-bdc7-30dc2ed6f05d","status":"enabled","created_at":"2026-07-03T15:28:00.965072Z","updated_at":"2026-07-03T15:28:00.965072Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "294"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:34 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 08602a94-5be2-4d1f-830f-516830ea3218
+                - 75f71d8c-440b-4bed-829e-9afa6573ee60
         status: 200 OK
         code: 200
-        duration: 44.139454ms
+        duration: 36.818745ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -278,29 +278,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/2c4667fd-76d8-4205-b60b-efc0cd3ce15f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/950b1fc8-caea-478e-bdc7-30dc2ed6f05d
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 433
-        body: '{"id":"2c4667fd-76d8-4205-b60b-efc0cd3ce15f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-multi-1","status":"ready","created_at":"2026-06-04T09:49:33.744869Z","updated_at":"2026-06-04T09:49:33.744869Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"950b1fc8-caea-478e-bdc7-30dc2ed6f05d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-multi-1","status":"ready","created_at":"2026-07-03T15:28:00.513850Z","updated_at":"2026-07-03T15:28:00.513850Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "433"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:34 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 946252cb-f206-4996-ab49-f459830bb973
+                - a8c891ba-bc14-4509-b469-490a06356dff
         status: 200 OK
         code: 200
-        duration: 40.572571ms
+        duration: 39.975274ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -313,29 +313,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/2c4667fd-76d8-4205-b60b-efc0cd3ce15f/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/950b1fc8-caea-478e-bdc7-30dc2ed6f05d/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 325
-        body: '{"versions":[{"revision":1,"secret_id":"2c4667fd-76d8-4205-b60b-efc0cd3ce15f","status":"enabled","created_at":"2026-06-04T09:49:34.091013Z","updated_at":"2026-06-04T09:49:34.091013Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        body: '{"versions":[{"revision":1,"secret_id":"950b1fc8-caea-478e-bdc7-30dc2ed6f05d","status":"enabled","created_at":"2026-07-03T15:28:00.965072Z","updated_at":"2026-07-03T15:28:00.965072Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "325"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:34 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 02700e1f-4625-48da-9759-b8a3c48fa4b9
+                - 8b98ed2d-5894-46df-8a39-de90d1d18d63
         status: 200 OK
         code: 200
-        duration: 43.498445ms
+        duration: 60.616603ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -345,29 +345,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/2c4667fd-76d8-4205-b60b-efc0cd3ce15f/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/950b1fc8-caea-478e-bdc7-30dc2ed6f05d/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 294
-        body: '{"revision":1,"secret_id":"2c4667fd-76d8-4205-b60b-efc0cd3ce15f","status":"enabled","created_at":"2026-06-04T09:49:34.091013Z","updated_at":"2026-06-04T09:49:34.091013Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"950b1fc8-caea-478e-bdc7-30dc2ed6f05d","status":"enabled","created_at":"2026-07-03T15:28:00.965072Z","updated_at":"2026-07-03T15:28:00.965072Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "294"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:34 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 28944a62-03df-4291-96bf-cd044a219fa4
+                - 98a993d0-5768-4c67-93a9-4141c830e8ba
         status: 200 OK
         code: 200
-        duration: 46.517022ms
+        duration: 40.732046ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -380,7 +380,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets
         method: POST
       response:
@@ -388,21 +388,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 433
-        body: '{"id":"cbfa0f8d-5515-4516-9d3c-7a53761312b9","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-multi-2","status":"ready","created_at":"2026-06-04T09:49:35.223211Z","updated_at":"2026-06-04T09:49:35.223211Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"33e6bcc8-7aea-4d36-ae89-148fec90061d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-multi-2","status":"ready","created_at":"2026-07-03T15:28:02.717693Z","updated_at":"2026-07-03T15:28:02.717693Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "433"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:35 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 45390284-e19b-4e3c-a7bd-87595c439a13
+                - b25615e0-5d3b-4d91-a3ba-504e7dc8b553
         status: 200 OK
         code: 200
-        duration: 121.995907ms
+        duration: 102.538063ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -412,29 +412,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/cbfa0f8d-5515-4516-9d3c-7a53761312b9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/33e6bcc8-7aea-4d36-ae89-148fec90061d
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 433
-        body: '{"id":"cbfa0f8d-5515-4516-9d3c-7a53761312b9","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-multi-2","status":"ready","created_at":"2026-06-04T09:49:35.223211Z","updated_at":"2026-06-04T09:49:35.223211Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"33e6bcc8-7aea-4d36-ae89-148fec90061d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-multi-2","status":"ready","created_at":"2026-07-03T15:28:02.717693Z","updated_at":"2026-07-03T15:28:02.717693Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "433"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:35 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - b752fc60-6548-44ef-9d33-48fd1c2f139b
+                - f2ebba93-763a-4245-83db-dc5a4c6792c3
         status: 200 OK
         code: 200
-        duration: 47.350502ms
+        duration: 46.100158ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -447,8 +447,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/cbfa0f8d-5515-4516-9d3c-7a53761312b9/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/33e6bcc8-7aea-4d36-ae89-148fec90061d/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -462,14 +462,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:35 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - d1a9eabc-3ad4-4cd5-aeac-e4ca83bd826f
+                - 164046d2-de47-4cca-bd8f-bf481dac6ff5
         status: 200 OK
         code: 200
-        duration: 48.928324ms
+        duration: 35.793249ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -482,29 +482,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/cbfa0f8d-5515-4516-9d3c-7a53761312b9/versions
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/33e6bcc8-7aea-4d36-ae89-148fec90061d/versions
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 294
-        body: '{"revision":1,"secret_id":"cbfa0f8d-5515-4516-9d3c-7a53761312b9","status":"enabled","created_at":"2026-06-04T09:49:35.601163Z","updated_at":"2026-06-04T09:49:35.601163Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"33e6bcc8-7aea-4d36-ae89-148fec90061d","status":"enabled","created_at":"2026-07-03T15:28:03.081766Z","updated_at":"2026-07-03T15:28:03.081766Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "294"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:35 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 51177388-846f-4d61-9154-341090d29519
+                - 1a22944c-a463-4cb9-b1cf-86eee1cb47d8
         status: 200 OK
         code: 200
-        duration: 281.755631ms
+        duration: 283.816662ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -514,29 +514,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/cbfa0f8d-5515-4516-9d3c-7a53761312b9/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/33e6bcc8-7aea-4d36-ae89-148fec90061d/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 294
-        body: '{"revision":1,"secret_id":"cbfa0f8d-5515-4516-9d3c-7a53761312b9","status":"enabled","created_at":"2026-06-04T09:49:35.601163Z","updated_at":"2026-06-04T09:49:35.601163Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"33e6bcc8-7aea-4d36-ae89-148fec90061d","status":"enabled","created_at":"2026-07-03T15:28:03.081766Z","updated_at":"2026-07-03T15:28:03.081766Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "294"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:35 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - fc772c40-d5d4-440d-8278-2d6d7c679e52
+                - 9f563d28-d71b-4fe7-a7ac-8569af97e1d5
         status: 200 OK
         code: 200
-        duration: 39.778196ms
+        duration: 44.372944ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -546,29 +546,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/cbfa0f8d-5515-4516-9d3c-7a53761312b9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/33e6bcc8-7aea-4d36-ae89-148fec90061d
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 433
-        body: '{"id":"cbfa0f8d-5515-4516-9d3c-7a53761312b9","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-multi-2","status":"ready","created_at":"2026-06-04T09:49:35.223211Z","updated_at":"2026-06-04T09:49:35.223211Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"33e6bcc8-7aea-4d36-ae89-148fec90061d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-multi-2","status":"ready","created_at":"2026-07-03T15:28:02.717693Z","updated_at":"2026-07-03T15:28:02.717693Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "433"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:36 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - d78cfff9-0b1c-4d3f-a6ba-87a1a3fa8879
+                - 25df3ec8-efc8-4b1e-8f3c-5654c647346a
         status: 200 OK
         code: 200
-        duration: 55.218112ms
+        duration: 41.035164ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -578,29 +578,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/2c4667fd-76d8-4205-b60b-efc0cd3ce15f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/950b1fc8-caea-478e-bdc7-30dc2ed6f05d
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 433
-        body: '{"id":"2c4667fd-76d8-4205-b60b-efc0cd3ce15f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-multi-1","status":"ready","created_at":"2026-06-04T09:49:33.744869Z","updated_at":"2026-06-04T09:49:33.744869Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"950b1fc8-caea-478e-bdc7-30dc2ed6f05d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-multi-1","status":"ready","created_at":"2026-07-03T15:28:00.513850Z","updated_at":"2026-07-03T15:28:00.513850Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "433"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:36 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 93bfe56e-b11f-477c-b7fa-8202b0758604
+                - ec401d86-8d25-4ad6-bc9e-338562edb341
         status: 200 OK
         code: 200
-        duration: 54.729247ms
+        duration: 51.978579ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -613,29 +613,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/cbfa0f8d-5515-4516-9d3c-7a53761312b9/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/33e6bcc8-7aea-4d36-ae89-148fec90061d/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 325
-        body: '{"versions":[{"revision":1,"secret_id":"cbfa0f8d-5515-4516-9d3c-7a53761312b9","status":"enabled","created_at":"2026-06-04T09:49:35.601163Z","updated_at":"2026-06-04T09:49:35.601163Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        body: '{"versions":[{"revision":1,"secret_id":"33e6bcc8-7aea-4d36-ae89-148fec90061d","status":"enabled","created_at":"2026-07-03T15:28:03.081766Z","updated_at":"2026-07-03T15:28:03.081766Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "325"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:36 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 1ef11169-460e-489d-a2a4-21c206ca0730
+                - 8f2b0d7e-653f-4b57-bc87-4e8fef40f0c0
         status: 200 OK
         code: 200
-        duration: 34.351083ms
+        duration: 50.142851ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -648,29 +648,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/2c4667fd-76d8-4205-b60b-efc0cd3ce15f/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/950b1fc8-caea-478e-bdc7-30dc2ed6f05d/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 325
-        body: '{"versions":[{"revision":1,"secret_id":"2c4667fd-76d8-4205-b60b-efc0cd3ce15f","status":"enabled","created_at":"2026-06-04T09:49:34.091013Z","updated_at":"2026-06-04T09:49:34.091013Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        body: '{"versions":[{"revision":1,"secret_id":"950b1fc8-caea-478e-bdc7-30dc2ed6f05d","status":"enabled","created_at":"2026-07-03T15:28:00.965072Z","updated_at":"2026-07-03T15:28:00.965072Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "325"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:36 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 81dab731-89a9-4603-8c7f-b6bdc22775c4
+                - 983ddd76-7a01-459a-add7-503efd467e70
         status: 200 OK
         code: 200
-        duration: 53.698889ms
+        duration: 53.961764ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -680,29 +680,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/cbfa0f8d-5515-4516-9d3c-7a53761312b9/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/33e6bcc8-7aea-4d36-ae89-148fec90061d/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 294
-        body: '{"revision":1,"secret_id":"cbfa0f8d-5515-4516-9d3c-7a53761312b9","status":"enabled","created_at":"2026-06-04T09:49:35.601163Z","updated_at":"2026-06-04T09:49:35.601163Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"33e6bcc8-7aea-4d36-ae89-148fec90061d","status":"enabled","created_at":"2026-07-03T15:28:03.081766Z","updated_at":"2026-07-03T15:28:03.081766Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "294"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:36 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - bae2d92f-e815-4843-9ac8-b31733fe6985
+                - a0308f3e-0855-45e0-941a-641088d6ac40
         status: 200 OK
         code: 200
-        duration: 43.881474ms
+        duration: 37.637513ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -712,29 +712,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/2c4667fd-76d8-4205-b60b-efc0cd3ce15f/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/950b1fc8-caea-478e-bdc7-30dc2ed6f05d/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 294
-        body: '{"revision":1,"secret_id":"2c4667fd-76d8-4205-b60b-efc0cd3ce15f","status":"enabled","created_at":"2026-06-04T09:49:34.091013Z","updated_at":"2026-06-04T09:49:34.091013Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"950b1fc8-caea-478e-bdc7-30dc2ed6f05d","status":"enabled","created_at":"2026-07-03T15:28:00.965072Z","updated_at":"2026-07-03T15:28:00.965072Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "294"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:36 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - c48de011-9c78-4c1a-9584-04a98e2ab3d6
+                - 017dab8b-6328-40e0-a6bf-1ed6953d1e7f
         status: 200 OK
         code: 200
-        duration: 38.561741ms
+        duration: 38.655755ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -747,29 +747,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/2c4667fd-76d8-4205-b60b-efc0cd3ce15f/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/33e6bcc8-7aea-4d36-ae89-148fec90061d/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 325
-        body: '{"versions":[{"revision":1,"secret_id":"2c4667fd-76d8-4205-b60b-efc0cd3ce15f","status":"enabled","created_at":"2026-06-04T09:49:34.091013Z","updated_at":"2026-06-04T09:49:34.091013Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        body: '{"versions":[{"revision":1,"secret_id":"33e6bcc8-7aea-4d36-ae89-148fec90061d","status":"enabled","created_at":"2026-07-03T15:28:03.081766Z","updated_at":"2026-07-03T15:28:03.081766Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "325"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:36 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 62eca309-04f8-4e89-9013-902141fecd27
+                - df534a6b-e1dd-4b94-a4f1-b500e838af6c
         status: 200 OK
         code: 200
-        duration: 45.380268ms
+        duration: 47.193432ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -782,29 +782,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/cbfa0f8d-5515-4516-9d3c-7a53761312b9/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/950b1fc8-caea-478e-bdc7-30dc2ed6f05d/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 325
-        body: '{"versions":[{"revision":1,"secret_id":"cbfa0f8d-5515-4516-9d3c-7a53761312b9","status":"enabled","created_at":"2026-06-04T09:49:35.601163Z","updated_at":"2026-06-04T09:49:35.601163Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        body: '{"versions":[{"revision":1,"secret_id":"950b1fc8-caea-478e-bdc7-30dc2ed6f05d","status":"enabled","created_at":"2026-07-03T15:28:00.965072Z","updated_at":"2026-07-03T15:28:00.965072Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "325"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:36 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - ec1cad20-2023-4d43-9c99-0c98ea14a31f
+                - f4f6c854-9dfd-4fe9-9b34-df8509a0f6b9
         status: 200 OK
         code: 200
-        duration: 62.754882ms
+        duration: 56.903339ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -814,8 +814,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/cbfa0f8d-5515-4516-9d3c-7a53761312b9/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/33e6bcc8-7aea-4d36-ae89-148fec90061d/versions/1
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -827,14 +827,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:36 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - f720d103-dcdb-4772-8f9f-2b55b8ae06f5
+                - 9ac1107e-7023-4b85-99f3-f220682a07ea
         status: 204 No Content
         code: 204
-        duration: 65.359915ms
+        duration: 64.848011ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -844,8 +844,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/2c4667fd-76d8-4205-b60b-efc0cd3ce15f/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/950b1fc8-caea-478e-bdc7-30dc2ed6f05d/versions/1
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -857,14 +857,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:36 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - be992f4e-8e4c-48a1-86c4-97d2218a9a9b
+                - 1e067e7f-79f0-4182-9c9e-beef411eef04
         status: 204 No Content
         code: 204
-        duration: 110.540038ms
+        duration: 141.061871ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -874,8 +874,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/cbfa0f8d-5515-4516-9d3c-7a53761312b9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/950b1fc8-caea-478e-bdc7-30dc2ed6f05d
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -887,14 +887,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:36 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 659299a2-6a38-44f5-b27f-c54070390601
+                - da74c83d-7ec2-4481-b708-7ee8eff25237
         status: 204 No Content
         code: 204
-        duration: 54.745788ms
+        duration: 54.914413ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -904,8 +904,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/2c4667fd-76d8-4205-b60b-efc0cd3ce15f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/33e6bcc8-7aea-4d36-ae89-148fec90061d
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -917,14 +917,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:36 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 83ad1b49-13f7-4488-8a68-78a7b73ea170
+                - 78eae8d2-59a4-454a-a51a-90d8120c3f65
         status: 204 No Content
         code: 204
-        duration: 45.346294ms
+        duration: 140.786564ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -934,29 +934,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/2c4667fd-76d8-4205-b60b-efc0cd3ce15f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/33e6bcc8-7aea-4d36-ae89-148fec90061d
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 458
-        body: '{"id":"2c4667fd-76d8-4205-b60b-efc0cd3ce15f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-multi-1","status":"ready","created_at":"2026-06-04T09:49:33.744869Z","updated_at":"2026-06-04T09:49:33.744869Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-06-04T09:49:36.859391Z","key_id":null,"region":"fr-par"}'
+        body: '{"id":"33e6bcc8-7aea-4d36-ae89-148fec90061d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-multi-2","status":"ready","created_at":"2026-07-03T15:28:02.717693Z","updated_at":"2026-07-03T15:28:04.923130Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-07-03T15:28:04.923130Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "458"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:36 GMT
+                - Fri, 03 Jul 2026 15:28:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 12a5280a-2d16-4b6f-9e17-3ea67f68cc7f
+                - c479f936-7be0-410d-a427-dd17e2b862f7
         status: 200 OK
         code: 200
-        duration: 60.228395ms
+        duration: 45.005472ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -966,26 +966,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/cbfa0f8d-5515-4516-9d3c-7a53761312b9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/950b1fc8-caea-478e-bdc7-30dc2ed6f05d
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 458
-        body: '{"id":"cbfa0f8d-5515-4516-9d3c-7a53761312b9","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-multi-2","status":"ready","created_at":"2026-06-04T09:49:35.223211Z","updated_at":"2026-06-04T09:49:35.223211Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-06-04T09:49:36.814793Z","key_id":null,"region":"fr-par"}'
+        body: '{"id":"950b1fc8-caea-478e-bdc7-30dc2ed6f05d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-multi-1","status":"ready","created_at":"2026-07-03T15:28:00.513850Z","updated_at":"2026-07-03T15:28:04.923055Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-07-03T15:28:04.923055Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "458"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:36 GMT
+                - Fri, 03 Jul 2026 15:28:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 4d5c8532-0216-4274-b978-85c9b9e58de2
+                - e1344352-3e60-4a20-b323-7faa1ebe60e6
         status: 200 OK
         code: 200
-        duration: 37.853707ms
+        duration: 38.695841ms

--- a/internal/services/secret/testdata/list-secrets-basic.cassette.yaml
+++ b/internal/services/secret/testdata/list-secrets-basic.cassette.yaml
@@ -13,7 +13,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets
         method: POST
       response:
@@ -21,21 +21,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 432
-        body: '{"id":"de2a02cf-256a-4d44-b890-0e092416e7be","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-list-1","status":"ready","created_at":"2026-05-28T14:24:38.201207Z","updated_at":"2026-05-28T14:24:38.201207Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"60b542c7-81ba-4853-882b-4f3db0eb4f59","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-list-1","status":"ready","created_at":"2026-07-03T15:28:05.410808Z","updated_at":"2026-07-03T15:28:05.410808Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "432"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:38 GMT
+                - Fri, 03 Jul 2026 15:28:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 277476b1-1a5f-4759-9868-a7b2c1747d79
+                - e044c0f0-a84c-4b4a-8987-5cf0d27d81dc
         status: 200 OK
         code: 200
-        duration: 267.413724ms
+        duration: 104.854945ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -45,29 +45,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/de2a02cf-256a-4d44-b890-0e092416e7be
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/60b542c7-81ba-4853-882b-4f3db0eb4f59
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 432
-        body: '{"id":"de2a02cf-256a-4d44-b890-0e092416e7be","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-list-1","status":"ready","created_at":"2026-05-28T14:24:38.201207Z","updated_at":"2026-05-28T14:24:38.201207Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"60b542c7-81ba-4853-882b-4f3db0eb4f59","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-list-1","status":"ready","created_at":"2026-07-03T15:28:05.410808Z","updated_at":"2026-07-03T15:28:05.410808Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "432"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:38 GMT
+                - Fri, 03 Jul 2026 15:28:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - f4c1a4a3-f13f-4438-8d6c-d609871e9ab4
+                - 41bc74ec-d184-4915-aa0e-504b065e7621
         status: 200 OK
         code: 200
-        duration: 81.041909ms
+        duration: 38.117956ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -80,8 +80,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/de2a02cf-256a-4d44-b890-0e092416e7be/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/60b542c7-81ba-4853-882b-4f3db0eb4f59/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -95,14 +95,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:38 GMT
+                - Fri, 03 Jul 2026 15:28:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 2d08eff3-e4d0-4b63-8080-4ac114dde988
+                - 72fd6db7-ad59-47e9-b4b9-9066560b94fb
         status: 200 OK
         code: 200
-        duration: 86.110307ms
+        duration: 47.321182ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -112,29 +112,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/de2a02cf-256a-4d44-b890-0e092416e7be
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/60b542c7-81ba-4853-882b-4f3db0eb4f59
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 432
-        body: '{"id":"de2a02cf-256a-4d44-b890-0e092416e7be","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-list-1","status":"ready","created_at":"2026-05-28T14:24:38.201207Z","updated_at":"2026-05-28T14:24:38.201207Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"60b542c7-81ba-4853-882b-4f3db0eb4f59","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-list-1","status":"ready","created_at":"2026-07-03T15:28:05.410808Z","updated_at":"2026-07-03T15:28:05.410808Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "432"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:39 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 0bc66208-995c-4b99-94af-78df03f71462
+                - ad123ae4-c419-40b8-ac86-b84ec26dd021
         status: 200 OK
         code: 200
-        duration: 34.942273ms
+        duration: 36.340638ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -147,8 +147,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/de2a02cf-256a-4d44-b890-0e092416e7be/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/60b542c7-81ba-4853-882b-4f3db0eb4f59/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -162,14 +162,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:39 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 45e71dfc-b2d3-44bb-a3c9-f58e4055691b
+                - 86a38711-11be-4da5-bed3-bd65cc6cf92d
         status: 200 OK
         code: 200
-        duration: 78.161005ms
+        duration: 45.044265ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -179,29 +179,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/de2a02cf-256a-4d44-b890-0e092416e7be
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/60b542c7-81ba-4853-882b-4f3db0eb4f59
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 432
-        body: '{"id":"de2a02cf-256a-4d44-b890-0e092416e7be","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-list-1","status":"ready","created_at":"2026-05-28T14:24:38.201207Z","updated_at":"2026-05-28T14:24:38.201207Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"60b542c7-81ba-4853-882b-4f3db0eb4f59","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-list-1","status":"ready","created_at":"2026-07-03T15:28:05.410808Z","updated_at":"2026-07-03T15:28:05.410808Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "432"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:39 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 818744e1-94ea-4387-bf53-a7fa19945635
+                - c2b5a104-555d-45b5-b8c0-2412281903f6
         status: 200 OK
         code: 200
-        duration: 41.776145ms
+        duration: 47.370263ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -214,8 +214,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/de2a02cf-256a-4d44-b890-0e092416e7be/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/60b542c7-81ba-4853-882b-4f3db0eb4f59/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -229,14 +229,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:39 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 763b6f10-1c60-474f-b9c2-8db1bf39e2d6
+                - c9772748-3a36-48bc-9bf6-3d4bc4792aa0
         status: 200 OK
         code: 200
-        duration: 34.338081ms
+        duration: 42.258011ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -249,7 +249,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets
         method: POST
       response:
@@ -257,21 +257,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 442
-        body: '{"id":"c1760beb-b536-48a5-bf8a-fefa55d87b7c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-list-2","status":"ready","created_at":"2026-05-28T14:24:39.868244Z","updated_at":"2026-05-28T14:24:39.868244Z","tags":["test-tag"],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"00155e5a-c3c8-4b4d-ad3c-ab7c45aa02af","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-list-2","status":"ready","created_at":"2026-07-03T15:28:06.950950Z","updated_at":"2026-07-03T15:28:06.950950Z","tags":["test-tag"],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "442"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:39 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - e9103da4-f846-492a-8502-a31217b2a55a
+                - 96f8ea30-3ffa-49be-9f18-ceeae5440e78
         status: 200 OK
         code: 200
-        duration: 97.585236ms
+        duration: 141.449469ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -281,29 +281,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c1760beb-b536-48a5-bf8a-fefa55d87b7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/00155e5a-c3c8-4b4d-ad3c-ab7c45aa02af
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 442
-        body: '{"id":"c1760beb-b536-48a5-bf8a-fefa55d87b7c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-list-2","status":"ready","created_at":"2026-05-28T14:24:39.868244Z","updated_at":"2026-05-28T14:24:39.868244Z","tags":["test-tag"],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"00155e5a-c3c8-4b4d-ad3c-ab7c45aa02af","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-list-2","status":"ready","created_at":"2026-07-03T15:28:06.950950Z","updated_at":"2026-07-03T15:28:06.950950Z","tags":["test-tag"],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "442"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:39 GMT
+                - Fri, 03 Jul 2026 15:28:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - c82c625b-02be-4518-99ce-bb60d4cde324
+                - 506c212a-b3ee-4f85-a985-073d417aa867
         status: 200 OK
         code: 200
-        duration: 83.7602ms
+        duration: 62.454836ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -316,8 +316,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c1760beb-b536-48a5-bf8a-fefa55d87b7c/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/00155e5a-c3c8-4b4d-ad3c-ab7c45aa02af/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -331,14 +331,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:40 GMT
+                - Fri, 03 Jul 2026 15:28:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - bc3a4d10-ba0e-4deb-b34b-48c24e8a7dea
+                - 3c94945a-8971-4cea-849b-952fb4ddcc97
         status: 200 OK
         code: 200
-        duration: 36.750877ms
+        duration: 40.815873ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -348,29 +348,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/de2a02cf-256a-4d44-b890-0e092416e7be
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/60b542c7-81ba-4853-882b-4f3db0eb4f59
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 432
-        body: '{"id":"de2a02cf-256a-4d44-b890-0e092416e7be","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-list-1","status":"ready","created_at":"2026-05-28T14:24:38.201207Z","updated_at":"2026-05-28T14:24:38.201207Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"60b542c7-81ba-4853-882b-4f3db0eb4f59","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-list-1","status":"ready","created_at":"2026-07-03T15:28:05.410808Z","updated_at":"2026-07-03T15:28:05.410808Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "432"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:40 GMT
+                - Fri, 03 Jul 2026 15:28:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 96039e1a-6b12-4b8c-9733-a6313eff0d2d
+                - 0e0017d4-9a14-42ef-a296-19fd107129a9
         status: 200 OK
         code: 200
-        duration: 44.418092ms
+        duration: 44.51991ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -380,29 +380,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c1760beb-b536-48a5-bf8a-fefa55d87b7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/00155e5a-c3c8-4b4d-ad3c-ab7c45aa02af
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 442
-        body: '{"id":"c1760beb-b536-48a5-bf8a-fefa55d87b7c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-list-2","status":"ready","created_at":"2026-05-28T14:24:39.868244Z","updated_at":"2026-05-28T14:24:39.868244Z","tags":["test-tag"],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"00155e5a-c3c8-4b4d-ad3c-ab7c45aa02af","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-list-2","status":"ready","created_at":"2026-07-03T15:28:06.950950Z","updated_at":"2026-07-03T15:28:06.950950Z","tags":["test-tag"],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "442"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:40 GMT
+                - Fri, 03 Jul 2026 15:28:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 3fb78a5a-5f08-487a-b3f1-45e51e2457ff
+                - d4d590ec-bf2c-4bdd-b407-27fd69e26f66
         status: 200 OK
         code: 200
-        duration: 80.831084ms
+        duration: 47.92193ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -415,8 +415,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/de2a02cf-256a-4d44-b890-0e092416e7be/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/60b542c7-81ba-4853-882b-4f3db0eb4f59/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -430,14 +430,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:40 GMT
+                - Fri, 03 Jul 2026 15:28:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 9fc933e0-735b-4f83-901e-71d48da0ca5f
+                - be5d87a5-470e-4ac5-b375-f83d011540bd
         status: 200 OK
         code: 200
-        duration: 76.179247ms
+        duration: 42.659766ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -450,8 +450,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c1760beb-b536-48a5-bf8a-fefa55d87b7c/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/00155e5a-c3c8-4b4d-ad3c-ab7c45aa02af/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -465,14 +465,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:40 GMT
+                - Fri, 03 Jul 2026 15:28:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - b6110c0f-29f3-4c2a-8542-fb9591433ac4
+                - c92f6854-d0dc-46ec-bbe2-4c1c14e05439
         status: 200 OK
         code: 200
-        duration: 46.984646ms
+        duration: 45.198695ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -493,29 +493,29 @@ interactions:
                 - unknown_type
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets?order_by=name_asc&page=1&project_id=105bdce1-64c0-48ab-899d-868455867ecf&scheduled_for_deletion=false&type=unknown_type
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 2664
-        body: '{"secrets":[{"id":"44520e31-5af9-42c1-898d-1af0ead2c7fc","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-filter-1","status":"ready","created_at":"2026-05-28T14:24:38.225637Z","updated_at":"2026-05-28T14:24:38.225637Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"bb5865be-6a39-4d37-9e24-234d0c62b04f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-filter-2","status":"ready","created_at":"2026-05-28T14:24:39.895802Z","updated_at":"2026-05-28T14:24:39.895802Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"de2a02cf-256a-4d44-b890-0e092416e7be","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-list-1","status":"ready","created_at":"2026-05-28T14:24:38.201207Z","updated_at":"2026-05-28T14:24:38.201207Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"c1760beb-b536-48a5-bf8a-fefa55d87b7c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-list-2","status":"ready","created_at":"2026-05-28T14:24:39.868244Z","updated_at":"2026-05-28T14:24:39.868244Z","tags":["test-tag"],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"ad9431f0-d273-4f64-803b-d33eb8d5e810","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-tag-1","status":"ready","created_at":"2026-05-28T14:24:38.248650Z","updated_at":"2026-05-28T14:24:38.248650Z","tags":["production"],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"865424a4-805d-4f87-b070-d300a226b150","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-tag-2","status":"ready","created_at":"2026-05-28T14:24:39.964286Z","updated_at":"2026-05-28T14:24:39.964286Z","tags":["development"],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}],"total_count":6}'
+        content_length: 15884
+        body: '{"secrets":[{"id":"40cb655e-0b83-4cba-8de5-ed05b59bbf6e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"connection_08d6273a-c2b5-46e5-b354-3fe4c0479914","status":"ready","created_at":"2026-06-16T03:39:38.598272Z","updated_at":"2026-06-16T03:39:38.598272Z","tags":["S2S VPN"],"version_count":1,"description":"Generated by Scaleway","managed":false,"type":"opaque","protected":true,"path":"/s2s_vpn","ephemeral_policy":null,"used_by":["s2s_vpn"],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"1eb6c146-1818-452b-b826-a8e4621b99d8","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"connection_2218b908-d9a5-44b7-8c09-68a460b916c1","status":"ready","created_at":"2026-06-30T03:03:53.867704Z","updated_at":"2026-06-30T03:03:53.867704Z","tags":["S2S VPN"],"version_count":1,"description":"Generated by Scaleway","managed":false,"type":"opaque","protected":true,"path":"/s2s_vpn","ephemeral_policy":null,"used_by":["s2s_vpn"],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"0cda53cf-8fee-4e91-b213-8a2b694d6f59","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"connection_28bd4354-390f-49e4-80af-05bf69ec081c","status":"ready","created_at":"2026-06-13T03:00:04.370651Z","updated_at":"2026-06-13T03:00:04.370651Z","tags":["S2S VPN"],"version_count":1,"description":"Generated by Scaleway","managed":false,"type":"opaque","protected":true,"path":"/s2s_vpn","ephemeral_policy":null,"used_by":["s2s_vpn"],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"6565cc4a-8b55-4f35-8169-a8a2eff35aac","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"connection_2f4a7c59-b5e2-485a-a443-5ac94ab7bf52","status":"ready","created_at":"2026-06-23T02:54:56.356466Z","updated_at":"2026-06-23T02:54:56.356466Z","tags":["S2S VPN"],"version_count":1,"description":"Generated by Scaleway","managed":false,"type":"opaque","protected":true,"path":"/s2s_vpn","ephemeral_policy":null,"used_by":["s2s_vpn"],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"932f9b5d-10f2-4d45-8e89-88bd6fb5b415","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"connection_38db8a48-71b2-4da0-a0f1-ac4ca533fad6","status":"ready","created_at":"2026-06-10T02:55:49.355268Z","updated_at":"2026-06-10T02:55:49.355268Z","tags":["S2S VPN"],"version_count":1,"description":"Generated by Scaleway","managed":false,"type":"opaque","protected":true,"path":"/s2s_vpn","ephemeral_policy":null,"used_by":["s2s_vpn"],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"03a5e79f-e5d8-46b4-9d78-4b012a4960f8","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"connection_3a323e68-069a-4c54-b729-d70c1f5dc749","status":"ready","created_at":"2026-06-09T02:47:26.614803Z","updated_at":"2026-06-09T02:47:26.614803Z","tags":["S2S VPN"],"version_count":1,"description":"Generated by Scaleway","managed":false,"type":"opaque","protected":true,"path":"/s2s_vpn","ephemeral_policy":null,"used_by":["s2s_vpn"],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"b051d579-0885-4d53-b335-43090b05c930","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"connection_4ef585a5-b8e7-45ba-a98f-82437b07f860","status":"ready","created_at":"2026-06-07T03:30:50.371185Z","updated_at":"2026-06-07T03:30:50.371185Z","tags":["S2S VPN"],"version_count":1,"description":"Generated by Scaleway","managed":false,"type":"opaque","protected":true,"path":"/s2s_vpn","ephemeral_policy":null,"used_by":["s2s_vpn"],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"f17b0b58-d687-48c6-ace5-1b3edff8b7fd","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"connection_5a276b66-5f6c-4104-9e2d-4453f934da3f","status":"ready","created_at":"2026-06-15T03:42:24.708279Z","updated_at":"2026-06-15T03:42:24.708279Z","tags":["S2S VPN"],"version_count":1,"description":"Generated by Scaleway","managed":false,"type":"opaque","protected":true,"path":"/s2s_vpn","ephemeral_policy":null,"used_by":["s2s_vpn"],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"eb9e6f63-703e-407b-aaf5-211287c2c8d1","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"connection_5c577157-6841-4a76-a264-f31292b60af0","status":"ready","created_at":"2026-06-11T03:34:53.359914Z","updated_at":"2026-06-11T03:34:53.359914Z","tags":["S2S VPN"],"version_count":1,"description":"Generated by Scaleway","managed":false,"type":"opaque","protected":true,"path":"/s2s_vpn","ephemeral_policy":null,"used_by":["s2s_vpn"],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"71fcf44c-86b2-4efc-8a06-56d3ff907d16","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"connection_609879df-0176-499b-b792-b60cb848b535","status":"ready","created_at":"2026-06-28T02:57:22.343631Z","updated_at":"2026-06-28T02:57:22.343631Z","tags":["S2S VPN"],"version_count":1,"description":"Generated by Scaleway","managed":false,"type":"opaque","protected":true,"path":"/s2s_vpn","ephemeral_policy":null,"used_by":["s2s_vpn"],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"935e292f-3075-4a76-9270-5fede1a9d84c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"connection_61246285-fec6-48a0-a472-2c283079c1cb","status":"ready","created_at":"2026-06-27T02:42:57.828042Z","updated_at":"2026-06-27T02:42:57.828042Z","tags":["S2S VPN"],"version_count":1,"description":"Generated by Scaleway","managed":false,"type":"opaque","protected":true,"path":"/s2s_vpn","ephemeral_policy":null,"used_by":["s2s_vpn"],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"60158ec5-ca94-45ee-8de2-9b1d4f74e9e0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"connection_67777f4e-f46e-4474-ac8a-6a628db42fb0","status":"ready","created_at":"2026-06-08T03:38:49.349096Z","updated_at":"2026-06-08T03:38:49.349096Z","tags":["S2S VPN"],"version_count":1,"description":"Generated by Scaleway","managed":false,"type":"opaque","protected":true,"path":"/s2s_vpn","ephemeral_policy":null,"used_by":["s2s_vpn"],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"f04c6727-cc01-4883-b3c2-7977ec93c412","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"connection_6abf2567-64e9-4db7-9d26-861cf31761a3","status":"ready","created_at":"2026-06-17T03:41:09.832399Z","updated_at":"2026-06-17T03:41:09.832399Z","tags":["S2S VPN"],"version_count":1,"description":"Generated by Scaleway","managed":false,"type":"opaque","protected":true,"path":"/s2s_vpn","ephemeral_policy":null,"used_by":["s2s_vpn"],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"69e8cdc3-e1d1-44df-9d60-38efcfaa5599","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"connection_7642b0ed-2468-4b9f-b360-1954814c5abe","status":"ready","created_at":"2026-07-03T02:44:04.981824Z","updated_at":"2026-07-03T02:44:04.981824Z","tags":["S2S VPN"],"version_count":1,"description":"Generated by Scaleway","managed":false,"type":"opaque","protected":true,"path":"/s2s_vpn","ephemeral_policy":null,"used_by":["s2s_vpn"],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"cf003fb7-b3ab-4784-881d-d5ac9108d88e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"connection_816b8ad4-15e0-491c-b2d1-b951119feb06","status":"ready","created_at":"2026-07-01T02:58:58.984933Z","updated_at":"2026-07-01T02:58:58.984933Z","tags":["S2S VPN"],"version_count":1,"description":"Generated by Scaleway","managed":false,"type":"opaque","protected":true,"path":"/s2s_vpn","ephemeral_policy":null,"used_by":["s2s_vpn"],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"2051831a-b6a9-4342-aac3-75676ab86fb6","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"connection_9327b21d-6975-4771-b2f5-7f208bcd9c58","status":"ready","created_at":"2026-06-12T03:29:22.193932Z","updated_at":"2026-06-12T03:29:22.193932Z","tags":["S2S VPN"],"version_count":1,"description":"Generated by Scaleway","managed":false,"type":"opaque","protected":true,"path":"/s2s_vpn","ephemeral_policy":null,"used_by":["s2s_vpn"],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"b85dc0f7-3f60-4680-9548-6f317b30b91c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"connection_99f1556f-fe16-4d9e-86d6-e58a2754fc74","status":"ready","created_at":"2026-06-25T02:52:24.034368Z","updated_at":"2026-06-25T02:52:24.034368Z","tags":["S2S VPN"],"version_count":1,"description":"Generated by Scaleway","managed":false,"type":"opaque","protected":true,"path":"/s2s_vpn","ephemeral_policy":null,"used_by":["s2s_vpn"],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"cf90ef51-4870-474f-82f1-7524e12e6e14","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"connection_a0b68f59-3041-4dc9-b44e-ff04519300f7","status":"ready","created_at":"2026-06-29T03:04:43.735589Z","updated_at":"2026-06-29T03:04:43.735589Z","tags":["S2S VPN"],"version_count":1,"description":"Generated by Scaleway","managed":false,"type":"opaque","protected":true,"path":"/s2s_vpn","ephemeral_policy":null,"used_by":["s2s_vpn"],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"36ed51b8-d388-42f7-bec2-3d5be6d0bf69","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"connection_b43308f8-116b-4d75-929f-09cc3c1500ef","status":"ready","created_at":"2026-06-14T03:34:12.810033Z","updated_at":"2026-06-14T03:34:12.810033Z","tags":["S2S VPN"],"version_count":1,"description":"Generated by Scaleway","managed":false,"type":"opaque","protected":true,"path":"/s2s_vpn","ephemeral_policy":null,"used_by":["s2s_vpn"],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"e8f8a3c7-2ea6-46a9-a627-1ca88d9391f3","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"connection_ba0f7ebc-bb17-4656-ba62-04dc5d7f7928","status":"ready","created_at":"2026-06-24T02:51:41.970106Z","updated_at":"2026-06-24T02:51:41.970106Z","tags":["S2S VPN"],"version_count":1,"description":"Generated by Scaleway","managed":false,"type":"opaque","protected":true,"path":"/s2s_vpn","ephemeral_policy":null,"used_by":["s2s_vpn"],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"4eba51ea-465a-4af0-b701-4f2b16e2ccbc","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"connection_bec5dbc9-809d-4a84-807f-266b9f521a17","status":"ready","created_at":"2026-06-26T02:59:26.822728Z","updated_at":"2026-06-26T02:59:26.822728Z","tags":["S2S VPN"],"version_count":1,"description":"Generated by Scaleway","managed":false,"type":"opaque","protected":true,"path":"/s2s_vpn","ephemeral_policy":null,"used_by":["s2s_vpn"],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"f07b7fe0-2825-4575-8e05-327c8975c5df","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"connection_c3dc67eb-bf73-47cb-ab52-5d450de73dff","status":"ready","created_at":"2026-06-06T02:43:45.366752Z","updated_at":"2026-06-06T02:43:45.366752Z","tags":["S2S VPN"],"version_count":1,"description":"Generated by Scaleway","managed":false,"type":"opaque","protected":true,"path":"/s2s_vpn","ephemeral_policy":null,"used_by":["s2s_vpn"],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"a5db1324-1270-4e43-9391-d1db13528db0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"connection_d878de1e-4248-434c-827f-add38f0d7de4","status":"ready","created_at":"2026-06-23T02:53:55.162445Z","updated_at":"2026-06-23T02:53:55.162445Z","tags":["S2S VPN"],"version_count":1,"description":"Generated by Scaleway","managed":false,"type":"opaque","protected":true,"path":"/s2s_vpn","ephemeral_policy":null,"used_by":["s2s_vpn"],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"e3e583f3-49bc-455c-8de9-af902f679cb8","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"connection_e28fa068-9beb-4de5-b358-bc2e746ce25b","status":"ready","created_at":"2026-06-24T02:52:29.661712Z","updated_at":"2026-06-24T02:52:29.661712Z","tags":["S2S VPN"],"version_count":1,"description":"Generated by Scaleway","managed":false,"type":"opaque","protected":true,"path":"/s2s_vpn","ephemeral_policy":null,"used_by":["s2s_vpn"],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"32e4fa9a-2007-4928-8b7e-a56603c988b7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"connection_f175e613-0952-4a51-9148-b8a7b3a7fc5a","status":"ready","created_at":"2026-06-05T02:56:25.887171Z","updated_at":"2026-06-05T02:56:25.887171Z","tags":["S2S VPN"],"version_count":1,"description":"Generated by Scaleway","managed":false,"type":"opaque","protected":true,"path":"/s2s_vpn","ephemeral_policy":null,"used_by":["s2s_vpn"],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"debe451d-dc87-49c1-b272-be84929d6b27","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"connection_fe011434-8c96-45c1-bbf2-55cb66f7748f","status":"ready","created_at":"2026-07-02T02:54:07.800400Z","updated_at":"2026-07-02T02:54:07.800400Z","tags":["S2S VPN"],"version_count":1,"description":"Generated by Scaleway","managed":false,"type":"opaque","protected":true,"path":"/s2s_vpn","ephemeral_policy":null,"used_by":["s2s_vpn"],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"c02805ba-64eb-435b-80fb-74fd55caad1c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"dsSecretVersionByNameSecret","status":"ready","created_at":"2026-07-03T15:28:04.271187Z","updated_at":"2026-07-03T15:28:04.271187Z","tags":["devtools","provider","terraform"],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"08d258d7-bf41-4122-904d-764b1a49274a","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-filter-1","status":"ready","created_at":"2026-07-03T15:28:05.374218Z","updated_at":"2026-07-03T15:28:05.374218Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"ca5c7d3f-5eb5-42d5-8d63-741d8e3fbb32","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-filter-2","status":"ready","created_at":"2026-07-03T15:28:06.912899Z","updated_at":"2026-07-03T15:28:06.912899Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"60b542c7-81ba-4853-882b-4f3db0eb4f59","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-list-1","status":"ready","created_at":"2026-07-03T15:28:05.410808Z","updated_at":"2026-07-03T15:28:05.410808Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"00155e5a-c3c8-4b4d-ad3c-ab7c45aa02af","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-list-2","status":"ready","created_at":"2026-07-03T15:28:06.950950Z","updated_at":"2026-07-03T15:28:06.950950Z","tags":["test-tag"],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"},{"id":"d023fa93-eb36-44b5-91b8-13b998e2e630","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-tests-edge-dns-wildcard-cert","status":"ready","created_at":"2026-06-26T09:32:44.780706Z","updated_at":"2026-06-26T09:32:44.780706Z","tags":[],"version_count":1,"description":"","managed":false,"type":"certificate","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}],"total_count":32}'
         headers:
             Content-Length:
-                - "2664"
+                - "15884"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:41 GMT
+                - Fri, 03 Jul 2026 15:28:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 556f3eab-35c3-4337-86ab-827485e1461d
+                - 5c8178c4-9ffe-499f-8dd1-4a5b855a96bf
         status: 200 OK
         code: 200
-        duration: 92.506318ms
+        duration: 164.672638ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -525,8 +525,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c1760beb-b536-48a5-bf8a-fefa55d87b7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/60b542c7-81ba-4853-882b-4f3db0eb4f59
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -538,14 +538,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:41 GMT
+                - Fri, 03 Jul 2026 15:28:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 5d26be8c-e8a6-491a-aea9-a6614d5f4f24
+                - e8e8eebc-9b75-46cc-9721-0221d5309246
         status: 204 No Content
         code: 204
-        duration: 91.176202ms
+        duration: 69.213402ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -555,8 +555,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/de2a02cf-256a-4d44-b890-0e092416e7be
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/00155e5a-c3c8-4b4d-ad3c-ab7c45aa02af
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -568,14 +568,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:41 GMT
+                - Fri, 03 Jul 2026 15:28:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 8de0c0ac-a37d-483f-bfee-6ac4456e2db0
+                - 5ad308fe-3c8c-4830-a4d0-0ce95660a778
         status: 204 No Content
         code: 204
-        duration: 92.309388ms
+        duration: 78.590974ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -585,29 +585,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c1760beb-b536-48a5-bf8a-fefa55d87b7c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/60b542c7-81ba-4853-882b-4f3db0eb4f59
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 467
-        body: '{"id":"c1760beb-b536-48a5-bf8a-fefa55d87b7c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-list-2","status":"ready","created_at":"2026-05-28T14:24:39.868244Z","updated_at":"2026-05-28T14:24:39.868244Z","tags":["test-tag"],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-05-28T14:24:41.484039Z","key_id":null,"region":"fr-par"}'
+        content_length: 457
+        body: '{"id":"60b542c7-81ba-4853-882b-4f3db0eb4f59","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-list-1","status":"ready","created_at":"2026-07-03T15:28:05.410808Z","updated_at":"2026-07-03T15:28:08.137289Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-07-03T15:28:08.137289Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "467"
+                - "457"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:41 GMT
+                - Fri, 03 Jul 2026 15:28:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 67ca054b-6afc-4ea5-8571-30db2cf6b131
+                - fec808fd-f67b-48c6-a663-643e8875c8a6
         status: 200 OK
         code: 200
-        duration: 29.484956ms
+        duration: 47.252843ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -617,26 +617,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/de2a02cf-256a-4d44-b890-0e092416e7be
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/00155e5a-c3c8-4b4d-ad3c-ab7c45aa02af
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 457
-        body: '{"id":"de2a02cf-256a-4d44-b890-0e092416e7be","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-list-1","status":"ready","created_at":"2026-05-28T14:24:38.201207Z","updated_at":"2026-05-28T14:24:38.201207Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-05-28T14:24:41.487357Z","key_id":null,"region":"fr-par"}'
+        content_length: 467
+        body: '{"id":"00155e5a-c3c8-4b4d-ad3c-ab7c45aa02af","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-list-2","status":"ready","created_at":"2026-07-03T15:28:06.950950Z","updated_at":"2026-07-03T15:28:08.149042Z","tags":["test-tag"],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-07-03T15:28:08.149042Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "457"
+                - "467"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:41 GMT
+                - Fri, 03 Jul 2026 15:28:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 13c811df-3a32-448f-9635-f18ba19fb48f
+                - c1ed51cf-9925-4b69-878d-39ade26692d3
         status: 200 OK
         code: 200
-        duration: 46.006581ms
+        duration: 58.155682ms

--- a/internal/services/secret/testdata/list-secrets-by-name.cassette.yaml
+++ b/internal/services/secret/testdata/list-secrets-by-name.cassette.yaml
@@ -13,7 +13,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets
         method: POST
       response:
@@ -21,21 +21,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 434
-        body: '{"id":"44520e31-5af9-42c1-898d-1af0ead2c7fc","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-filter-1","status":"ready","created_at":"2026-05-28T14:24:38.225637Z","updated_at":"2026-05-28T14:24:38.225637Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"08d258d7-bf41-4122-904d-764b1a49274a","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-filter-1","status":"ready","created_at":"2026-07-03T15:28:05.374218Z","updated_at":"2026-07-03T15:28:05.374218Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "434"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:38 GMT
+                - Fri, 03 Jul 2026 15:28:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 8410a656-093a-4231-bf94-3edcc8e63fc1
+                - c6f4f085-b609-4399-b2d2-ee66af98c574
         status: 200 OK
         code: 200
-        duration: 279.504427ms
+        duration: 101.549266ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -45,29 +45,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/44520e31-5af9-42c1-898d-1af0ead2c7fc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/08d258d7-bf41-4122-904d-764b1a49274a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 434
-        body: '{"id":"44520e31-5af9-42c1-898d-1af0ead2c7fc","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-filter-1","status":"ready","created_at":"2026-05-28T14:24:38.225637Z","updated_at":"2026-05-28T14:24:38.225637Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"08d258d7-bf41-4122-904d-764b1a49274a","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-filter-1","status":"ready","created_at":"2026-07-03T15:28:05.374218Z","updated_at":"2026-07-03T15:28:05.374218Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "434"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:38 GMT
+                - Fri, 03 Jul 2026 15:28:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 1bc2495b-98c7-4f29-acab-e4ce5cb3fd2f
+                - 0e550c8c-07f7-48b9-aad6-7ce1c17f24bd
         status: 200 OK
         code: 200
-        duration: 78.342656ms
+        duration: 44.805306ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -80,8 +80,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/44520e31-5af9-42c1-898d-1af0ead2c7fc/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/08d258d7-bf41-4122-904d-764b1a49274a/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -95,14 +95,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:38 GMT
+                - Fri, 03 Jul 2026 15:28:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - fc13bea6-9ded-4d6d-b408-dccea4ca8863
+                - c819a1e4-5bfe-4ae5-ae7c-d674fb07bccd
         status: 200 OK
         code: 200
-        duration: 74.575287ms
+        duration: 58.320381ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -112,29 +112,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/44520e31-5af9-42c1-898d-1af0ead2c7fc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/08d258d7-bf41-4122-904d-764b1a49274a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 434
-        body: '{"id":"44520e31-5af9-42c1-898d-1af0ead2c7fc","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-filter-1","status":"ready","created_at":"2026-05-28T14:24:38.225637Z","updated_at":"2026-05-28T14:24:38.225637Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"08d258d7-bf41-4122-904d-764b1a49274a","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-filter-1","status":"ready","created_at":"2026-07-03T15:28:05.374218Z","updated_at":"2026-07-03T15:28:05.374218Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "434"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:38 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - a9734fb2-58f7-49bb-a129-6181287f287a
+                - 5a49def7-2777-42f2-82f2-6f4c9d70b438
         status: 200 OK
         code: 200
-        duration: 35.458452ms
+        duration: 48.740287ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -147,8 +147,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/44520e31-5af9-42c1-898d-1af0ead2c7fc/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/08d258d7-bf41-4122-904d-764b1a49274a/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -162,14 +162,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:39 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - e49254e9-cdb1-44d3-ad58-a9cd579ade92
+                - e493537f-f7ad-4575-95c6-3facb97aac90
         status: 200 OK
         code: 200
-        duration: 37.156508ms
+        duration: 44.185222ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -179,29 +179,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/44520e31-5af9-42c1-898d-1af0ead2c7fc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/08d258d7-bf41-4122-904d-764b1a49274a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 434
-        body: '{"id":"44520e31-5af9-42c1-898d-1af0ead2c7fc","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-filter-1","status":"ready","created_at":"2026-05-28T14:24:38.225637Z","updated_at":"2026-05-28T14:24:38.225637Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"08d258d7-bf41-4122-904d-764b1a49274a","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-filter-1","status":"ready","created_at":"2026-07-03T15:28:05.374218Z","updated_at":"2026-07-03T15:28:05.374218Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "434"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:39 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 2312c75b-8e74-49d1-99c3-e3cea360a29e
+                - 10c00fb2-8e55-4ca0-be06-95f52298a7fc
         status: 200 OK
         code: 200
-        duration: 31.302395ms
+        duration: 34.476165ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -214,8 +214,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/44520e31-5af9-42c1-898d-1af0ead2c7fc/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/08d258d7-bf41-4122-904d-764b1a49274a/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -229,14 +229,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:39 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 9ad68063-3a9e-4e49-b219-7d6623a3e916
+                - eca6943e-66ac-498a-85af-a1e780c81d82
         status: 200 OK
         code: 200
-        duration: 88.529196ms
+        duration: 45.922164ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -249,7 +249,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets
         method: POST
       response:
@@ -257,21 +257,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 434
-        body: '{"id":"bb5865be-6a39-4d37-9e24-234d0c62b04f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-filter-2","status":"ready","created_at":"2026-05-28T14:24:39.895802Z","updated_at":"2026-05-28T14:24:39.895802Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"ca5c7d3f-5eb5-42d5-8d63-741d8e3fbb32","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-filter-2","status":"ready","created_at":"2026-07-03T15:28:06.912899Z","updated_at":"2026-07-03T15:28:06.912899Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "434"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:39 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - cb19d437-dea6-4f1a-888d-73912f388acf
+                - aeab2df4-a3c2-47dd-bd48-6fb699650d7f
         status: 200 OK
         code: 200
-        duration: 167.381798ms
+        duration: 115.406373ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -281,29 +281,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/bb5865be-6a39-4d37-9e24-234d0c62b04f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ca5c7d3f-5eb5-42d5-8d63-741d8e3fbb32
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 434
-        body: '{"id":"bb5865be-6a39-4d37-9e24-234d0c62b04f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-filter-2","status":"ready","created_at":"2026-05-28T14:24:39.895802Z","updated_at":"2026-05-28T14:24:39.895802Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"ca5c7d3f-5eb5-42d5-8d63-741d8e3fbb32","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-filter-2","status":"ready","created_at":"2026-07-03T15:28:06.912899Z","updated_at":"2026-07-03T15:28:06.912899Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "434"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:40 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 4c5d2306-efde-451b-9343-d27567c1ad80
+                - 25d03bad-6c13-49e1-b8a8-7d1296bc017e
         status: 200 OK
         code: 200
-        duration: 99.195948ms
+        duration: 47.894389ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -316,8 +316,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/bb5865be-6a39-4d37-9e24-234d0c62b04f/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ca5c7d3f-5eb5-42d5-8d63-741d8e3fbb32/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -331,14 +331,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:40 GMT
+                - Fri, 03 Jul 2026 15:28:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 7d7a4295-be98-4128-84f9-9658305acf0d
+                - c33a9f2c-0543-4109-b19d-8000c30778ce
         status: 200 OK
         code: 200
-        duration: 86.864132ms
+        duration: 39.991044ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -348,29 +348,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/44520e31-5af9-42c1-898d-1af0ead2c7fc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ca5c7d3f-5eb5-42d5-8d63-741d8e3fbb32
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 434
-        body: '{"id":"44520e31-5af9-42c1-898d-1af0ead2c7fc","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-filter-1","status":"ready","created_at":"2026-05-28T14:24:38.225637Z","updated_at":"2026-05-28T14:24:38.225637Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"ca5c7d3f-5eb5-42d5-8d63-741d8e3fbb32","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-filter-2","status":"ready","created_at":"2026-07-03T15:28:06.912899Z","updated_at":"2026-07-03T15:28:06.912899Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "434"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:40 GMT
+                - Fri, 03 Jul 2026 15:28:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 24e1db6f-cfee-4314-9695-1366624c97eb
+                - 80391a12-be75-482c-a47c-5a7046942d80
         status: 200 OK
         code: 200
-        duration: 72.999261ms
+        duration: 47.470913ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -380,29 +380,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/bb5865be-6a39-4d37-9e24-234d0c62b04f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/08d258d7-bf41-4122-904d-764b1a49274a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 434
-        body: '{"id":"bb5865be-6a39-4d37-9e24-234d0c62b04f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-filter-2","status":"ready","created_at":"2026-05-28T14:24:39.895802Z","updated_at":"2026-05-28T14:24:39.895802Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"08d258d7-bf41-4122-904d-764b1a49274a","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-filter-1","status":"ready","created_at":"2026-07-03T15:28:05.374218Z","updated_at":"2026-07-03T15:28:05.374218Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "434"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:40 GMT
+                - Fri, 03 Jul 2026 15:28:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - cf01f109-3dc3-43a9-9ee3-74c5310ee7db
+                - 2893ddad-850f-42e2-8ec6-b25d5c175425
         status: 200 OK
         code: 200
-        duration: 74.771767ms
+        duration: 52.216476ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -415,8 +415,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/bb5865be-6a39-4d37-9e24-234d0c62b04f/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/08d258d7-bf41-4122-904d-764b1a49274a/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -430,14 +430,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:40 GMT
+                - Fri, 03 Jul 2026 15:28:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 61a36d4d-89be-4799-9d2b-6fb202ccb915
+                - acb84b35-0e20-4fb8-888d-4331b2f96c49
         status: 200 OK
         code: 200
-        duration: 38.721163ms
+        duration: 40.592964ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -450,8 +450,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/44520e31-5af9-42c1-898d-1af0ead2c7fc/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ca5c7d3f-5eb5-42d5-8d63-741d8e3fbb32/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -465,14 +465,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:40 GMT
+                - Fri, 03 Jul 2026 15:28:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 70c724a5-f2a9-442f-a4b0-c0a86a68d10c
+                - a59e0d00-36ee-4981-ac1c-91c0ec088211
         status: 200 OK
         code: 200
-        duration: 51.975339ms
+        duration: 49.144877ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -495,7 +495,7 @@ interactions:
                 - unknown_type
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets?name=test-secret-filter-1&order_by=name_asc&page=1&project_id=105bdce1-64c0-48ab-899d-868455867ecf&scheduled_for_deletion=false&type=unknown_type
         method: GET
       response:
@@ -503,21 +503,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 464
-        body: '{"secrets":[{"id":"44520e31-5af9-42c1-898d-1af0ead2c7fc","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-filter-1","status":"ready","created_at":"2026-05-28T14:24:38.225637Z","updated_at":"2026-05-28T14:24:38.225637Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}],"total_count":1}'
+        body: '{"secrets":[{"id":"08d258d7-bf41-4122-904d-764b1a49274a","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-filter-1","status":"ready","created_at":"2026-07-03T15:28:05.374218Z","updated_at":"2026-07-03T15:28:05.374218Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "464"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:41 GMT
+                - Fri, 03 Jul 2026 15:28:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - dc1a76c4-1580-4203-9f71-a01d20af909a
+                - 98980c21-efd8-4cb7-9c61-6ba0a0cf3a8b
         status: 200 OK
         code: 200
-        duration: 101.838946ms
+        duration: 41.859293ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -527,8 +527,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/bb5865be-6a39-4d37-9e24-234d0c62b04f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ca5c7d3f-5eb5-42d5-8d63-741d8e3fbb32
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -540,14 +540,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:41 GMT
+                - Fri, 03 Jul 2026 15:28:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 69f90e16-b90c-45b0-8421-de01d8c6624d
+                - b36216c4-8277-4162-8c35-028b0443804a
         status: 204 No Content
         code: 204
-        duration: 105.053898ms
+        duration: 65.988053ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -557,8 +557,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/44520e31-5af9-42c1-898d-1af0ead2c7fc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/08d258d7-bf41-4122-904d-764b1a49274a
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -570,14 +570,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:41 GMT
+                - Fri, 03 Jul 2026 15:28:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - cdff3ef0-951f-47de-a7d2-16dcb02d0d28
+                - 8f011e31-ece4-4f06-98b7-ca4f1ea5b6b8
         status: 204 No Content
         code: 204
-        duration: 105.08709ms
+        duration: 70.14986ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -587,29 +587,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/44520e31-5af9-42c1-898d-1af0ead2c7fc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/08d258d7-bf41-4122-904d-764b1a49274a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 459
-        body: '{"id":"44520e31-5af9-42c1-898d-1af0ead2c7fc","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-filter-1","status":"ready","created_at":"2026-05-28T14:24:38.225637Z","updated_at":"2026-05-28T14:24:38.225637Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-05-28T14:24:41.607019Z","key_id":null,"region":"fr-par"}'
+        body: '{"id":"08d258d7-bf41-4122-904d-764b1a49274a","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-filter-1","status":"ready","created_at":"2026-07-03T15:28:05.374218Z","updated_at":"2026-07-03T15:28:07.980312Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-07-03T15:28:07.980312Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "459"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:41 GMT
+                - Fri, 03 Jul 2026 15:28:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 3daccbe5-c99b-491c-9dcc-eb00a72f0250
+                - 060a019b-c053-464c-88f0-a9aa81bb9402
         status: 200 OK
         code: 200
-        duration: 44.561971ms
+        duration: 48.20429ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -619,26 +619,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/bb5865be-6a39-4d37-9e24-234d0c62b04f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ca5c7d3f-5eb5-42d5-8d63-741d8e3fbb32
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 459
-        body: '{"id":"bb5865be-6a39-4d37-9e24-234d0c62b04f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-filter-2","status":"ready","created_at":"2026-05-28T14:24:39.895802Z","updated_at":"2026-05-28T14:24:39.895802Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-05-28T14:24:41.605400Z","key_id":null,"region":"fr-par"}'
+        body: '{"id":"ca5c7d3f-5eb5-42d5-8d63-741d8e3fbb32","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-filter-2","status":"ready","created_at":"2026-07-03T15:28:06.912899Z","updated_at":"2026-07-03T15:28:07.978768Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-07-03T15:28:07.978768Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "459"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:41 GMT
+                - Fri, 03 Jul 2026 15:28:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 3a354c6c-0435-4113-bee2-04d92c39f86e
+                - 198f9ad1-1e79-41a1-8d28-3498866d912d
         status: 200 OK
         code: 200
-        duration: 48.385605ms
+        duration: 57.91504ms

--- a/internal/services/secret/testdata/list-secrets-by-tags.cassette.yaml
+++ b/internal/services/secret/testdata/list-secrets-by-tags.cassette.yaml
@@ -13,7 +13,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets
         method: POST
       response:
@@ -21,21 +21,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 443
-        body: '{"id":"ad9431f0-d273-4f64-803b-d33eb8d5e810","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-tag-1","status":"ready","created_at":"2026-05-28T14:24:38.248650Z","updated_at":"2026-05-28T14:24:38.248650Z","tags":["production"],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"ca5a952d-4152-4dc8-8168-656f0a6d2bc7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-tag-1","status":"ready","created_at":"2026-07-03T15:27:54.621216Z","updated_at":"2026-07-03T15:27:54.621216Z","tags":["production"],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "443"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:38 GMT
+                - Fri, 03 Jul 2026 15:27:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - d17e6ddc-6825-4340-ac96-edbebd6894f7
+                - 75a5f996-567b-4244-acf8-750b7d351030
         status: 200 OK
         code: 200
-        duration: 292.378439ms
+        duration: 319.672626ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -45,29 +45,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ad9431f0-d273-4f64-803b-d33eb8d5e810
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ca5a952d-4152-4dc8-8168-656f0a6d2bc7
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 443
-        body: '{"id":"ad9431f0-d273-4f64-803b-d33eb8d5e810","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-tag-1","status":"ready","created_at":"2026-05-28T14:24:38.248650Z","updated_at":"2026-05-28T14:24:38.248650Z","tags":["production"],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"ca5a952d-4152-4dc8-8168-656f0a6d2bc7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-tag-1","status":"ready","created_at":"2026-07-03T15:27:54.621216Z","updated_at":"2026-07-03T15:27:54.621216Z","tags":["production"],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "443"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:38 GMT
+                - Fri, 03 Jul 2026 15:27:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - b10591a2-904a-4f13-8948-b24631b68577
+                - f1090c13-1907-45f1-a02e-6ce84eabeaa3
         status: 200 OK
         code: 200
-        duration: 79.306874ms
+        duration: 202.644587ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -80,8 +80,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ad9431f0-d273-4f64-803b-d33eb8d5e810/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ca5a952d-4152-4dc8-8168-656f0a6d2bc7/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -95,14 +95,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:38 GMT
+                - Fri, 03 Jul 2026 15:27:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 7bb048f4-af75-463d-b8f7-51a6d2c4c7bd
+                - 3b7f762b-803a-452b-9aa7-e18a27f9c096
         status: 200 OK
         code: 200
-        duration: 103.780969ms
+        duration: 44.361061ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -112,29 +112,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ad9431f0-d273-4f64-803b-d33eb8d5e810
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ca5a952d-4152-4dc8-8168-656f0a6d2bc7
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 443
-        body: '{"id":"ad9431f0-d273-4f64-803b-d33eb8d5e810","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-tag-1","status":"ready","created_at":"2026-05-28T14:24:38.248650Z","updated_at":"2026-05-28T14:24:38.248650Z","tags":["production"],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"ca5a952d-4152-4dc8-8168-656f0a6d2bc7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-tag-1","status":"ready","created_at":"2026-07-03T15:27:54.621216Z","updated_at":"2026-07-03T15:27:54.621216Z","tags":["production"],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "443"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:39 GMT
+                - Fri, 03 Jul 2026 15:27:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 670db6f6-a139-4960-a6d4-5fbedf921d60
+                - 7af89e8c-f3b7-467e-b52c-a56852eb967a
         status: 200 OK
         code: 200
-        duration: 77.458366ms
+        duration: 52.396204ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -147,8 +147,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ad9431f0-d273-4f64-803b-d33eb8d5e810/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ca5a952d-4152-4dc8-8168-656f0a6d2bc7/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -162,14 +162,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:39 GMT
+                - Fri, 03 Jul 2026 15:27:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 8e5ef645-860d-458e-98d0-d1d6678f08f8
+                - 13187985-bf6e-4da5-a344-c588f27435fa
         status: 200 OK
         code: 200
-        duration: 32.006827ms
+        duration: 48.831849ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -179,29 +179,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ad9431f0-d273-4f64-803b-d33eb8d5e810
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ca5a952d-4152-4dc8-8168-656f0a6d2bc7
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 443
-        body: '{"id":"ad9431f0-d273-4f64-803b-d33eb8d5e810","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-tag-1","status":"ready","created_at":"2026-05-28T14:24:38.248650Z","updated_at":"2026-05-28T14:24:38.248650Z","tags":["production"],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"ca5a952d-4152-4dc8-8168-656f0a6d2bc7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-tag-1","status":"ready","created_at":"2026-07-03T15:27:54.621216Z","updated_at":"2026-07-03T15:27:54.621216Z","tags":["production"],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "443"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:39 GMT
+                - Fri, 03 Jul 2026 15:27:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 69ce3c1e-0e65-49c4-81a6-5f5e13deef00
+                - e1b24c84-c495-456d-84fe-85d22f45e2da
         status: 200 OK
         code: 200
-        duration: 35.319251ms
+        duration: 67.726528ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -214,8 +214,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ad9431f0-d273-4f64-803b-d33eb8d5e810/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ca5a952d-4152-4dc8-8168-656f0a6d2bc7/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -229,14 +229,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:39 GMT
+                - Fri, 03 Jul 2026 15:27:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 9d9a0eba-2d63-4a14-9d85-a7b2d6426be3
+                - bbbb1f0f-586c-49d5-a60e-38639c0027e8
         status: 200 OK
         code: 200
-        duration: 76.262042ms
+        duration: 35.976683ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -249,7 +249,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets
         method: POST
       response:
@@ -257,21 +257,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 444
-        body: '{"id":"865424a4-805d-4f87-b070-d300a226b150","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-tag-2","status":"ready","created_at":"2026-05-28T14:24:39.964286Z","updated_at":"2026-05-28T14:24:39.964286Z","tags":["development"],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"87ea6548-6b82-420f-8627-6e200cfcb1f3","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-tag-2","status":"ready","created_at":"2026-07-03T15:27:56.257196Z","updated_at":"2026-07-03T15:27:56.257196Z","tags":["development"],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "444"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:39 GMT
+                - Fri, 03 Jul 2026 15:27:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - c01ea17f-00f5-4c09-beac-0990cf9ad7e9
+                - dd48328b-300f-406a-bfe4-4737670d6fb0
         status: 200 OK
         code: 200
-        duration: 101.143852ms
+        duration: 261.057963ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -281,29 +281,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/865424a4-805d-4f87-b070-d300a226b150
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/87ea6548-6b82-420f-8627-6e200cfcb1f3
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 444
-        body: '{"id":"865424a4-805d-4f87-b070-d300a226b150","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-tag-2","status":"ready","created_at":"2026-05-28T14:24:39.964286Z","updated_at":"2026-05-28T14:24:39.964286Z","tags":["development"],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"87ea6548-6b82-420f-8627-6e200cfcb1f3","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-tag-2","status":"ready","created_at":"2026-07-03T15:27:56.257196Z","updated_at":"2026-07-03T15:27:56.257196Z","tags":["development"],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "444"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:40 GMT
+                - Fri, 03 Jul 2026 15:27:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - e7eb97c7-5138-4254-849b-452b00ea7f2a
+                - 2e7e21ac-0c65-4324-ba0b-2bad482864a0
         status: 200 OK
         code: 200
-        duration: 60.644683ms
+        duration: 44.271994ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -316,8 +316,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/865424a4-805d-4f87-b070-d300a226b150/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/87ea6548-6b82-420f-8627-6e200cfcb1f3/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -331,14 +331,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:40 GMT
+                - Fri, 03 Jul 2026 15:27:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 08346f78-9450-446a-bc8e-6b8d3e1f417b
+                - da3dfd08-9824-4862-bc02-661c9bfbb1ef
         status: 200 OK
         code: 200
-        duration: 100.432277ms
+        duration: 46.465433ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -348,30 +348,62 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/865424a4-805d-4f87-b070-d300a226b150
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/87ea6548-6b82-420f-8627-6e200cfcb1f3
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 444
-        body: '{"id":"865424a4-805d-4f87-b070-d300a226b150","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-tag-2","status":"ready","created_at":"2026-05-28T14:24:39.964286Z","updated_at":"2026-05-28T14:24:39.964286Z","tags":["development"],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"87ea6548-6b82-420f-8627-6e200cfcb1f3","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-tag-2","status":"ready","created_at":"2026-07-03T15:27:56.257196Z","updated_at":"2026-07-03T15:27:56.257196Z","tags":["development"],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "444"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:40 GMT
+                - Fri, 03 Jul 2026 15:27:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - e67dc5b3-5617-4312-bf31-7af8406d2189
+                - b0acbe4f-e0d1-4af9-9f5f-30770e3d4c4e
         status: 200 OK
         code: 200
-        duration: 32.530569ms
+        duration: 34.44713ms
     - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ca5a952d-4152-4dc8-8168-656f0a6d2bc7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 443
+        body: '{"id":"ca5a952d-4152-4dc8-8168-656f0a6d2bc7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-tag-1","status":"ready","created_at":"2026-07-03T15:27:54.621216Z","updated_at":"2026-07-03T15:27:54.621216Z","tags":["production"],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "443"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:27:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 51b1a949-682b-4bd7-adc8-bf2bc4249893
+        status: 200 OK
+        code: 200
+        duration: 146.367365ms
+    - id: 12
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -383,8 +415,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/865424a4-805d-4f87-b070-d300a226b150/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/87ea6548-6b82-420f-8627-6e200cfcb1f3/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -398,46 +430,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:40 GMT
+                - Fri, 03 Jul 2026 15:27:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 75016b90-9e3b-4553-8f08-031d2d6bfe28
+                - aeb8849f-8122-479a-98b3-18ddb13b2031
         status: 200 OK
         code: 200
-        duration: 44.604991ms
-    - id: 12
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ad9431f0-d273-4f64-803b-d33eb8d5e810
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 443
-        body: '{"id":"ad9431f0-d273-4f64-803b-d33eb8d5e810","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-tag-1","status":"ready","created_at":"2026-05-28T14:24:38.248650Z","updated_at":"2026-05-28T14:24:38.248650Z","tags":["production"],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "443"
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 28 May 2026 14:24:40 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            X-Request-Id:
-                - 97fba294-059c-480c-9549-d12680246957
-        status: 200 OK
-        code: 200
-        duration: 94.713277ms
+        duration: 110.995017ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -450,8 +450,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ad9431f0-d273-4f64-803b-d33eb8d5e810/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ca5a952d-4152-4dc8-8168-656f0a6d2bc7/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -465,14 +465,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:40 GMT
+                - Fri, 03 Jul 2026 15:27:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - dfa308ea-ff68-4914-a408-d3b29728613d
+                - 3f7c398c-edc2-4f90-9284-62b253b6cf17
         status: 200 OK
         code: 200
-        duration: 48.501352ms
+        duration: 52.872017ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -495,7 +495,7 @@ interactions:
                 - unknown_type
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets?order_by=name_asc&page=1&project_id=105bdce1-64c0-48ab-899d-868455867ecf&scheduled_for_deletion=false&tags=production&type=unknown_type
         method: GET
       response:
@@ -503,21 +503,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 473
-        body: '{"secrets":[{"id":"ad9431f0-d273-4f64-803b-d33eb8d5e810","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-tag-1","status":"ready","created_at":"2026-05-28T14:24:38.248650Z","updated_at":"2026-05-28T14:24:38.248650Z","tags":["production"],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}],"total_count":1}'
+        body: '{"secrets":[{"id":"ca5a952d-4152-4dc8-8168-656f0a6d2bc7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-tag-1","status":"ready","created_at":"2026-07-03T15:27:54.621216Z","updated_at":"2026-07-03T15:27:54.621216Z","tags":["production"],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "473"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:41 GMT
+                - Fri, 03 Jul 2026 15:27:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - cd08ec9a-2f16-42c6-902c-f2827356ae51
+                - 8e0ee7b4-7c43-46d2-9499-0c842e2f76d8
         status: 200 OK
         code: 200
-        duration: 99.584276ms
+        duration: 1.082075173s
     - id: 15
       request:
         proto: HTTP/1.1
@@ -527,8 +527,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/865424a4-805d-4f87-b070-d300a226b150
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ca5a952d-4152-4dc8-8168-656f0a6d2bc7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -540,14 +540,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:41 GMT
+                - Fri, 03 Jul 2026 15:27:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 3ee6315a-5ddf-4ccd-a1e0-c95dc01a5b27
+                - 07d242a3-d11e-4c45-b2dd-340df567ca72
         status: 204 No Content
         code: 204
-        duration: 89.289021ms
+        duration: 130.896036ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -557,8 +557,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ad9431f0-d273-4f64-803b-d33eb8d5e810
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/87ea6548-6b82-420f-8627-6e200cfcb1f3
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -570,14 +570,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:41 GMT
+                - Fri, 03 Jul 2026 15:27:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - bba80f98-f8f1-4baf-9b9f-1f122539988b
+                - 31d8ca31-a27c-46ca-ae09-0112e735a488
         status: 204 No Content
         code: 204
-        duration: 99.825298ms
+        duration: 130.751855ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -587,29 +587,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ad9431f0-d273-4f64-803b-d33eb8d5e810
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ca5a952d-4152-4dc8-8168-656f0a6d2bc7
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 468
-        body: '{"id":"ad9431f0-d273-4f64-803b-d33eb8d5e810","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-tag-1","status":"ready","created_at":"2026-05-28T14:24:38.248650Z","updated_at":"2026-05-28T14:24:38.248650Z","tags":["production"],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-05-28T14:24:41.690677Z","key_id":null,"region":"fr-par"}'
+        body: '{"id":"ca5a952d-4152-4dc8-8168-656f0a6d2bc7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-tag-1","status":"ready","created_at":"2026-07-03T15:27:54.621216Z","updated_at":"2026-07-03T15:27:58.933645Z","tags":["production"],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-07-03T15:27:58.933645Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "468"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:41 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - f82c7e91-02e1-442a-bdbc-5b3a8930b51e
+                - 70584c14-4392-4267-aa20-8f77f5bcd364
         status: 200 OK
         code: 200
-        duration: 45.665151ms
+        duration: 43.416277ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -619,26 +619,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/865424a4-805d-4f87-b070-d300a226b150
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/87ea6548-6b82-420f-8627-6e200cfcb1f3
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 469
-        body: '{"id":"865424a4-805d-4f87-b070-d300a226b150","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-tag-2","status":"ready","created_at":"2026-05-28T14:24:39.964286Z","updated_at":"2026-05-28T14:24:39.964286Z","tags":["development"],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-05-28T14:24:41.686292Z","key_id":null,"region":"fr-par"}'
+        body: '{"id":"87ea6548-6b82-420f-8627-6e200cfcb1f3","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-tag-2","status":"ready","created_at":"2026-07-03T15:27:56.257196Z","updated_at":"2026-07-03T15:27:58.935314Z","tags":["development"],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-07-03T15:27:58.935314Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "469"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:24:41 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 28105668-f52e-4999-aa6e-fff408a09f15
+                - ab0ad39e-3b0a-4b8b-8107-45c62086420f
         status: 200 OK
         code: 200
-        duration: 42.250915ms
+        duration: 44.716699ms

--- a/internal/services/secret/testdata/secret-basic.cassette.yaml
+++ b/internal/services/secret/testdata/secret-basic.cassette.yaml
@@ -13,7 +13,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets
         method: POST
       response:
@@ -21,21 +21,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 480
-        body: '{"id":"93ac26bb-9ff1-423c-b95d-ff11c5ac91e2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasic","status":"ready","created_at":"2026-06-24T09:38:38.866269Z","updated_at":"2026-06-24T09:38:38.866269Z","tags":["devtools","provider","terraform"],"version_count":0,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"98ba1319-16e6-4547-b249-175a9393989d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasic","status":"ready","created_at":"2026-07-03T15:27:54.719648Z","updated_at":"2026-07-03T15:27:54.719648Z","tags":["devtools","provider","terraform"],"version_count":0,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "480"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:38 GMT
+                - Fri, 03 Jul 2026 15:27:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 14bde24a-136c-4246-850e-57027d670cd4
+                - f8d0dbbb-d8b9-4cb7-beb4-83b3e0bfee65
         status: 200 OK
         code: 200
-        duration: 311.450492ms
+        duration: 471.329886ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -45,29 +45,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/93ac26bb-9ff1-423c-b95d-ff11c5ac91e2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/98ba1319-16e6-4547-b249-175a9393989d
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 480
-        body: '{"id":"93ac26bb-9ff1-423c-b95d-ff11c5ac91e2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasic","status":"ready","created_at":"2026-06-24T09:38:38.866269Z","updated_at":"2026-06-24T09:38:38.866269Z","tags":["devtools","provider","terraform"],"version_count":0,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"98ba1319-16e6-4547-b249-175a9393989d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasic","status":"ready","created_at":"2026-07-03T15:27:54.719648Z","updated_at":"2026-07-03T15:27:54.719648Z","tags":["devtools","provider","terraform"],"version_count":0,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "480"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:38 GMT
+                - Fri, 03 Jul 2026 15:27:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 511d4590-d802-4752-860a-b79b1fa95d63
+                - 5f0d4d03-ffec-445d-a708-81ac966f5a62
         status: 200 OK
         code: 200
-        duration: 103.032463ms
+        duration: 136.881638ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -80,8 +80,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/93ac26bb-9ff1-423c-b95d-ff11c5ac91e2/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/98ba1319-16e6-4547-b249-175a9393989d/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -95,14 +95,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:39 GMT
+                - Fri, 03 Jul 2026 15:27:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 3638ba4d-0b4a-4fa7-a4df-b2b724e1a817
+                - c2f82d4c-e6a3-4d82-bd65-ae7603e46bd4
         status: 200 OK
         code: 200
-        duration: 25.708317ms
+        duration: 199.969614ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -112,29 +112,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/93ac26bb-9ff1-423c-b95d-ff11c5ac91e2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/98ba1319-16e6-4547-b249-175a9393989d
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 480
-        body: '{"id":"93ac26bb-9ff1-423c-b95d-ff11c5ac91e2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasic","status":"ready","created_at":"2026-06-24T09:38:38.866269Z","updated_at":"2026-06-24T09:38:38.866269Z","tags":["devtools","provider","terraform"],"version_count":0,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"98ba1319-16e6-4547-b249-175a9393989d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasic","status":"ready","created_at":"2026-07-03T15:27:54.719648Z","updated_at":"2026-07-03T15:27:54.719648Z","tags":["devtools","provider","terraform"],"version_count":0,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "480"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:39 GMT
+                - Fri, 03 Jul 2026 15:27:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 88a21857-e628-40ef-8951-4c09593665b0
+                - 9d79f0b3-242c-4483-8de9-933b0d5a9bc2
         status: 200 OK
         code: 200
-        duration: 107.794319ms
+        duration: 103.675328ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -144,29 +144,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/93ac26bb-9ff1-423c-b95d-ff11c5ac91e2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/98ba1319-16e6-4547-b249-175a9393989d
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 480
-        body: '{"id":"93ac26bb-9ff1-423c-b95d-ff11c5ac91e2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasic","status":"ready","created_at":"2026-06-24T09:38:38.866269Z","updated_at":"2026-06-24T09:38:38.866269Z","tags":["devtools","provider","terraform"],"version_count":0,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"98ba1319-16e6-4547-b249-175a9393989d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasic","status":"ready","created_at":"2026-07-03T15:27:54.719648Z","updated_at":"2026-07-03T15:27:54.719648Z","tags":["devtools","provider","terraform"],"version_count":0,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "480"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:39 GMT
+                - Fri, 03 Jul 2026 15:27:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - f0143bc1-0aaf-4422-923e-2b5e30aa425d
+                - 4f33d099-34f7-40ce-87bb-e9317d2362fc
         status: 200 OK
         code: 200
-        duration: 22.354813ms
+        duration: 31.258311ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -179,8 +179,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/93ac26bb-9ff1-423c-b95d-ff11c5ac91e2/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/98ba1319-16e6-4547-b249-175a9393989d/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -194,14 +194,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:39 GMT
+                - Fri, 03 Jul 2026 15:27:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 1c2dbd26-ae5b-43be-9cda-f3caecd43669
+                - 9604cf13-9de1-4714-ae06-bf7a6215a3ab
         status: 200 OK
         code: 200
-        duration: 116.078474ms
+        duration: 48.692637ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -211,29 +211,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/93ac26bb-9ff1-423c-b95d-ff11c5ac91e2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/98ba1319-16e6-4547-b249-175a9393989d
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 480
-        body: '{"id":"93ac26bb-9ff1-423c-b95d-ff11c5ac91e2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasic","status":"ready","created_at":"2026-06-24T09:38:38.866269Z","updated_at":"2026-06-24T09:38:38.866269Z","tags":["devtools","provider","terraform"],"version_count":0,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"98ba1319-16e6-4547-b249-175a9393989d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasic","status":"ready","created_at":"2026-07-03T15:27:54.719648Z","updated_at":"2026-07-03T15:27:54.719648Z","tags":["devtools","provider","terraform"],"version_count":0,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "480"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:39 GMT
+                - Fri, 03 Jul 2026 15:27:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - ed72cd7e-be7c-493c-8ca8-c29052d9fb32
+                - cf5ab97f-a85c-4f90-a694-c44a229b5c33
         status: 200 OK
         code: 200
-        duration: 22.755612ms
+        duration: 42.844132ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -246,8 +246,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/93ac26bb-9ff1-423c-b95d-ff11c5ac91e2/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/98ba1319-16e6-4547-b249-175a9393989d/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -261,14 +261,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:39 GMT
+                - Fri, 03 Jul 2026 15:27:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 969713c9-ad5e-4f26-b6e7-97b98e9ef6b9
+                - 2d9cbd9b-3795-452a-83ed-61ab7f54db2a
         status: 200 OK
         code: 200
-        duration: 20.168217ms
+        duration: 51.379233ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -281,29 +281,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/93ac26bb-9ff1-423c-b95d-ff11c5ac91e2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/98ba1319-16e6-4547-b249-175a9393989d
         method: PATCH
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 464
-        body: '{"id":"93ac26bb-9ff1-423c-b95d-ff11c5ac91e2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasicUpdated","status":"ready","created_at":"2026-06-24T09:38:38.866269Z","updated_at":"2026-06-24T09:38:40.269297Z","tags":["devtools"],"version_count":0,"description":"update description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"98ba1319-16e6-4547-b249-175a9393989d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasicUpdated","status":"ready","created_at":"2026-07-03T15:27:54.719648Z","updated_at":"2026-07-03T15:27:56.620990Z","tags":["devtools"],"version_count":0,"description":"update description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "464"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:40 GMT
+                - Fri, 03 Jul 2026 15:27:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 3dedd87b-bcb9-4f9e-a7e2-b37c4dc7fc87
+                - 2458f130-24f7-498d-97a4-42503770b05b
         status: 200 OK
         code: 200
-        duration: 180.002839ms
+        duration: 163.600393ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -313,29 +313,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/93ac26bb-9ff1-423c-b95d-ff11c5ac91e2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/98ba1319-16e6-4547-b249-175a9393989d
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 464
-        body: '{"id":"93ac26bb-9ff1-423c-b95d-ff11c5ac91e2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasicUpdated","status":"ready","created_at":"2026-06-24T09:38:38.866269Z","updated_at":"2026-06-24T09:38:40.269297Z","tags":["devtools"],"version_count":0,"description":"update description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"98ba1319-16e6-4547-b249-175a9393989d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasicUpdated","status":"ready","created_at":"2026-07-03T15:27:54.719648Z","updated_at":"2026-07-03T15:27:56.620990Z","tags":["devtools"],"version_count":0,"description":"update description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "464"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:40 GMT
+                - Fri, 03 Jul 2026 15:27:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 026c148d-2fe9-4260-9023-04a5f289396c
+                - a52de8a7-afd8-4776-96a7-976676d94ca7
         status: 200 OK
         code: 200
-        duration: 29.51414ms
+        duration: 92.172072ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -348,8 +348,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/93ac26bb-9ff1-423c-b95d-ff11c5ac91e2/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/98ba1319-16e6-4547-b249-175a9393989d/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -363,14 +363,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:40 GMT
+                - Fri, 03 Jul 2026 15:27:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 4c8c7c52-3ee6-4b2b-8d5f-de8596c87ebe
+                - 261c6b78-f86e-4297-b9d4-09b06e00da1a
         status: 200 OK
         code: 200
-        duration: 23.878677ms
+        duration: 39.451951ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -380,29 +380,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/93ac26bb-9ff1-423c-b95d-ff11c5ac91e2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/98ba1319-16e6-4547-b249-175a9393989d
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 464
-        body: '{"id":"93ac26bb-9ff1-423c-b95d-ff11c5ac91e2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasicUpdated","status":"ready","created_at":"2026-06-24T09:38:38.866269Z","updated_at":"2026-06-24T09:38:40.269297Z","tags":["devtools"],"version_count":0,"description":"update description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"98ba1319-16e6-4547-b249-175a9393989d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasicUpdated","status":"ready","created_at":"2026-07-03T15:27:54.719648Z","updated_at":"2026-07-03T15:27:56.620990Z","tags":["devtools"],"version_count":0,"description":"update description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "464"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:40 GMT
+                - Fri, 03 Jul 2026 15:27:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 8662f971-fb4e-4bcb-9e4c-d94b54e1837c
+                - 4f10c475-53e7-40a5-bb0d-d3e008ce8749
         status: 200 OK
         code: 200
-        duration: 22.340236ms
+        duration: 43.893102ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -412,29 +412,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/93ac26bb-9ff1-423c-b95d-ff11c5ac91e2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/98ba1319-16e6-4547-b249-175a9393989d
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 464
-        body: '{"id":"93ac26bb-9ff1-423c-b95d-ff11c5ac91e2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasicUpdated","status":"ready","created_at":"2026-06-24T09:38:38.866269Z","updated_at":"2026-06-24T09:38:40.269297Z","tags":["devtools"],"version_count":0,"description":"update description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"98ba1319-16e6-4547-b249-175a9393989d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasicUpdated","status":"ready","created_at":"2026-07-03T15:27:54.719648Z","updated_at":"2026-07-03T15:27:56.620990Z","tags":["devtools"],"version_count":0,"description":"update description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "464"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:40 GMT
+                - Fri, 03 Jul 2026 15:27:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - fa997123-c8c5-451b-a893-04230fb270b9
+                - d2eeb1ad-dd80-40d2-a82a-01464cb18848
         status: 200 OK
         code: 200
-        duration: 99.328665ms
+        duration: 936.010045ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -447,8 +447,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/93ac26bb-9ff1-423c-b95d-ff11c5ac91e2/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/98ba1319-16e6-4547-b249-175a9393989d/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -462,14 +462,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:40 GMT
+                - Fri, 03 Jul 2026 15:27:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 4f5f88ea-ae1f-48e6-af16-273cdb03afb8
+                - 2cc3bb31-80a0-4943-923e-23f5f62f9800
         status: 200 OK
         code: 200
-        duration: 27.397649ms
+        duration: 47.558166ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -479,29 +479,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/93ac26bb-9ff1-423c-b95d-ff11c5ac91e2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/98ba1319-16e6-4547-b249-175a9393989d
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 464
-        body: '{"id":"93ac26bb-9ff1-423c-b95d-ff11c5ac91e2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasicUpdated","status":"ready","created_at":"2026-06-24T09:38:38.866269Z","updated_at":"2026-06-24T09:38:40.269297Z","tags":["devtools"],"version_count":0,"description":"update description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"98ba1319-16e6-4547-b249-175a9393989d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasicUpdated","status":"ready","created_at":"2026-07-03T15:27:54.719648Z","updated_at":"2026-07-03T15:27:56.620990Z","tags":["devtools"],"version_count":0,"description":"update description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "464"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:41 GMT
+                - Fri, 03 Jul 2026 15:27:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - f879ab81-c7f7-4166-96b0-f6857c2f7a95
+                - 00fcc7f6-6048-4f5d-bedb-03af598cd956
         status: 200 OK
         code: 200
-        duration: 26.486591ms
+        duration: 53.81035ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -514,8 +514,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/93ac26bb-9ff1-423c-b95d-ff11c5ac91e2/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/98ba1319-16e6-4547-b249-175a9393989d/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -529,14 +529,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:41 GMT
+                - Fri, 03 Jul 2026 15:27:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 4ca18041-37f4-4952-b640-5f9e396919a8
+                - 5b3aeb5a-d678-4bb0-a807-1fadc54c76ec
         status: 200 OK
         code: 200
-        duration: 26.316775ms
+        duration: 53.446366ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -549,29 +549,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/93ac26bb-9ff1-423c-b95d-ff11c5ac91e2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/98ba1319-16e6-4547-b249-175a9393989d
         method: PATCH
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 429
-        body: '{"id":"93ac26bb-9ff1-423c-b95d-ff11c5ac91e2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasic","status":"ready","created_at":"2026-06-24T09:38:38.866269Z","updated_at":"2026-06-24T09:38:41.483263Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"98ba1319-16e6-4547-b249-175a9393989d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasic","status":"ready","created_at":"2026-07-03T15:27:54.719648Z","updated_at":"2026-07-03T15:27:59.315408Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "429"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:41 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - cac5de8d-48d6-48a9-9df4-18071fbd79d7
+                - c2c356ed-5408-4e85-aac7-2cc793cf9496
         status: 200 OK
         code: 200
-        duration: 117.858409ms
+        duration: 156.704651ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -581,29 +581,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/93ac26bb-9ff1-423c-b95d-ff11c5ac91e2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/98ba1319-16e6-4547-b249-175a9393989d
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 429
-        body: '{"id":"93ac26bb-9ff1-423c-b95d-ff11c5ac91e2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasic","status":"ready","created_at":"2026-06-24T09:38:38.866269Z","updated_at":"2026-06-24T09:38:41.483263Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"98ba1319-16e6-4547-b249-175a9393989d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasic","status":"ready","created_at":"2026-07-03T15:27:54.719648Z","updated_at":"2026-07-03T15:27:59.315408Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "429"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:41 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 2e3a3e4d-3c95-441f-9782-93d0082d4c73
+                - 7ff5d4c7-a344-4d52-9e55-1d480effa285
         status: 200 OK
         code: 200
-        duration: 27.496459ms
+        duration: 41.258514ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -616,8 +616,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/93ac26bb-9ff1-423c-b95d-ff11c5ac91e2/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/98ba1319-16e6-4547-b249-175a9393989d/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -631,14 +631,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:41 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 75386456-0483-4b57-889e-0ca2b171d649
+                - c8a74da6-f5aa-4747-99e6-1d4ca1180aaa
         status: 200 OK
         code: 200
-        duration: 32.597907ms
+        duration: 58.38915ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -648,29 +648,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/93ac26bb-9ff1-423c-b95d-ff11c5ac91e2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/98ba1319-16e6-4547-b249-175a9393989d
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 429
-        body: '{"id":"93ac26bb-9ff1-423c-b95d-ff11c5ac91e2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasic","status":"ready","created_at":"2026-06-24T09:38:38.866269Z","updated_at":"2026-06-24T09:38:41.483263Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"98ba1319-16e6-4547-b249-175a9393989d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasic","status":"ready","created_at":"2026-07-03T15:27:54.719648Z","updated_at":"2026-07-03T15:27:59.315408Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "429"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:41 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - c5854f28-d462-43fe-8caa-e940ed015d91
+                - dd30ab3b-7219-46f0-a250-daffbd135020
         status: 200 OK
         code: 200
-        duration: 33.355921ms
+        duration: 46.22335ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -680,29 +680,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/93ac26bb-9ff1-423c-b95d-ff11c5ac91e2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/98ba1319-16e6-4547-b249-175a9393989d
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 429
-        body: '{"id":"93ac26bb-9ff1-423c-b95d-ff11c5ac91e2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasic","status":"ready","created_at":"2026-06-24T09:38:38.866269Z","updated_at":"2026-06-24T09:38:41.483263Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"98ba1319-16e6-4547-b249-175a9393989d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasic","status":"ready","created_at":"2026-07-03T15:27:54.719648Z","updated_at":"2026-07-03T15:27:59.315408Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "429"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:41 GMT
+                - Fri, 03 Jul 2026 15:28:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 1cb49bfc-01b4-4d76-8f4f-e9a39d1fdcc2
+                - 735239f9-28cc-4775-a8b9-840d6d0878f1
         status: 200 OK
         code: 200
-        duration: 17.874216ms
+        duration: 51.529767ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -715,8 +715,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/93ac26bb-9ff1-423c-b95d-ff11c5ac91e2/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/98ba1319-16e6-4547-b249-175a9393989d/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -730,14 +730,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:42 GMT
+                - Fri, 03 Jul 2026 15:28:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 338f7141-acad-4a2b-a314-0b0ac481d308
+                - 9c584ca9-7b37-432c-9d97-ed84ac064a62
         status: 200 OK
         code: 200
-        duration: 32.725852ms
+        duration: 79.783945ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -747,29 +747,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/93ac26bb-9ff1-423c-b95d-ff11c5ac91e2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/98ba1319-16e6-4547-b249-175a9393989d
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 429
-        body: '{"id":"93ac26bb-9ff1-423c-b95d-ff11c5ac91e2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasic","status":"ready","created_at":"2026-06-24T09:38:38.866269Z","updated_at":"2026-06-24T09:38:41.483263Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"98ba1319-16e6-4547-b249-175a9393989d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasic","status":"ready","created_at":"2026-07-03T15:27:54.719648Z","updated_at":"2026-07-03T15:27:59.315408Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "429"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:42 GMT
+                - Fri, 03 Jul 2026 15:28:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 33955ce6-7e59-49a6-b42a-e854fd69d722
+                - 8b0f15b6-5f73-4b27-9e25-3aef1b48c662
         status: 200 OK
         code: 200
-        duration: 22.487868ms
+        duration: 50.291771ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -782,8 +782,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/93ac26bb-9ff1-423c-b95d-ff11c5ac91e2/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/98ba1319-16e6-4547-b249-175a9393989d/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -797,14 +797,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:42 GMT
+                - Fri, 03 Jul 2026 15:28:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 144d6322-fc80-4a48-b42c-09937ac70cd3
+                - 582403bc-aef5-4a7a-8e73-fa8e10e67b95
         status: 200 OK
         code: 200
-        duration: 25.512822ms
+        duration: 51.344519ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -814,8 +814,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/93ac26bb-9ff1-423c-b95d-ff11c5ac91e2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/98ba1319-16e6-4547-b249-175a9393989d
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -827,14 +827,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:42 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 068deb48-41a3-4bdf-ae60-4a675452675d
+                - 3ba97023-8d90-4017-9475-3ae032ec7507
         status: 204 No Content
         code: 204
-        duration: 136.677489ms
+        duration: 138.493416ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -844,26 +844,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/93ac26bb-9ff1-423c-b95d-ff11c5ac91e2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/98ba1319-16e6-4547-b249-175a9393989d
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 454
-        body: '{"id":"93ac26bb-9ff1-423c-b95d-ff11c5ac91e2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasic","status":"ready","created_at":"2026-06-24T09:38:38.866269Z","updated_at":"2026-06-24T09:38:42.626825Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-06-24T09:38:42.626825Z","key_id":null,"region":"fr-par"}'
+        body: '{"id":"98ba1319-16e6-4547-b249-175a9393989d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasic","status":"ready","created_at":"2026-07-03T15:27:54.719648Z","updated_at":"2026-07-03T15:28:01.446701Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-07-03T15:28:01.446701Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "454"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:42 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 63b95d11-750f-47a7-b3f5-33e8b9fcf1ad
+                - ef74ee96-bfb1-452b-8e58-d104245bc98c
         status: 200 OK
         code: 200
-        duration: 17.701325ms
+        duration: 57.888119ms

--- a/internal/services/secret/testdata/secret-ephemeral-policy.cassette.yaml
+++ b/internal/services/secret/testdata/secret-ephemeral-policy.cassette.yaml
@@ -13,7 +13,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets
         method: POST
       response:
@@ -21,21 +21,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 508
-        body: '{"id":"1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-policy-secret","status":"ready","created_at":"2026-06-24T09:38:38.825020Z","updated_at":"2026-06-24T09:38:38.825020Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":{"time_to_live":"1800s","expires_once_accessed":false,"action":"disable"},"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"6da2f4bd-2fd8-4342-9e3a-1e31fd4ddae9","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-policy-secret","status":"ready","created_at":"2026-07-03T15:27:54.536518Z","updated_at":"2026-07-03T15:27:54.536518Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":{"time_to_live":"1800s","expires_once_accessed":false,"action":"disable"},"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "508"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:38 GMT
+                - Fri, 03 Jul 2026 15:27:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 10c6ba3d-b8b4-4d7f-afb8-20fccccae381
+                - f994398d-d060-4d3d-8972-3385fbf673b7
         status: 200 OK
         code: 200
-        duration: 293.097658ms
+        duration: 261.490014ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -45,29 +45,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6da2f4bd-2fd8-4342-9e3a-1e31fd4ddae9
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 508
-        body: '{"id":"1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-policy-secret","status":"ready","created_at":"2026-06-24T09:38:38.825020Z","updated_at":"2026-06-24T09:38:38.825020Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":{"time_to_live":"1800s","expires_once_accessed":false,"action":"disable"},"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"6da2f4bd-2fd8-4342-9e3a-1e31fd4ddae9","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-policy-secret","status":"ready","created_at":"2026-07-03T15:27:54.536518Z","updated_at":"2026-07-03T15:27:54.536518Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":{"time_to_live":"1800s","expires_once_accessed":false,"action":"disable"},"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "508"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:38 GMT
+                - Fri, 03 Jul 2026 15:27:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 071d2d6f-589e-414c-a744-23dcae887071
+                - 6a5fa488-b543-4121-8aea-4b0b69bb521f
         status: 200 OK
         code: 200
-        duration: 88.599399ms
+        duration: 117.365492ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -80,8 +80,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6da2f4bd-2fd8-4342-9e3a-1e31fd4ddae9/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -95,14 +95,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:39 GMT
+                - Fri, 03 Jul 2026 15:27:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 2ddb2ca4-2481-4b85-9ff6-191afc5377c1
+                - 6f0e2d7b-bbf3-4858-8ae9-33284bf24124
         status: 200 OK
         code: 200
-        duration: 131.939217ms
+        duration: 38.433788ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -112,29 +112,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6da2f4bd-2fd8-4342-9e3a-1e31fd4ddae9
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 508
-        body: '{"id":"1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-policy-secret","status":"ready","created_at":"2026-06-24T09:38:38.825020Z","updated_at":"2026-06-24T09:38:38.825020Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":{"time_to_live":"1800s","expires_once_accessed":false,"action":"disable"},"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"6da2f4bd-2fd8-4342-9e3a-1e31fd4ddae9","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-policy-secret","status":"ready","created_at":"2026-07-03T15:27:54.536518Z","updated_at":"2026-07-03T15:27:54.536518Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":{"time_to_live":"1800s","expires_once_accessed":false,"action":"disable"},"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "508"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:39 GMT
+                - Fri, 03 Jul 2026 15:27:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 6f200806-5592-48db-9202-484497e63ddb
+                - 7bfb602b-1f27-4936-a330-af3fa405f0c9
         status: 200 OK
         code: 200
-        duration: 21.526715ms
+        duration: 123.253851ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -144,29 +144,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6da2f4bd-2fd8-4342-9e3a-1e31fd4ddae9
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 508
-        body: '{"id":"1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-policy-secret","status":"ready","created_at":"2026-06-24T09:38:38.825020Z","updated_at":"2026-06-24T09:38:38.825020Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":{"time_to_live":"1800s","expires_once_accessed":false,"action":"disable"},"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"6da2f4bd-2fd8-4342-9e3a-1e31fd4ddae9","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-policy-secret","status":"ready","created_at":"2026-07-03T15:27:54.536518Z","updated_at":"2026-07-03T15:27:54.536518Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":{"time_to_live":"1800s","expires_once_accessed":false,"action":"disable"},"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "508"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:39 GMT
+                - Fri, 03 Jul 2026 15:27:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 533c742a-a8b8-4165-864e-366af7a44fef
+                - ae01a636-a957-49b2-b768-cac4bb321588
         status: 200 OK
         code: 200
-        duration: 26.562917ms
+        duration: 82.378978ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -179,8 +179,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6da2f4bd-2fd8-4342-9e3a-1e31fd4ddae9/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -194,14 +194,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:39 GMT
+                - Fri, 03 Jul 2026 15:27:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 3a6cc7c2-c3d3-4916-849b-f5e5c0abd897
+                - 9bbab8d3-1be5-4ea1-9798-ddf215c9de1d
         status: 200 OK
         code: 200
-        duration: 30.784658ms
+        duration: 58.350587ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -211,29 +211,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6da2f4bd-2fd8-4342-9e3a-1e31fd4ddae9
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 508
-        body: '{"id":"1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-policy-secret","status":"ready","created_at":"2026-06-24T09:38:38.825020Z","updated_at":"2026-06-24T09:38:38.825020Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":{"time_to_live":"1800s","expires_once_accessed":false,"action":"disable"},"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"6da2f4bd-2fd8-4342-9e3a-1e31fd4ddae9","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-policy-secret","status":"ready","created_at":"2026-07-03T15:27:54.536518Z","updated_at":"2026-07-03T15:27:54.536518Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":{"time_to_live":"1800s","expires_once_accessed":false,"action":"disable"},"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "508"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:39 GMT
+                - Fri, 03 Jul 2026 15:27:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - f91cb815-d9f5-42d2-8ca1-5c54ea99c695
+                - eafa8ce9-6768-4361-b7c1-9eb3233a0cd3
         status: 200 OK
         code: 200
-        duration: 18.529624ms
+        duration: 48.244225ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -246,8 +246,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6da2f4bd-2fd8-4342-9e3a-1e31fd4ddae9/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -261,14 +261,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:39 GMT
+                - Fri, 03 Jul 2026 15:27:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 41d3cd85-213f-4db8-8302-9e8a3c735fff
+                - 92700857-a4a6-4d46-9465-cbeefaa5fc39
         status: 200 OK
         code: 200
-        duration: 114.587674ms
+        duration: 39.369797ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -281,29 +281,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6da2f4bd-2fd8-4342-9e3a-1e31fd4ddae9
         method: PATCH
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 507
-        body: '{"id":"1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-policy-secret","status":"ready","created_at":"2026-06-24T09:38:38.825020Z","updated_at":"2026-06-24T09:38:40.268544Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":{"time_to_live":"18000s","expires_once_accessed":true,"action":"delete"},"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"6da2f4bd-2fd8-4342-9e3a-1e31fd4ddae9","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-policy-secret","status":"ready","created_at":"2026-07-03T15:27:54.536518Z","updated_at":"2026-07-03T15:27:56.219435Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":{"time_to_live":"18000s","expires_once_accessed":true,"action":"delete"},"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "507"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:40 GMT
+                - Fri, 03 Jul 2026 15:27:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 60156ea9-00da-4dd3-8e64-5b4cc84c3e67
+                - 80e51f85-5d3c-4478-b6a2-2b916e814de5
         status: 200 OK
         code: 200
-        duration: 113.236652ms
+        duration: 208.697447ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -313,29 +313,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6da2f4bd-2fd8-4342-9e3a-1e31fd4ddae9
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 507
-        body: '{"id":"1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-policy-secret","status":"ready","created_at":"2026-06-24T09:38:38.825020Z","updated_at":"2026-06-24T09:38:40.268544Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":{"time_to_live":"18000s","expires_once_accessed":true,"action":"delete"},"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"6da2f4bd-2fd8-4342-9e3a-1e31fd4ddae9","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-policy-secret","status":"ready","created_at":"2026-07-03T15:27:54.536518Z","updated_at":"2026-07-03T15:27:56.219435Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":{"time_to_live":"18000s","expires_once_accessed":true,"action":"delete"},"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "507"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:40 GMT
+                - Fri, 03 Jul 2026 15:27:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - c531e017-c512-425c-9162-33678e39a1d9
+                - 062b3e1b-08f8-4138-b71d-0cc4913e05e3
         status: 200 OK
         code: 200
-        duration: 117.959212ms
+        duration: 52.842281ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -348,8 +348,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6da2f4bd-2fd8-4342-9e3a-1e31fd4ddae9/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -363,14 +363,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:40 GMT
+                - Fri, 03 Jul 2026 15:27:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - d5ae0666-1aaa-4b47-b275-b7b36653cd4f
+                - 630b51d8-a206-4b2b-b196-ccd273eb4138
         status: 200 OK
         code: 200
-        duration: 93.063003ms
+        duration: 49.805257ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -380,29 +380,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6da2f4bd-2fd8-4342-9e3a-1e31fd4ddae9
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 507
-        body: '{"id":"1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-policy-secret","status":"ready","created_at":"2026-06-24T09:38:38.825020Z","updated_at":"2026-06-24T09:38:40.268544Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":{"time_to_live":"18000s","expires_once_accessed":true,"action":"delete"},"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"6da2f4bd-2fd8-4342-9e3a-1e31fd4ddae9","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-policy-secret","status":"ready","created_at":"2026-07-03T15:27:54.536518Z","updated_at":"2026-07-03T15:27:56.219435Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":{"time_to_live":"18000s","expires_once_accessed":true,"action":"delete"},"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "507"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:40 GMT
+                - Fri, 03 Jul 2026 15:27:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - fd0c4dde-2dcf-4bbc-8b8e-bc26f7cadfbc
+                - bde249a7-c40b-464c-a743-9414b43eda1f
         status: 200 OK
         code: 200
-        duration: 22.621615ms
+        duration: 32.894745ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -412,29 +412,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6da2f4bd-2fd8-4342-9e3a-1e31fd4ddae9
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 507
-        body: '{"id":"1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-policy-secret","status":"ready","created_at":"2026-06-24T09:38:38.825020Z","updated_at":"2026-06-24T09:38:40.268544Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":{"time_to_live":"18000s","expires_once_accessed":true,"action":"delete"},"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"6da2f4bd-2fd8-4342-9e3a-1e31fd4ddae9","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-policy-secret","status":"ready","created_at":"2026-07-03T15:27:54.536518Z","updated_at":"2026-07-03T15:27:56.219435Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":{"time_to_live":"18000s","expires_once_accessed":true,"action":"delete"},"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "507"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:40 GMT
+                - Fri, 03 Jul 2026 15:27:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - e397306e-2c98-4d96-b470-280ae44f13bc
+                - a3fe8a6d-3434-4bc1-923d-b7caa2102156
         status: 200 OK
         code: 200
-        duration: 22.604973ms
+        duration: 146.390639ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -447,8 +447,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6da2f4bd-2fd8-4342-9e3a-1e31fd4ddae9/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -462,14 +462,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:40 GMT
+                - Fri, 03 Jul 2026 15:27:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 43ec3eff-9408-43f4-a1a2-a6bc508a2690
+                - 1ba3fd35-bc35-4f3d-b652-35d1cf4b9f22
         status: 200 OK
         code: 200
-        duration: 25.601894ms
+        duration: 43.91871ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -479,29 +479,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6da2f4bd-2fd8-4342-9e3a-1e31fd4ddae9
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 507
-        body: '{"id":"1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-policy-secret","status":"ready","created_at":"2026-06-24T09:38:38.825020Z","updated_at":"2026-06-24T09:38:40.268544Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":{"time_to_live":"18000s","expires_once_accessed":true,"action":"delete"},"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"6da2f4bd-2fd8-4342-9e3a-1e31fd4ddae9","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-policy-secret","status":"ready","created_at":"2026-07-03T15:27:54.536518Z","updated_at":"2026-07-03T15:27:56.219435Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":{"time_to_live":"18000s","expires_once_accessed":true,"action":"delete"},"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "507"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:41 GMT
+                - Fri, 03 Jul 2026 15:27:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - f8b37acd-49ea-41ef-841a-8db52cc6fc4b
+                - 8f74d8e2-573e-4f37-9d3e-6473f2fd4347
         status: 200 OK
         code: 200
-        duration: 15.437079ms
+        duration: 859.450017ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -514,8 +514,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6da2f4bd-2fd8-4342-9e3a-1e31fd4ddae9/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -529,14 +529,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:41 GMT
+                - Fri, 03 Jul 2026 15:27:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - e9cc5893-b64f-45df-87d1-a79780eb232b
+                - 4db8f09f-5b60-4b44-97a9-f25244d23c34
         status: 200 OK
         code: 200
-        duration: 21.980435ms
+        duration: 47.408916ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -549,29 +549,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6da2f4bd-2fd8-4342-9e3a-1e31fd4ddae9
         method: PATCH
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 503
-        body: '{"id":"1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-policy-secret","status":"ready","created_at":"2026-06-24T09:38:38.825020Z","updated_at":"2026-06-24T09:38:41.500550Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":{"time_to_live":null,"expires_once_accessed":true,"action":"delete"},"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"6da2f4bd-2fd8-4342-9e3a-1e31fd4ddae9","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-policy-secret","status":"ready","created_at":"2026-07-03T15:27:54.536518Z","updated_at":"2026-07-03T15:27:58.856149Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":{"time_to_live":null,"expires_once_accessed":true,"action":"delete"},"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "503"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:41 GMT
+                - Fri, 03 Jul 2026 15:27:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 39b31aa7-b46c-4aaa-87e7-8791886d2cc1
+                - 10c80a2b-f596-4928-8191-08b28adb2a1e
         status: 200 OK
         code: 200
-        duration: 105.169843ms
+        duration: 112.164644ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -581,29 +581,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6da2f4bd-2fd8-4342-9e3a-1e31fd4ddae9
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 503
-        body: '{"id":"1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-policy-secret","status":"ready","created_at":"2026-06-24T09:38:38.825020Z","updated_at":"2026-06-24T09:38:41.500550Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":{"time_to_live":null,"expires_once_accessed":true,"action":"delete"},"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"6da2f4bd-2fd8-4342-9e3a-1e31fd4ddae9","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-policy-secret","status":"ready","created_at":"2026-07-03T15:27:54.536518Z","updated_at":"2026-07-03T15:27:58.856149Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":{"time_to_live":null,"expires_once_accessed":true,"action":"delete"},"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "503"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:41 GMT
+                - Fri, 03 Jul 2026 15:27:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - ecfbe72f-db67-4d5f-a3f2-68e928870c89
+                - 97a5e7be-f220-497c-a7e9-d385d5635e64
         status: 200 OK
         code: 200
-        duration: 34.809661ms
+        duration: 38.797331ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -616,8 +616,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6da2f4bd-2fd8-4342-9e3a-1e31fd4ddae9/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -631,14 +631,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:41 GMT
+                - Fri, 03 Jul 2026 15:27:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 7e964d38-9440-44ce-8513-25e24636b423
+                - 634eef54-3db1-45ba-92e5-9ee01622964d
         status: 200 OK
         code: 200
-        duration: 29.957781ms
+        duration: 44.742378ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -648,29 +648,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6da2f4bd-2fd8-4342-9e3a-1e31fd4ddae9
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 503
-        body: '{"id":"1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-policy-secret","status":"ready","created_at":"2026-06-24T09:38:38.825020Z","updated_at":"2026-06-24T09:38:41.500550Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":{"time_to_live":null,"expires_once_accessed":true,"action":"delete"},"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"6da2f4bd-2fd8-4342-9e3a-1e31fd4ddae9","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-policy-secret","status":"ready","created_at":"2026-07-03T15:27:54.536518Z","updated_at":"2026-07-03T15:27:58.856149Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":{"time_to_live":null,"expires_once_accessed":true,"action":"delete"},"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "503"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:41 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 5234301d-3f3f-4631-92bd-7f099874c495
+                - 30d4a883-9a9d-489a-8314-704244534c44
         status: 200 OK
         code: 200
-        duration: 21.2955ms
+        duration: 66.07163ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -680,29 +680,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6da2f4bd-2fd8-4342-9e3a-1e31fd4ddae9
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 503
-        body: '{"id":"1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-policy-secret","status":"ready","created_at":"2026-06-24T09:38:38.825020Z","updated_at":"2026-06-24T09:38:41.500550Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":{"time_to_live":null,"expires_once_accessed":true,"action":"delete"},"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"6da2f4bd-2fd8-4342-9e3a-1e31fd4ddae9","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-policy-secret","status":"ready","created_at":"2026-07-03T15:27:54.536518Z","updated_at":"2026-07-03T15:27:58.856149Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":{"time_to_live":null,"expires_once_accessed":true,"action":"delete"},"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "503"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:41 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 4f08b957-f2f0-44e3-b910-b9bc12e9cc08
+                - e9e5af7b-9bfa-403d-9064-ebca18f0605c
         status: 200 OK
         code: 200
-        duration: 29.989763ms
+        duration: 61.486487ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -715,8 +715,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6da2f4bd-2fd8-4342-9e3a-1e31fd4ddae9/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -730,14 +730,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:42 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - cf46978b-5ebd-4667-af7b-7d1a1defc016
+                - aa0ecce8-e45d-4644-bc3d-08f9dd2ba3b6
         status: 200 OK
         code: 200
-        duration: 24.176619ms
+        duration: 48.232823ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -747,8 +747,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6da2f4bd-2fd8-4342-9e3a-1e31fd4ddae9
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -760,14 +760,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:42 GMT
+                - Fri, 03 Jul 2026 15:28:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 3dd56b6a-65f0-43c5-b096-593d5f2f40b6
+                - 3441f623-970b-4a07-8cec-20b9dc829ef5
         status: 204 No Content
         code: 204
-        duration: 57.20958ms
+        duration: 171.628894ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -777,26 +777,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6da2f4bd-2fd8-4342-9e3a-1e31fd4ddae9
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 127
-        body: '{"message":"resource is not found","resource":"secret","resource_id":"1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"secret","resource_id":"6da2f4bd-2fd8-4342-9e3a-1e31fd4ddae9","type":"not_found"}'
         headers:
             Content-Length:
                 - "127"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:42 GMT
+                - Fri, 03 Jul 2026 15:28:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 1ec913cb-6188-48df-939f-10f8b37e14b7
+                - 2bed45ae-2026-4447-b99c-4b9679fab0eb
         status: 404 Not Found
         code: 404
-        duration: 21.713373ms
+        duration: 43.719377ms

--- a/internal/services/secret/testdata/secret-path.cassette.yaml
+++ b/internal/services/secret/testdata/secret-path.cassette.yaml
@@ -13,7 +13,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets
         method: POST
       response:
@@ -21,21 +21,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 437
-        body: '{"id":"547a210e-1b14-4d88-b602-a8ebfe1e0a1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-06-24T09:38:38.845335Z","updated_at":"2026-06-24T09:38:38.845335Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"41d5d749-aaab-4503-8ae3-c593c4846010","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-07-03T15:27:54.644460Z","updated_at":"2026-07-03T15:27:54.644460Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "437"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:38 GMT
+                - Fri, 03 Jul 2026 15:27:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 4f507ac7-8312-4d31-8645-b58367a8d9a3
+                - c949bdaa-877c-4b4e-980b-b5d1f939962a
         status: 200 OK
         code: 200
-        duration: 329.077013ms
+        duration: 325.277664ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -45,29 +45,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/41d5d749-aaab-4503-8ae3-c593c4846010
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 437
-        body: '{"id":"547a210e-1b14-4d88-b602-a8ebfe1e0a1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-06-24T09:38:38.845335Z","updated_at":"2026-06-24T09:38:38.845335Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"41d5d749-aaab-4503-8ae3-c593c4846010","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-07-03T15:27:54.644460Z","updated_at":"2026-07-03T15:27:54.644460Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "437"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:38 GMT
+                - Fri, 03 Jul 2026 15:27:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 8a1265e5-a2c5-47c5-ab16-83d37abfcbfa
+                - d6352f01-b54f-4322-a4c8-cfc923bd48c1
         status: 200 OK
         code: 200
-        duration: 104.260298ms
+        duration: 202.713597ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -80,8 +80,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/41d5d749-aaab-4503-8ae3-c593c4846010/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -95,14 +95,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:39 GMT
+                - Fri, 03 Jul 2026 15:27:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - bda98486-dc24-48e3-8c50-5f494730df10
+                - 1b6403cd-3d76-4327-8d86-60fd688fffb9
         status: 200 OK
         code: 200
-        duration: 103.10409ms
+        duration: 201.21352ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -112,29 +112,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/41d5d749-aaab-4503-8ae3-c593c4846010
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 437
-        body: '{"id":"547a210e-1b14-4d88-b602-a8ebfe1e0a1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-06-24T09:38:38.845335Z","updated_at":"2026-06-24T09:38:38.845335Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"41d5d749-aaab-4503-8ae3-c593c4846010","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-07-03T15:27:54.644460Z","updated_at":"2026-07-03T15:27:54.644460Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "437"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:39 GMT
+                - Fri, 03 Jul 2026 15:27:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 198c95e5-d508-4ed2-866f-22cee9f39c86
+                - bf09ece5-6b11-427f-9d9f-fda678b0f9c9
         status: 200 OK
         code: 200
-        duration: 22.98388ms
+        duration: 106.082429ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -144,29 +144,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/41d5d749-aaab-4503-8ae3-c593c4846010
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 437
-        body: '{"id":"547a210e-1b14-4d88-b602-a8ebfe1e0a1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-06-24T09:38:38.845335Z","updated_at":"2026-06-24T09:38:38.845335Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"41d5d749-aaab-4503-8ae3-c593c4846010","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-07-03T15:27:54.644460Z","updated_at":"2026-07-03T15:27:54.644460Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "437"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:39 GMT
+                - Fri, 03 Jul 2026 15:27:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 3d8624e2-46c9-4609-9e63-d07087aee2fc
+                - 485a4f0d-02c9-431e-b889-480b09f618cf
         status: 200 OK
         code: 200
-        duration: 101.668545ms
+        duration: 33.313521ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -179,8 +179,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/41d5d749-aaab-4503-8ae3-c593c4846010/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -194,14 +194,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:39 GMT
+                - Fri, 03 Jul 2026 15:27:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 9ca10d82-1b71-498d-8e25-55bd895a6812
+                - ed2de031-cc3b-4fd9-a71e-d8fc56fe9683
         status: 200 OK
         code: 200
-        duration: 20.227401ms
+        duration: 41.173054ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -211,29 +211,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/41d5d749-aaab-4503-8ae3-c593c4846010
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 437
-        body: '{"id":"547a210e-1b14-4d88-b602-a8ebfe1e0a1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-06-24T09:38:38.845335Z","updated_at":"2026-06-24T09:38:38.845335Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"41d5d749-aaab-4503-8ae3-c593c4846010","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-07-03T15:27:54.644460Z","updated_at":"2026-07-03T15:27:54.644460Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "437"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:39 GMT
+                - Fri, 03 Jul 2026 15:27:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - dc9eb504-69ac-4bba-9142-41193bb2cb10
+                - a8f9ef83-6ab8-4bb8-b5a7-e1bbf6ce3875
         status: 200 OK
         code: 200
-        duration: 24.290788ms
+        duration: 54.639547ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -246,8 +246,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/41d5d749-aaab-4503-8ae3-c593c4846010/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -261,14 +261,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:39 GMT
+                - Fri, 03 Jul 2026 15:27:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 4addb209-e17f-44f8-a78b-e5c85778bd7e
+                - 034150b3-745f-4d6a-b163-0332d6c0c483
         status: 200 OK
         code: 200
-        duration: 27.312405ms
+        duration: 48.919733ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -281,29 +281,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/41d5d749-aaab-4503-8ae3-c593c4846010
         method: PATCH
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 453
-        body: '{"id":"547a210e-1b14-4d88-b602-a8ebfe1e0a1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-06-24T09:38:38.845335Z","updated_at":"2026-06-24T09:38:40.262601Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"41d5d749-aaab-4503-8ae3-c593c4846010","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-07-03T15:27:54.644460Z","updated_at":"2026-07-03T15:27:56.647509Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "453"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:40 GMT
+                - Fri, 03 Jul 2026 15:27:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 4f1b394f-05b7-4128-ae30-34e60781784a
+                - d33d35e7-9a23-4a30-822e-7a98e37e690d
         status: 200 OK
         code: 200
-        duration: 132.414248ms
+        duration: 266.80109ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -313,29 +313,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/41d5d749-aaab-4503-8ae3-c593c4846010
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 453
-        body: '{"id":"547a210e-1b14-4d88-b602-a8ebfe1e0a1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-06-24T09:38:38.845335Z","updated_at":"2026-06-24T09:38:40.262601Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"41d5d749-aaab-4503-8ae3-c593c4846010","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-07-03T15:27:54.644460Z","updated_at":"2026-07-03T15:27:56.647509Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "453"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:40 GMT
+                - Fri, 03 Jul 2026 15:27:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 6551bf44-bc79-4edf-a2ac-cadf629ae82b
+                - 7fd14a43-4bda-4fec-a5d4-989b8c5c0eb6
         status: 200 OK
         code: 200
-        duration: 119.946035ms
+        duration: 31.786232ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -348,8 +348,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/41d5d749-aaab-4503-8ae3-c593c4846010/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -363,14 +363,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:40 GMT
+                - Fri, 03 Jul 2026 15:27:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - d108e4ff-e3ce-4e51-be37-f345a0c8d73a
+                - f4be4530-d4c0-4524-b731-c1de8a524038
         status: 200 OK
         code: 200
-        duration: 111.707848ms
+        duration: 41.370063ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -380,29 +380,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/41d5d749-aaab-4503-8ae3-c593c4846010
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 453
-        body: '{"id":"547a210e-1b14-4d88-b602-a8ebfe1e0a1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-06-24T09:38:38.845335Z","updated_at":"2026-06-24T09:38:40.262601Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"41d5d749-aaab-4503-8ae3-c593c4846010","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-07-03T15:27:54.644460Z","updated_at":"2026-07-03T15:27:56.647509Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "453"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:40 GMT
+                - Fri, 03 Jul 2026 15:27:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 004381dd-c2be-46bb-86cf-6c9aedbe6855
+                - c6de1fc0-e973-426f-9e06-8585107d11e5
         status: 200 OK
         code: 200
-        duration: 17.227375ms
+        duration: 42.713937ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -412,29 +412,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/41d5d749-aaab-4503-8ae3-c593c4846010
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 453
-        body: '{"id":"547a210e-1b14-4d88-b602-a8ebfe1e0a1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-06-24T09:38:38.845335Z","updated_at":"2026-06-24T09:38:40.262601Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"41d5d749-aaab-4503-8ae3-c593c4846010","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-07-03T15:27:54.644460Z","updated_at":"2026-07-03T15:27:56.647509Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "453"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:41 GMT
+                - Fri, 03 Jul 2026 15:27:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 8a41d6b0-7c6a-4fcb-9e74-ff08c50d75bd
+                - faa9911f-499d-4228-b42c-7e755ff3bf20
         status: 200 OK
         code: 200
-        duration: 100.786794ms
+        duration: 942.847167ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -447,8 +447,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/41d5d749-aaab-4503-8ae3-c593c4846010/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -462,14 +462,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:41 GMT
+                - Fri, 03 Jul 2026 15:27:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 9ac886e3-2769-4153-9a74-13f052f300cd
+                - 5da44857-650c-4cd9-9343-9e85f35e83fc
         status: 200 OK
         code: 200
-        duration: 68.740525ms
+        duration: 47.43254ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -479,29 +479,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/41d5d749-aaab-4503-8ae3-c593c4846010
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 453
-        body: '{"id":"547a210e-1b14-4d88-b602-a8ebfe1e0a1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-06-24T09:38:38.845335Z","updated_at":"2026-06-24T09:38:40.262601Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"41d5d749-aaab-4503-8ae3-c593c4846010","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-07-03T15:27:54.644460Z","updated_at":"2026-07-03T15:27:56.647509Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "453"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:41 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 8946ce63-91f0-41f6-925a-aafda679fdd8
+                - ee556e2f-e54e-47ba-903c-8937de6bf556
         status: 200 OK
         code: 200
-        duration: 22.640401ms
+        duration: 49.299437ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -514,8 +514,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/41d5d749-aaab-4503-8ae3-c593c4846010/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -529,14 +529,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:41 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 47c54600-a88d-402d-97f6-d2cf69dc37f5
+                - 1a6e085a-3a8c-4d72-99b5-4722593cf2b5
         status: 200 OK
         code: 200
-        duration: 24.466595ms
+        duration: 43.972141ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -546,29 +546,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/41d5d749-aaab-4503-8ae3-c593c4846010
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 453
-        body: '{"id":"547a210e-1b14-4d88-b602-a8ebfe1e0a1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-06-24T09:38:38.845335Z","updated_at":"2026-06-24T09:38:40.262601Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"41d5d749-aaab-4503-8ae3-c593c4846010","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-07-03T15:27:54.644460Z","updated_at":"2026-07-03T15:27:56.647509Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "453"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:41 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - de19128c-85dd-4af7-80bd-e78213fa16f3
+                - 849d2e9b-e9e2-43a8-b6f2-4962bb247e83
         status: 200 OK
         code: 200
-        duration: 32.708349ms
+        duration: 41.566553ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -581,8 +581,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/41d5d749-aaab-4503-8ae3-c593c4846010/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -596,14 +596,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:41 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - c2d7727f-d2f9-4c76-be59-e8d5bed48da5
+                - 5a5ee544-4911-4506-94c5-5f5f83ad5aa6
         status: 200 OK
         code: 200
-        duration: 22.225636ms
+        duration: 55.37061ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -616,29 +616,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/41d5d749-aaab-4503-8ae3-c593c4846010
         method: PATCH
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 460
-        body: '{"id":"547a210e-1b14-4d88-b602-a8ebfe1e0a1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-06-24T09:38:38.845335Z","updated_at":"2026-06-24T09:38:42.135617Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-path-change","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"41d5d749-aaab-4503-8ae3-c593c4846010","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-07-03T15:27:54.644460Z","updated_at":"2026-07-03T15:28:00.056060Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-path-change","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "460"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:42 GMT
+                - Fri, 03 Jul 2026 15:28:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 7fb1e0f0-8bb7-4964-b2f6-8d1040d3ff10
+                - 9dede035-bb20-49a7-911a-88b62a4b4ce6
         status: 200 OK
         code: 200
-        duration: 165.620713ms
+        duration: 158.997829ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -648,29 +648,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/41d5d749-aaab-4503-8ae3-c593c4846010
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 460
-        body: '{"id":"547a210e-1b14-4d88-b602-a8ebfe1e0a1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-06-24T09:38:38.845335Z","updated_at":"2026-06-24T09:38:42.135617Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-path-change","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"41d5d749-aaab-4503-8ae3-c593c4846010","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-07-03T15:27:54.644460Z","updated_at":"2026-07-03T15:28:00.056060Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-path-change","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "460"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:42 GMT
+                - Fri, 03 Jul 2026 15:28:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 1fe29752-fbcb-4d62-8c24-b180924bb02c
+                - 36d94e01-5506-4865-b597-98a9c3aa2c40
         status: 200 OK
         code: 200
-        duration: 36.26825ms
+        duration: 40.768003ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -683,8 +683,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/41d5d749-aaab-4503-8ae3-c593c4846010/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -698,14 +698,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:42 GMT
+                - Fri, 03 Jul 2026 15:28:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 00827b84-66fc-47ab-b92e-9f51aae7930c
+                - 3ddd9de6-ee17-4a49-96cf-03c3cca124c8
         status: 200 OK
         code: 200
-        duration: 19.13737ms
+        duration: 33.810355ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -715,29 +715,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/41d5d749-aaab-4503-8ae3-c593c4846010
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 460
-        body: '{"id":"547a210e-1b14-4d88-b602-a8ebfe1e0a1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-06-24T09:38:38.845335Z","updated_at":"2026-06-24T09:38:42.135617Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-path-change","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"41d5d749-aaab-4503-8ae3-c593c4846010","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-07-03T15:27:54.644460Z","updated_at":"2026-07-03T15:28:00.056060Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-path-change","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "460"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:42 GMT
+                - Fri, 03 Jul 2026 15:28:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 25849092-bc38-4394-86a0-d8dda89b8f1d
+                - f2321596-66ec-4c2c-a26d-db7fd88b8546
         status: 200 OK
         code: 200
-        duration: 26.264895ms
+        duration: 49.555267ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -747,29 +747,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/41d5d749-aaab-4503-8ae3-c593c4846010
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 460
-        body: '{"id":"547a210e-1b14-4d88-b602-a8ebfe1e0a1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-06-24T09:38:38.845335Z","updated_at":"2026-06-24T09:38:42.135617Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-path-change","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"41d5d749-aaab-4503-8ae3-c593c4846010","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-07-03T15:27:54.644460Z","updated_at":"2026-07-03T15:28:00.056060Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-path-change","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "460"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:42 GMT
+                - Fri, 03 Jul 2026 15:28:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - df58c789-e283-463a-b803-665841257bce
+                - a50a14e2-f2ce-479f-841a-cec5245f8658
         status: 200 OK
         code: 200
-        duration: 24.576907ms
+        duration: 41.112209ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -782,8 +782,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/41d5d749-aaab-4503-8ae3-c593c4846010/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -797,14 +797,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:42 GMT
+                - Fri, 03 Jul 2026 15:28:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - c74a68af-a0b6-4ac5-aadd-5d007df6c27a
+                - 20586e14-4064-4e9c-83b0-4d1861be447f
         status: 200 OK
         code: 200
-        duration: 23.26008ms
+        duration: 31.429232ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -814,29 +814,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/41d5d749-aaab-4503-8ae3-c593c4846010
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 460
-        body: '{"id":"547a210e-1b14-4d88-b602-a8ebfe1e0a1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-06-24T09:38:38.845335Z","updated_at":"2026-06-24T09:38:42.135617Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-path-change","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"41d5d749-aaab-4503-8ae3-c593c4846010","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-07-03T15:27:54.644460Z","updated_at":"2026-07-03T15:28:00.056060Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-path-change","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "460"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:42 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - c97e8933-13b7-4a66-be3b-42aa5454301d
+                - 6f40b2de-32a8-4923-ae8b-d0b6e26e826a
         status: 200 OK
         code: 200
-        duration: 28.41437ms
+        duration: 52.909357ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -849,8 +849,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/41d5d749-aaab-4503-8ae3-c593c4846010/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -864,14 +864,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:42 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 5dcce2b4-a43b-4581-b6c4-bac34da14309
+                - b52b27a6-97c9-49a4-b9d6-f832d5697b77
         status: 200 OK
         code: 200
-        duration: 53.030171ms
+        duration: 51.306396ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -884,29 +884,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/41d5d749-aaab-4503-8ae3-c593c4846010
         method: PATCH
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 437
-        body: '{"id":"547a210e-1b14-4d88-b602-a8ebfe1e0a1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-06-24T09:38:38.845335Z","updated_at":"2026-06-24T09:38:43.009903Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"41d5d749-aaab-4503-8ae3-c593c4846010","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-07-03T15:27:54.644460Z","updated_at":"2026-07-03T15:28:01.714669Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "437"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:43 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 5d52d11f-9745-41f3-9170-9fce7489833d
+                - 890ce096-217b-4cd7-bf53-b68daf2fa92e
         status: 200 OK
         code: 200
-        duration: 77.532555ms
+        duration: 71.872955ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -916,29 +916,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/41d5d749-aaab-4503-8ae3-c593c4846010
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 437
-        body: '{"id":"547a210e-1b14-4d88-b602-a8ebfe1e0a1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-06-24T09:38:38.845335Z","updated_at":"2026-06-24T09:38:43.009903Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"41d5d749-aaab-4503-8ae3-c593c4846010","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-07-03T15:27:54.644460Z","updated_at":"2026-07-03T15:28:01.714669Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "437"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:43 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - b64fd64e-31dd-4137-b885-e94f589c31d3
+                - b5c974fb-df14-456c-bc9d-2dbd2d6d327c
         status: 200 OK
         code: 200
-        duration: 19.826001ms
+        duration: 90.033456ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -951,8 +951,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/41d5d749-aaab-4503-8ae3-c593c4846010/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -966,14 +966,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:43 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 5be164cd-b54c-4d6f-8900-3064b9625901
+                - 9722740a-bcce-4ad4-916e-2f3074197398
         status: 200 OK
         code: 200
-        duration: 36.568726ms
+        duration: 42.806712ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -983,29 +983,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/41d5d749-aaab-4503-8ae3-c593c4846010
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 437
-        body: '{"id":"547a210e-1b14-4d88-b602-a8ebfe1e0a1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-06-24T09:38:38.845335Z","updated_at":"2026-06-24T09:38:43.009903Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"41d5d749-aaab-4503-8ae3-c593c4846010","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-07-03T15:27:54.644460Z","updated_at":"2026-07-03T15:28:01.714669Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "437"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:43 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 7c2fdcf4-8a04-4976-bb9a-9d452609cb8c
+                - 9e407807-5756-466f-bb84-42d640947527
         status: 200 OK
         code: 200
-        duration: 26.984266ms
+        duration: 39.104107ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1015,29 +1015,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/41d5d749-aaab-4503-8ae3-c593c4846010
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 437
-        body: '{"id":"547a210e-1b14-4d88-b602-a8ebfe1e0a1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-06-24T09:38:38.845335Z","updated_at":"2026-06-24T09:38:43.009903Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"41d5d749-aaab-4503-8ae3-c593c4846010","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-07-03T15:27:54.644460Z","updated_at":"2026-07-03T15:28:01.714669Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "437"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:43 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - b16c5ac4-5e2f-4097-a21b-38dde29f3c78
+                - 96159ba8-1fdc-4308-a49a-24c3162d168d
         status: 200 OK
         code: 200
-        duration: 36.315461ms
+        duration: 35.419216ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1050,8 +1050,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/41d5d749-aaab-4503-8ae3-c593c4846010/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -1065,14 +1065,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:43 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 55a1edb0-3fbb-42da-8f07-21b5e4695271
+                - b9c87eb3-5ad9-4043-991a-427852d14dc6
         status: 200 OK
         code: 200
-        duration: 35.759142ms
+        duration: 37.889556ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1082,8 +1082,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/41d5d749-aaab-4503-8ae3-c593c4846010
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1095,14 +1095,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:43 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 283e35cb-74d2-403c-85e4-418d6beb397c
+                - f128b8d2-f3e5-4e68-914e-c85730aab72b
         status: 204 No Content
         code: 204
-        duration: 121.93439ms
+        duration: 73.655243ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1112,26 +1112,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/41d5d749-aaab-4503-8ae3-c593c4846010
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 462
-        body: '{"id":"547a210e-1b14-4d88-b602-a8ebfe1e0a1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-06-24T09:38:38.845335Z","updated_at":"2026-06-24T09:38:43.796133Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-06-24T09:38:43.796133Z","key_id":null,"region":"fr-par"}'
+        body: '{"id":"41d5d749-aaab-4503-8ae3-c593c4846010","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-07-03T15:27:54.644460Z","updated_at":"2026-07-03T15:28:03.197022Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-07-03T15:28:03.197022Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "462"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:43 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 4e79eb75-bc5b-4fdb-9956-2fcc1919b715
+                - fcaf6ef6-8562-41e7-881d-dee508f94130
         status: 200 OK
         code: 200
-        duration: 23.642955ms
+        duration: 42.608129ms

--- a/internal/services/secret/testdata/secret-protected.cassette.yaml
+++ b/internal/services/secret/testdata/secret-protected.cassette.yaml
@@ -13,7 +13,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets
         method: POST
       response:
@@ -21,21 +21,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 441
-        body: '{"id":"7bdd4085-74b0-4037-889b-bf3266488a97","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-protected-secret","status":"ready","created_at":"2026-06-24T09:38:38.782934Z","updated_at":"2026-06-24T09:38:38.782934Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":true,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"624d7f85-d701-41e3-8c42-be04a5b42fc8","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-protected-secret","status":"ready","created_at":"2026-07-03T15:27:54.805853Z","updated_at":"2026-07-03T15:27:54.805853Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":true,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "441"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:38 GMT
+                - Fri, 03 Jul 2026 15:27:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - a64024a8-7e55-455e-9a11-064c4353474c
+                - 75daa4f5-faa2-493f-993c-4faf9665921c
         status: 200 OK
         code: 200
-        duration: 258.120426ms
+        duration: 567.497493ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -45,29 +45,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7bdd4085-74b0-4037-889b-bf3266488a97
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/624d7f85-d701-41e3-8c42-be04a5b42fc8
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 441
-        body: '{"id":"7bdd4085-74b0-4037-889b-bf3266488a97","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-protected-secret","status":"ready","created_at":"2026-06-24T09:38:38.782934Z","updated_at":"2026-06-24T09:38:38.782934Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":true,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"624d7f85-d701-41e3-8c42-be04a5b42fc8","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-protected-secret","status":"ready","created_at":"2026-07-03T15:27:54.805853Z","updated_at":"2026-07-03T15:27:54.805853Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":true,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "441"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:38 GMT
+                - Fri, 03 Jul 2026 15:27:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 8624f0a6-f6ed-48a4-8d23-e51a0aaeb7f8
+                - a8d3f99c-b9a1-4f33-9121-61e86eba1b44
         status: 200 OK
         code: 200
-        duration: 93.336829ms
+        duration: 200.726285ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -80,8 +80,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7bdd4085-74b0-4037-889b-bf3266488a97/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/624d7f85-d701-41e3-8c42-be04a5b42fc8/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -95,14 +95,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:39 GMT
+                - Fri, 03 Jul 2026 15:27:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 4b54c8ff-8cee-43bc-b155-67de83b1f6b3
+                - d32b83e1-6d6c-4670-b167-a2912963c3f5
         status: 200 OK
         code: 200
-        duration: 109.473401ms
+        duration: 207.690666ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -112,29 +112,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7bdd4085-74b0-4037-889b-bf3266488a97
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/624d7f85-d701-41e3-8c42-be04a5b42fc8
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 441
-        body: '{"id":"7bdd4085-74b0-4037-889b-bf3266488a97","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-protected-secret","status":"ready","created_at":"2026-06-24T09:38:38.782934Z","updated_at":"2026-06-24T09:38:38.782934Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":true,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"624d7f85-d701-41e3-8c42-be04a5b42fc8","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-protected-secret","status":"ready","created_at":"2026-07-03T15:27:54.805853Z","updated_at":"2026-07-03T15:27:54.805853Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":true,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "441"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:39 GMT
+                - Fri, 03 Jul 2026 15:27:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - c9cc92f5-0e07-407a-a18f-a78a05c47d35
+                - 4709f7f2-2ea4-4e0b-ab11-48311ec338ce
         status: 200 OK
         code: 200
-        duration: 18.364547ms
+        duration: 97.420811ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -144,29 +144,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7bdd4085-74b0-4037-889b-bf3266488a97
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/624d7f85-d701-41e3-8c42-be04a5b42fc8
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 441
-        body: '{"id":"7bdd4085-74b0-4037-889b-bf3266488a97","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-protected-secret","status":"ready","created_at":"2026-06-24T09:38:38.782934Z","updated_at":"2026-06-24T09:38:38.782934Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":true,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"624d7f85-d701-41e3-8c42-be04a5b42fc8","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-protected-secret","status":"ready","created_at":"2026-07-03T15:27:54.805853Z","updated_at":"2026-07-03T15:27:54.805853Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":true,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "441"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:39 GMT
+                - Fri, 03 Jul 2026 15:27:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 4404edeb-9a38-4fec-a386-22adabceb730
+                - 4ab23aa7-a3ec-4d79-8594-b30c9b20aa2c
         status: 200 OK
         code: 200
-        duration: 23.267154ms
+        duration: 34.892537ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -179,8 +179,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7bdd4085-74b0-4037-889b-bf3266488a97/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/624d7f85-d701-41e3-8c42-be04a5b42fc8/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -194,14 +194,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:39 GMT
+                - Fri, 03 Jul 2026 15:27:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - d1cc6843-1e2a-41e0-8304-2ebd143c392f
+                - 5356e6b7-ea02-4842-8772-bf68e4eea189
         status: 200 OK
         code: 200
-        duration: 35.177326ms
+        duration: 32.261205ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -211,29 +211,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7bdd4085-74b0-4037-889b-bf3266488a97
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/624d7f85-d701-41e3-8c42-be04a5b42fc8
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 441
-        body: '{"id":"7bdd4085-74b0-4037-889b-bf3266488a97","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-protected-secret","status":"ready","created_at":"2026-06-24T09:38:38.782934Z","updated_at":"2026-06-24T09:38:38.782934Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":true,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"624d7f85-d701-41e3-8c42-be04a5b42fc8","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-protected-secret","status":"ready","created_at":"2026-07-03T15:27:54.805853Z","updated_at":"2026-07-03T15:27:54.805853Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":true,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "441"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:39 GMT
+                - Fri, 03 Jul 2026 15:27:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 773f1684-8aca-4845-a53f-0780332c7818
+                - 028da271-0f4c-458b-b784-e8ca1391e0d6
         status: 200 OK
         code: 200
-        duration: 96.951455ms
+        duration: 68.71797ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -246,8 +246,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7bdd4085-74b0-4037-889b-bf3266488a97/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/624d7f85-d701-41e3-8c42-be04a5b42fc8/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -261,14 +261,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:39 GMT
+                - Fri, 03 Jul 2026 15:27:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 35b35711-071e-484b-9e81-1c10456cfd00
+                - f7f791e6-90ac-4db8-ab6b-fea7112401eb
         status: 200 OK
         code: 200
-        duration: 25.861551ms
+        duration: 37.885418ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -278,8 +278,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7bdd4085-74b0-4037-889b-bf3266488a97
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/624d7f85-d701-41e3-8c42-be04a5b42fc8
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -293,14 +293,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:40 GMT
+                - Fri, 03 Jul 2026 15:27:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 72d924a0-2a39-4723-b13f-b845e2179266
+                - 68f0d1fd-8f10-4d59-9344-4d19b2f7f357
         status: 412 Precondition Failed
         code: 412
-        duration: 153.940131ms
+        duration: 121.788379ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -310,29 +310,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7bdd4085-74b0-4037-889b-bf3266488a97
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/624d7f85-d701-41e3-8c42-be04a5b42fc8
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 441
-        body: '{"id":"7bdd4085-74b0-4037-889b-bf3266488a97","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-protected-secret","status":"ready","created_at":"2026-06-24T09:38:38.782934Z","updated_at":"2026-06-24T09:38:38.782934Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":true,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"624d7f85-d701-41e3-8c42-be04a5b42fc8","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-protected-secret","status":"ready","created_at":"2026-07-03T15:27:54.805853Z","updated_at":"2026-07-03T15:27:54.805853Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":true,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "441"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:40 GMT
+                - Fri, 03 Jul 2026 15:27:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - b78d1858-6381-453b-b7c8-e481f1e1ea87
+                - 956beaba-ac21-4cac-ad10-49c79434f6ef
         status: 200 OK
         code: 200
-        duration: 104.513614ms
+        duration: 52.934765ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -345,8 +345,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7bdd4085-74b0-4037-889b-bf3266488a97/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/624d7f85-d701-41e3-8c42-be04a5b42fc8/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -360,14 +360,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:40 GMT
+                - Fri, 03 Jul 2026 15:27:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 004b6300-c656-49ee-90e8-759588029dcf
+                - 38f31866-3d71-4595-81ec-17a64d4bf075
         status: 200 OK
         code: 200
-        duration: 21.949184ms
+        duration: 194.733058ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -377,29 +377,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7bdd4085-74b0-4037-889b-bf3266488a97
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/624d7f85-d701-41e3-8c42-be04a5b42fc8
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 441
-        body: '{"id":"7bdd4085-74b0-4037-889b-bf3266488a97","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-protected-secret","status":"ready","created_at":"2026-06-24T09:38:38.782934Z","updated_at":"2026-06-24T09:38:38.782934Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":true,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"624d7f85-d701-41e3-8c42-be04a5b42fc8","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-protected-secret","status":"ready","created_at":"2026-07-03T15:27:54.805853Z","updated_at":"2026-07-03T15:27:54.805853Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":true,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "441"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:40 GMT
+                - Fri, 03 Jul 2026 15:27:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 428a8d57-8673-4eb3-a0a6-46f03740558f
+                - 1cead94a-a331-40c6-bdc8-944268e3f8f0
         status: 200 OK
         code: 200
-        duration: 19.017149ms
+        duration: 929.377517ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -412,29 +412,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7bdd4085-74b0-4037-889b-bf3266488a97/unprotect
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/624d7f85-d701-41e3-8c42-be04a5b42fc8/unprotect
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 442
-        body: '{"id":"7bdd4085-74b0-4037-889b-bf3266488a97","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-protected-secret","status":"ready","created_at":"2026-06-24T09:38:38.782934Z","updated_at":"2026-06-24T09:38:38.782934Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"624d7f85-d701-41e3-8c42-be04a5b42fc8","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-protected-secret","status":"ready","created_at":"2026-07-03T15:27:54.805853Z","updated_at":"2026-07-03T15:27:54.805853Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "442"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:40 GMT
+                - Fri, 03 Jul 2026 15:27:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 5b19b3cc-8b88-48a7-9fb9-3aab790db0ab
+                - 36f365a6-9182-4f7a-848b-7917781c1c61
         status: 200 OK
         code: 200
-        duration: 122.84143ms
+        duration: 126.767702ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -444,29 +444,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7bdd4085-74b0-4037-889b-bf3266488a97
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/624d7f85-d701-41e3-8c42-be04a5b42fc8
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 442
-        body: '{"id":"7bdd4085-74b0-4037-889b-bf3266488a97","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-protected-secret","status":"ready","created_at":"2026-06-24T09:38:38.782934Z","updated_at":"2026-06-24T09:38:38.782934Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"624d7f85-d701-41e3-8c42-be04a5b42fc8","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-protected-secret","status":"ready","created_at":"2026-07-03T15:27:54.805853Z","updated_at":"2026-07-03T15:27:54.805853Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "442"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:40 GMT
+                - Fri, 03 Jul 2026 15:27:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 21e3c0fe-aa50-4a41-9a6e-65fc53977f99
+                - 1356bfb9-9a5c-4d99-b099-bf238f5c17f4
         status: 200 OK
         code: 200
-        duration: 37.836929ms
+        duration: 75.486122ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -479,8 +479,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7bdd4085-74b0-4037-889b-bf3266488a97/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/624d7f85-d701-41e3-8c42-be04a5b42fc8/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -494,14 +494,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:40 GMT
+                - Fri, 03 Jul 2026 15:27:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - de2c821d-5b6e-45ba-a271-0194e3f8d723
+                - e3434c01-0cc5-4f90-99c0-c1116060480c
         status: 200 OK
         code: 200
-        duration: 21.187654ms
+        duration: 43.360812ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -511,29 +511,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7bdd4085-74b0-4037-889b-bf3266488a97
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/624d7f85-d701-41e3-8c42-be04a5b42fc8
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 442
-        body: '{"id":"7bdd4085-74b0-4037-889b-bf3266488a97","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-protected-secret","status":"ready","created_at":"2026-06-24T09:38:38.782934Z","updated_at":"2026-06-24T09:38:38.782934Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"624d7f85-d701-41e3-8c42-be04a5b42fc8","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-protected-secret","status":"ready","created_at":"2026-07-03T15:27:54.805853Z","updated_at":"2026-07-03T15:27:54.805853Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "442"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:40 GMT
+                - Fri, 03 Jul 2026 15:27:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 3d9d9d10-17b9-4e41-801d-d3fee5074f60
+                - c4697c74-18e8-4ab2-8150-1d9ed88f0369
         status: 200 OK
         code: 200
-        duration: 19.037298ms
+        duration: 39.555606ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -543,29 +543,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7bdd4085-74b0-4037-889b-bf3266488a97
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/624d7f85-d701-41e3-8c42-be04a5b42fc8
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 442
-        body: '{"id":"7bdd4085-74b0-4037-889b-bf3266488a97","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-protected-secret","status":"ready","created_at":"2026-06-24T09:38:38.782934Z","updated_at":"2026-06-24T09:38:38.782934Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"624d7f85-d701-41e3-8c42-be04a5b42fc8","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-protected-secret","status":"ready","created_at":"2026-07-03T15:27:54.805853Z","updated_at":"2026-07-03T15:27:54.805853Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "442"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:41 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - ecc5d61d-204e-4df1-9519-903cb90a7a2c
+                - f4ca6fba-175f-4465-99a8-5f1b1eb49933
         status: 200 OK
         code: 200
-        duration: 22.247938ms
+        duration: 32.036383ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -578,8 +578,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7bdd4085-74b0-4037-889b-bf3266488a97/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/624d7f85-d701-41e3-8c42-be04a5b42fc8/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -593,14 +593,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:41 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 8c417051-2059-4ded-b8c9-ef8af5a800ef
+                - e699dc3a-b44a-428a-a8f1-c4faf8b57e4c
         status: 200 OK
         code: 200
-        duration: 115.120657ms
+        duration: 38.803042ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -610,8 +610,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7bdd4085-74b0-4037-889b-bf3266488a97
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/624d7f85-d701-41e3-8c42-be04a5b42fc8
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -623,14 +623,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:41 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 6ab20f98-51d6-4e45-a8bb-7da7810df03c
+                - 3e74914f-5384-43c3-a078-6a680d748867
         status: 204 No Content
         code: 204
-        duration: 124.150112ms
+        duration: 124.635046ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -640,26 +640,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7bdd4085-74b0-4037-889b-bf3266488a97
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/624d7f85-d701-41e3-8c42-be04a5b42fc8
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 467
-        body: '{"id":"7bdd4085-74b0-4037-889b-bf3266488a97","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-protected-secret","status":"ready","created_at":"2026-06-24T09:38:38.782934Z","updated_at":"2026-06-24T09:38:41.771276Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-06-24T09:38:41.771276Z","key_id":null,"region":"fr-par"}'
+        body: '{"id":"624d7f85-d701-41e3-8c42-be04a5b42fc8","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-protected-secret","status":"ready","created_at":"2026-07-03T15:27:54.805853Z","updated_at":"2026-07-03T15:27:59.957733Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-07-03T15:27:59.957733Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "467"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:41 GMT
+                - Fri, 03 Jul 2026 15:28:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 47f19f71-c465-4380-8150-b83552f0e250
+                - c3fc6cb7-27f6-439e-b222-2ef2fbdd7a0f
         status: 200 OK
         code: 200
-        duration: 88.841524ms
+        duration: 51.661343ms

--- a/internal/services/secret/testdata/secret-version-basic.cassette.yaml
+++ b/internal/services/secret/testdata/secret-version-basic.cassette.yaml
@@ -13,7 +13,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets
         method: POST
       response:
@@ -21,21 +21,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 487
-        body: '{"id":"18b64d48-e8ce-47e2-a752-a21efb7cfb4d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretVersionNameBasic","status":"ready","created_at":"2026-06-04T09:49:23.380512Z","updated_at":"2026-06-04T09:49:23.380512Z","tags":["devtools","provider","terraform"],"version_count":0,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"842d724a-1e9c-4017-ac08-6bf83cab4c64","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretVersionNameBasic","status":"ready","created_at":"2026-07-03T15:27:59.863920Z","updated_at":"2026-07-03T15:27:59.863920Z","tags":["devtools","provider","terraform"],"version_count":0,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "487"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:23 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 766d5ca2-5bb3-4188-be33-2d8211a4dc28
+                - 31912f03-1b79-4744-9739-c9856ae657a0
         status: 200 OK
         code: 200
-        duration: 272.69987ms
+        duration: 96.60565ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -45,29 +45,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18b64d48-e8ce-47e2-a752-a21efb7cfb4d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/842d724a-1e9c-4017-ac08-6bf83cab4c64
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 487
-        body: '{"id":"18b64d48-e8ce-47e2-a752-a21efb7cfb4d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretVersionNameBasic","status":"ready","created_at":"2026-06-04T09:49:23.380512Z","updated_at":"2026-06-04T09:49:23.380512Z","tags":["devtools","provider","terraform"],"version_count":0,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"842d724a-1e9c-4017-ac08-6bf83cab4c64","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretVersionNameBasic","status":"ready","created_at":"2026-07-03T15:27:59.863920Z","updated_at":"2026-07-03T15:27:59.863920Z","tags":["devtools","provider","terraform"],"version_count":0,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "487"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:23 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 94818a80-2f0a-464d-98d9-4a5599b1242e
+                - 0c93d1f3-36c1-4a2f-8386-370552ee6eb1
         status: 200 OK
         code: 200
-        duration: 49.471578ms
+        duration: 54.061572ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -80,8 +80,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18b64d48-e8ce-47e2-a752-a21efb7cfb4d/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/842d724a-1e9c-4017-ac08-6bf83cab4c64/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -95,14 +95,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:23 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - bde9c746-ebc3-4548-9a64-cc2598c9617b
+                - 22b2b011-8d0c-430a-9381-8bdafe31b5a7
         status: 200 OK
         code: 200
-        duration: 96.966237ms
+        duration: 58.365736ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -115,29 +115,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18b64d48-e8ce-47e2-a752-a21efb7cfb4d/versions
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/842d724a-1e9c-4017-ac08-6bf83cab4c64/versions
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"18b64d48-e8ce-47e2-a752-a21efb7cfb4d","status":"enabled","created_at":"2026-06-04T09:49:23.957523Z","updated_at":"2026-06-04T09:49:23.957523Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"842d724a-1e9c-4017-ac08-6bf83cab4c64","status":"enabled","created_at":"2026-07-03T15:28:00.329374Z","updated_at":"2026-07-03T15:28:00.329374Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:23 GMT
+                - Fri, 03 Jul 2026 15:28:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 83bd6b27-e483-4769-bd49-2c32dc6e47b6
+                - b327757e-4017-427a-ad3c-9c8a2b46fae5
         status: 200 OK
         code: 200
-        duration: 431.413548ms
+        duration: 349.010181ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -147,29 +147,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18b64d48-e8ce-47e2-a752-a21efb7cfb4d/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/842d724a-1e9c-4017-ac08-6bf83cab4c64/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"18b64d48-e8ce-47e2-a752-a21efb7cfb4d","status":"enabled","created_at":"2026-06-04T09:49:23.957523Z","updated_at":"2026-06-04T09:49:23.957523Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"842d724a-1e9c-4017-ac08-6bf83cab4c64","status":"enabled","created_at":"2026-07-03T15:28:00.329374Z","updated_at":"2026-07-03T15:28:00.329374Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:24 GMT
+                - Fri, 03 Jul 2026 15:28:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - b4b3d9d4-86ab-4d6a-ab46-241934453dd0
+                - ad70e0c7-1508-4be8-8ffd-ca33ffc2d544
         status: 200 OK
         code: 200
-        duration: 35.477713ms
+        duration: 47.715592ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -179,29 +179,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18b64d48-e8ce-47e2-a752-a21efb7cfb4d/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/842d724a-1e9c-4017-ac08-6bf83cab4c64/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"18b64d48-e8ce-47e2-a752-a21efb7cfb4d","status":"enabled","created_at":"2026-06-04T09:49:23.957523Z","updated_at":"2026-06-04T09:49:23.957523Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"842d724a-1e9c-4017-ac08-6bf83cab4c64","status":"enabled","created_at":"2026-07-03T15:28:00.329374Z","updated_at":"2026-07-03T15:28:00.329374Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:24 GMT
+                - Fri, 03 Jul 2026 15:28:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 5450dd2e-a98a-45e3-b011-760abadcdc15
+                - 2dc23400-1ca2-4b2f-be93-51f367db2adf
         status: 200 OK
         code: 200
-        duration: 47.458072ms
+        duration: 41.514384ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -211,29 +211,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18b64d48-e8ce-47e2-a752-a21efb7cfb4d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/842d724a-1e9c-4017-ac08-6bf83cab4c64
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 487
-        body: '{"id":"18b64d48-e8ce-47e2-a752-a21efb7cfb4d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretVersionNameBasic","status":"ready","created_at":"2026-06-04T09:49:23.380512Z","updated_at":"2026-06-04T09:49:23.380512Z","tags":["devtools","provider","terraform"],"version_count":1,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"842d724a-1e9c-4017-ac08-6bf83cab4c64","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretVersionNameBasic","status":"ready","created_at":"2026-07-03T15:27:59.863920Z","updated_at":"2026-07-03T15:27:59.863920Z","tags":["devtools","provider","terraform"],"version_count":1,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "487"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:24 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - b6105bdf-0e64-4589-9359-e9da5fe6c150
+                - b95d6f31-d090-48a1-973a-a967905651ed
         status: 200 OK
         code: 200
-        duration: 84.51041ms
+        duration: 60.730167ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -246,29 +246,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18b64d48-e8ce-47e2-a752-a21efb7cfb4d/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/842d724a-1e9c-4017-ac08-6bf83cab4c64/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 333
-        body: '{"versions":[{"revision":1,"secret_id":"18b64d48-e8ce-47e2-a752-a21efb7cfb4d","status":"enabled","created_at":"2026-06-04T09:49:23.957523Z","updated_at":"2026-06-04T09:49:23.957523Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        body: '{"versions":[{"revision":1,"secret_id":"842d724a-1e9c-4017-ac08-6bf83cab4c64","status":"enabled","created_at":"2026-07-03T15:28:00.329374Z","updated_at":"2026-07-03T15:28:00.329374Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "333"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:24 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - c8cd521c-ba51-4470-b4c9-4981de7d6bd0
+                - 3e11949b-d3a0-47e4-83b3-23702dabc4e4
         status: 200 OK
         code: 200
-        duration: 33.167341ms
+        duration: 52.758585ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -278,29 +278,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18b64d48-e8ce-47e2-a752-a21efb7cfb4d/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/842d724a-1e9c-4017-ac08-6bf83cab4c64/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"18b64d48-e8ce-47e2-a752-a21efb7cfb4d","status":"enabled","created_at":"2026-06-04T09:49:23.957523Z","updated_at":"2026-06-04T09:49:23.957523Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"842d724a-1e9c-4017-ac08-6bf83cab4c64","status":"enabled","created_at":"2026-07-03T15:28:00.329374Z","updated_at":"2026-07-03T15:28:00.329374Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:24 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 1368f447-f8c4-4246-9f07-00bf10f99252
+                - 255a4d29-1371-47d3-be77-d1d956b0c2b7
         status: 200 OK
         code: 200
-        duration: 52.69609ms
+        duration: 45.08416ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -310,29 +310,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18b64d48-e8ce-47e2-a752-a21efb7cfb4d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/842d724a-1e9c-4017-ac08-6bf83cab4c64
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 487
-        body: '{"id":"18b64d48-e8ce-47e2-a752-a21efb7cfb4d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretVersionNameBasic","status":"ready","created_at":"2026-06-04T09:49:23.380512Z","updated_at":"2026-06-04T09:49:23.380512Z","tags":["devtools","provider","terraform"],"version_count":1,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"842d724a-1e9c-4017-ac08-6bf83cab4c64","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretVersionNameBasic","status":"ready","created_at":"2026-07-03T15:27:59.863920Z","updated_at":"2026-07-03T15:27:59.863920Z","tags":["devtools","provider","terraform"],"version_count":1,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "487"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:24 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - cdf21efc-167a-4030-9967-b090ca378160
+                - 4b108210-010e-40b6-8302-1f6217ce2be6
         status: 200 OK
         code: 200
-        duration: 36.301033ms
+        duration: 51.268906ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -345,29 +345,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18b64d48-e8ce-47e2-a752-a21efb7cfb4d/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/842d724a-1e9c-4017-ac08-6bf83cab4c64/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 333
-        body: '{"versions":[{"revision":1,"secret_id":"18b64d48-e8ce-47e2-a752-a21efb7cfb4d","status":"enabled","created_at":"2026-06-04T09:49:23.957523Z","updated_at":"2026-06-04T09:49:23.957523Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        body: '{"versions":[{"revision":1,"secret_id":"842d724a-1e9c-4017-ac08-6bf83cab4c64","status":"enabled","created_at":"2026-07-03T15:28:00.329374Z","updated_at":"2026-07-03T15:28:00.329374Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "333"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:24 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 89349b45-477b-4f0f-9c9d-a25c151c9933
+                - 61b246f6-d4ba-45c0-8894-db8320d22fff
         status: 200 OK
         code: 200
-        duration: 42.974886ms
+        duration: 39.726176ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -377,29 +377,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18b64d48-e8ce-47e2-a752-a21efb7cfb4d/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/842d724a-1e9c-4017-ac08-6bf83cab4c64/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"18b64d48-e8ce-47e2-a752-a21efb7cfb4d","status":"enabled","created_at":"2026-06-04T09:49:23.957523Z","updated_at":"2026-06-04T09:49:23.957523Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"842d724a-1e9c-4017-ac08-6bf83cab4c64","status":"enabled","created_at":"2026-07-03T15:28:00.329374Z","updated_at":"2026-07-03T15:28:00.329374Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:24 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - f5c3d35f-0888-407d-818a-c925cea46d88
+                - 9c199fef-3765-4cda-8c6e-ecea8b978add
         status: 200 OK
         code: 200
-        duration: 30.032357ms
+        duration: 119.590762ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -412,29 +412,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18b64d48-e8ce-47e2-a752-a21efb7cfb4d/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/842d724a-1e9c-4017-ac08-6bf83cab4c64/versions/1
         method: PATCH
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 320
-        body: '{"revision":1,"secret_id":"18b64d48-e8ce-47e2-a752-a21efb7cfb4d","status":"enabled","created_at":"2026-06-04T09:49:23.957523Z","updated_at":"2026-06-04T09:49:25.233459Z","deleted_at":null,"description":"secret version description","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"842d724a-1e9c-4017-ac08-6bf83cab4c64","status":"enabled","created_at":"2026-07-03T15:28:00.329374Z","updated_at":"2026-07-03T15:28:02.406879Z","deleted_at":null,"description":"secret version description","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "320"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:25 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - e8f42d5a-5285-477d-b31a-fb555b506376
+                - dda034e4-433f-4de5-a7ea-5c7d29d30aff
         status: 200 OK
         code: 200
-        duration: 119.451812ms
+        duration: 171.567789ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -444,29 +444,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18b64d48-e8ce-47e2-a752-a21efb7cfb4d/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/842d724a-1e9c-4017-ac08-6bf83cab4c64/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 320
-        body: '{"revision":1,"secret_id":"18b64d48-e8ce-47e2-a752-a21efb7cfb4d","status":"enabled","created_at":"2026-06-04T09:49:23.957523Z","updated_at":"2026-06-04T09:49:25.233459Z","deleted_at":null,"description":"secret version description","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"842d724a-1e9c-4017-ac08-6bf83cab4c64","status":"enabled","created_at":"2026-07-03T15:28:00.329374Z","updated_at":"2026-07-03T15:28:02.406879Z","deleted_at":null,"description":"secret version description","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "320"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:25 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - f377d987-9c87-42a6-a995-079a4d82f133
+                - d0ecf648-ecce-49fa-ab34-a9c4d3b7e97a
         status: 200 OK
         code: 200
-        duration: 49.742807ms
+        duration: 42.442969ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -476,29 +476,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18b64d48-e8ce-47e2-a752-a21efb7cfb4d/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/842d724a-1e9c-4017-ac08-6bf83cab4c64/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 320
-        body: '{"revision":1,"secret_id":"18b64d48-e8ce-47e2-a752-a21efb7cfb4d","status":"enabled","created_at":"2026-06-04T09:49:23.957523Z","updated_at":"2026-06-04T09:49:25.233459Z","deleted_at":null,"description":"secret version description","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"842d724a-1e9c-4017-ac08-6bf83cab4c64","status":"enabled","created_at":"2026-07-03T15:28:00.329374Z","updated_at":"2026-07-03T15:28:02.406879Z","deleted_at":null,"description":"secret version description","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "320"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:25 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - be04104d-cbe3-4a38-acac-a99f8d52a34d
+                - afc64ede-ceaa-4aaa-8d46-825cfa5cec22
         status: 200 OK
         code: 200
-        duration: 39.076305ms
+        duration: 33.546529ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -508,29 +508,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18b64d48-e8ce-47e2-a752-a21efb7cfb4d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/842d724a-1e9c-4017-ac08-6bf83cab4c64
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 487
-        body: '{"id":"18b64d48-e8ce-47e2-a752-a21efb7cfb4d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretVersionNameBasic","status":"ready","created_at":"2026-06-04T09:49:23.380512Z","updated_at":"2026-06-04T09:49:23.380512Z","tags":["devtools","provider","terraform"],"version_count":1,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"842d724a-1e9c-4017-ac08-6bf83cab4c64","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretVersionNameBasic","status":"ready","created_at":"2026-07-03T15:27:59.863920Z","updated_at":"2026-07-03T15:27:59.863920Z","tags":["devtools","provider","terraform"],"version_count":1,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "487"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:25 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 27253a2d-f487-4f4f-8e7b-eea2348e828a
+                - 9146d67e-603a-4bae-955c-6066e1552cae
         status: 200 OK
         code: 200
-        duration: 73.248857ms
+        duration: 53.907493ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -543,29 +543,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18b64d48-e8ce-47e2-a752-a21efb7cfb4d/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/842d724a-1e9c-4017-ac08-6bf83cab4c64/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 351
-        body: '{"versions":[{"revision":1,"secret_id":"18b64d48-e8ce-47e2-a752-a21efb7cfb4d","status":"enabled","created_at":"2026-06-04T09:49:23.957523Z","updated_at":"2026-06-04T09:49:25.233459Z","deleted_at":null,"description":"secret version description","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        body: '{"versions":[{"revision":1,"secret_id":"842d724a-1e9c-4017-ac08-6bf83cab4c64","status":"enabled","created_at":"2026-07-03T15:28:00.329374Z","updated_at":"2026-07-03T15:28:02.406879Z","deleted_at":null,"description":"secret version description","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "351"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:25 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - b544df7f-3834-4ef2-b377-81221c8496be
+                - 7404c45c-1e21-43a6-b2c1-62c5b953e0d0
         status: 200 OK
         code: 200
-        duration: 46.957988ms
+        duration: 42.282839ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -575,29 +575,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18b64d48-e8ce-47e2-a752-a21efb7cfb4d/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/842d724a-1e9c-4017-ac08-6bf83cab4c64/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 320
-        body: '{"revision":1,"secret_id":"18b64d48-e8ce-47e2-a752-a21efb7cfb4d","status":"enabled","created_at":"2026-06-04T09:49:23.957523Z","updated_at":"2026-06-04T09:49:25.233459Z","deleted_at":null,"description":"secret version description","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"842d724a-1e9c-4017-ac08-6bf83cab4c64","status":"enabled","created_at":"2026-07-03T15:28:00.329374Z","updated_at":"2026-07-03T15:28:02.406879Z","deleted_at":null,"description":"secret version description","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "320"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:25 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 81bc4a8e-1877-4320-84d7-c83dc7052017
+                - af552ccd-a648-4de6-b535-cbafd4805d49
         status: 200 OK
         code: 200
-        duration: 41.373562ms
+        duration: 38.303424ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -607,29 +607,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18b64d48-e8ce-47e2-a752-a21efb7cfb4d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/842d724a-1e9c-4017-ac08-6bf83cab4c64
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 487
-        body: '{"id":"18b64d48-e8ce-47e2-a752-a21efb7cfb4d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretVersionNameBasic","status":"ready","created_at":"2026-06-04T09:49:23.380512Z","updated_at":"2026-06-04T09:49:23.380512Z","tags":["devtools","provider","terraform"],"version_count":1,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"842d724a-1e9c-4017-ac08-6bf83cab4c64","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretVersionNameBasic","status":"ready","created_at":"2026-07-03T15:27:59.863920Z","updated_at":"2026-07-03T15:27:59.863920Z","tags":["devtools","provider","terraform"],"version_count":1,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "487"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:26 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 7d1f3fa5-a791-4ad1-8e56-9798bca46296
+                - cfc50707-a428-406d-a332-cde31a2524b3
         status: 200 OK
         code: 200
-        duration: 34.145331ms
+        duration: 46.387087ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -642,29 +642,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18b64d48-e8ce-47e2-a752-a21efb7cfb4d/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/842d724a-1e9c-4017-ac08-6bf83cab4c64/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 351
-        body: '{"versions":[{"revision":1,"secret_id":"18b64d48-e8ce-47e2-a752-a21efb7cfb4d","status":"enabled","created_at":"2026-06-04T09:49:23.957523Z","updated_at":"2026-06-04T09:49:25.233459Z","deleted_at":null,"description":"secret version description","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        body: '{"versions":[{"revision":1,"secret_id":"842d724a-1e9c-4017-ac08-6bf83cab4c64","status":"enabled","created_at":"2026-07-03T15:28:00.329374Z","updated_at":"2026-07-03T15:28:02.406879Z","deleted_at":null,"description":"secret version description","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "351"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:26 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 0256d61d-f104-483e-8471-5c2bfd58d281
+                - 096f8fe1-330c-485a-b681-7734ce0175c0
         status: 200 OK
         code: 200
-        duration: 41.089371ms
+        duration: 46.839015ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -674,29 +674,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18b64d48-e8ce-47e2-a752-a21efb7cfb4d/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/842d724a-1e9c-4017-ac08-6bf83cab4c64/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 320
-        body: '{"revision":1,"secret_id":"18b64d48-e8ce-47e2-a752-a21efb7cfb4d","status":"enabled","created_at":"2026-06-04T09:49:23.957523Z","updated_at":"2026-06-04T09:49:25.233459Z","deleted_at":null,"description":"secret version description","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"842d724a-1e9c-4017-ac08-6bf83cab4c64","status":"enabled","created_at":"2026-07-03T15:28:00.329374Z","updated_at":"2026-07-03T15:28:02.406879Z","deleted_at":null,"description":"secret version description","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "320"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:26 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 0530a759-73c9-4f7d-9d62-881879c9bd2f
+                - c79fceab-331b-492d-b286-29b95e863a52
         status: 200 OK
         code: 200
-        duration: 29.121534ms
+        duration: 32.038146ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -709,29 +709,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18b64d48-e8ce-47e2-a752-a21efb7cfb4d/versions
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/842d724a-1e9c-4017-ac08-6bf83cab4c64/versions
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":2,"secret_id":"18b64d48-e8ce-47e2-a752-a21efb7cfb4d","status":"enabled","created_at":"2026-06-04T09:49:26.388010Z","updated_at":"2026-06-04T09:49:26.388010Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":2,"secret_id":"842d724a-1e9c-4017-ac08-6bf83cab4c64","status":"enabled","created_at":"2026-07-03T15:28:04.432512Z","updated_at":"2026-07-03T15:28:04.432512Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:26 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - eb09794c-d715-42b6-9f06-f6df693b93a3
+                - 79f1351e-b448-444e-93fb-5a4f692f3c77
         status: 200 OK
         code: 200
-        duration: 175.462707ms
+        duration: 138.269576ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -741,29 +741,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18b64d48-e8ce-47e2-a752-a21efb7cfb4d/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/842d724a-1e9c-4017-ac08-6bf83cab4c64/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":2,"secret_id":"18b64d48-e8ce-47e2-a752-a21efb7cfb4d","status":"enabled","created_at":"2026-06-04T09:49:26.388010Z","updated_at":"2026-06-04T09:49:26.388010Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":2,"secret_id":"842d724a-1e9c-4017-ac08-6bf83cab4c64","status":"enabled","created_at":"2026-07-03T15:28:04.432512Z","updated_at":"2026-07-03T15:28:04.432512Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:26 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - d7006076-ce39-4715-8c46-5ce4a33b444b
+                - d13d6241-faa8-4edf-a537-134939cf6d81
         status: 200 OK
         code: 200
-        duration: 35.416239ms
+        duration: 44.711038ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -773,29 +773,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18b64d48-e8ce-47e2-a752-a21efb7cfb4d/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/842d724a-1e9c-4017-ac08-6bf83cab4c64/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 321
-        body: '{"revision":1,"secret_id":"18b64d48-e8ce-47e2-a752-a21efb7cfb4d","status":"enabled","created_at":"2026-06-04T09:49:23.957523Z","updated_at":"2026-06-04T09:49:25.233459Z","deleted_at":null,"description":"secret version description","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"842d724a-1e9c-4017-ac08-6bf83cab4c64","status":"enabled","created_at":"2026-07-03T15:28:00.329374Z","updated_at":"2026-07-03T15:28:02.406879Z","deleted_at":null,"description":"secret version description","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "321"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:26 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 67686042-80f7-4bf4-a77e-59bc1849f82f
+                - 0b8cfd28-c7c1-41dc-8499-3774113accdf
         status: 200 OK
         code: 200
-        duration: 34.700911ms
+        duration: 52.00531ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -805,29 +805,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18b64d48-e8ce-47e2-a752-a21efb7cfb4d/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/842d724a-1e9c-4017-ac08-6bf83cab4c64/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":2,"secret_id":"18b64d48-e8ce-47e2-a752-a21efb7cfb4d","status":"enabled","created_at":"2026-06-04T09:49:26.388010Z","updated_at":"2026-06-04T09:49:26.388010Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":2,"secret_id":"842d724a-1e9c-4017-ac08-6bf83cab4c64","status":"enabled","created_at":"2026-07-03T15:28:04.432512Z","updated_at":"2026-07-03T15:28:04.432512Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:26 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 26c678fe-5e01-4d67-8628-650f17450d51
+                - d899e00a-1c28-45dc-a675-6cc6196b53c5
         status: 200 OK
         code: 200
-        duration: 30.040033ms
+        duration: 40.514087ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -837,29 +837,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18b64d48-e8ce-47e2-a752-a21efb7cfb4d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/842d724a-1e9c-4017-ac08-6bf83cab4c64
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 487
-        body: '{"id":"18b64d48-e8ce-47e2-a752-a21efb7cfb4d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretVersionNameBasic","status":"ready","created_at":"2026-06-04T09:49:23.380512Z","updated_at":"2026-06-04T09:49:23.380512Z","tags":["devtools","provider","terraform"],"version_count":2,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"842d724a-1e9c-4017-ac08-6bf83cab4c64","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretVersionNameBasic","status":"ready","created_at":"2026-07-03T15:27:59.863920Z","updated_at":"2026-07-03T15:27:59.863920Z","tags":["devtools","provider","terraform"],"version_count":2,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "487"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:26 GMT
+                - Fri, 03 Jul 2026 15:28:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 9f7db355-db29-4e1b-a4d6-771027b9987b
+                - 111f30a2-7b74-4a7e-a4af-5a7e2dc56b32
         status: 200 OK
         code: 200
-        duration: 57.49012ms
+        duration: 44.602435ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -872,29 +872,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18b64d48-e8ce-47e2-a752-a21efb7cfb4d/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/842d724a-1e9c-4017-ac08-6bf83cab4c64/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 655
-        body: '{"versions":[{"revision":2,"secret_id":"18b64d48-e8ce-47e2-a752-a21efb7cfb4d","status":"enabled","created_at":"2026-06-04T09:49:26.388010Z","updated_at":"2026-06-04T09:49:26.388010Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"18b64d48-e8ce-47e2-a752-a21efb7cfb4d","status":"enabled","created_at":"2026-06-04T09:49:23.957523Z","updated_at":"2026-06-04T09:49:25.233459Z","deleted_at":null,"description":"secret version description","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":2}'
+        body: '{"versions":[{"revision":2,"secret_id":"842d724a-1e9c-4017-ac08-6bf83cab4c64","status":"enabled","created_at":"2026-07-03T15:28:04.432512Z","updated_at":"2026-07-03T15:28:04.432512Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"842d724a-1e9c-4017-ac08-6bf83cab4c64","status":"enabled","created_at":"2026-07-03T15:28:00.329374Z","updated_at":"2026-07-03T15:28:02.406879Z","deleted_at":null,"description":"secret version description","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":2}'
         headers:
             Content-Length:
                 - "655"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:26 GMT
+                - Fri, 03 Jul 2026 15:28:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 06049c92-1625-493c-8694-8638f3bcf9a7
+                - f94d8383-bd6c-44e5-8541-58c4ab9ff2ec
         status: 200 OK
         code: 200
-        duration: 46.791687ms
+        duration: 42.355975ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -904,29 +904,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18b64d48-e8ce-47e2-a752-a21efb7cfb4d/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/842d724a-1e9c-4017-ac08-6bf83cab4c64/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 321
-        body: '{"revision":1,"secret_id":"18b64d48-e8ce-47e2-a752-a21efb7cfb4d","status":"enabled","created_at":"2026-06-04T09:49:23.957523Z","updated_at":"2026-06-04T09:49:25.233459Z","deleted_at":null,"description":"secret version description","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"842d724a-1e9c-4017-ac08-6bf83cab4c64","status":"enabled","created_at":"2026-07-03T15:28:00.329374Z","updated_at":"2026-07-03T15:28:02.406879Z","deleted_at":null,"description":"secret version description","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "321"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:26 GMT
+                - Fri, 03 Jul 2026 15:28:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - f7d13c61-aae6-4a4b-9a01-c9af1cda4e75
+                - 450cc620-cb1f-4b0e-b1c6-0836c61bb9d7
         status: 200 OK
         code: 200
-        duration: 48.909289ms
+        duration: 37.837068ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -936,29 +936,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18b64d48-e8ce-47e2-a752-a21efb7cfb4d/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/842d724a-1e9c-4017-ac08-6bf83cab4c64/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":2,"secret_id":"18b64d48-e8ce-47e2-a752-a21efb7cfb4d","status":"enabled","created_at":"2026-06-04T09:49:26.388010Z","updated_at":"2026-06-04T09:49:26.388010Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":2,"secret_id":"842d724a-1e9c-4017-ac08-6bf83cab4c64","status":"enabled","created_at":"2026-07-03T15:28:04.432512Z","updated_at":"2026-07-03T15:28:04.432512Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:27 GMT
+                - Fri, 03 Jul 2026 15:28:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - ae4ad60f-7141-497d-8829-96a310042998
+                - 36b1d008-aa80-4d92-9e11-d8a5875bf947
         status: 200 OK
         code: 200
-        duration: 50.676696ms
+        duration: 53.737804ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -968,29 +968,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18b64d48-e8ce-47e2-a752-a21efb7cfb4d/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/842d724a-1e9c-4017-ac08-6bf83cab4c64/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 321
-        body: '{"revision":1,"secret_id":"18b64d48-e8ce-47e2-a752-a21efb7cfb4d","status":"enabled","created_at":"2026-06-04T09:49:23.957523Z","updated_at":"2026-06-04T09:49:25.233459Z","deleted_at":null,"description":"secret version description","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"842d724a-1e9c-4017-ac08-6bf83cab4c64","status":"enabled","created_at":"2026-07-03T15:28:00.329374Z","updated_at":"2026-07-03T15:28:02.406879Z","deleted_at":null,"description":"secret version description","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "321"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:27 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 9ae9a0cb-0471-452f-b526-9baca1bd989c
+                - b4763188-085d-4245-b4be-c66db686f3d2
         status: 200 OK
         code: 200
-        duration: 53.619441ms
+        duration: 43.17279ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1000,8 +1000,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18b64d48-e8ce-47e2-a752-a21efb7cfb4d/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/842d724a-1e9c-4017-ac08-6bf83cab4c64/versions/2
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1013,14 +1013,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:27 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 3ac21c41-7674-4bcf-beec-a27c6286fedd
+                - 70087c1c-11d2-4136-9792-7c802cb66948
         status: 204 No Content
         code: 204
-        duration: 107.002089ms
+        duration: 134.457616ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1030,8 +1030,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18b64d48-e8ce-47e2-a752-a21efb7cfb4d/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/842d724a-1e9c-4017-ac08-6bf83cab4c64/versions/1
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1043,14 +1043,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:27 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 079d9b56-f4c0-43bb-99a7-97553784353e
+                - 27c42bfb-42f0-4266-bf7b-ccfcd30c7375
         status: 204 No Content
         code: 204
-        duration: 57.127803ms
+        duration: 63.845719ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1060,8 +1060,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18b64d48-e8ce-47e2-a752-a21efb7cfb4d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/842d724a-1e9c-4017-ac08-6bf83cab4c64
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1073,14 +1073,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:27 GMT
+                - Fri, 03 Jul 2026 15:28:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - b12fe040-0c55-434f-a712-c160acef509f
+                - 5ddb0304-b152-404b-bda8-95f5123adcb1
         status: 204 No Content
         code: 204
-        duration: 59.191243ms
+        duration: 79.623584ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1090,26 +1090,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18b64d48-e8ce-47e2-a752-a21efb7cfb4d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/842d724a-1e9c-4017-ac08-6bf83cab4c64
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 512
-        body: '{"id":"18b64d48-e8ce-47e2-a752-a21efb7cfb4d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretVersionNameBasic","status":"ready","created_at":"2026-06-04T09:49:23.380512Z","updated_at":"2026-06-04T09:49:23.380512Z","tags":["devtools","provider","terraform"],"version_count":2,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-06-04T09:49:27.874729Z","key_id":null,"region":"fr-par"}'
+        body: '{"id":"842d724a-1e9c-4017-ac08-6bf83cab4c64","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretVersionNameBasic","status":"ready","created_at":"2026-07-03T15:27:59.863920Z","updated_at":"2026-07-03T15:28:06.955940Z","tags":["devtools","provider","terraform"],"version_count":2,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-07-03T15:28:06.955940Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "512"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:27 GMT
+                - Fri, 03 Jul 2026 15:28:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - b594b73e-6fff-483a-b9f2-1377989eb514
+                - 28ab0bca-412c-4965-941c-44d5a2fdf888
         status: 200 OK
         code: 200
-        duration: 55.134335ms
+        duration: 51.985122ms

--- a/internal/services/secret/testdata/secret-version-data-wo.cassette.yaml
+++ b/internal/services/secret/testdata/secret-version-data-wo.cassette.yaml
@@ -13,7 +13,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets
         method: POST
       response:
@@ -21,21 +21,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 488
-        body: '{"id":"b526abed-eb2c-461c-8e15-8131d7347881","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretVersionNameDataWO","status":"ready","created_at":"2026-06-04T09:49:23.342116Z","updated_at":"2026-06-04T09:49:23.342116Z","tags":["devtools","provider","terraform"],"version_count":0,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"e52321be-7d3f-4417-8fb7-4d3c11c9790f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretVersionNameDataWO","status":"ready","created_at":"2026-07-03T15:27:59.801664Z","updated_at":"2026-07-03T15:27:59.801664Z","tags":["devtools","provider","terraform"],"version_count":0,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "488"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:23 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 713e7471-ce94-44f2-a272-400c2c0e8220
+                - ea2fba22-0634-4d0c-b9f2-3ed826c1855d
         status: 200 OK
         code: 200
-        duration: 250.179806ms
+        duration: 100.448809ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -48,7 +48,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets
         method: POST
       response:
@@ -56,21 +56,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 490
-        body: '{"id":"ad0360b7-7394-4360-9099-17a04ac8d64b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretVersionNameDataWOB","status":"ready","created_at":"2026-06-04T09:49:23.363193Z","updated_at":"2026-06-04T09:49:23.363193Z","tags":["devtools","provider","terraform"],"version_count":0,"description":"secret descriptionB","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"646cb095-08ab-467f-aa7f-0cce3b822253","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretVersionNameDataWOB","status":"ready","created_at":"2026-07-03T15:27:59.827262Z","updated_at":"2026-07-03T15:27:59.827262Z","tags":["devtools","provider","terraform"],"version_count":0,"description":"secret descriptionB","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "490"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:23 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 715adbb4-8e6f-49d1-979d-87ca3f1a1a50
+                - 835c4c96-1fd8-49c5-8bba-3f1a0972ba3b
         status: 200 OK
         code: 200
-        duration: 274.083719ms
+        duration: 130.118616ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -80,29 +80,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b526abed-eb2c-461c-8e15-8131d7347881
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e52321be-7d3f-4417-8fb7-4d3c11c9790f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 488
-        body: '{"id":"b526abed-eb2c-461c-8e15-8131d7347881","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretVersionNameDataWO","status":"ready","created_at":"2026-06-04T09:49:23.342116Z","updated_at":"2026-06-04T09:49:23.342116Z","tags":["devtools","provider","terraform"],"version_count":0,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"e52321be-7d3f-4417-8fb7-4d3c11c9790f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretVersionNameDataWO","status":"ready","created_at":"2026-07-03T15:27:59.801664Z","updated_at":"2026-07-03T15:27:59.801664Z","tags":["devtools","provider","terraform"],"version_count":0,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "488"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:23 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 8ddf792d-907a-4c46-9661-20f9f661111a
+                - aec06c25-c13b-4d26-bcda-d9c9aafd4281
         status: 200 OK
         code: 200
-        duration: 45.04612ms
+        duration: 51.13285ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -112,29 +112,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ad0360b7-7394-4360-9099-17a04ac8d64b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/646cb095-08ab-467f-aa7f-0cce3b822253
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 490
-        body: '{"id":"ad0360b7-7394-4360-9099-17a04ac8d64b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretVersionNameDataWOB","status":"ready","created_at":"2026-06-04T09:49:23.363193Z","updated_at":"2026-06-04T09:49:23.363193Z","tags":["devtools","provider","terraform"],"version_count":0,"description":"secret descriptionB","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"646cb095-08ab-467f-aa7f-0cce3b822253","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretVersionNameDataWOB","status":"ready","created_at":"2026-07-03T15:27:59.827262Z","updated_at":"2026-07-03T15:27:59.827262Z","tags":["devtools","provider","terraform"],"version_count":0,"description":"secret descriptionB","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "490"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:23 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - e0d4d776-82ed-408b-bc83-0fd4e091bd38
+                - 7df8587f-2549-474b-8f13-a0e76346eff3
         status: 200 OK
         code: 200
-        duration: 78.256521ms
+        duration: 48.31641ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -147,8 +147,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b526abed-eb2c-461c-8e15-8131d7347881/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e52321be-7d3f-4417-8fb7-4d3c11c9790f/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -162,14 +162,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:23 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - c446dae0-2f98-41ea-9b70-df2e7c8eb3e2
+                - 0026e449-e8ba-4345-897f-a84909a89b1b
         status: 200 OK
         code: 200
-        duration: 86.926938ms
+        duration: 54.084264ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -182,8 +182,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ad0360b7-7394-4360-9099-17a04ac8d64b/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/646cb095-08ab-467f-aa7f-0cce3b822253/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -197,82 +197,15 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:23 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 796ab88f-c910-44b8-9ede-96d4b7f73e2e
+                - 7c829c22-5561-438c-9395-cf64617707be
         status: 200 OK
         code: 200
-        duration: 92.622963ms
+        duration: 53.360535ms
     - id: 6
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 66
-        host: api.scaleway.com
-        body: '{"data":"bXlfc3VwZXJfc2VjcmV0","description":"secret description"}'
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b526abed-eb2c-461c-8e15-8131d7347881/versions
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 312
-        body: '{"revision":1,"secret_id":"b526abed-eb2c-461c-8e15-8131d7347881","status":"enabled","created_at":"2026-06-04T09:49:23.821455Z","updated_at":"2026-06-04T09:49:23.821455Z","deleted_at":null,"description":"secret description","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "312"
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 04 Jun 2026 09:49:23 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
-            X-Request-Id:
-                - c0e3ed90-7a40-49f5-a2f3-a4e1989cde61
-        status: 200 OK
-        code: 200
-        duration: 341.230658ms
-    - id: 7
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b526abed-eb2c-461c-8e15-8131d7347881/versions/1
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 312
-        body: '{"revision":1,"secret_id":"b526abed-eb2c-461c-8e15-8131d7347881","status":"enabled","created_at":"2026-06-04T09:49:23.821455Z","updated_at":"2026-06-04T09:49:23.821455Z","deleted_at":null,"description":"secret description","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "312"
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 04 Jun 2026 09:49:23 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
-            X-Request-Id:
-                - 77f88ff4-ec78-4e22-bcc2-078fbf94a8bc
-        status: 200 OK
-        code: 200
-        duration: 38.318115ms
-    - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -284,29 +217,96 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ad0360b7-7394-4360-9099-17a04ac8d64b/versions
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/646cb095-08ab-467f-aa7f-0cce3b822253/versions
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 313
-        body: '{"revision":1,"secret_id":"ad0360b7-7394-4360-9099-17a04ac8d64b","status":"enabled","created_at":"2026-06-04T09:49:24.069044Z","updated_at":"2026-06-04T09:49:24.069044Z","deleted_at":null,"description":"secret descriptionB","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"646cb095-08ab-467f-aa7f-0cce3b822253","status":"enabled","created_at":"2026-07-03T15:28:00.241314Z","updated_at":"2026-07-03T15:28:00.241314Z","deleted_at":null,"description":"secret descriptionB","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "313"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:24 GMT
+                - Fri, 03 Jul 2026 15:28:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - efcdadee-7930-422a-a307-593c522c9ba6
+                - 3db33002-402f-4449-ae27-1e653da77a11
         status: 200 OK
         code: 200
-        duration: 535.177022ms
+        duration: 299.142276ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/646cb095-08ab-467f-aa7f-0cce3b822253/versions/1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 313
+        body: '{"revision":1,"secret_id":"646cb095-08ab-467f-aa7f-0cce3b822253","status":"enabled","created_at":"2026-07-03T15:28:00.241314Z","updated_at":"2026-07-03T15:28:00.241314Z","deleted_at":null,"description":"secret descriptionB","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "313"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:00 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - a491bacc-b507-439e-9a83-7db137cd212b
+        status: 200 OK
+        code: 200
+        duration: 52.848323ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 66
+        host: api.scaleway.com
+        body: '{"data":"bXlfc3VwZXJfc2VjcmV0","description":"secret description"}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e52321be-7d3f-4417-8fb7-4d3c11c9790f/versions
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 312
+        body: '{"revision":1,"secret_id":"e52321be-7d3f-4417-8fb7-4d3c11c9790f","status":"enabled","created_at":"2026-07-03T15:28:00.438195Z","updated_at":"2026-07-03T15:28:00.438195Z","deleted_at":null,"description":"secret description","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "312"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:28:00 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 511eb752-e8e6-4f5f-b730-9590e144e992
+        status: 200 OK
+        code: 200
+        duration: 524.883807ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -316,29 +316,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ad0360b7-7394-4360-9099-17a04ac8d64b/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e52321be-7d3f-4417-8fb7-4d3c11c9790f/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 313
-        body: '{"revision":1,"secret_id":"ad0360b7-7394-4360-9099-17a04ac8d64b","status":"enabled","created_at":"2026-06-04T09:49:24.069044Z","updated_at":"2026-06-04T09:49:24.069044Z","deleted_at":null,"description":"secret descriptionB","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 312
+        body: '{"revision":1,"secret_id":"e52321be-7d3f-4417-8fb7-4d3c11c9790f","status":"enabled","created_at":"2026-07-03T15:28:00.438195Z","updated_at":"2026-07-03T15:28:00.438195Z","deleted_at":null,"description":"secret description","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "313"
+                - "312"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:24 GMT
+                - Fri, 03 Jul 2026 15:28:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - d19b0729-9df9-4936-a05a-8eeafd696820
+                - bc3833a1-fda6-477f-8d27-310cf4c5de46
         status: 200 OK
         code: 200
-        duration: 74.265998ms
+        duration: 39.567237ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -348,29 +348,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b526abed-eb2c-461c-8e15-8131d7347881/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e52321be-7d3f-4417-8fb7-4d3c11c9790f/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 312
-        body: '{"revision":1,"secret_id":"b526abed-eb2c-461c-8e15-8131d7347881","status":"enabled","created_at":"2026-06-04T09:49:23.821455Z","updated_at":"2026-06-04T09:49:23.821455Z","deleted_at":null,"description":"secret description","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"e52321be-7d3f-4417-8fb7-4d3c11c9790f","status":"enabled","created_at":"2026-07-03T15:28:00.438195Z","updated_at":"2026-07-03T15:28:00.438195Z","deleted_at":null,"description":"secret description","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "312"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:24 GMT
+                - Fri, 03 Jul 2026 15:28:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 5261dfdb-b6cd-4f62-b220-84b5a332ede8
+                - 10b90ade-02f9-48e3-b3ec-b60684c1f015
         status: 200 OK
         code: 200
-        duration: 39.559036ms
+        duration: 36.999114ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -380,29 +380,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ad0360b7-7394-4360-9099-17a04ac8d64b/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/646cb095-08ab-467f-aa7f-0cce3b822253/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 313
-        body: '{"revision":1,"secret_id":"ad0360b7-7394-4360-9099-17a04ac8d64b","status":"enabled","created_at":"2026-06-04T09:49:24.069044Z","updated_at":"2026-06-04T09:49:24.069044Z","deleted_at":null,"description":"secret descriptionB","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"646cb095-08ab-467f-aa7f-0cce3b822253","status":"enabled","created_at":"2026-07-03T15:28:00.241314Z","updated_at":"2026-07-03T15:28:00.241314Z","deleted_at":null,"description":"secret descriptionB","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "313"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:24 GMT
+                - Fri, 03 Jul 2026 15:28:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 6faa2e72-0584-4bed-8378-f24d6e98e7fd
+                - a85e0b85-2899-4c88-b27c-3004fa42d3ea
         status: 200 OK
         code: 200
-        duration: 36.505805ms
+        duration: 39.330112ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -412,29 +412,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ad0360b7-7394-4360-9099-17a04ac8d64b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e52321be-7d3f-4417-8fb7-4d3c11c9790f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 490
-        body: '{"id":"ad0360b7-7394-4360-9099-17a04ac8d64b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretVersionNameDataWOB","status":"ready","created_at":"2026-06-04T09:49:23.363193Z","updated_at":"2026-06-04T09:49:23.363193Z","tags":["devtools","provider","terraform"],"version_count":1,"description":"secret descriptionB","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        content_length: 488
+        body: '{"id":"e52321be-7d3f-4417-8fb7-4d3c11c9790f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretVersionNameDataWO","status":"ready","created_at":"2026-07-03T15:27:59.801664Z","updated_at":"2026-07-03T15:27:59.801664Z","tags":["devtools","provider","terraform"],"version_count":1,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "490"
+                - "488"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:24 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 5e584d27-b92f-43a3-9ce8-3bd7544c9436
+                - a1853c85-bef5-4c29-9b4f-72f21dfea16f
         status: 200 OK
         code: 200
-        duration: 43.590879ms
+        duration: 58.16559ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -444,29 +444,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b526abed-eb2c-461c-8e15-8131d7347881
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/646cb095-08ab-467f-aa7f-0cce3b822253
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 488
-        body: '{"id":"b526abed-eb2c-461c-8e15-8131d7347881","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretVersionNameDataWO","status":"ready","created_at":"2026-06-04T09:49:23.342116Z","updated_at":"2026-06-04T09:49:23.342116Z","tags":["devtools","provider","terraform"],"version_count":1,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        content_length: 490
+        body: '{"id":"646cb095-08ab-467f-aa7f-0cce3b822253","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretVersionNameDataWOB","status":"ready","created_at":"2026-07-03T15:27:59.827262Z","updated_at":"2026-07-03T15:27:59.827262Z","tags":["devtools","provider","terraform"],"version_count":1,"description":"secret descriptionB","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "488"
+                - "490"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:24 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - ca0db43c-0c54-45e1-be88-a835c6f285ca
+                - 401cd677-329e-4a3d-8270-44636ba426a4
         status: 200 OK
         code: 200
-        duration: 51.608206ms
+        duration: 57.886226ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -479,29 +479,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ad0360b7-7394-4360-9099-17a04ac8d64b/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/646cb095-08ab-467f-aa7f-0cce3b822253/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 344
-        body: '{"versions":[{"revision":1,"secret_id":"ad0360b7-7394-4360-9099-17a04ac8d64b","status":"enabled","created_at":"2026-06-04T09:49:24.069044Z","updated_at":"2026-06-04T09:49:24.069044Z","deleted_at":null,"description":"secret descriptionB","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        body: '{"versions":[{"revision":1,"secret_id":"646cb095-08ab-467f-aa7f-0cce3b822253","status":"enabled","created_at":"2026-07-03T15:28:00.241314Z","updated_at":"2026-07-03T15:28:00.241314Z","deleted_at":null,"description":"secret descriptionB","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "344"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:24 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - d16faff8-7e74-4f2a-8179-5d2c9ec885ba
+                - f31030dc-fb76-4add-bc79-20d6d826e207
         status: 200 OK
         code: 200
-        duration: 49.117897ms
+        duration: 54.199651ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -514,29 +514,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b526abed-eb2c-461c-8e15-8131d7347881/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e52321be-7d3f-4417-8fb7-4d3c11c9790f/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 343
-        body: '{"versions":[{"revision":1,"secret_id":"b526abed-eb2c-461c-8e15-8131d7347881","status":"enabled","created_at":"2026-06-04T09:49:23.821455Z","updated_at":"2026-06-04T09:49:23.821455Z","deleted_at":null,"description":"secret description","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        body: '{"versions":[{"revision":1,"secret_id":"e52321be-7d3f-4417-8fb7-4d3c11c9790f","status":"enabled","created_at":"2026-07-03T15:28:00.438195Z","updated_at":"2026-07-03T15:28:00.438195Z","deleted_at":null,"description":"secret description","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "343"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:24 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - a876b717-d899-4bb4-9a92-1399f7595773
+                - 22a8e2ed-40c8-46f8-adce-9ad8ffb1d004
         status: 200 OK
         code: 200
-        duration: 51.381201ms
+        duration: 65.41747ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -546,29 +546,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ad0360b7-7394-4360-9099-17a04ac8d64b/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/646cb095-08ab-467f-aa7f-0cce3b822253/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 313
-        body: '{"revision":1,"secret_id":"ad0360b7-7394-4360-9099-17a04ac8d64b","status":"enabled","created_at":"2026-06-04T09:49:24.069044Z","updated_at":"2026-06-04T09:49:24.069044Z","deleted_at":null,"description":"secret descriptionB","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"646cb095-08ab-467f-aa7f-0cce3b822253","status":"enabled","created_at":"2026-07-03T15:28:00.241314Z","updated_at":"2026-07-03T15:28:00.241314Z","deleted_at":null,"description":"secret descriptionB","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "313"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:24 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - a4450e47-e513-48e8-b3bf-2235fbe667a0
+                - 3628aa57-fb2d-4883-93c8-476f50218ca2
         status: 200 OK
         code: 200
-        duration: 31.509941ms
+        duration: 37.663622ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -578,29 +578,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b526abed-eb2c-461c-8e15-8131d7347881/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e52321be-7d3f-4417-8fb7-4d3c11c9790f/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 312
-        body: '{"revision":1,"secret_id":"b526abed-eb2c-461c-8e15-8131d7347881","status":"enabled","created_at":"2026-06-04T09:49:23.821455Z","updated_at":"2026-06-04T09:49:23.821455Z","deleted_at":null,"description":"secret description","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"e52321be-7d3f-4417-8fb7-4d3c11c9790f","status":"enabled","created_at":"2026-07-03T15:28:00.438195Z","updated_at":"2026-07-03T15:28:00.438195Z","deleted_at":null,"description":"secret description","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "312"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:24 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 6ce849f8-94aa-4510-9382-3a816ff248cc
+                - 282b996a-e8ea-4c07-a9ee-5dd31599af13
         status: 200 OK
         code: 200
-        duration: 29.207604ms
+        duration: 52.235101ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -610,29 +610,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ad0360b7-7394-4360-9099-17a04ac8d64b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/646cb095-08ab-467f-aa7f-0cce3b822253
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 490
-        body: '{"id":"ad0360b7-7394-4360-9099-17a04ac8d64b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretVersionNameDataWOB","status":"ready","created_at":"2026-06-04T09:49:23.363193Z","updated_at":"2026-06-04T09:49:23.363193Z","tags":["devtools","provider","terraform"],"version_count":1,"description":"secret descriptionB","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"646cb095-08ab-467f-aa7f-0cce3b822253","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretVersionNameDataWOB","status":"ready","created_at":"2026-07-03T15:27:59.827262Z","updated_at":"2026-07-03T15:27:59.827262Z","tags":["devtools","provider","terraform"],"version_count":1,"description":"secret descriptionB","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "490"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:25 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - dbf72497-ad63-49d1-9e26-c3bab4a57536
+                - 7b52975a-1f1a-4714-9c01-9e413accf560
         status: 200 OK
         code: 200
-        duration: 35.755272ms
+        duration: 34.182363ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -642,29 +642,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b526abed-eb2c-461c-8e15-8131d7347881
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e52321be-7d3f-4417-8fb7-4d3c11c9790f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 488
-        body: '{"id":"b526abed-eb2c-461c-8e15-8131d7347881","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretVersionNameDataWO","status":"ready","created_at":"2026-06-04T09:49:23.342116Z","updated_at":"2026-06-04T09:49:23.342116Z","tags":["devtools","provider","terraform"],"version_count":1,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"e52321be-7d3f-4417-8fb7-4d3c11c9790f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretVersionNameDataWO","status":"ready","created_at":"2026-07-03T15:27:59.801664Z","updated_at":"2026-07-03T15:27:59.801664Z","tags":["devtools","provider","terraform"],"version_count":1,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "488"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:25 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 97cd0610-4c84-419a-a76d-96458c85326c
+                - bf0eaa9b-e0be-4d02-b036-3815753d8242
         status: 200 OK
         code: 200
-        duration: 38.846845ms
+        duration: 38.254501ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -677,29 +677,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ad0360b7-7394-4360-9099-17a04ac8d64b/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/646cb095-08ab-467f-aa7f-0cce3b822253/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 344
-        body: '{"versions":[{"revision":1,"secret_id":"ad0360b7-7394-4360-9099-17a04ac8d64b","status":"enabled","created_at":"2026-06-04T09:49:24.069044Z","updated_at":"2026-06-04T09:49:24.069044Z","deleted_at":null,"description":"secret descriptionB","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        body: '{"versions":[{"revision":1,"secret_id":"646cb095-08ab-467f-aa7f-0cce3b822253","status":"enabled","created_at":"2026-07-03T15:28:00.241314Z","updated_at":"2026-07-03T15:28:00.241314Z","deleted_at":null,"description":"secret descriptionB","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "344"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:25 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 8315b727-ba08-4e3f-94e3-2fd31713b82b
+                - 0d9f5e61-d36b-4ab5-b9f6-07dd8b999c9c
         status: 200 OK
         code: 200
-        duration: 42.851205ms
+        duration: 46.490071ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -712,29 +712,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b526abed-eb2c-461c-8e15-8131d7347881/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e52321be-7d3f-4417-8fb7-4d3c11c9790f/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 343
-        body: '{"versions":[{"revision":1,"secret_id":"b526abed-eb2c-461c-8e15-8131d7347881","status":"enabled","created_at":"2026-06-04T09:49:23.821455Z","updated_at":"2026-06-04T09:49:23.821455Z","deleted_at":null,"description":"secret description","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        body: '{"versions":[{"revision":1,"secret_id":"e52321be-7d3f-4417-8fb7-4d3c11c9790f","status":"enabled","created_at":"2026-07-03T15:28:00.438195Z","updated_at":"2026-07-03T15:28:00.438195Z","deleted_at":null,"description":"secret description","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "343"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:25 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - d158d12b-6673-44dd-8f97-f0f7b3c0a210
+                - 6d93edb2-a25c-4f6d-929b-137666b24009
         status: 200 OK
         code: 200
-        duration: 49.15611ms
+        duration: 70.738334ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -744,29 +744,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ad0360b7-7394-4360-9099-17a04ac8d64b/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/646cb095-08ab-467f-aa7f-0cce3b822253/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 313
-        body: '{"revision":1,"secret_id":"ad0360b7-7394-4360-9099-17a04ac8d64b","status":"enabled","created_at":"2026-06-04T09:49:24.069044Z","updated_at":"2026-06-04T09:49:24.069044Z","deleted_at":null,"description":"secret descriptionB","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"646cb095-08ab-467f-aa7f-0cce3b822253","status":"enabled","created_at":"2026-07-03T15:28:00.241314Z","updated_at":"2026-07-03T15:28:00.241314Z","deleted_at":null,"description":"secret descriptionB","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "313"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:25 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - b6924314-4a0e-4c10-a86b-3b897e829ef4
+                - 309ec5ef-3c7a-4b9d-b4cb-ec11a67afc60
         status: 200 OK
         code: 200
-        duration: 36.165661ms
+        duration: 60.485818ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -776,29 +776,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b526abed-eb2c-461c-8e15-8131d7347881/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e52321be-7d3f-4417-8fb7-4d3c11c9790f/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 312
-        body: '{"revision":1,"secret_id":"b526abed-eb2c-461c-8e15-8131d7347881","status":"enabled","created_at":"2026-06-04T09:49:23.821455Z","updated_at":"2026-06-04T09:49:23.821455Z","deleted_at":null,"description":"secret description","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"e52321be-7d3f-4417-8fb7-4d3c11c9790f","status":"enabled","created_at":"2026-07-03T15:28:00.438195Z","updated_at":"2026-07-03T15:28:00.438195Z","deleted_at":null,"description":"secret description","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "312"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:25 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - a5a378aa-ccd7-4a9c-9ac3-fb6e570ad7fb
+                - 1d9df2ec-30cb-4d15-beb9-e60dfecd1b83
         status: 200 OK
         code: 200
-        duration: 33.612395ms
+        duration: 61.665403ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -808,8 +808,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ad0360b7-7394-4360-9099-17a04ac8d64b/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/646cb095-08ab-467f-aa7f-0cce3b822253/versions/1
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -821,14 +821,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:25 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 8dcc5b40-f0c0-45b0-97dd-b235fe2197d5
+                - bb6dff78-40e0-4d65-ab10-386c246fbe2d
         status: 204 No Content
         code: 204
-        duration: 96.010854ms
+        duration: 65.213458ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -841,29 +841,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ad0360b7-7394-4360-9099-17a04ac8d64b/versions
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/646cb095-08ab-467f-aa7f-0cce3b822253/versions
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 313
-        body: '{"revision":2,"secret_id":"ad0360b7-7394-4360-9099-17a04ac8d64b","status":"enabled","created_at":"2026-06-04T09:49:25.540443Z","updated_at":"2026-06-04T09:49:25.540443Z","deleted_at":null,"description":"secret descriptionB","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":2,"secret_id":"646cb095-08ab-467f-aa7f-0cce3b822253","status":"enabled","created_at":"2026-07-03T15:28:02.539758Z","updated_at":"2026-07-03T15:28:02.539758Z","deleted_at":null,"description":"secret descriptionB","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "313"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:25 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - b67246ad-14c6-4242-96a0-55b0c81c774a
+                - b8fc738c-d606-4b49-9b43-82da625e4c32
         status: 200 OK
         code: 200
-        duration: 179.621914ms
+        duration: 150.679865ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -873,29 +873,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ad0360b7-7394-4360-9099-17a04ac8d64b/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/646cb095-08ab-467f-aa7f-0cce3b822253/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 313
-        body: '{"revision":2,"secret_id":"ad0360b7-7394-4360-9099-17a04ac8d64b","status":"enabled","created_at":"2026-06-04T09:49:25.540443Z","updated_at":"2026-06-04T09:49:25.540443Z","deleted_at":null,"description":"secret descriptionB","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":2,"secret_id":"646cb095-08ab-467f-aa7f-0cce3b822253","status":"enabled","created_at":"2026-07-03T15:28:02.539758Z","updated_at":"2026-07-03T15:28:02.539758Z","deleted_at":null,"description":"secret descriptionB","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "313"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:25 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 4161e7a4-a012-499d-a6f0-76a364e02a2d
+                - e843338a-b922-4cd3-aebb-a49842c0cf9f
         status: 200 OK
         code: 200
-        duration: 33.908428ms
+        duration: 50.42974ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -905,29 +905,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b526abed-eb2c-461c-8e15-8131d7347881/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e52321be-7d3f-4417-8fb7-4d3c11c9790f/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 312
-        body: '{"revision":1,"secret_id":"b526abed-eb2c-461c-8e15-8131d7347881","status":"enabled","created_at":"2026-06-04T09:49:23.821455Z","updated_at":"2026-06-04T09:49:23.821455Z","deleted_at":null,"description":"secret description","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"e52321be-7d3f-4417-8fb7-4d3c11c9790f","status":"enabled","created_at":"2026-07-03T15:28:00.438195Z","updated_at":"2026-07-03T15:28:00.438195Z","deleted_at":null,"description":"secret description","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "312"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:25 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 36cfe997-b3d1-40c9-a3cf-ee8969efb001
+                - 44451b6c-5cfd-42d0-84aa-df68b2e88437
         status: 200 OK
         code: 200
-        duration: 36.384219ms
+        duration: 59.671609ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -937,29 +937,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ad0360b7-7394-4360-9099-17a04ac8d64b/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/646cb095-08ab-467f-aa7f-0cce3b822253/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 313
-        body: '{"revision":2,"secret_id":"ad0360b7-7394-4360-9099-17a04ac8d64b","status":"enabled","created_at":"2026-06-04T09:49:25.540443Z","updated_at":"2026-06-04T09:49:25.540443Z","deleted_at":null,"description":"secret descriptionB","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":2,"secret_id":"646cb095-08ab-467f-aa7f-0cce3b822253","status":"enabled","created_at":"2026-07-03T15:28:02.539758Z","updated_at":"2026-07-03T15:28:02.539758Z","deleted_at":null,"description":"secret descriptionB","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "313"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:25 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - f0687f67-7a64-4423-b959-e71387e79029
+                - b4d76d2c-430c-41ff-9226-e337e3882e35
         status: 200 OK
         code: 200
-        duration: 56.008407ms
+        duration: 56.894904ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -969,29 +969,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b526abed-eb2c-461c-8e15-8131d7347881
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/646cb095-08ab-467f-aa7f-0cce3b822253
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 488
-        body: '{"id":"b526abed-eb2c-461c-8e15-8131d7347881","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretVersionNameDataWO","status":"ready","created_at":"2026-06-04T09:49:23.342116Z","updated_at":"2026-06-04T09:49:23.342116Z","tags":["devtools","provider","terraform"],"version_count":1,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        content_length: 490
+        body: '{"id":"646cb095-08ab-467f-aa7f-0cce3b822253","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretVersionNameDataWOB","status":"ready","created_at":"2026-07-03T15:27:59.827262Z","updated_at":"2026-07-03T15:27:59.827262Z","tags":["devtools","provider","terraform"],"version_count":2,"description":"secret descriptionB","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "488"
+                - "490"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:26 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - bbf0bc9b-cc35-489c-80e2-151a0cfd6a1a
+                - 0354b71c-455f-4e81-9d2a-c530bf82225a
         status: 200 OK
         code: 200
-        duration: 52.682837ms
+        duration: 45.437564ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1001,29 +1001,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ad0360b7-7394-4360-9099-17a04ac8d64b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e52321be-7d3f-4417-8fb7-4d3c11c9790f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 490
-        body: '{"id":"ad0360b7-7394-4360-9099-17a04ac8d64b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretVersionNameDataWOB","status":"ready","created_at":"2026-06-04T09:49:23.363193Z","updated_at":"2026-06-04T09:49:23.363193Z","tags":["devtools","provider","terraform"],"version_count":2,"description":"secret descriptionB","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        content_length: 488
+        body: '{"id":"e52321be-7d3f-4417-8fb7-4d3c11c9790f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretVersionNameDataWO","status":"ready","created_at":"2026-07-03T15:27:59.801664Z","updated_at":"2026-07-03T15:27:59.801664Z","tags":["devtools","provider","terraform"],"version_count":1,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "490"
+                - "488"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:26 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 3b055146-5082-41a4-a1aa-bb82569346ce
+                - b2939aca-e666-45ac-ab64-d39a41d4a372
         status: 200 OK
         code: 200
-        duration: 52.388197ms
+        duration: 55.998079ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1036,29 +1036,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b526abed-eb2c-461c-8e15-8131d7347881/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/646cb095-08ab-467f-aa7f-0cce3b822253/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 343
-        body: '{"versions":[{"revision":1,"secret_id":"b526abed-eb2c-461c-8e15-8131d7347881","status":"enabled","created_at":"2026-06-04T09:49:23.821455Z","updated_at":"2026-06-04T09:49:23.821455Z","deleted_at":null,"description":"secret description","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        content_length: 699
+        body: '{"versions":[{"revision":2,"secret_id":"646cb095-08ab-467f-aa7f-0cce3b822253","status":"enabled","created_at":"2026-07-03T15:28:02.539758Z","updated_at":"2026-07-03T15:28:02.539758Z","deleted_at":null,"description":"secret descriptionB","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"646cb095-08ab-467f-aa7f-0cce3b822253","status":"scheduled_for_deletion","created_at":"2026-07-03T15:28:00.241314Z","updated_at":"2026-07-03T15:28:00.241314Z","deleted_at":null,"description":"secret descriptionB","latest":false,"ephemeral_properties":null,"deletion_requested_at":"2026-07-03T15:28:02.387345Z","region":"fr-par"}],"total_count":2}'
         headers:
             Content-Length:
-                - "343"
+                - "699"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:26 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - f377ad06-0147-418d-b12c-7789625a9cc2
+                - 5e8140f4-ad5f-4e2c-9c69-43b263925c9d
         status: 200 OK
         code: 200
-        duration: 33.899312ms
+        duration: 47.902283ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1071,29 +1071,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ad0360b7-7394-4360-9099-17a04ac8d64b/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e52321be-7d3f-4417-8fb7-4d3c11c9790f/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 699
-        body: '{"versions":[{"revision":2,"secret_id":"ad0360b7-7394-4360-9099-17a04ac8d64b","status":"enabled","created_at":"2026-06-04T09:49:25.540443Z","updated_at":"2026-06-04T09:49:25.540443Z","deleted_at":null,"description":"secret descriptionB","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"ad0360b7-7394-4360-9099-17a04ac8d64b","status":"scheduled_for_deletion","created_at":"2026-06-04T09:49:24.069044Z","updated_at":"2026-06-04T09:49:24.069044Z","deleted_at":null,"description":"secret descriptionB","latest":false,"ephemeral_properties":null,"deletion_requested_at":"2026-06-04T09:49:25.363188Z","region":"fr-par"}],"total_count":2}'
+        content_length: 343
+        body: '{"versions":[{"revision":1,"secret_id":"e52321be-7d3f-4417-8fb7-4d3c11c9790f","status":"enabled","created_at":"2026-07-03T15:28:00.438195Z","updated_at":"2026-07-03T15:28:00.438195Z","deleted_at":null,"description":"secret description","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
-                - "699"
+                - "343"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:26 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 0ec55f99-9314-4d1a-a757-f93657649455
+                - 47b0061c-5b09-40f0-9a92-1f62ce589fe2
         status: 200 OK
         code: 200
-        duration: 72.268094ms
+        duration: 38.322319ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1103,29 +1103,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b526abed-eb2c-461c-8e15-8131d7347881/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/646cb095-08ab-467f-aa7f-0cce3b822253/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 312
-        body: '{"revision":1,"secret_id":"b526abed-eb2c-461c-8e15-8131d7347881","status":"enabled","created_at":"2026-06-04T09:49:23.821455Z","updated_at":"2026-06-04T09:49:23.821455Z","deleted_at":null,"description":"secret description","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 313
+        body: '{"revision":2,"secret_id":"646cb095-08ab-467f-aa7f-0cce3b822253","status":"enabled","created_at":"2026-07-03T15:28:02.539758Z","updated_at":"2026-07-03T15:28:02.539758Z","deleted_at":null,"description":"secret descriptionB","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "312"
+                - "313"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:26 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - c165b9dc-1282-4587-aa78-a32d2b602df1
+                - 5366bbd5-f1db-4a71-81b3-4d4a045a9ed0
         status: 200 OK
         code: 200
-        duration: 40.406253ms
+        duration: 45.910652ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1135,29 +1135,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ad0360b7-7394-4360-9099-17a04ac8d64b/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e52321be-7d3f-4417-8fb7-4d3c11c9790f/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 313
-        body: '{"revision":2,"secret_id":"ad0360b7-7394-4360-9099-17a04ac8d64b","status":"enabled","created_at":"2026-06-04T09:49:25.540443Z","updated_at":"2026-06-04T09:49:25.540443Z","deleted_at":null,"description":"secret descriptionB","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 312
+        body: '{"revision":1,"secret_id":"e52321be-7d3f-4417-8fb7-4d3c11c9790f","status":"enabled","created_at":"2026-07-03T15:28:00.438195Z","updated_at":"2026-07-03T15:28:00.438195Z","deleted_at":null,"description":"secret description","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "313"
+                - "312"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:26 GMT
+                - Fri, 03 Jul 2026 15:28:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - d75b3e4f-833e-4641-85f8-6fb66312dd5a
+                - 07fe131f-b1ef-4e9a-aa6a-de750091f87b
         status: 200 OK
         code: 200
-        duration: 32.788794ms
+        duration: 40.352121ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1167,8 +1167,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b526abed-eb2c-461c-8e15-8131d7347881/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e52321be-7d3f-4417-8fb7-4d3c11c9790f/versions/1
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1180,14 +1180,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:26 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 343a199a-5d8c-4afc-a661-fad6b71a5b5e
+                - 12edeb62-bc50-444c-bc7b-87ebe9cff426
         status: 204 No Content
         code: 204
-        duration: 103.791811ms
+        duration: 58.938582ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1197,8 +1197,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ad0360b7-7394-4360-9099-17a04ac8d64b/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/646cb095-08ab-467f-aa7f-0cce3b822253/versions/2
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1210,14 +1210,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:26 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 166e6dd5-cd9d-4df7-a815-f84ba7e0bfd3
+                - 2a44f4f6-d138-4333-9b37-1aac94c92962
         status: 204 No Content
         code: 204
-        duration: 112.946186ms
+        duration: 61.389857ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1227,8 +1227,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ad0360b7-7394-4360-9099-17a04ac8d64b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/646cb095-08ab-467f-aa7f-0cce3b822253
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1240,14 +1240,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:26 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 23a3d54d-d06f-4360-b53a-d4bc6675c156
+                - 5dee65e1-4bf6-473b-8a89-c34316a05dff
         status: 204 No Content
         code: 204
-        duration: 46.896463ms
+        duration: 56.923908ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1257,8 +1257,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b526abed-eb2c-461c-8e15-8131d7347881
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e52321be-7d3f-4417-8fb7-4d3c11c9790f
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1270,14 +1270,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:26 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - a5e4f589-dad4-40c6-aa4f-3b6a0587dfa9
+                - d693cd76-c269-4425-bfbb-22ea8b72546b
         status: 204 No Content
         code: 204
-        duration: 74.092326ms
+        duration: 143.976315ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1287,29 +1287,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b526abed-eb2c-461c-8e15-8131d7347881
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/e52321be-7d3f-4417-8fb7-4d3c11c9790f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 513
-        body: '{"id":"b526abed-eb2c-461c-8e15-8131d7347881","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretVersionNameDataWO","status":"ready","created_at":"2026-06-04T09:49:23.342116Z","updated_at":"2026-06-04T09:49:23.342116Z","tags":["devtools","provider","terraform"],"version_count":1,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-06-04T09:49:26.562737Z","key_id":null,"region":"fr-par"}'
+        body: '{"id":"e52321be-7d3f-4417-8fb7-4d3c11c9790f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretVersionNameDataWO","status":"ready","created_at":"2026-07-03T15:27:59.801664Z","updated_at":"2026-07-03T15:28:04.423935Z","tags":["devtools","provider","terraform"],"version_count":1,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-07-03T15:28:04.423935Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "513"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:26 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - be7b4ff3-fbda-4798-ae09-329694102ca6
+                - 5debf8c2-7218-40ed-9042-4718cc625689
         status: 200 OK
         code: 200
-        duration: 35.358942ms
+        duration: 42.782417ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -1319,26 +1319,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ad0360b7-7394-4360-9099-17a04ac8d64b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/646cb095-08ab-467f-aa7f-0cce3b822253
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 515
-        body: '{"id":"ad0360b7-7394-4360-9099-17a04ac8d64b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretVersionNameDataWOB","status":"ready","created_at":"2026-06-04T09:49:23.363193Z","updated_at":"2026-06-04T09:49:23.363193Z","tags":["devtools","provider","terraform"],"version_count":2,"description":"secret descriptionB","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-06-04T09:49:26.557064Z","key_id":null,"region":"fr-par"}'
+        body: '{"id":"646cb095-08ab-467f-aa7f-0cce3b822253","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretVersionNameDataWOB","status":"ready","created_at":"2026-07-03T15:27:59.827262Z","updated_at":"2026-07-03T15:28:04.336425Z","tags":["devtools","provider","terraform"],"version_count":2,"description":"secret descriptionB","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-07-03T15:28:04.336425Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "515"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:26 GMT
+                - Fri, 03 Jul 2026 15:28:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 12d85317-3c82-4e81-bff0-a1eb550c190d
+                - 8d86a830-1060-4805-920a-9606e12ad767
         status: 200 OK
         code: 200
-        duration: 33.393506ms
+        duration: 48.563175ms

--- a/internal/services/secret/testdata/secret-version-type.cassette.yaml
+++ b/internal/services/secret/testdata/secret-version-type.cassette.yaml
@@ -13,7 +13,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets
         method: POST
       response:
@@ -21,21 +21,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 438
-        body: '{"id":"de82cac9-f60e-479a-b73b-bdaa521a7d46","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretVersionNameType","status":"ready","created_at":"2026-06-04T09:49:23.308666Z","updated_at":"2026-06-04T09:49:23.308666Z","tags":[],"version_count":0,"description":"","managed":false,"type":"key_value","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"35e00bac-dfad-4406-83ba-2711dcb02254","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretVersionNameType","status":"ready","created_at":"2026-07-03T15:27:59.160617Z","updated_at":"2026-07-03T15:27:59.160617Z","tags":[],"version_count":0,"description":"","managed":false,"type":"key_value","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "438"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:23 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 6cca4c92-a8ed-4ad5-8be5-08e00a95fcfc
+                - 63ac4bc8-ec9e-417d-b2a3-848408fceabc
         status: 200 OK
         code: 200
-        duration: 214.933607ms
+        duration: 92.571944ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -45,29 +45,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/de82cac9-f60e-479a-b73b-bdaa521a7d46
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/35e00bac-dfad-4406-83ba-2711dcb02254
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 438
-        body: '{"id":"de82cac9-f60e-479a-b73b-bdaa521a7d46","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretVersionNameType","status":"ready","created_at":"2026-06-04T09:49:23.308666Z","updated_at":"2026-06-04T09:49:23.308666Z","tags":[],"version_count":0,"description":"","managed":false,"type":"key_value","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"35e00bac-dfad-4406-83ba-2711dcb02254","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretVersionNameType","status":"ready","created_at":"2026-07-03T15:27:59.160617Z","updated_at":"2026-07-03T15:27:59.160617Z","tags":[],"version_count":0,"description":"","managed":false,"type":"key_value","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "438"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:23 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - af577e74-10c3-4d33-8952-eeb8e5e71fc2
+                - bb98fb55-b3bd-41c5-a32c-e36ada1ca18c
         status: 200 OK
         code: 200
-        duration: 41.846835ms
+        duration: 52.241623ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -80,8 +80,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/de82cac9-f60e-479a-b73b-bdaa521a7d46/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/35e00bac-dfad-4406-83ba-2711dcb02254/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -95,14 +95,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:23 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 874b503e-674d-47c9-b4af-b5e239e78472
+                - 4236e45f-ffe6-4949-a857-df67db89f092
         status: 200 OK
         code: 200
-        duration: 50.28543ms
+        duration: 68.23356ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -115,29 +115,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/de82cac9-f60e-479a-b73b-bdaa521a7d46/versions
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/35e00bac-dfad-4406-83ba-2711dcb02254/versions
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"de82cac9-f60e-479a-b73b-bdaa521a7d46","status":"enabled","created_at":"2026-06-04T09:49:23.735735Z","updated_at":"2026-06-04T09:49:23.735735Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"35e00bac-dfad-4406-83ba-2711dcb02254","status":"enabled","created_at":"2026-07-03T15:27:59.581552Z","updated_at":"2026-07-03T15:27:59.581552Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:23 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 00073e2e-6038-41f9-bf39-dc3da5934fed
+                - f59dab61-2584-4295-8f83-f0ceaae64065
         status: 200 OK
         code: 200
-        duration: 331.770944ms
+        duration: 298.963931ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -147,29 +147,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/de82cac9-f60e-479a-b73b-bdaa521a7d46/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/35e00bac-dfad-4406-83ba-2711dcb02254/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"de82cac9-f60e-479a-b73b-bdaa521a7d46","status":"enabled","created_at":"2026-06-04T09:49:23.735735Z","updated_at":"2026-06-04T09:49:23.735735Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"35e00bac-dfad-4406-83ba-2711dcb02254","status":"enabled","created_at":"2026-07-03T15:27:59.581552Z","updated_at":"2026-07-03T15:27:59.581552Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:23 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 44cd570b-39f2-4599-9c85-abd8690cb3d7
+                - e36b1f50-d09b-47e8-a78a-866fed30cde6
         status: 200 OK
         code: 200
-        duration: 40.745435ms
+        duration: 46.08031ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -179,29 +179,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/de82cac9-f60e-479a-b73b-bdaa521a7d46/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/35e00bac-dfad-4406-83ba-2711dcb02254/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"de82cac9-f60e-479a-b73b-bdaa521a7d46","status":"enabled","created_at":"2026-06-04T09:49:23.735735Z","updated_at":"2026-06-04T09:49:23.735735Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"35e00bac-dfad-4406-83ba-2711dcb02254","status":"enabled","created_at":"2026-07-03T15:27:59.581552Z","updated_at":"2026-07-03T15:27:59.581552Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:23 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - b8727300-3426-49eb-a2bd-d164f769f303
+                - e2a58029-1634-453b-b87b-f3e4ba326ae6
         status: 200 OK
         code: 200
-        duration: 35.503621ms
+        duration: 42.34245ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -211,29 +211,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/de82cac9-f60e-479a-b73b-bdaa521a7d46
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/35e00bac-dfad-4406-83ba-2711dcb02254
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 438
-        body: '{"id":"de82cac9-f60e-479a-b73b-bdaa521a7d46","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretVersionNameType","status":"ready","created_at":"2026-06-04T09:49:23.308666Z","updated_at":"2026-06-04T09:49:23.308666Z","tags":[],"version_count":1,"description":"","managed":false,"type":"key_value","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"35e00bac-dfad-4406-83ba-2711dcb02254","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretVersionNameType","status":"ready","created_at":"2026-07-03T15:27:59.160617Z","updated_at":"2026-07-03T15:27:59.160617Z","tags":[],"version_count":1,"description":"","managed":false,"type":"key_value","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "438"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:24 GMT
+                - Fri, 03 Jul 2026 15:28:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 0d696bef-0980-46fc-acb4-e8964fef3cca
+                - 4f36cf74-4028-436d-bba3-0d8c4565ce14
         status: 200 OK
         code: 200
-        duration: 39.4749ms
+        duration: 53.633297ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -246,29 +246,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/de82cac9-f60e-479a-b73b-bdaa521a7d46/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/35e00bac-dfad-4406-83ba-2711dcb02254/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 333
-        body: '{"versions":[{"revision":1,"secret_id":"de82cac9-f60e-479a-b73b-bdaa521a7d46","status":"enabled","created_at":"2026-06-04T09:49:23.735735Z","updated_at":"2026-06-04T09:49:23.735735Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        body: '{"versions":[{"revision":1,"secret_id":"35e00bac-dfad-4406-83ba-2711dcb02254","status":"enabled","created_at":"2026-07-03T15:27:59.581552Z","updated_at":"2026-07-03T15:27:59.581552Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "333"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:24 GMT
+                - Fri, 03 Jul 2026 15:28:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 1e3c924f-2371-47ae-9248-70060ffa89e1
+                - f3a08375-ac14-41cb-a3b8-72b816368314
         status: 200 OK
         code: 200
-        duration: 38.544259ms
+        duration: 58.744848ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -278,29 +278,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/de82cac9-f60e-479a-b73b-bdaa521a7d46/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/35e00bac-dfad-4406-83ba-2711dcb02254/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"de82cac9-f60e-479a-b73b-bdaa521a7d46","status":"enabled","created_at":"2026-06-04T09:49:23.735735Z","updated_at":"2026-06-04T09:49:23.735735Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"35e00bac-dfad-4406-83ba-2711dcb02254","status":"enabled","created_at":"2026-07-03T15:27:59.581552Z","updated_at":"2026-07-03T15:27:59.581552Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:24 GMT
+                - Fri, 03 Jul 2026 15:28:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 328ddd08-2909-4a8e-9d3e-a01392be12d7
+                - a0001e7c-69e0-473f-98c5-ca0c584bef13
         status: 200 OK
         code: 200
-        duration: 39.056016ms
+        duration: 55.803032ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -310,29 +310,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/de82cac9-f60e-479a-b73b-bdaa521a7d46
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/35e00bac-dfad-4406-83ba-2711dcb02254
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 438
-        body: '{"id":"de82cac9-f60e-479a-b73b-bdaa521a7d46","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretVersionNameType","status":"ready","created_at":"2026-06-04T09:49:23.308666Z","updated_at":"2026-06-04T09:49:23.308666Z","tags":[],"version_count":1,"description":"","managed":false,"type":"key_value","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"35e00bac-dfad-4406-83ba-2711dcb02254","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretVersionNameType","status":"ready","created_at":"2026-07-03T15:27:59.160617Z","updated_at":"2026-07-03T15:27:59.160617Z","tags":[],"version_count":1,"description":"","managed":false,"type":"key_value","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "438"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:24 GMT
+                - Fri, 03 Jul 2026 15:28:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - ec1099d8-bc76-40dc-8879-6f18a293b821
+                - aa0c344b-e604-4e28-9f03-7df9ef3fee82
         status: 200 OK
         code: 200
-        duration: 47.195591ms
+        duration: 34.819991ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -345,29 +345,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/de82cac9-f60e-479a-b73b-bdaa521a7d46/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/35e00bac-dfad-4406-83ba-2711dcb02254/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 333
-        body: '{"versions":[{"revision":1,"secret_id":"de82cac9-f60e-479a-b73b-bdaa521a7d46","status":"enabled","created_at":"2026-06-04T09:49:23.735735Z","updated_at":"2026-06-04T09:49:23.735735Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        body: '{"versions":[{"revision":1,"secret_id":"35e00bac-dfad-4406-83ba-2711dcb02254","status":"enabled","created_at":"2026-07-03T15:27:59.581552Z","updated_at":"2026-07-03T15:27:59.581552Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "333"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:24 GMT
+                - Fri, 03 Jul 2026 15:28:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 073c591f-91ab-47b4-84a3-40ac967dd2bd
+                - 700aa9ce-2a9d-49c1-905b-e1f3111eb0d9
         status: 200 OK
         code: 200
-        duration: 48.55814ms
+        duration: 48.556221ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -377,29 +377,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/de82cac9-f60e-479a-b73b-bdaa521a7d46/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/35e00bac-dfad-4406-83ba-2711dcb02254/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"de82cac9-f60e-479a-b73b-bdaa521a7d46","status":"enabled","created_at":"2026-06-04T09:49:23.735735Z","updated_at":"2026-06-04T09:49:23.735735Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"35e00bac-dfad-4406-83ba-2711dcb02254","status":"enabled","created_at":"2026-07-03T15:27:59.581552Z","updated_at":"2026-07-03T15:27:59.581552Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:24 GMT
+                - Fri, 03 Jul 2026 15:28:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 18baee67-e972-4942-9951-ced9e19d363e
+                - de1dada4-6a56-47cf-8274-50e784a97b50
         status: 200 OK
         code: 200
-        duration: 43.014681ms
+        duration: 51.471798ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -409,8 +409,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/de82cac9-f60e-479a-b73b-bdaa521a7d46/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/35e00bac-dfad-4406-83ba-2711dcb02254/versions/1
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -422,14 +422,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:25 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 7e92ab4a-b248-4558-b13b-30fe3e7da984
+                - 3694fd8e-f659-4895-a91e-40c742b87a95
         status: 204 No Content
         code: 204
-        duration: 104.852092ms
+        duration: 86.881936ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -442,8 +442,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/de82cac9-f60e-479a-b73b-bdaa521a7d46/versions
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/35e00bac-dfad-4406-83ba-2711dcb02254/versions
         method: POST
       response:
         proto: HTTP/2.0
@@ -457,14 +457,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:25 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 4089a13f-ffb7-42b0-90ec-c389b7e11797
+                - 18c57bdd-6505-4824-b6a9-0576fd9ab8bf
         status: 400 Bad Request
         code: 400
-        duration: 109.850513ms
+        duration: 58.742393ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -474,8 +474,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/de82cac9-f60e-479a-b73b-bdaa521a7d46
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/35e00bac-dfad-4406-83ba-2711dcb02254
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -487,14 +487,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:25 GMT
+                - Fri, 03 Jul 2026 15:28:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - b7bad5ba-092b-4f91-8feb-abfa3ee5006a
+                - 3a1a01b5-6c1a-42b1-80b8-9c2310f93373
         status: 204 No Content
         code: 204
-        duration: 103.251368ms
+        duration: 135.606094ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -504,26 +504,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/de82cac9-f60e-479a-b73b-bdaa521a7d46
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/35e00bac-dfad-4406-83ba-2711dcb02254
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 463
-        body: '{"id":"de82cac9-f60e-479a-b73b-bdaa521a7d46","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretVersionNameType","status":"ready","created_at":"2026-06-04T09:49:23.308666Z","updated_at":"2026-06-04T09:49:23.308666Z","tags":[],"version_count":1,"description":"","managed":false,"type":"key_value","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-06-04T09:49:25.466929Z","key_id":null,"region":"fr-par"}'
+        body: '{"id":"35e00bac-dfad-4406-83ba-2711dcb02254","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretVersionNameType","status":"ready","created_at":"2026-07-03T15:27:59.160617Z","updated_at":"2026-07-03T15:28:01.908841Z","tags":[],"version_count":1,"description":"","managed":false,"type":"key_value","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-07-03T15:28:01.908841Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "463"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 04 Jun 2026 09:49:25 GMT
+                - Fri, 03 Jul 2026 15:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 538ecec5-cb24-4034-b555-87b169345246
+                - db8f44a6-abea-4c2e-a3da-b43f9ff9e23c
         status: 200 OK
         code: 200
-        duration: 34.291865ms
+        duration: 45.810304ms

--- a/internal/services/secret/testdata/secret-with-versions.cassette.yaml
+++ b/internal/services/secret/testdata/secret-with-versions.cassette.yaml
@@ -13,7 +13,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets
         method: POST
       response:
@@ -21,21 +21,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 443
-        body: '{"id":"3630efdd-2523-4b3f-9a52-5dc510686b2b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-resource-versions","status":"ready","created_at":"2026-06-24T09:38:38.806136Z","updated_at":"2026-06-24T09:38:38.806136Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"20300372-99a5-4956-ae62-81622b0bb166","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-resource-versions","status":"ready","created_at":"2026-07-03T15:27:54.575729Z","updated_at":"2026-07-03T15:27:54.575729Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "443"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:38 GMT
+                - Fri, 03 Jul 2026 15:27:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - cfa00fac-93db-490f-a525-d6b5b00d8459
+                - e97b5d51-aa02-407d-995c-c3b7f898c3e9
         status: 200 OK
         code: 200
-        duration: 270.306257ms
+        duration: 297.511462ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -45,29 +45,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3630efdd-2523-4b3f-9a52-5dc510686b2b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/20300372-99a5-4956-ae62-81622b0bb166
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 443
-        body: '{"id":"3630efdd-2523-4b3f-9a52-5dc510686b2b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-resource-versions","status":"ready","created_at":"2026-06-24T09:38:38.806136Z","updated_at":"2026-06-24T09:38:38.806136Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"20300372-99a5-4956-ae62-81622b0bb166","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-resource-versions","status":"ready","created_at":"2026-07-03T15:27:54.575729Z","updated_at":"2026-07-03T15:27:54.575729Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "443"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:38 GMT
+                - Fri, 03 Jul 2026 15:27:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 625d7364-7812-4029-b76c-f27b71756f98
+                - a1eb5410-6f51-46ad-8e15-bac766c7b6f4
         status: 200 OK
         code: 200
-        duration: 140.028779ms
+        duration: 202.619862ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -80,8 +80,8 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3630efdd-2523-4b3f-9a52-5dc510686b2b/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/20300372-99a5-4956-ae62-81622b0bb166/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -95,14 +95,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:39 GMT
+                - Fri, 03 Jul 2026 15:27:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 30e98660-5cb7-4637-8ddc-5b66c7308295
+                - a0cecb64-ea3e-4e49-a352-c46f3548ffda
         status: 200 OK
         code: 200
-        duration: 138.437826ms
+        duration: 58.938531ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -115,29 +115,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3630efdd-2523-4b3f-9a52-5dc510686b2b/versions
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/20300372-99a5-4956-ae62-81622b0bb166/versions
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 294
-        body: '{"revision":1,"secret_id":"3630efdd-2523-4b3f-9a52-5dc510686b2b","status":"enabled","created_at":"2026-06-24T09:38:39.446382Z","updated_at":"2026-06-24T09:38:39.446382Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"20300372-99a5-4956-ae62-81622b0bb166","status":"enabled","created_at":"2026-07-03T15:27:55.307475Z","updated_at":"2026-07-03T15:27:55.307475Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "294"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:39 GMT
+                - Fri, 03 Jul 2026 15:27:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - fe57e7c3-d498-4801-953c-2b017591bef2
+                - cfd56496-408e-4b01-bcbe-88a982499816
         status: 200 OK
         code: 200
-        duration: 357.764967ms
+        duration: 389.375245ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -147,29 +147,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3630efdd-2523-4b3f-9a52-5dc510686b2b/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/20300372-99a5-4956-ae62-81622b0bb166/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 294
-        body: '{"revision":1,"secret_id":"3630efdd-2523-4b3f-9a52-5dc510686b2b","status":"enabled","created_at":"2026-06-24T09:38:39.446382Z","updated_at":"2026-06-24T09:38:39.446382Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"20300372-99a5-4956-ae62-81622b0bb166","status":"enabled","created_at":"2026-07-03T15:27:55.307475Z","updated_at":"2026-07-03T15:27:55.307475Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "294"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:39 GMT
+                - Fri, 03 Jul 2026 15:27:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 8c26ecfd-4be9-48a5-8ce8-6b8d33ee770b
+                - 0daa5822-5624-43c3-ba8a-5ab26b51c5c7
         status: 200 OK
         code: 200
-        duration: 18.282379ms
+        duration: 46.27173ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -182,29 +182,29 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3630efdd-2523-4b3f-9a52-5dc510686b2b/versions
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/20300372-99a5-4956-ae62-81622b0bb166/versions
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 294
-        body: '{"revision":2,"secret_id":"3630efdd-2523-4b3f-9a52-5dc510686b2b","status":"enabled","created_at":"2026-06-24T09:38:39.651671Z","updated_at":"2026-06-24T09:38:39.651671Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":2,"secret_id":"20300372-99a5-4956-ae62-81622b0bb166","status":"enabled","created_at":"2026-07-03T15:27:55.657530Z","updated_at":"2026-07-03T15:27:55.657530Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "294"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:39 GMT
+                - Fri, 03 Jul 2026 15:27:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - aec9fdfc-40e5-40c9-988b-e9c37fc5ab3f
+                - f0b6957e-a3a1-480b-8061-5cb715e59903
         status: 200 OK
         code: 200
-        duration: 561.449505ms
+        duration: 753.210059ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -214,29 +214,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3630efdd-2523-4b3f-9a52-5dc510686b2b/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/20300372-99a5-4956-ae62-81622b0bb166/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 294
-        body: '{"revision":2,"secret_id":"3630efdd-2523-4b3f-9a52-5dc510686b2b","status":"enabled","created_at":"2026-06-24T09:38:39.651671Z","updated_at":"2026-06-24T09:38:39.651671Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":2,"secret_id":"20300372-99a5-4956-ae62-81622b0bb166","status":"enabled","created_at":"2026-07-03T15:27:55.657530Z","updated_at":"2026-07-03T15:27:55.657530Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "294"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:39 GMT
+                - Fri, 03 Jul 2026 15:27:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - c095db93-8a9f-4150-b988-3645f10e7f50
+                - 5b239b6a-0fb6-405e-befe-26af89ebf017
         status: 200 OK
         code: 200
-        duration: 21.276564ms
+        duration: 32.954527ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -246,29 +246,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3630efdd-2523-4b3f-9a52-5dc510686b2b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/20300372-99a5-4956-ae62-81622b0bb166
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 443
-        body: '{"id":"3630efdd-2523-4b3f-9a52-5dc510686b2b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-resource-versions","status":"ready","created_at":"2026-06-24T09:38:38.806136Z","updated_at":"2026-06-24T09:38:38.806136Z","tags":[],"version_count":2,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"20300372-99a5-4956-ae62-81622b0bb166","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-resource-versions","status":"ready","created_at":"2026-07-03T15:27:54.575729Z","updated_at":"2026-07-03T15:27:54.575729Z","tags":[],"version_count":2,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "443"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:39 GMT
+                - Fri, 03 Jul 2026 15:27:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 0dd4dfbd-a6d2-4ae2-8896-810530af1b34
+                - 088b7d10-3ad9-4eb1-bc32-556aa7db32e5
         status: 200 OK
         code: 200
-        duration: 100.486457ms
+        duration: 82.996599ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -278,29 +278,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3630efdd-2523-4b3f-9a52-5dc510686b2b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/20300372-99a5-4956-ae62-81622b0bb166
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 443
-        body: '{"id":"3630efdd-2523-4b3f-9a52-5dc510686b2b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-resource-versions","status":"ready","created_at":"2026-06-24T09:38:38.806136Z","updated_at":"2026-06-24T09:38:38.806136Z","tags":[],"version_count":2,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"20300372-99a5-4956-ae62-81622b0bb166","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-resource-versions","status":"ready","created_at":"2026-07-03T15:27:54.575729Z","updated_at":"2026-07-03T15:27:54.575729Z","tags":[],"version_count":2,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "443"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:40 GMT
+                - Fri, 03 Jul 2026 15:27:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - afcf8c15-12ca-4ab8-b71d-9a15a1407dd2
+                - 6c2ec011-e644-42a1-a003-7942d3580115
         status: 200 OK
         code: 200
-        duration: 18.771488ms
+        duration: 115.77791ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -313,29 +313,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3630efdd-2523-4b3f-9a52-5dc510686b2b/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/20300372-99a5-4956-ae62-81622b0bb166/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 621
-        body: '{"versions":[{"revision":2,"secret_id":"3630efdd-2523-4b3f-9a52-5dc510686b2b","status":"enabled","created_at":"2026-06-24T09:38:39.651671Z","updated_at":"2026-06-24T09:38:39.651671Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"3630efdd-2523-4b3f-9a52-5dc510686b2b","status":"enabled","created_at":"2026-06-24T09:38:39.446382Z","updated_at":"2026-06-24T09:38:39.446382Z","deleted_at":null,"description":"","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":2}'
+        body: '{"versions":[{"revision":2,"secret_id":"20300372-99a5-4956-ae62-81622b0bb166","status":"enabled","created_at":"2026-07-03T15:27:55.657530Z","updated_at":"2026-07-03T15:27:55.657530Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"20300372-99a5-4956-ae62-81622b0bb166","status":"enabled","created_at":"2026-07-03T15:27:55.307475Z","updated_at":"2026-07-03T15:27:55.307475Z","deleted_at":null,"description":"","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":2}'
         headers:
             Content-Length:
                 - "621"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:40 GMT
+                - Fri, 03 Jul 2026 15:27:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 3c308f67-de26-4167-a4c6-0e7a3db9685f
+                - 3af32334-6799-4c96-bbd1-224f6d01e57c
         status: 200 OK
         code: 200
-        duration: 120.950673ms
+        duration: 37.290171ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -345,29 +345,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3630efdd-2523-4b3f-9a52-5dc510686b2b/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/20300372-99a5-4956-ae62-81622b0bb166/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 295
-        body: '{"revision":1,"secret_id":"3630efdd-2523-4b3f-9a52-5dc510686b2b","status":"enabled","created_at":"2026-06-24T09:38:39.446382Z","updated_at":"2026-06-24T09:38:39.446382Z","deleted_at":null,"description":"","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"20300372-99a5-4956-ae62-81622b0bb166","status":"enabled","created_at":"2026-07-03T15:27:55.307475Z","updated_at":"2026-07-03T15:27:55.307475Z","deleted_at":null,"description":"","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "295"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:40 GMT
+                - Fri, 03 Jul 2026 15:27:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - e66aa54c-7031-4260-b323-1abc45577264
+                - dbe19b1f-21d4-4ef8-b5d1-eb12ed9f4aad
         status: 200 OK
         code: 200
-        duration: 23.768305ms
+        duration: 31.455712ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -377,29 +377,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3630efdd-2523-4b3f-9a52-5dc510686b2b/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/20300372-99a5-4956-ae62-81622b0bb166/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 294
-        body: '{"revision":2,"secret_id":"3630efdd-2523-4b3f-9a52-5dc510686b2b","status":"enabled","created_at":"2026-06-24T09:38:39.651671Z","updated_at":"2026-06-24T09:38:39.651671Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":2,"secret_id":"20300372-99a5-4956-ae62-81622b0bb166","status":"enabled","created_at":"2026-07-03T15:27:55.657530Z","updated_at":"2026-07-03T15:27:55.657530Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "294"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:40 GMT
+                - Fri, 03 Jul 2026 15:27:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - d58d80f2-46dc-40d1-a5ff-a096bd6da8a7
+                - 2118bb04-a602-4c46-89b1-753c0404d1ae
         status: 200 OK
         code: 200
-        duration: 91.67496ms
+        duration: 39.131348ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -409,29 +409,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3630efdd-2523-4b3f-9a52-5dc510686b2b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/20300372-99a5-4956-ae62-81622b0bb166
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 443
-        body: '{"id":"3630efdd-2523-4b3f-9a52-5dc510686b2b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-resource-versions","status":"ready","created_at":"2026-06-24T09:38:38.806136Z","updated_at":"2026-06-24T09:38:38.806136Z","tags":[],"version_count":2,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"20300372-99a5-4956-ae62-81622b0bb166","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-resource-versions","status":"ready","created_at":"2026-07-03T15:27:54.575729Z","updated_at":"2026-07-03T15:27:54.575729Z","tags":[],"version_count":2,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "443"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:40 GMT
+                - Fri, 03 Jul 2026 15:27:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - bc9a2b1a-d813-4639-862d-e881d9e734a3
+                - d9107e24-aedf-4287-81cf-67f6fcadb4cd
         status: 200 OK
         code: 200
-        duration: 21.465808ms
+        duration: 133.572553ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -444,29 +444,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3630efdd-2523-4b3f-9a52-5dc510686b2b/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/20300372-99a5-4956-ae62-81622b0bb166/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 621
-        body: '{"versions":[{"revision":2,"secret_id":"3630efdd-2523-4b3f-9a52-5dc510686b2b","status":"enabled","created_at":"2026-06-24T09:38:39.651671Z","updated_at":"2026-06-24T09:38:39.651671Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"3630efdd-2523-4b3f-9a52-5dc510686b2b","status":"enabled","created_at":"2026-06-24T09:38:39.446382Z","updated_at":"2026-06-24T09:38:39.446382Z","deleted_at":null,"description":"","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":2}'
+        body: '{"versions":[{"revision":2,"secret_id":"20300372-99a5-4956-ae62-81622b0bb166","status":"enabled","created_at":"2026-07-03T15:27:55.657530Z","updated_at":"2026-07-03T15:27:55.657530Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"20300372-99a5-4956-ae62-81622b0bb166","status":"enabled","created_at":"2026-07-03T15:27:55.307475Z","updated_at":"2026-07-03T15:27:55.307475Z","deleted_at":null,"description":"","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":2}'
         headers:
             Content-Length:
                 - "621"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:40 GMT
+                - Fri, 03 Jul 2026 15:27:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 205b2031-f191-4adc-a2d0-d680bc76ef78
+                - a0fd32af-2583-4507-a4fd-e314836ef1bd
         status: 200 OK
         code: 200
-        duration: 26.010057ms
+        duration: 108.038704ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -476,29 +476,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3630efdd-2523-4b3f-9a52-5dc510686b2b/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/20300372-99a5-4956-ae62-81622b0bb166/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 294
-        body: '{"revision":2,"secret_id":"3630efdd-2523-4b3f-9a52-5dc510686b2b","status":"enabled","created_at":"2026-06-24T09:38:39.651671Z","updated_at":"2026-06-24T09:38:39.651671Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 295
+        body: '{"revision":1,"secret_id":"20300372-99a5-4956-ae62-81622b0bb166","status":"enabled","created_at":"2026-07-03T15:27:55.307475Z","updated_at":"2026-07-03T15:27:55.307475Z","deleted_at":null,"description":"","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "294"
+                - "295"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:40 GMT
+                - Fri, 03 Jul 2026 15:27:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 0ea0cae7-bd96-48ae-99c4-edf06657c0ef
+                - 279f5c10-1742-4169-ae60-88f28a41e2c1
         status: 200 OK
         code: 200
-        duration: 17.192427ms
+        duration: 32.671475ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -508,29 +508,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3630efdd-2523-4b3f-9a52-5dc510686b2b/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/20300372-99a5-4956-ae62-81622b0bb166/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 295
-        body: '{"revision":1,"secret_id":"3630efdd-2523-4b3f-9a52-5dc510686b2b","status":"enabled","created_at":"2026-06-24T09:38:39.446382Z","updated_at":"2026-06-24T09:38:39.446382Z","deleted_at":null,"description":"","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 294
+        body: '{"revision":2,"secret_id":"20300372-99a5-4956-ae62-81622b0bb166","status":"enabled","created_at":"2026-07-03T15:27:55.657530Z","updated_at":"2026-07-03T15:27:55.657530Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "295"
+                - "294"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:40 GMT
+                - Fri, 03 Jul 2026 15:27:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - ab7c1854-7ab6-4638-8f05-e376720b5484
+                - b6def010-b80b-43ef-9866-f7c76da0ce5b
         status: 200 OK
         code: 200
-        duration: 23.065897ms
+        duration: 855.735569ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -540,29 +540,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3630efdd-2523-4b3f-9a52-5dc510686b2b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/20300372-99a5-4956-ae62-81622b0bb166
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 443
-        body: '{"id":"3630efdd-2523-4b3f-9a52-5dc510686b2b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-resource-versions","status":"ready","created_at":"2026-06-24T09:38:38.806136Z","updated_at":"2026-06-24T09:38:38.806136Z","tags":[],"version_count":2,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"20300372-99a5-4956-ae62-81622b0bb166","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-resource-versions","status":"ready","created_at":"2026-07-03T15:27:54.575729Z","updated_at":"2026-07-03T15:27:54.575729Z","tags":[],"version_count":2,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "443"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:40 GMT
+                - Fri, 03 Jul 2026 15:27:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - dd935dd6-dc76-4e0c-bb10-0eb98be2da17
+                - 41238474-07d9-49e2-8b1b-56ea1b11780a
         status: 200 OK
         code: 200
-        duration: 31.376083ms
+        duration: 156.761258ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -572,29 +572,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3630efdd-2523-4b3f-9a52-5dc510686b2b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/20300372-99a5-4956-ae62-81622b0bb166
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 443
-        body: '{"id":"3630efdd-2523-4b3f-9a52-5dc510686b2b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-resource-versions","status":"ready","created_at":"2026-06-24T09:38:38.806136Z","updated_at":"2026-06-24T09:38:38.806136Z","tags":[],"version_count":2,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"20300372-99a5-4956-ae62-81622b0bb166","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-resource-versions","status":"ready","created_at":"2026-07-03T15:27:54.575729Z","updated_at":"2026-07-03T15:27:54.575729Z","tags":[],"version_count":2,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "443"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:41 GMT
+                - Fri, 03 Jul 2026 15:27:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - c5e942b4-30a2-4155-abbe-5cf2cf0ec8b0
+                - 902c3fbc-91ae-4e08-a4ab-877fbead1bc8
         status: 200 OK
         code: 200
-        duration: 17.195605ms
+        duration: 41.317364ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -607,29 +607,29 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3630efdd-2523-4b3f-9a52-5dc510686b2b/versions?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/20300372-99a5-4956-ae62-81622b0bb166/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 621
-        body: '{"versions":[{"revision":2,"secret_id":"3630efdd-2523-4b3f-9a52-5dc510686b2b","status":"enabled","created_at":"2026-06-24T09:38:39.651671Z","updated_at":"2026-06-24T09:38:39.651671Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"3630efdd-2523-4b3f-9a52-5dc510686b2b","status":"enabled","created_at":"2026-06-24T09:38:39.446382Z","updated_at":"2026-06-24T09:38:39.446382Z","deleted_at":null,"description":"","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":2}'
+        body: '{"versions":[{"revision":2,"secret_id":"20300372-99a5-4956-ae62-81622b0bb166","status":"enabled","created_at":"2026-07-03T15:27:55.657530Z","updated_at":"2026-07-03T15:27:55.657530Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"20300372-99a5-4956-ae62-81622b0bb166","status":"enabled","created_at":"2026-07-03T15:27:55.307475Z","updated_at":"2026-07-03T15:27:55.307475Z","deleted_at":null,"description":"","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":2}'
         headers:
             Content-Length:
                 - "621"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:41 GMT
+                - Fri, 03 Jul 2026 15:27:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - febb86e3-04ff-4acb-99b4-158441d046cc
+                - 40ec6e85-eb7a-4976-b7db-eeb7072f23fd
         status: 200 OK
         code: 200
-        duration: 24.858367ms
+        duration: 44.973512ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -639,29 +639,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3630efdd-2523-4b3f-9a52-5dc510686b2b/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/20300372-99a5-4956-ae62-81622b0bb166/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 294
-        body: '{"revision":2,"secret_id":"3630efdd-2523-4b3f-9a52-5dc510686b2b","status":"enabled","created_at":"2026-06-24T09:38:39.651671Z","updated_at":"2026-06-24T09:38:39.651671Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 295
+        body: '{"revision":1,"secret_id":"20300372-99a5-4956-ae62-81622b0bb166","status":"enabled","created_at":"2026-07-03T15:27:55.307475Z","updated_at":"2026-07-03T15:27:55.307475Z","deleted_at":null,"description":"","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "294"
+                - "295"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:41 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 2882240c-0179-48d0-9fa0-fed569c21379
+                - ecebf6b5-919e-4b55-af67-e4a1dbb42844
         status: 200 OK
         code: 200
-        duration: 16.14045ms
+        duration: 38.502628ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -671,29 +671,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3630efdd-2523-4b3f-9a52-5dc510686b2b/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/20300372-99a5-4956-ae62-81622b0bb166/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 295
-        body: '{"revision":1,"secret_id":"3630efdd-2523-4b3f-9a52-5dc510686b2b","status":"enabled","created_at":"2026-06-24T09:38:39.446382Z","updated_at":"2026-06-24T09:38:39.446382Z","deleted_at":null,"description":"","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 294
+        body: '{"revision":2,"secret_id":"20300372-99a5-4956-ae62-81622b0bb166","status":"enabled","created_at":"2026-07-03T15:27:55.657530Z","updated_at":"2026-07-03T15:27:55.657530Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "295"
+                - "294"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:41 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 0e53ea1f-78cd-4324-b0c5-98cbf614e605
+                - b0353769-310f-4f1e-89e5-e86bebfba6e6
         status: 200 OK
         code: 200
-        duration: 22.781171ms
+        duration: 53.409677ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -703,8 +703,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3630efdd-2523-4b3f-9a52-5dc510686b2b/versions/2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/20300372-99a5-4956-ae62-81622b0bb166/versions/1
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -716,14 +716,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:41 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 27fce0c3-a678-4531-82f2-55d483b8e5db
+                - c493844a-f877-4665-ad7e-e6503288d460
         status: 204 No Content
         code: 204
-        duration: 122.447004ms
+        duration: 126.71846ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -733,8 +733,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3630efdd-2523-4b3f-9a52-5dc510686b2b/versions/1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/20300372-99a5-4956-ae62-81622b0bb166/versions/2
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -746,14 +746,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:41 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - a8053a3e-0036-4994-b6d1-52f557ffe331
+                - b49a7e6f-cb20-452c-a381-3c7713b9e7c2
         status: 204 No Content
         code: 204
-        duration: 207.101814ms
+        duration: 157.270073ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -763,8 +763,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3630efdd-2523-4b3f-9a52-5dc510686b2b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/20300372-99a5-4956-ae62-81622b0bb166
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -776,14 +776,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:41 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 04d63212-2474-43bd-99f0-50a385f1fce5
+                - 8473f092-7bb1-46a7-9711-fd6ca521efaa
         status: 204 No Content
         code: 204
-        duration: 41.87123ms
+        duration: 135.089001ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -793,26 +793,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3630efdd-2523-4b3f-9a52-5dc510686b2b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/20300372-99a5-4956-ae62-81622b0bb166
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 468
-        body: '{"id":"3630efdd-2523-4b3f-9a52-5dc510686b2b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-resource-versions","status":"ready","created_at":"2026-06-24T09:38:38.806136Z","updated_at":"2026-06-24T09:38:41.890014Z","tags":[],"version_count":2,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-06-24T09:38:41.890014Z","key_id":null,"region":"fr-par"}'
+        body: '{"id":"20300372-99a5-4956-ae62-81622b0bb166","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-resource-versions","status":"ready","created_at":"2026-07-03T15:27:54.575729Z","updated_at":"2026-07-03T15:27:59.789427Z","tags":[],"version_count":2,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-07-03T15:27:59.789427Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "468"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:41 GMT
+                - Fri, 03 Jul 2026 15:27:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 0b4a3833-1723-4ef4-838a-94860289d658
+                - 197261ee-c79b-4d25-8988-3e460e266b8e
         status: 200 OK
         code: 200
-        duration: 26.23593ms
+        duration: 40.925719ms

--- a/internal/services/secret/version.go
+++ b/internal/services/secret/version.go
@@ -13,6 +13,7 @@ import (
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/identity"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/locality"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/locality/regional"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/transport"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/types"
 )
 
@@ -142,7 +143,15 @@ func ResourceVersionCreate(ctx context.Context, d *schema.ResourceData, m any) d
 		Description: types.ExpandStringPtr(d.Get("description")),
 	}
 
-	secretResponse, err := api.CreateSecretVersion(secretCreateVersionRequest, scw.WithContext(ctx))
+	var secretResponse *secret.SecretVersion
+
+	err = transport.RetryOn403(ctx, func() error {
+		var err error
+
+		secretResponse, err = api.CreateSecretVersion(secretCreateVersionRequest, scw.WithContext(ctx))
+
+		return err
+	})
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -173,11 +182,14 @@ func ResourceVersionRead(ctx context.Context, d *schema.ResourceData, m any) dia
 		return diag.FromErr(err)
 	}
 
-	secretResponse, err := api.GetSecretVersion(&secret.GetSecretVersionRequest{
-		Region:   region,
-		SecretID: id,
-		Revision: revision,
-	}, scw.WithContext(ctx))
+	// Retry on 404 to handle eventual consistency issues
+	secretResponse, err := transport.RetryOn404(ctx, func(ctx context.Context) (*secret.SecretVersion, error) {
+		return api.GetSecretVersion(&secret.GetSecretVersionRequest{
+			Region:   region,
+			SecretID: id,
+			Revision: revision,
+		}, scw.WithContext(ctx))
+	})
 	if err != nil {
 		if httperrors.Is404(err) {
 			d.SetId("")
@@ -237,11 +249,13 @@ func ResourceVersionDelete(ctx context.Context, d *schema.ResourceData, m any) d
 		return diag.FromErr(err)
 	}
 
-	err = api.DeleteSecretVersion(&secret.DeleteSecretVersionRequest{
-		Region:   region,
-		SecretID: id,
-		Revision: revision,
-	}, scw.WithContext(ctx))
+	err = transport.RetryOn403(ctx, func() error {
+		return api.DeleteSecretVersion(&secret.DeleteSecretVersionRequest{
+			Region:   region,
+			SecretID: id,
+			Revision: revision,
+		}, scw.WithContext(ctx))
+	})
 	if err != nil && !httperrors.Is404(err) {
 		return diag.FromErr(err)
 	}

--- a/internal/transport/retry.go
+++ b/internal/transport/retry.go
@@ -22,6 +22,13 @@ const (
 
 	// RetryOn403WaitTime is the delay between retries on HTTP 403.
 	RetryOn403WaitTime = 2 * time.Second
+
+	// RetryOn404WaitTimeout bounds how long RetryOn404 keeps retrying a transient HTTP 404, typically
+	// to wait for consistency resolution in Secret/KM APIs.
+	RetryOn404WaitTimeout = 30 * time.Second
+
+	// RetryOn404WaitTime is the delay between retries on HTTP 404.
+	RetryOn404WaitTime = 2 * time.Second
 )
 
 // DefaultWaitRetryInterval is used to set the retry interval to 0 during acceptance tests
@@ -180,4 +187,31 @@ func RetryOnTransientStateError[T any, U any](action func() (T, error), waiter f
 	}
 
 	return t, err
+}
+
+// Retries the specified function when it returns a 404 error.
+func RetryOn404[T any](ctx context.Context, f func(context.Context) (T, error)) (T, error) {
+	wait := RetryOn404WaitTime
+	if DefaultWaitRetryInterval != nil {
+		wait = *DefaultWaitRetryInterval
+	}
+
+	deadline := time.Now().Add(RetryOn404WaitTimeout)
+
+	for {
+		result, err := f(ctx)
+		if err == nil {
+			return result, nil
+		}
+
+		if !httperrors.Is404(err) || time.Now().After(deadline) {
+			return result, err
+		}
+
+		select {
+		case <-ctx.Done():
+			return result, ctx.Err()
+		case <-time.After(wait):
+		}
+	}
 }


### PR DESCRIPTION
It was brought to my attention that some secret creations end up in `Provider produced inconsistent result after apply`. 

This appears to be due to a 404 in a Read after Create. However, rerunning a `terraform apply` returns `scaleway-sdk-go: invalid argument(s): name is wrongly formatted, cannot have same secret name in same path`, indicating that the create does properly finalize, but it is the read that fails, seemingly due to a race condition. 

This PR adds:
-  on `GET`  in the secret/kms `read` functions: a 404 retry (30s timeout, 2s backoff) . 
     - why:  this is an uncommon but legitimate scenario on their side, and in this case the 404 error is eventually consistent. The expected handling for their GET/List calls is to retry on 404 errors.
-  on `CREATE`  in the secret/kms `read` functions: a 403 retry (using the existing 2min timeout, 2s retry).
     - why: [similarly to rdb, cockpit](https://github.com/scaleway/terraform-provider-scaleway/commit/8ba88411b12b40ae602fc0ad033ada29298e3375), etc..  this retry allows for the resolution of IAM permissions consistency issues on create.
-  on `DELETE`  in the secret/kms `read` functions: a 403 retry (using the existing 2min timeout, 2s retry).
     - why: in my local tests, I ran into 403 on DELETE a few times that eventually resolved themselves on manual retry. As such, adding the retry here as well seems like a proper solution.