### PR TITLE
chore: force provider-name in `make docs` command

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -76,6 +76,6 @@ format_examples:
 	terraform fmt -recursive examples
 
 docs: format_examples
-	go tool tfplugindocs validate
+	go tool tfplugindocs validate -provider-name scaleway
 	rm -fr ./docs
-	go tool tfplugindocs generate
+	go tool tfplugindocs generate -provider-name scaleway


### PR DESCRIPTION
The Makefile command `make docs` did not work on git worktrees because of the name of the provider that defaulted to the name of the module.
This PR fixes this by providing the provider's name explicitly in the `go tool` commands.