### PR TITLE
feat(k8s): pool name optional and generated if not provided

### DIFF
--- a/docs/resources/k8s_pool.md
+++ b/docs/resources/k8s_pool.md
@@ -14,22 +14,30 @@ Refer to the Kubernetes [documentation](https://www.scaleway.com/en/docs/compute
 ## Example Usage
 
 ```terraform
+resource "scaleway_vpc" "main" {}
+
+resource "scaleway_vpc_private_network" "main" {
+  vpc_id = scaleway_vpc.main.id
+}
+
 resource "scaleway_k8s_cluster" "main" {
-  version = "1.35.3"
-  cni     = "cilium"
+  version                     = "1.35.3"
+  cni                         = "cilium"
+  name                        = "example-cluster"
+  delete_additional_resources = true
+  private_network_id          = scaleway_vpc_private_network.main.id
 }
 
 resource "scaleway_k8s_pool" "main" {
-  cluster_id         = scaleway_k8s_cluster.main.id
-  version            = scaleway_k8s_cluster.main.version
-  node_type          = "DEV1-M"
-  size               = 3
-  min_size           = 0
-  max_size           = 10
-  autoscaling        = true
-  autohealing        = true
-  container_runtime  = "containerd"
-  placement_group_id = "1267e3fd-a51c-49ed-ad12-857092ee3a3d"
+  cluster_id        = scaleway_k8s_cluster.main.id
+  version           = scaleway_k8s_cluster.main.version
+  node_type         = "DEV1-M"
+  size              = 3
+  min_size          = 1
+  max_size          = 10
+  autoscaling       = true
+  autohealing       = true
+  container_runtime = "containerd"
 
   labels = {
     "key" = "value"
@@ -49,6 +57,37 @@ resource "scaleway_k8s_pool" "main" {
 }
 ```
 
+```terraform
+resource "scaleway_vpc" "main" {}
+
+resource "scaleway_vpc_private_network" "main" {
+  vpc_id = scaleway_vpc.main.id
+}
+
+resource "scaleway_k8s_cluster" "main" {
+  version                     = "1.35.3"
+  cni                         = "cilium"
+  name                        = "example-cluster"
+  delete_additional_resources = true
+  private_network_id          = scaleway_vpc_private_network.main.id
+}
+
+resource "scaleway_instance_placement_group" "main" {}
+
+resource "scaleway_k8s_pool" "main" {
+  cluster_id         = scaleway_k8s_cluster.main.id
+  version            = scaleway_k8s_cluster.main.version
+  node_type          = "DEV1-M"
+  size               = 3
+  placement_group_id = scaleway_instance_placement_group.main.id
+
+  # Make sure that the new resource is created before destroying the old one on changes that require replacement
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+```
+
 
 
 
@@ -58,9 +97,11 @@ The following arguments are supported:
 
 - `cluster_id` - (Required) The ID of the Kubernetes cluster on which this pool will be created.
 
-- `name` - (Required) The name for the pool.
+- `name` - (Optional) The name for the pool. If not provided it will be generated.
 
 ~> **Important:** Updates to this field will recreate a new resource.
+
+~> Note: In order to use the `create_before_destroy` option of the `lifecycle` field, `name` has to be generated, otherwise Terraform will try to create the new pool with the same name and the API does not allow that.
 
 - `node_type` - (Required) The commercial type of the pool instances. Instances with insufficient memory are not eligible (DEV1-S, PLAY2-PICO, STARDUST). `external` is a special node type used to provision from other Cloud providers.
 

--- a/examples/resources/scaleway_k8s_pool/resource-placement-group.tf
+++ b/examples/resources/scaleway_k8s_pool/resource-placement-group.tf
@@ -12,27 +12,14 @@ resource "scaleway_k8s_cluster" "main" {
   private_network_id          = scaleway_vpc_private_network.main.id
 }
 
+resource "scaleway_instance_placement_group" "main" {}
+
 resource "scaleway_k8s_pool" "main" {
-  cluster_id        = scaleway_k8s_cluster.main.id
-  version           = scaleway_k8s_cluster.main.version
-  node_type         = "DEV1-M"
-  size              = 3
-  min_size          = 1
-  max_size          = 10
-  autoscaling       = true
-  autohealing       = true
-  container_runtime = "containerd"
-
-  labels = {
-    "key" = "value"
-    "foo" = "bar"
-  }
-
-  taints {
-    key    = "taint-key"
-    value  = "taint-value"
-    effect = "NoSchedule"
-  }
+  cluster_id         = scaleway_k8s_cluster.main.id
+  version            = scaleway_k8s_cluster.main.version
+  node_type          = "DEV1-M"
+  size               = 3
+  placement_group_id = scaleway_instance_placement_group.main.id
 
   # Make sure that the new resource is created before destroying the old one on changes that require replacement
   lifecycle {

--- a/internal/services/k8s/pool.go
+++ b/internal/services/k8s/pool.go
@@ -63,7 +63,7 @@ func poolSchema() map[string]*schema.Schema {
 		},
 		"name": {
 			Type:        schema.TypeString,
-			Required:    true,
+			Optional:    true,
 			ForceNew:    true,
 			Description: "The name of the pool",
 		},

--- a/templates/resources/k8s_pool.md.tmpl
+++ b/templates/resources/k8s_pool.md.tmpl
@@ -25,9 +25,11 @@ The following arguments are supported:
 
 - `cluster_id` - (Required) The ID of the Kubernetes cluster on which this pool will be created.
 
-- `name` - (Required) The name for the pool.
+- `name` - (Optional) The name for the pool. If not provided it will be generated.
 
 ~> **Important:** Updates to this field will recreate a new resource.
+
+~> Note: In order to use the `create_before_destroy` option of the `lifecycle` field, `name` has to be generated, otherwise Terraform will try to create the new pool with the same name and the API does not allow that.
 
 - `node_type` - (Required) The commercial type of the pool instances. Instances with insufficient memory are not eligible (DEV1-S, PLAY2-PICO, STARDUST). `external` is a special node type used to provision from other Cloud providers.
 


### PR DESCRIPTION
This PR fixes the examples given in the documentation so that they can be applied as is (VPC and private network were missing, cluster's required attributes were missing).

Also the `create_before_destroy` option was not working because the new pool was created with the same name as the existing, which is not allowed by the API. 
We can fix this by making the `name` attribute of the pool optional instead of required: when not explicitly defined, the name will be generated, therefore the new pool will be able to be created with a new generated name.

Closes #4161 