### PR TITLE
tests(function): update outdated runtimes in tests

### DIFF
--- a/internal/services/function/cron_test.go
+++ b/internal/services/function/cron_test.go
@@ -29,7 +29,7 @@ func TestAccFunctionCron_Basic(t *testing.T) {
 					resource scaleway_function main {
 						name = "tf-tests-cron-basic"
 						namespace_id = scaleway_function_namespace.main.id
-						runtime = "node20"
+						runtime = "node26"
 						privacy = "private"
 						handler = "handler.handle"
 					}
@@ -68,7 +68,7 @@ func TestAccFunctionCron_NameUpdate(t *testing.T) {
 					resource scaleway_function main {
 						name = "tf-tests-function-cron-name-update"
 						namespace_id = scaleway_function_namespace.main.id
-						runtime = "node20"
+						runtime = "node26"
 						privacy = "private"
 						handler = "handler.handle"
 					}
@@ -95,7 +95,7 @@ func TestAccFunctionCron_NameUpdate(t *testing.T) {
 					resource scaleway_function main {
 						name = "tf-tests-function-cron-name-update"
 						namespace_id = scaleway_function_namespace.main.id
-						runtime = "node20"
+						runtime = "node26"
 						privacy = "private"
 						handler = "handler.handle"
 					}
@@ -133,7 +133,7 @@ func TestAccFunctionCron_WithArgs(t *testing.T) {
 					resource scaleway_function main {
 						name = "tf-tests-cron-with-args"
 						namespace_id = scaleway_function_namespace.main.id
-						runtime = "node20"
+						runtime = "node26"
 						privacy = "private"
 						handler = "handler.handle"
 					}

--- a/internal/services/function/data_source_function_test.go
+++ b/internal/services/function/data_source_function_test.go
@@ -24,7 +24,7 @@ func TestAccDataSourceFunction_Basic(t *testing.T) {
 					resource scaleway_function main {
 						name = "tf-ds-function"
 						namespace_id = scaleway_function_namespace.main.id
-						runtime = "node22"
+						runtime = "node26"
 						privacy = "private"
 						handler = "handler.handle"
 					}
@@ -43,7 +43,7 @@ func TestAccDataSourceFunction_Basic(t *testing.T) {
 					resource scaleway_function main {
 						name = "tf-ds-function"
 						namespace_id = scaleway_function_namespace.main.id
-						runtime = "node22"
+						runtime = "node26"
 						privacy = "private"
 						handler = "handler.handle"
 					}					

--- a/internal/services/function/domain_test.go
+++ b/internal/services/function/domain_test.go
@@ -30,7 +30,7 @@ func TestAccFunctionDomain_Basic(t *testing.T) {
 
 					resource scaleway_function main {
 						namespace_id = scaleway_function_namespace.main.id
-						runtime = "go122"
+						runtime = "go126"
 						privacy = "private"
 						handler = "Handle"
 						zip_file = "testfixture/gofunction.zip"

--- a/internal/services/function/function_test.go
+++ b/internal/services/function/function_test.go
@@ -30,7 +30,7 @@ func TestAccFunction_Basic(t *testing.T) {
 					resource scaleway_function main {
 						name = "foobar"
 						namespace_id = scaleway_function_namespace.main.id
-						runtime = "node22"
+						runtime = "node26"
 						privacy = "private"
 						handler = "handler.handle"
 						tags = ["tag1", "tag2"]
@@ -39,7 +39,7 @@ func TestAccFunction_Basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFunctionExists(tt, "scaleway_function.main"),
 					resource.TestCheckResourceAttr("scaleway_function.main", "name", "foobar"),
-					resource.TestCheckResourceAttr("scaleway_function.main", "runtime", "node22"),
+					resource.TestCheckResourceAttr("scaleway_function.main", "runtime", "node26"),
 					resource.TestCheckResourceAttr("scaleway_function.main", "privacy", "private"),
 					resource.TestCheckResourceAttr("scaleway_function.main", "handler", "handler.handle"),
 					resource.TestCheckResourceAttrSet("scaleway_function.main", "namespace_id"),
@@ -68,7 +68,7 @@ func TestAccFunction_Timeout(t *testing.T) {
 					resource scaleway_function main {
 						name = "foobar"
 						namespace_id = scaleway_function_namespace.main.id
-						runtime = "node22"
+						runtime = "node26"
 						privacy = "private"
 						handler = "handler.handle"
 						timeout = 10
@@ -77,7 +77,7 @@ func TestAccFunction_Timeout(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFunctionExists(tt, "scaleway_function.main"),
 					resource.TestCheckResourceAttr("scaleway_function.main", "name", "foobar"),
-					resource.TestCheckResourceAttr("scaleway_function.main", "runtime", "node22"),
+					resource.TestCheckResourceAttr("scaleway_function.main", "runtime", "node26"),
 					resource.TestCheckResourceAttr("scaleway_function.main", "privacy", "private"),
 					resource.TestCheckResourceAttr("scaleway_function.main", "handler", "handler.handle"),
 					resource.TestCheckResourceAttr("scaleway_function.main", "timeout", "10"),
@@ -101,7 +101,7 @@ func TestAccFunction_NoName(t *testing.T) {
 
 					resource scaleway_function main {
 						namespace_id = scaleway_function_namespace.main.id
-						runtime = "node22"
+						runtime = "node26"
 						privacy = "private"
 						handler = "handler.handle"
 					}
@@ -130,7 +130,7 @@ func TestAccFunction_EnvironmentVariables(t *testing.T) {
 					resource scaleway_function main {
 						name = "foobar"
 						namespace_id = scaleway_function_namespace.main.id
-						runtime = "node22"
+						runtime = "node26"
 						privacy = "private"
 						handler = "handler.handle"
 						environment_variables = {
@@ -155,7 +155,7 @@ func TestAccFunction_EnvironmentVariables(t *testing.T) {
 					resource scaleway_function main {
 						name = "foobar"
 						namespace_id = scaleway_function_namespace.main.id
-						runtime = "node22"
+						runtime = "node26"
 						privacy = "private"
 						handler = "handler.handle"
 						environment_variables = {
@@ -192,7 +192,7 @@ func TestAccFunction_Upload(t *testing.T) {
 					resource scaleway_function main {
 						name = "foobar"
 						namespace_id = scaleway_function_namespace.main.id
-						runtime = "go122"
+						runtime = "go126"
 						privacy = "private"
 						handler = "Handle"
 						zip_file = "testfixture/gofunction.zip"
@@ -221,7 +221,7 @@ func TestAccFunction_Deploy(t *testing.T) {
 					resource scaleway_function main {
 						name = "foobar"
 						namespace_id = scaleway_function_namespace.main.id
-						runtime = "go122"
+						runtime = "go126"
 						privacy = "private"
 						handler = "Handle"
 						zip_file = "testfixture/gofunction.zip"
@@ -239,7 +239,7 @@ func TestAccFunction_Deploy(t *testing.T) {
 					resource scaleway_function main {
 						name = "foobar"
 						namespace_id = scaleway_function_namespace.main.id
-						runtime = "go122"
+						runtime = "go126"
 						privacy = "private"
 						handler = "Handle"
 						zip_file = "testfixture/gofunction.zip"
@@ -270,7 +270,7 @@ func TestAccFunction_HTTPOption(t *testing.T) {
 					resource scaleway_function main {
 						name = "foobar"
 						namespace_id = scaleway_function_namespace.main.id
-						runtime = "node22"
+						runtime = "node26"
 						privacy = "private"
 						handler = "handler.handle"
 						http_option = "enabled"
@@ -288,7 +288,7 @@ func TestAccFunction_HTTPOption(t *testing.T) {
 					resource scaleway_function main {
 						name = "foobar"
 						namespace_id = scaleway_function_namespace.main.id
-						runtime = "node22"
+						runtime = "node26"
 						privacy = "private"
 						handler = "handler.handle"
 						http_option = "redirected"
@@ -306,7 +306,7 @@ func TestAccFunction_HTTPOption(t *testing.T) {
 					resource scaleway_function main {
 						name = "foobar"
 						namespace_id = scaleway_function_namespace.main.id
-						runtime = "node22"
+						runtime = "node26"
 						privacy = "private"
 						handler = "handler.handle"
 					}
@@ -335,7 +335,7 @@ func TestAccFunction_Sandbox(t *testing.T) {
 					resource scaleway_function main {
 						name = "foobar"
 						namespace_id = scaleway_function_namespace.main.id
-						runtime = "node22"
+						runtime = "node26"
 						privacy = "private"
 						handler = "handler.handle"
 					}
@@ -352,7 +352,7 @@ func TestAccFunction_Sandbox(t *testing.T) {
 					resource scaleway_function main {
 						name = "foobar"
 						namespace_id = scaleway_function_namespace.main.id
-						runtime = "node22"
+						runtime = "node26"
 						privacy = "private"
 						handler = "handler.handle"
 						sandbox = "v2"
@@ -370,7 +370,7 @@ func TestAccFunction_Sandbox(t *testing.T) {
 					resource scaleway_function main {
 						name = "foobar"
 						namespace_id = scaleway_function_namespace.main.id
-						runtime = "node22"
+						runtime = "node26"
 						privacy = "private"
 						handler = "handler.handle"
 						sandbox = "v1"
@@ -388,7 +388,7 @@ func TestAccFunction_Sandbox(t *testing.T) {
 					resource scaleway_function main {
 						name = "foobar"
 						namespace_id = scaleway_function_namespace.main.id
-						runtime = "node22"
+						runtime = "node26"
 						privacy = "private"
 						handler = "handler.handle"
 						sandbox = "v2"
@@ -437,7 +437,7 @@ func TestAccFunction_PrivateNetwork(t *testing.T) {
 						name = "test-acc-function-pn-00"
 						namespace_id = scaleway_function_namespace.main.id
 						privacy = "private"
-						runtime = "go123"
+						runtime = "go126"
 						handler = "Handle"
 						sandbox = "v1"
 						private_network_id = scaleway_vpc_private_network.pn00.id
@@ -471,7 +471,7 @@ func TestAccFunction_PrivateNetwork(t *testing.T) {
 						name = "test-acc-function-pn-f00"
 						namespace_id = scaleway_function_namespace.main.id
 						privacy = "private"
-						runtime = "go123"
+						runtime = "go126"
 						handler = "Handle"
 						sandbox = "v1"
 						private_network_id = scaleway_vpc_private_network.pn00.id
@@ -481,7 +481,7 @@ func TestAccFunction_PrivateNetwork(t *testing.T) {
 						name = "test-acc-function-pn-f01"
 						namespace_id = scaleway_function_namespace.main.id
 						privacy = "private"
-						runtime = "go123"
+						runtime = "go126"
 						handler = "Handle"
 						sandbox = "v1"
 						private_network_id = scaleway_vpc_private_network.pn00.id
@@ -491,7 +491,7 @@ func TestAccFunction_PrivateNetwork(t *testing.T) {
 						name = "test-acc-function-pn-f02"
 						namespace_id = scaleway_function_namespace.main.id
 						privacy = "private"
-						runtime = "go123"
+						runtime = "go126"
 						handler = "Handle"
 						sandbox = "v1"
 						private_network_id = scaleway_vpc_private_network.pn00.id
@@ -531,7 +531,7 @@ func TestAccFunction_PrivateNetwork(t *testing.T) {
 						name = "test-acc-function-pn-f00"
 						namespace_id = scaleway_function_namespace.main.id
 						privacy = "private"
-						runtime = "go123"
+						runtime = "go126"
 						handler = "Handle"
 						sandbox = "v1"
 					}
@@ -540,7 +540,7 @@ func TestAccFunction_PrivateNetwork(t *testing.T) {
 						name = "test-acc-function-pn-f01"
 						namespace_id = scaleway_function_namespace.main.id
 						privacy = "private"
-						runtime = "go123"
+						runtime = "go126"
 						handler = "Handle"
 						sandbox = "v1"
 						private_network_id = scaleway_vpc_private_network.pn01.id
@@ -550,7 +550,7 @@ func TestAccFunction_PrivateNetwork(t *testing.T) {
 						name = "test-acc-function-pn-02"
 						namespace_id = scaleway_function_namespace.main.id
 						privacy = "private"
-						runtime = "go123"
+						runtime = "go126"
 						handler = "Handle"
 						sandbox = "v1"
 						private_network_id = scaleway_vpc_private_network.pn00.id

--- a/internal/services/function/testdata/data-source-function-basic.cassette.yaml
+++ b/internal/services/function/testdata/data-source-function-basic.cassette.yaml
@@ -29,7 +29,7 @@ interactions:
         trailer: {}
         content_length: 500
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.831655766Z","description":"","environment_variables":{},"error_message":null,"id":"f3a5e537-c29c-4f59-8730-fbac2d11f3b3","name":"tf-ds-function","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-05-04T12:38:57.831655766Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.925323134Z","description":"","environment_variables":{},"error_message":null,"id":"cb64b31e-c3b0-469e-baf6-7fc8ad8ead9d","name":"tf-ds-function","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-07-03T15:01:47.925323134Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "500"
@@ -38,9 +38,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:38:57 GMT
+                - Fri, 03 Jul 2026 15:01:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 79718ce1-8e83-4bfd-b9b1-919482fc0f07
+                - a082d99c-8d72-4676-92d8-a46b15c44214
         status: 200 OK
         code: 200
-        duration: 1.84606128s
+        duration: 4.393362791s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -68,7 +68,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/f3a5e537-c29c-4f59-8730-fbac2d11f3b3
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/cb64b31e-c3b0-469e-baf6-7fc8ad8ead9d
         method: GET
       response:
         proto: HTTP/2.0
@@ -78,7 +78,7 @@ interactions:
         trailer: {}
         content_length: 494
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.831656Z","description":"","environment_variables":{},"error_message":null,"id":"f3a5e537-c29c-4f59-8730-fbac2d11f3b3","name":"tf-ds-function","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-05-04T12:38:57.831656Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.925323Z","description":"","environment_variables":{},"error_message":null,"id":"cb64b31e-c3b0-469e-baf6-7fc8ad8ead9d","name":"tf-ds-function","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-07-03T15:01:47.925323Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "494"
@@ -87,9 +87,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:38:57 GMT
+                - Fri, 03 Jul 2026 15:01:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 92c9fceb-e130-4b47-8216-014375806d33
+                - cdfc4ca7-65c4-4069-a5c6-8a7fc18e2e52
         status: 200 OK
         code: 200
-        duration: 28.225101ms
+        duration: 41.505719ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -117,7 +117,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/f3a5e537-c29c-4f59-8730-fbac2d11f3b3
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/cb64b31e-c3b0-469e-baf6-7fc8ad8ead9d
         method: GET
       response:
         proto: HTTP/2.0
@@ -127,7 +127,7 @@ interactions:
         trailer: {}
         content_length: 575
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.831656Z","description":"","environment_variables":{},"error_message":null,"id":"f3a5e537-c29c-4f59-8730-fbac2d11f3b3","name":"tf-ds-function","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunction0wb23wag","registry_namespace_id":"12e043d9-7083-40b9-bb75-f98246c88b01","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:25.072876Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.925323Z","description":"","environment_variables":{},"error_message":null,"id":"cb64b31e-c3b0-469e-baf6-7fc8ad8ead9d","name":"tf-ds-function","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunctionikvf2s9q","registry_namespace_id":"e103ceda-ac90-4b14-adc4-6716fe1501cc","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:01:55.482771Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "575"
@@ -136,9 +136,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:28 GMT
+                - Fri, 03 Jul 2026 15:01:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 37cd00db-5859-4c56-b8f3-eca3e0287135
+                - cfc38504-25cc-44d6-bc55-f471def95935
         status: 200 OK
         code: 200
-        duration: 64.129293ms
+        duration: 29.760841ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -166,7 +166,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/f3a5e537-c29c-4f59-8730-fbac2d11f3b3
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/cb64b31e-c3b0-469e-baf6-7fc8ad8ead9d
         method: GET
       response:
         proto: HTTP/2.0
@@ -176,7 +176,7 @@ interactions:
         trailer: {}
         content_length: 575
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.831656Z","description":"","environment_variables":{},"error_message":null,"id":"f3a5e537-c29c-4f59-8730-fbac2d11f3b3","name":"tf-ds-function","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunction0wb23wag","registry_namespace_id":"12e043d9-7083-40b9-bb75-f98246c88b01","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:25.072876Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.925323Z","description":"","environment_variables":{},"error_message":null,"id":"cb64b31e-c3b0-469e-baf6-7fc8ad8ead9d","name":"tf-ds-function","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunctionikvf2s9q","registry_namespace_id":"e103ceda-ac90-4b14-adc4-6716fe1501cc","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:01:55.482771Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "575"
@@ -185,9 +185,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:28 GMT
+                - Fri, 03 Jul 2026 15:01:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,10 +195,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 065db256-723f-439c-a695-3843e0e29ea2
+                - 991eb3b7-f17e-4693-98a2-2e6561674f18
         status: 200 OK
         code: 200
-        duration: 42.654967ms
+        duration: 30.10592ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -210,7 +210,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-ds-function","namespace_id":"f3a5e537-c29c-4f59-8730-fbac2d11f3b3","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node22","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox","tags":null}'
+        body: '{"name":"tf-ds-function","namespace_id":"cb64b31e-c3b0-469e-baf6-7fc8ad8ead9d","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node26","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox","tags":null}'
         form: {}
         headers:
             Content-Type:
@@ -227,7 +227,7 @@ interactions:
         trailer: {}
         content_length: 714
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:28.247349131Z","description":"","domain_name":"tfdsfunction0wb23wag-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e29b610e-ffac-49b2-82ec-c0c1c79bdf05","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"f3a5e537-c29c-4f59-8730-fbac2d11f3b3","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:28.247349131Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:01:58.206272634Z","description":"","domain_name":"tfdsfunctionikvf2s9q-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"9cb69ab4-1b61-4c1d-b8ae-6285c4cdd92a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"cb64b31e-c3b0-469e-baf6-7fc8ad8ead9d","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:01:58.206272634Z"}'
         headers:
             Content-Length:
                 - "714"
@@ -236,9 +236,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:28 GMT
+                - Fri, 03 Jul 2026 15:01:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -246,10 +246,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5e74ca97-5196-4963-b564-83bf8a57a534
+                - 83f43ea5-79ae-41df-8b39-af069c407860
         status: 200 OK
         code: 200
-        duration: 118.0627ms
+        duration: 149.516973ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -266,7 +266,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e29b610e-ffac-49b2-82ec-c0c1c79bdf05
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/9cb69ab4-1b61-4c1d-b8ae-6285c4cdd92a
         method: GET
       response:
         proto: HTTP/2.0
@@ -276,7 +276,7 @@ interactions:
         trailer: {}
         content_length: 708
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:28.247349Z","description":"","domain_name":"tfdsfunction0wb23wag-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e29b610e-ffac-49b2-82ec-c0c1c79bdf05","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"f3a5e537-c29c-4f59-8730-fbac2d11f3b3","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:28.247349Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:01:58.206273Z","description":"","domain_name":"tfdsfunctionikvf2s9q-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"9cb69ab4-1b61-4c1d-b8ae-6285c4cdd92a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"cb64b31e-c3b0-469e-baf6-7fc8ad8ead9d","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:01:58.206273Z"}'
         headers:
             Content-Length:
                 - "708"
@@ -285,9 +285,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:28 GMT
+                - Fri, 03 Jul 2026 15:01:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -295,10 +295,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7a53b80a-805f-4cf7-9078-56aca3bb1c4c
+                - 9adb8ff4-4754-4eb7-8ba5-e038b0131819
         status: 200 OK
         code: 200
-        duration: 63.066913ms
+        duration: 145.667583ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -315,7 +315,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e29b610e-ffac-49b2-82ec-c0c1c79bdf05
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/9cb69ab4-1b61-4c1d-b8ae-6285c4cdd92a
         method: GET
       response:
         proto: HTTP/2.0
@@ -325,7 +325,7 @@ interactions:
         trailer: {}
         content_length: 708
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:28.247349Z","description":"","domain_name":"tfdsfunction0wb23wag-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e29b610e-ffac-49b2-82ec-c0c1c79bdf05","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"f3a5e537-c29c-4f59-8730-fbac2d11f3b3","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:28.247349Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:01:58.206273Z","description":"","domain_name":"tfdsfunctionikvf2s9q-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"9cb69ab4-1b61-4c1d-b8ae-6285c4cdd92a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"cb64b31e-c3b0-469e-baf6-7fc8ad8ead9d","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:01:58.206273Z"}'
         headers:
             Content-Length:
                 - "708"
@@ -334,9 +334,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:28 GMT
+                - Fri, 03 Jul 2026 15:01:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -344,10 +344,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4f939033-470f-45cd-a526-7dacbb88630f
+                - 58c69306-4933-49e1-a092-51dd9b0b0517
         status: 200 OK
         code: 200
-        duration: 38.848996ms
+        duration: 41.795774ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -364,7 +364,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e29b610e-ffac-49b2-82ec-c0c1c79bdf05
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/9cb69ab4-1b61-4c1d-b8ae-6285c4cdd92a
         method: GET
       response:
         proto: HTTP/2.0
@@ -374,7 +374,7 @@ interactions:
         trailer: {}
         content_length: 708
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:28.247349Z","description":"","domain_name":"tfdsfunction0wb23wag-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e29b610e-ffac-49b2-82ec-c0c1c79bdf05","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"f3a5e537-c29c-4f59-8730-fbac2d11f3b3","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:28.247349Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:01:58.206273Z","description":"","domain_name":"tfdsfunctionikvf2s9q-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"9cb69ab4-1b61-4c1d-b8ae-6285c4cdd92a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"cb64b31e-c3b0-469e-baf6-7fc8ad8ead9d","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:01:58.206273Z"}'
         headers:
             Content-Length:
                 - "708"
@@ -383,9 +383,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:28 GMT
+                - Fri, 03 Jul 2026 15:01:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -393,10 +393,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 248f8fa8-3a1f-4387-b284-ad74dd0f8691
+                - 0c8e4775-94a2-4653-bbb8-1c80b8644b53
         status: 200 OK
         code: 200
-        duration: 40.548113ms
+        duration: 49.540449ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -413,7 +413,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/f3a5e537-c29c-4f59-8730-fbac2d11f3b3
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/cb64b31e-c3b0-469e-baf6-7fc8ad8ead9d
         method: GET
       response:
         proto: HTTP/2.0
@@ -423,7 +423,7 @@ interactions:
         trailer: {}
         content_length: 575
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.831656Z","description":"","environment_variables":{},"error_message":null,"id":"f3a5e537-c29c-4f59-8730-fbac2d11f3b3","name":"tf-ds-function","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunction0wb23wag","registry_namespace_id":"12e043d9-7083-40b9-bb75-f98246c88b01","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:25.072876Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.925323Z","description":"","environment_variables":{},"error_message":null,"id":"cb64b31e-c3b0-469e-baf6-7fc8ad8ead9d","name":"tf-ds-function","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunctionikvf2s9q","registry_namespace_id":"e103ceda-ac90-4b14-adc4-6716fe1501cc","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:01:55.482771Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "575"
@@ -432,9 +432,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:28 GMT
+                - Fri, 03 Jul 2026 15:01:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -442,10 +442,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f071292c-cbcc-422e-b862-023e74baf18a
+                - 9d766725-716d-45df-90a9-5ff6ca01e8d2
         status: 200 OK
         code: 200
-        duration: 35.207034ms
+        duration: 40.991631ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -462,7 +462,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e29b610e-ffac-49b2-82ec-c0c1c79bdf05
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/9cb69ab4-1b61-4c1d-b8ae-6285c4cdd92a
         method: GET
       response:
         proto: HTTP/2.0
@@ -472,7 +472,7 @@ interactions:
         trailer: {}
         content_length: 708
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:28.247349Z","description":"","domain_name":"tfdsfunction0wb23wag-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e29b610e-ffac-49b2-82ec-c0c1c79bdf05","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"f3a5e537-c29c-4f59-8730-fbac2d11f3b3","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:28.247349Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:01:58.206273Z","description":"","domain_name":"tfdsfunctionikvf2s9q-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"9cb69ab4-1b61-4c1d-b8ae-6285c4cdd92a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"cb64b31e-c3b0-469e-baf6-7fc8ad8ead9d","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:01:58.206273Z"}'
         headers:
             Content-Length:
                 - "708"
@@ -481,9 +481,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:28 GMT
+                - Fri, 03 Jul 2026 15:01:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -491,10 +491,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b79e4e95-db2d-4038-85fd-288bc49a6c4c
+                - efdeca95-be07-4ddb-b4bc-4b76fcd446d2
         status: 200 OK
         code: 200
-        duration: 37.871476ms
+        duration: 93.054576ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -511,7 +511,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/f3a5e537-c29c-4f59-8730-fbac2d11f3b3
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/cb64b31e-c3b0-469e-baf6-7fc8ad8ead9d
         method: GET
       response:
         proto: HTTP/2.0
@@ -521,7 +521,7 @@ interactions:
         trailer: {}
         content_length: 575
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.831656Z","description":"","environment_variables":{},"error_message":null,"id":"f3a5e537-c29c-4f59-8730-fbac2d11f3b3","name":"tf-ds-function","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunction0wb23wag","registry_namespace_id":"12e043d9-7083-40b9-bb75-f98246c88b01","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:25.072876Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.925323Z","description":"","environment_variables":{},"error_message":null,"id":"cb64b31e-c3b0-469e-baf6-7fc8ad8ead9d","name":"tf-ds-function","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunctionikvf2s9q","registry_namespace_id":"e103ceda-ac90-4b14-adc4-6716fe1501cc","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:01:55.482771Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "575"
@@ -530,9 +530,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:28 GMT
+                - Fri, 03 Jul 2026 15:01:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -540,10 +540,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ae32baeb-b491-4c2f-9f65-d4ffac69ddb6
+                - c38525aa-8f60-4b87-9f6f-62c5aba6de5c
         status: 200 OK
         code: 200
-        duration: 31.329177ms
+        duration: 39.319446ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -560,7 +560,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e29b610e-ffac-49b2-82ec-c0c1c79bdf05
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/9cb69ab4-1b61-4c1d-b8ae-6285c4cdd92a
         method: GET
       response:
         proto: HTTP/2.0
@@ -570,7 +570,7 @@ interactions:
         trailer: {}
         content_length: 708
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:28.247349Z","description":"","domain_name":"tfdsfunction0wb23wag-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e29b610e-ffac-49b2-82ec-c0c1c79bdf05","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"f3a5e537-c29c-4f59-8730-fbac2d11f3b3","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:28.247349Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:01:58.206273Z","description":"","domain_name":"tfdsfunctionikvf2s9q-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"9cb69ab4-1b61-4c1d-b8ae-6285c4cdd92a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"cb64b31e-c3b0-469e-baf6-7fc8ad8ead9d","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:01:58.206273Z"}'
         headers:
             Content-Length:
                 - "708"
@@ -579,9 +579,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:29 GMT
+                - Fri, 03 Jul 2026 15:01:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -589,10 +589,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9d1467e2-ae40-45fe-a6aa-22b4e43a730f
+                - f0fc28b5-b793-4f46-8aed-0cdaa7bfc8be
         status: 200 OK
         code: 200
-        duration: 50.907835ms
+        duration: 50.911719ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -609,7 +609,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions?name=tf-ds-function&namespace_id=f3a5e537-c29c-4f59-8730-fbac2d11f3b3&order_by=created_at_asc
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions?name=tf-ds-function&namespace_id=cb64b31e-c3b0-469e-baf6-7fc8ad8ead9d&order_by=created_at_asc
         method: GET
       response:
         proto: HTTP/2.0
@@ -619,7 +619,7 @@ interactions:
         trailer: {}
         content_length: 740
         uncompressed: false
-        body: '{"functions":[{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:28.247349Z","description":"","domain_name":"tfdsfunction0wb23wag-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e29b610e-ffac-49b2-82ec-c0c1c79bdf05","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"f3a5e537-c29c-4f59-8730-fbac2d11f3b3","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:28.247349Z"}],"total_count":1}'
+        body: '{"functions":[{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:01:58.206273Z","description":"","domain_name":"tfdsfunctionikvf2s9q-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"9cb69ab4-1b61-4c1d-b8ae-6285c4cdd92a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"cb64b31e-c3b0-469e-baf6-7fc8ad8ead9d","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:01:58.206273Z"}],"total_count":1}'
         headers:
             Content-Length:
                 - "740"
@@ -628,9 +628,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:29 GMT
+                - Fri, 03 Jul 2026 15:01:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -638,10 +638,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 269325ee-e5ba-4da0-9d10-eddcbbfe6ada
+                - e86dda09-e11c-4945-bfef-f02d1dc8cd34
         status: 200 OK
         code: 200
-        duration: 55.208097ms
+        duration: 48.01463ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -658,7 +658,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e29b610e-ffac-49b2-82ec-c0c1c79bdf05
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/9cb69ab4-1b61-4c1d-b8ae-6285c4cdd92a
         method: GET
       response:
         proto: HTTP/2.0
@@ -668,7 +668,7 @@ interactions:
         trailer: {}
         content_length: 708
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:28.247349Z","description":"","domain_name":"tfdsfunction0wb23wag-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e29b610e-ffac-49b2-82ec-c0c1c79bdf05","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"f3a5e537-c29c-4f59-8730-fbac2d11f3b3","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:28.247349Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:01:58.206273Z","description":"","domain_name":"tfdsfunctionikvf2s9q-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"9cb69ab4-1b61-4c1d-b8ae-6285c4cdd92a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"cb64b31e-c3b0-469e-baf6-7fc8ad8ead9d","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:01:58.206273Z"}'
         headers:
             Content-Length:
                 - "708"
@@ -677,9 +677,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:29 GMT
+                - Fri, 03 Jul 2026 15:01:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -687,10 +687,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4706ee47-afde-4766-8700-1b53a3a5b049
+                - 384866cf-140f-4cef-a283-75d74ae7c5f8
         status: 200 OK
         code: 200
-        duration: 85.115349ms
+        duration: 54.702067ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -707,7 +707,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e29b610e-ffac-49b2-82ec-c0c1c79bdf05
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/9cb69ab4-1b61-4c1d-b8ae-6285c4cdd92a
         method: GET
       response:
         proto: HTTP/2.0
@@ -717,7 +717,7 @@ interactions:
         trailer: {}
         content_length: 708
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:28.247349Z","description":"","domain_name":"tfdsfunction0wb23wag-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e29b610e-ffac-49b2-82ec-c0c1c79bdf05","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"f3a5e537-c29c-4f59-8730-fbac2d11f3b3","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:28.247349Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:01:58.206273Z","description":"","domain_name":"tfdsfunctionikvf2s9q-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"9cb69ab4-1b61-4c1d-b8ae-6285c4cdd92a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"cb64b31e-c3b0-469e-baf6-7fc8ad8ead9d","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:01:58.206273Z"}'
         headers:
             Content-Length:
                 - "708"
@@ -726,9 +726,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:29 GMT
+                - Fri, 03 Jul 2026 15:01:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -736,10 +736,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 746043d3-081c-42e8-81b2-55726abfb4f6
+                - 8ff449df-f375-4db1-8379-bd7987d5aa0d
         status: 200 OK
         code: 200
-        duration: 46.909954ms
+        duration: 64.916256ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -756,7 +756,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e29b610e-ffac-49b2-82ec-c0c1c79bdf05
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/9cb69ab4-1b61-4c1d-b8ae-6285c4cdd92a
         method: GET
       response:
         proto: HTTP/2.0
@@ -766,7 +766,7 @@ interactions:
         trailer: {}
         content_length: 708
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:28.247349Z","description":"","domain_name":"tfdsfunction0wb23wag-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e29b610e-ffac-49b2-82ec-c0c1c79bdf05","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"f3a5e537-c29c-4f59-8730-fbac2d11f3b3","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:28.247349Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:01:58.206273Z","description":"","domain_name":"tfdsfunctionikvf2s9q-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"9cb69ab4-1b61-4c1d-b8ae-6285c4cdd92a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"cb64b31e-c3b0-469e-baf6-7fc8ad8ead9d","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:01:58.206273Z"}'
         headers:
             Content-Length:
                 - "708"
@@ -775,9 +775,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:29 GMT
+                - Fri, 03 Jul 2026 15:01:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -785,10 +785,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cb9d593f-a822-4eb3-8a18-c1714c16d8af
+                - b1dd264b-96d6-4b7e-a792-8760a138f693
         status: 200 OK
         code: 200
-        duration: 48.585967ms
+        duration: 59.966747ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -805,7 +805,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e29b610e-ffac-49b2-82ec-c0c1c79bdf05
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/9cb69ab4-1b61-4c1d-b8ae-6285c4cdd92a
         method: GET
       response:
         proto: HTTP/2.0
@@ -815,7 +815,7 @@ interactions:
         trailer: {}
         content_length: 708
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:28.247349Z","description":"","domain_name":"tfdsfunction0wb23wag-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e29b610e-ffac-49b2-82ec-c0c1c79bdf05","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"f3a5e537-c29c-4f59-8730-fbac2d11f3b3","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:28.247349Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:01:58.206273Z","description":"","domain_name":"tfdsfunctionikvf2s9q-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"9cb69ab4-1b61-4c1d-b8ae-6285c4cdd92a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"cb64b31e-c3b0-469e-baf6-7fc8ad8ead9d","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:01:58.206273Z"}'
         headers:
             Content-Length:
                 - "708"
@@ -824,9 +824,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:29 GMT
+                - Fri, 03 Jul 2026 15:01:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -834,10 +834,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dac40afc-e200-4735-8688-2752b1d91578
+                - 7155484b-5ae6-40bf-96bb-9055c2171a3b
         status: 200 OK
         code: 200
-        duration: 42.984758ms
+        duration: 41.202869ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -854,7 +854,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions?name=tf-ds-function&namespace_id=f3a5e537-c29c-4f59-8730-fbac2d11f3b3&order_by=created_at_asc
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions?name=tf-ds-function&namespace_id=cb64b31e-c3b0-469e-baf6-7fc8ad8ead9d&order_by=created_at_asc
         method: GET
       response:
         proto: HTTP/2.0
@@ -864,7 +864,7 @@ interactions:
         trailer: {}
         content_length: 740
         uncompressed: false
-        body: '{"functions":[{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:28.247349Z","description":"","domain_name":"tfdsfunction0wb23wag-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e29b610e-ffac-49b2-82ec-c0c1c79bdf05","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"f3a5e537-c29c-4f59-8730-fbac2d11f3b3","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:28.247349Z"}],"total_count":1}'
+        body: '{"functions":[{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:01:58.206273Z","description":"","domain_name":"tfdsfunctionikvf2s9q-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"9cb69ab4-1b61-4c1d-b8ae-6285c4cdd92a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"cb64b31e-c3b0-469e-baf6-7fc8ad8ead9d","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:01:58.206273Z"}],"total_count":1}'
         headers:
             Content-Length:
                 - "740"
@@ -873,9 +873,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:29 GMT
+                - Fri, 03 Jul 2026 15:01:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -883,10 +883,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d68b34d3-0794-4cd4-8cfc-5ecd45f1cbd6
+                - 87480fae-574c-456d-be7b-334f046c0414
         status: 200 OK
         code: 200
-        duration: 54.086536ms
+        duration: 44.817076ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -903,7 +903,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e29b610e-ffac-49b2-82ec-c0c1c79bdf05
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/9cb69ab4-1b61-4c1d-b8ae-6285c4cdd92a
         method: GET
       response:
         proto: HTTP/2.0
@@ -913,7 +913,7 @@ interactions:
         trailer: {}
         content_length: 708
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:28.247349Z","description":"","domain_name":"tfdsfunction0wb23wag-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e29b610e-ffac-49b2-82ec-c0c1c79bdf05","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"f3a5e537-c29c-4f59-8730-fbac2d11f3b3","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:28.247349Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:01:58.206273Z","description":"","domain_name":"tfdsfunctionikvf2s9q-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"9cb69ab4-1b61-4c1d-b8ae-6285c4cdd92a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"cb64b31e-c3b0-469e-baf6-7fc8ad8ead9d","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:01:58.206273Z"}'
         headers:
             Content-Length:
                 - "708"
@@ -922,9 +922,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:29 GMT
+                - Fri, 03 Jul 2026 15:01:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -932,10 +932,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 35dcf7e0-9106-4f0d-aa7d-8a353091e588
+                - a2d9b175-5425-48cc-abaf-0361fa8e83dc
         status: 200 OK
         code: 200
-        duration: 55.348421ms
+        duration: 39.079996ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -952,7 +952,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/f3a5e537-c29c-4f59-8730-fbac2d11f3b3
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/cb64b31e-c3b0-469e-baf6-7fc8ad8ead9d
         method: GET
       response:
         proto: HTTP/2.0
@@ -962,7 +962,7 @@ interactions:
         trailer: {}
         content_length: 575
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.831656Z","description":"","environment_variables":{},"error_message":null,"id":"f3a5e537-c29c-4f59-8730-fbac2d11f3b3","name":"tf-ds-function","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunction0wb23wag","registry_namespace_id":"12e043d9-7083-40b9-bb75-f98246c88b01","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:25.072876Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.925323Z","description":"","environment_variables":{},"error_message":null,"id":"cb64b31e-c3b0-469e-baf6-7fc8ad8ead9d","name":"tf-ds-function","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunctionikvf2s9q","registry_namespace_id":"e103ceda-ac90-4b14-adc4-6716fe1501cc","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:01:55.482771Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "575"
@@ -971,9 +971,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:29 GMT
+                - Fri, 03 Jul 2026 15:01:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -981,10 +981,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 55235e2d-3a9c-49fa-909c-bde6e5f0880f
+                - c514c936-1b15-4439-b306-766e5e1540dd
         status: 200 OK
         code: 200
-        duration: 33.497647ms
+        duration: 31.546629ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1001,7 +1001,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e29b610e-ffac-49b2-82ec-c0c1c79bdf05
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/9cb69ab4-1b61-4c1d-b8ae-6285c4cdd92a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1011,7 +1011,7 @@ interactions:
         trailer: {}
         content_length: 708
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:28.247349Z","description":"","domain_name":"tfdsfunction0wb23wag-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e29b610e-ffac-49b2-82ec-c0c1c79bdf05","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"f3a5e537-c29c-4f59-8730-fbac2d11f3b3","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:28.247349Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:01:58.206273Z","description":"","domain_name":"tfdsfunctionikvf2s9q-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"9cb69ab4-1b61-4c1d-b8ae-6285c4cdd92a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"cb64b31e-c3b0-469e-baf6-7fc8ad8ead9d","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:01:58.206273Z"}'
         headers:
             Content-Length:
                 - "708"
@@ -1020,9 +1020,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:29 GMT
+                - Fri, 03 Jul 2026 15:01:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1030,10 +1030,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 20ea811b-7376-4b4a-ac80-658c57af06b3
+                - de416ac7-9ad4-4b4f-b269-81291d8e31dd
         status: 200 OK
         code: 200
-        duration: 37.55953ms
+        duration: 39.632736ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1050,7 +1050,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions?name=tf-ds-function&namespace_id=f3a5e537-c29c-4f59-8730-fbac2d11f3b3&order_by=created_at_asc
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions?name=tf-ds-function&namespace_id=cb64b31e-c3b0-469e-baf6-7fc8ad8ead9d&order_by=created_at_asc
         method: GET
       response:
         proto: HTTP/2.0
@@ -1060,7 +1060,7 @@ interactions:
         trailer: {}
         content_length: 740
         uncompressed: false
-        body: '{"functions":[{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:28.247349Z","description":"","domain_name":"tfdsfunction0wb23wag-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e29b610e-ffac-49b2-82ec-c0c1c79bdf05","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"f3a5e537-c29c-4f59-8730-fbac2d11f3b3","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:28.247349Z"}],"total_count":1}'
+        body: '{"functions":[{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:01:58.206273Z","description":"","domain_name":"tfdsfunctionikvf2s9q-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"9cb69ab4-1b61-4c1d-b8ae-6285c4cdd92a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"cb64b31e-c3b0-469e-baf6-7fc8ad8ead9d","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:01:58.206273Z"}],"total_count":1}'
         headers:
             Content-Length:
                 - "740"
@@ -1069,9 +1069,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:30 GMT
+                - Fri, 03 Jul 2026 15:01:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1079,10 +1079,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 87957d3b-61b4-4fd1-8ab6-6afe99c4cc81
+                - 5fc615ca-7bb3-4133-8a17-d6b3c9e7f4e4
         status: 200 OK
         code: 200
-        duration: 289.731105ms
+        duration: 49.654224ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1099,7 +1099,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e29b610e-ffac-49b2-82ec-c0c1c79bdf05
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/9cb69ab4-1b61-4c1d-b8ae-6285c4cdd92a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1109,7 +1109,7 @@ interactions:
         trailer: {}
         content_length: 708
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:28.247349Z","description":"","domain_name":"tfdsfunction0wb23wag-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e29b610e-ffac-49b2-82ec-c0c1c79bdf05","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"f3a5e537-c29c-4f59-8730-fbac2d11f3b3","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:28.247349Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:01:58.206273Z","description":"","domain_name":"tfdsfunctionikvf2s9q-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"9cb69ab4-1b61-4c1d-b8ae-6285c4cdd92a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"cb64b31e-c3b0-469e-baf6-7fc8ad8ead9d","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:01:58.206273Z"}'
         headers:
             Content-Length:
                 - "708"
@@ -1118,9 +1118,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:30 GMT
+                - Fri, 03 Jul 2026 15:01:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1128,10 +1128,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3b7e4de0-5b90-4d3a-bcee-16dd09da5b29
+                - 0d14d50e-0eab-4955-b6c4-08366566c1ab
         status: 200 OK
         code: 200
-        duration: 98.730447ms
+        duration: 58.675219ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1148,7 +1148,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e29b610e-ffac-49b2-82ec-c0c1c79bdf05
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/9cb69ab4-1b61-4c1d-b8ae-6285c4cdd92a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1158,7 +1158,7 @@ interactions:
         trailer: {}
         content_length: 708
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:28.247349Z","description":"","domain_name":"tfdsfunction0wb23wag-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e29b610e-ffac-49b2-82ec-c0c1c79bdf05","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"f3a5e537-c29c-4f59-8730-fbac2d11f3b3","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:28.247349Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:01:58.206273Z","description":"","domain_name":"tfdsfunctionikvf2s9q-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"9cb69ab4-1b61-4c1d-b8ae-6285c4cdd92a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"cb64b31e-c3b0-469e-baf6-7fc8ad8ead9d","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:01:58.206273Z"}'
         headers:
             Content-Length:
                 - "708"
@@ -1167,9 +1167,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:30 GMT
+                - Fri, 03 Jul 2026 15:02:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1177,10 +1177,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4ef2520c-733e-4fd4-a55e-cb00a1c0924b
+                - 385c4850-114e-414c-8c04-5797d92c159c
         status: 200 OK
         code: 200
-        duration: 404.189234ms
+        duration: 50.38614ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1197,7 +1197,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e29b610e-ffac-49b2-82ec-c0c1c79bdf05
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/9cb69ab4-1b61-4c1d-b8ae-6285c4cdd92a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1207,7 +1207,7 @@ interactions:
         trailer: {}
         content_length: 708
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:28.247349Z","description":"","domain_name":"tfdsfunction0wb23wag-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e29b610e-ffac-49b2-82ec-c0c1c79bdf05","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"f3a5e537-c29c-4f59-8730-fbac2d11f3b3","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:28.247349Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:01:58.206273Z","description":"","domain_name":"tfdsfunctionikvf2s9q-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"9cb69ab4-1b61-4c1d-b8ae-6285c4cdd92a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"cb64b31e-c3b0-469e-baf6-7fc8ad8ead9d","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:01:58.206273Z"}'
         headers:
             Content-Length:
                 - "708"
@@ -1216,9 +1216,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:30 GMT
+                - Fri, 03 Jul 2026 15:02:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1226,10 +1226,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ab539572-1909-4a86-985b-e98acde5d0a0
+                - 1ca93bfc-6bf0-41c9-bd17-1ef2851b63f6
         status: 200 OK
         code: 200
-        duration: 52.037501ms
+        duration: 91.012805ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1246,7 +1246,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e29b610e-ffac-49b2-82ec-c0c1c79bdf05
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/9cb69ab4-1b61-4c1d-b8ae-6285c4cdd92a
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1256,7 +1256,7 @@ interactions:
         trailer: {}
         content_length: 712
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:28.247349Z","description":"","domain_name":"tfdsfunction0wb23wag-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e29b610e-ffac-49b2-82ec-c0c1c79bdf05","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"f3a5e537-c29c-4f59-8730-fbac2d11f3b3","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:30.496627230Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:01:58.206273Z","description":"","domain_name":"tfdsfunctionikvf2s9q-tf-ds-function.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"9cb69ab4-1b61-4c1d-b8ae-6285c4cdd92a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-ds-function","namespace_id":"cb64b31e-c3b0-469e-baf6-7fc8ad8ead9d","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:00.405921427Z"}'
         headers:
             Content-Length:
                 - "712"
@@ -1265,9 +1265,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:30 GMT
+                - Fri, 03 Jul 2026 15:02:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1275,10 +1275,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 510bcf83-5b02-41d1-b59f-991fe903857f
+                - 80489e91-cfa1-48c3-9a3f-ca6eea3caf34
         status: 200 OK
         code: 200
-        duration: 150.082398ms
+        duration: 252.613664ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1295,7 +1295,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/f3a5e537-c29c-4f59-8730-fbac2d11f3b3
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/cb64b31e-c3b0-469e-baf6-7fc8ad8ead9d
         method: GET
       response:
         proto: HTTP/2.0
@@ -1305,7 +1305,7 @@ interactions:
         trailer: {}
         content_length: 575
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.831656Z","description":"","environment_variables":{},"error_message":null,"id":"f3a5e537-c29c-4f59-8730-fbac2d11f3b3","name":"tf-ds-function","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunction0wb23wag","registry_namespace_id":"12e043d9-7083-40b9-bb75-f98246c88b01","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:25.072876Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.925323Z","description":"","environment_variables":{},"error_message":null,"id":"cb64b31e-c3b0-469e-baf6-7fc8ad8ead9d","name":"tf-ds-function","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunctionikvf2s9q","registry_namespace_id":"e103ceda-ac90-4b14-adc4-6716fe1501cc","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:01:55.482771Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "575"
@@ -1314,9 +1314,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:30 GMT
+                - Fri, 03 Jul 2026 15:02:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1324,10 +1324,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a5de6d3a-5fca-40c8-a244-c166bab98507
+                - 8db3f10c-298e-49bf-9ea7-914e44c6eac5
         status: 200 OK
         code: 200
-        duration: 44.111618ms
+        duration: 41.985331ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1344,7 +1344,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/f3a5e537-c29c-4f59-8730-fbac2d11f3b3
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/cb64b31e-c3b0-469e-baf6-7fc8ad8ead9d
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1354,7 +1354,7 @@ interactions:
         trailer: {}
         content_length: 581
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.831656Z","description":"","environment_variables":{},"error_message":null,"id":"f3a5e537-c29c-4f59-8730-fbac2d11f3b3","name":"tf-ds-function","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunction0wb23wag","registry_namespace_id":"12e043d9-7083-40b9-bb75-f98246c88b01","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-05-04T12:39:30.679348990Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.925323Z","description":"","environment_variables":{},"error_message":null,"id":"cb64b31e-c3b0-469e-baf6-7fc8ad8ead9d","name":"tf-ds-function","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunctionikvf2s9q","registry_namespace_id":"e103ceda-ac90-4b14-adc4-6716fe1501cc","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-07-03T15:02:00.687793964Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "581"
@@ -1363,9 +1363,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:30 GMT
+                - Fri, 03 Jul 2026 15:02:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1373,10 +1373,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5d33a9f1-c6c5-4a25-b150-dbefeccff491
+                - 6e622711-3b96-4f31-ac9a-4738db4225f0
         status: 200 OK
         code: 200
-        duration: 316.490604ms
+        duration: 308.088765ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1393,7 +1393,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/f3a5e537-c29c-4f59-8730-fbac2d11f3b3
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/cb64b31e-c3b0-469e-baf6-7fc8ad8ead9d
         method: GET
       response:
         proto: HTTP/2.0
@@ -1403,7 +1403,7 @@ interactions:
         trailer: {}
         content_length: 578
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.831656Z","description":"","environment_variables":{},"error_message":null,"id":"f3a5e537-c29c-4f59-8730-fbac2d11f3b3","name":"tf-ds-function","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunction0wb23wag","registry_namespace_id":"12e043d9-7083-40b9-bb75-f98246c88b01","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-05-04T12:39:30.679349Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.925323Z","description":"","environment_variables":{},"error_message":null,"id":"cb64b31e-c3b0-469e-baf6-7fc8ad8ead9d","name":"tf-ds-function","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfdsfunctionikvf2s9q","registry_namespace_id":"e103ceda-ac90-4b14-adc4-6716fe1501cc","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-07-03T15:02:00.687794Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "578"
@@ -1412,9 +1412,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:30 GMT
+                - Fri, 03 Jul 2026 15:02:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1422,10 +1422,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 57dd20b8-503b-4bf0-bb6d-f3cb22b368c6
+                - e557deb2-e0cb-42a2-8afd-a1041c384a9b
         status: 200 OK
         code: 200
-        duration: 29.473155ms
+        duration: 43.507574ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1442,7 +1442,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/f3a5e537-c29c-4f59-8730-fbac2d11f3b3
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/cb64b31e-c3b0-469e-baf6-7fc8ad8ead9d
         method: GET
       response:
         proto: HTTP/2.0
@@ -1461,9 +1461,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:36 GMT
+                - Fri, 03 Jul 2026 15:02:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1471,10 +1471,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 419e7e3f-4282-430b-bfb0-29c1dcbe295d
+                - de61d711-0be9-440e-99e4-f076fa419411
         status: 404 Not Found
         code: 404
-        duration: 65.882675ms
+        duration: 33.484404ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1491,7 +1491,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e29b610e-ffac-49b2-82ec-c0c1c79bdf05
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/9cb69ab4-1b61-4c1d-b8ae-6285c4cdd92a
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1510,9 +1510,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:36 GMT
+                - Fri, 03 Jul 2026 15:02:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1520,10 +1520,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2af1638e-38cb-4ff1-a9a7-0f6dec2863d5
+                - abf85a5c-f8c3-42c9-a978-5b28d8955f38
         status: 404 Not Found
         code: 404
-        duration: 68.081732ms
+        duration: 29.270789ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1540,7 +1540,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e29b610e-ffac-49b2-82ec-c0c1c79bdf05
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/9cb69ab4-1b61-4c1d-b8ae-6285c4cdd92a
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1559,9 +1559,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:36 GMT
+                - Fri, 03 Jul 2026 15:02:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1569,10 +1569,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2b186ebb-0e48-4507-967d-21981fe97c4a
+                - 7a321ab3-c8a3-42d2-a35f-b63ef6c069a7
         status: 404 Not Found
         code: 404
-        duration: 23.695936ms
+        duration: 20.438248ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1589,7 +1589,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e29b610e-ffac-49b2-82ec-c0c1c79bdf05
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/9cb69ab4-1b61-4c1d-b8ae-6285c4cdd92a
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1608,9 +1608,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:36 GMT
+                - Fri, 03 Jul 2026 15:02:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1618,7 +1618,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d1a14139-4584-4ad0-8e82-af69cf683726
+                - 80c4701f-60f6-4a0e-93cc-eb6d80b7796a
         status: 404 Not Found
         code: 404
-        duration: 87.309011ms
+        duration: 24.204962ms

--- a/internal/services/function/testdata/data-source-function-namespace-basic.cassette.yaml
+++ b/internal/services/function/testdata/data-source-function-namespace-basic.cassette.yaml
@@ -29,7 +29,7 @@ interactions:
         trailer: {}
         content_length: 498
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.825839612Z","description":"","environment_variables":{},"error_message":null,"id":"e08913fd-9b67-4c8e-b68b-779c58433459","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-05-04T12:38:57.825839612Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.489088696Z","description":"","environment_variables":{},"error_message":null,"id":"efe72a18-22cb-47eb-87a2-6fcfbcd372d0","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-07-03T15:01:47.489088696Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "498"
@@ -38,9 +38,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:38:57 GMT
+                - Fri, 03 Jul 2026 15:01:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 86cd0acb-fc5c-403e-9437-2f205a27b346
+                - 329e34a7-35ff-4474-a3c5-9b756edb73a0
         status: 200 OK
         code: 200
-        duration: 1.818614505s
+        duration: 8.011812243s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -68,7 +68,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e08913fd-9b67-4c8e-b68b-779c58433459
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/efe72a18-22cb-47eb-87a2-6fcfbcd372d0
         method: GET
       response:
         proto: HTTP/2.0
@@ -78,7 +78,7 @@ interactions:
         trailer: {}
         content_length: 492
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.825840Z","description":"","environment_variables":{},"error_message":null,"id":"e08913fd-9b67-4c8e-b68b-779c58433459","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-05-04T12:38:57.825840Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.489089Z","description":"","environment_variables":{},"error_message":null,"id":"efe72a18-22cb-47eb-87a2-6fcfbcd372d0","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-07-03T15:01:47.489089Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "492"
@@ -87,9 +87,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:38:57 GMT
+                - Fri, 03 Jul 2026 15:01:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0bf8cb00-b0f9-4385-a4bc-780bbd34fb4e
+                - e74ad699-d0ac-43b1-878a-a4287884c0d5
         status: 200 OK
         code: 200
-        duration: 38.907708ms
+        duration: 34.340363ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -117,7 +117,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e08913fd-9b67-4c8e-b68b-779c58433459
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/efe72a18-22cb-47eb-87a2-6fcfbcd372d0
         method: GET
       response:
         proto: HTTP/2.0
@@ -127,7 +127,7 @@ interactions:
         trailer: {}
         content_length: 571
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.825840Z","description":"","environment_variables":{},"error_message":null,"id":"e08913fd-9b67-4c8e-b68b-779c58433459","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdataxaockfy1","registry_namespace_id":"b5145ab0-aaf4-4061-921e-db1774b44571","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:09.775268Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.489089Z","description":"","environment_variables":{},"error_message":null,"id":"efe72a18-22cb-47eb-87a2-6fcfbcd372d0","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdatalej38wa2","registry_namespace_id":"49637118-d193-4756-89fb-c88c8a8b9ce3","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:00.571528Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "571"
@@ -136,9 +136,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:12 GMT
+                - Fri, 03 Jul 2026 15:02:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 85af280b-b81e-4cef-b568-41dcf7ff41b4
+                - d27164dd-78cb-4fff-b029-17355d8d1839
         status: 200 OK
         code: 200
-        duration: 35.425541ms
+        duration: 34.640177ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -166,7 +166,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e08913fd-9b67-4c8e-b68b-779c58433459
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/efe72a18-22cb-47eb-87a2-6fcfbcd372d0
         method: GET
       response:
         proto: HTTP/2.0
@@ -176,7 +176,7 @@ interactions:
         trailer: {}
         content_length: 571
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.825840Z","description":"","environment_variables":{},"error_message":null,"id":"e08913fd-9b67-4c8e-b68b-779c58433459","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdataxaockfy1","registry_namespace_id":"b5145ab0-aaf4-4061-921e-db1774b44571","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:09.775268Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.489089Z","description":"","environment_variables":{},"error_message":null,"id":"efe72a18-22cb-47eb-87a2-6fcfbcd372d0","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdatalej38wa2","registry_namespace_id":"49637118-d193-4756-89fb-c88c8a8b9ce3","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:00.571528Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "571"
@@ -185,9 +185,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:13 GMT
+                - Fri, 03 Jul 2026 15:02:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,11 +195,60 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f52b0b45-6ad9-44ed-9aff-6f5682e239b2
+                - b173ffb8-e969-4af8-a105-a69c8ce87d58
         status: 200 OK
         code: 200
-        duration: 31.999695ms
+        duration: 79.624908ms
     - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/efe72a18-22cb-47eb-87a2-6fcfbcd372d0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 571
+        uncompressed: false
+        body: '{"created_at":"2026-07-03T15:01:47.489089Z","description":"","environment_variables":{},"error_message":null,"id":"efe72a18-22cb-47eb-87a2-6fcfbcd372d0","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdatalej38wa2","registry_namespace_id":"49637118-d193-4756-89fb-c88c8a8b9ce3","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:00.571528Z","vpc_integration_activated":false}'
+        headers:
+            Content-Length:
+                - "571"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:02:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 6b70cf0c-24a9-4927-b1f2-240edc38c7a6
+        status: 200 OK
+        code: 200
+        duration: 38.496479ms
+    - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -225,7 +274,7 @@ interactions:
         trailer: {}
         content_length: 604
         uncompressed: false
-        body: '{"namespaces":[{"created_at":"2026-05-04T12:38:57.825840Z","description":"","environment_variables":{},"error_message":null,"id":"e08913fd-9b67-4c8e-b68b-779c58433459","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdataxaockfy1","registry_namespace_id":"b5145ab0-aaf4-4061-921e-db1774b44571","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:09.775268Z","vpc_integration_activated":false}],"total_count":1}'
+        body: '{"namespaces":[{"created_at":"2026-07-03T15:01:47.489089Z","description":"","environment_variables":{},"error_message":null,"id":"efe72a18-22cb-47eb-87a2-6fcfbcd372d0","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdatalej38wa2","registry_namespace_id":"49637118-d193-4756-89fb-c88c8a8b9ce3","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:00.571528Z","vpc_integration_activated":false}],"total_count":1}'
         headers:
             Content-Length:
                 - "604"
@@ -234,9 +283,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:13 GMT
+                - Fri, 03 Jul 2026 15:02:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -244,59 +293,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e1d95276-6540-458f-b236-36f899e21ead
+                - 4a3b5cfe-921c-4ecf-bb4b-b75eda13a26f
         status: 200 OK
         code: 200
-        duration: 49.850982ms
-    - id: 5
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e08913fd-9b67-4c8e-b68b-779c58433459
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 571
-        uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.825840Z","description":"","environment_variables":{},"error_message":null,"id":"e08913fd-9b67-4c8e-b68b-779c58433459","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdataxaockfy1","registry_namespace_id":"b5145ab0-aaf4-4061-921e-db1774b44571","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:09.775268Z","vpc_integration_activated":false}'
-        headers:
-            Content-Length:
-                - "571"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 04 May 2026 12:39:13 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - c1271a34-ee05-4be5-b528-ec879c282461
-        status: 200 OK
-        code: 200
-        duration: 49.90359ms
+        duration: 42.603102ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -313,7 +313,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e08913fd-9b67-4c8e-b68b-779c58433459
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/efe72a18-22cb-47eb-87a2-6fcfbcd372d0
         method: GET
       response:
         proto: HTTP/2.0
@@ -323,7 +323,7 @@ interactions:
         trailer: {}
         content_length: 571
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.825840Z","description":"","environment_variables":{},"error_message":null,"id":"e08913fd-9b67-4c8e-b68b-779c58433459","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdataxaockfy1","registry_namespace_id":"b5145ab0-aaf4-4061-921e-db1774b44571","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:09.775268Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.489089Z","description":"","environment_variables":{},"error_message":null,"id":"efe72a18-22cb-47eb-87a2-6fcfbcd372d0","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdatalej38wa2","registry_namespace_id":"49637118-d193-4756-89fb-c88c8a8b9ce3","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:00.571528Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "571"
@@ -332,9 +332,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:13 GMT
+                - Fri, 03 Jul 2026 15:02:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -342,10 +342,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6905e7dc-74a3-41b8-8a05-de1880eecc52
+                - 20b72a48-0d28-4207-b081-cac03a15d718
         status: 200 OK
         code: 200
-        duration: 32.627957ms
+        duration: 28.898659ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -362,7 +362,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e08913fd-9b67-4c8e-b68b-779c58433459
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/efe72a18-22cb-47eb-87a2-6fcfbcd372d0
         method: GET
       response:
         proto: HTTP/2.0
@@ -372,7 +372,7 @@ interactions:
         trailer: {}
         content_length: 571
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.825840Z","description":"","environment_variables":{},"error_message":null,"id":"e08913fd-9b67-4c8e-b68b-779c58433459","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdataxaockfy1","registry_namespace_id":"b5145ab0-aaf4-4061-921e-db1774b44571","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:09.775268Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.489089Z","description":"","environment_variables":{},"error_message":null,"id":"efe72a18-22cb-47eb-87a2-6fcfbcd372d0","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdatalej38wa2","registry_namespace_id":"49637118-d193-4756-89fb-c88c8a8b9ce3","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:00.571528Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "571"
@@ -381,9 +381,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:13 GMT
+                - Fri, 03 Jul 2026 15:02:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -391,10 +391,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5d7d8ce3-f67b-4b40-9b01-d395db1197df
+                - a7525969-98c0-4f21-a868-e5a32d5b91db
         status: 200 OK
         code: 200
-        duration: 29.134634ms
+        duration: 223.301277ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -411,7 +411,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e08913fd-9b67-4c8e-b68b-779c58433459
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/efe72a18-22cb-47eb-87a2-6fcfbcd372d0
         method: GET
       response:
         proto: HTTP/2.0
@@ -421,7 +421,7 @@ interactions:
         trailer: {}
         content_length: 571
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.825840Z","description":"","environment_variables":{},"error_message":null,"id":"e08913fd-9b67-4c8e-b68b-779c58433459","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdataxaockfy1","registry_namespace_id":"b5145ab0-aaf4-4061-921e-db1774b44571","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:09.775268Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.489089Z","description":"","environment_variables":{},"error_message":null,"id":"efe72a18-22cb-47eb-87a2-6fcfbcd372d0","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdatalej38wa2","registry_namespace_id":"49637118-d193-4756-89fb-c88c8a8b9ce3","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:00.571528Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "571"
@@ -430,9 +430,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:13 GMT
+                - Fri, 03 Jul 2026 15:02:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -440,10 +440,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2ec70508-6e9b-497f-9106-7a1eeb63f8df
+                - b971bc94-c6ee-490a-ae0c-04d95f7c44a3
         status: 200 OK
         code: 200
-        duration: 27.879433ms
+        duration: 32.300186ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -470,7 +470,7 @@ interactions:
         trailer: {}
         content_length: 604
         uncompressed: false
-        body: '{"namespaces":[{"created_at":"2026-05-04T12:38:57.825840Z","description":"","environment_variables":{},"error_message":null,"id":"e08913fd-9b67-4c8e-b68b-779c58433459","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdataxaockfy1","registry_namespace_id":"b5145ab0-aaf4-4061-921e-db1774b44571","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:09.775268Z","vpc_integration_activated":false}],"total_count":1}'
+        body: '{"namespaces":[{"created_at":"2026-07-03T15:01:47.489089Z","description":"","environment_variables":{},"error_message":null,"id":"efe72a18-22cb-47eb-87a2-6fcfbcd372d0","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdatalej38wa2","registry_namespace_id":"49637118-d193-4756-89fb-c88c8a8b9ce3","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:00.571528Z","vpc_integration_activated":false}],"total_count":1}'
         headers:
             Content-Length:
                 - "604"
@@ -479,9 +479,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:13 GMT
+                - Fri, 03 Jul 2026 15:02:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -489,10 +489,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6cae2485-f66c-408c-a468-67176ea21ec8
+                - b7fb5ee3-8cee-40f9-9bbc-e3acd33c3741
         status: 200 OK
         code: 200
-        duration: 44.034038ms
+        duration: 39.489598ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -509,7 +509,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e08913fd-9b67-4c8e-b68b-779c58433459
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/efe72a18-22cb-47eb-87a2-6fcfbcd372d0
         method: GET
       response:
         proto: HTTP/2.0
@@ -519,7 +519,7 @@ interactions:
         trailer: {}
         content_length: 571
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.825840Z","description":"","environment_variables":{},"error_message":null,"id":"e08913fd-9b67-4c8e-b68b-779c58433459","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdataxaockfy1","registry_namespace_id":"b5145ab0-aaf4-4061-921e-db1774b44571","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:09.775268Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.489089Z","description":"","environment_variables":{},"error_message":null,"id":"efe72a18-22cb-47eb-87a2-6fcfbcd372d0","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdatalej38wa2","registry_namespace_id":"49637118-d193-4756-89fb-c88c8a8b9ce3","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:00.571528Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "571"
@@ -528,9 +528,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:13 GMT
+                - Fri, 03 Jul 2026 15:02:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -538,10 +538,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c0eb3ea7-cc53-4ff1-81e6-67f2bfa74f2c
+                - 6d9875d4-7e89-47c7-a8a4-0fa1ab514cd0
         status: 200 OK
         code: 200
-        duration: 31.76316ms
+        duration: 29.234931ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -558,7 +558,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e08913fd-9b67-4c8e-b68b-779c58433459
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/efe72a18-22cb-47eb-87a2-6fcfbcd372d0
         method: GET
       response:
         proto: HTTP/2.0
@@ -568,7 +568,7 @@ interactions:
         trailer: {}
         content_length: 571
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.825840Z","description":"","environment_variables":{},"error_message":null,"id":"e08913fd-9b67-4c8e-b68b-779c58433459","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdataxaockfy1","registry_namespace_id":"b5145ab0-aaf4-4061-921e-db1774b44571","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:09.775268Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.489089Z","description":"","environment_variables":{},"error_message":null,"id":"efe72a18-22cb-47eb-87a2-6fcfbcd372d0","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdatalej38wa2","registry_namespace_id":"49637118-d193-4756-89fb-c88c8a8b9ce3","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:00.571528Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "571"
@@ -577,9 +577,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:13 GMT
+                - Fri, 03 Jul 2026 15:02:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -587,11 +587,60 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 396dc2c6-0600-4dfb-ab47-9c63f2ecb11e
+                - 507ecee4-1cce-477f-beb3-b792ff684a92
         status: 200 OK
         code: 200
-        duration: 28.309462ms
+        duration: 36.397171ms
     - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/efe72a18-22cb-47eb-87a2-6fcfbcd372d0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 571
+        uncompressed: false
+        body: '{"created_at":"2026-07-03T15:01:47.489089Z","description":"","environment_variables":{},"error_message":null,"id":"efe72a18-22cb-47eb-87a2-6fcfbcd372d0","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdatalej38wa2","registry_namespace_id":"49637118-d193-4756-89fb-c88c8a8b9ce3","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:00.571528Z","vpc_integration_activated":false}'
+        headers:
+            Content-Length:
+                - "571"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:02:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f39657ec-b9cd-4e62-bf94-c1368371c8dd
+        status: 200 OK
+        code: 200
+        duration: 30.146475ms
+    - id: 13
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -617,7 +666,7 @@ interactions:
         trailer: {}
         content_length: 604
         uncompressed: false
-        body: '{"namespaces":[{"created_at":"2026-05-04T12:38:57.825840Z","description":"","environment_variables":{},"error_message":null,"id":"e08913fd-9b67-4c8e-b68b-779c58433459","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdataxaockfy1","registry_namespace_id":"b5145ab0-aaf4-4061-921e-db1774b44571","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:09.775268Z","vpc_integration_activated":false}],"total_count":1}'
+        body: '{"namespaces":[{"created_at":"2026-07-03T15:01:47.489089Z","description":"","environment_variables":{},"error_message":null,"id":"efe72a18-22cb-47eb-87a2-6fcfbcd372d0","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdatalej38wa2","registry_namespace_id":"49637118-d193-4756-89fb-c88c8a8b9ce3","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:00.571528Z","vpc_integration_activated":false}],"total_count":1}'
         headers:
             Content-Length:
                 - "604"
@@ -626,9 +675,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:13 GMT
+                - Fri, 03 Jul 2026 15:02:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -636,59 +685,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 21293cdc-7d81-4dea-8867-5474538a7419
+                - b32c017d-54b4-4951-934a-4f15672ac793
         status: 200 OK
         code: 200
-        duration: 33.461746ms
-    - id: 13
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e08913fd-9b67-4c8e-b68b-779c58433459
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 571
-        uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.825840Z","description":"","environment_variables":{},"error_message":null,"id":"e08913fd-9b67-4c8e-b68b-779c58433459","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdataxaockfy1","registry_namespace_id":"b5145ab0-aaf4-4061-921e-db1774b44571","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:09.775268Z","vpc_integration_activated":false}'
-        headers:
-            Content-Length:
-                - "571"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 04 May 2026 12:39:13 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 48124fa1-a3bf-46fd-b55a-8fbb216c2fca
-        status: 200 OK
-        code: 200
-        duration: 35.575914ms
+        duration: 45.105048ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -705,7 +705,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e08913fd-9b67-4c8e-b68b-779c58433459
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/efe72a18-22cb-47eb-87a2-6fcfbcd372d0
         method: GET
       response:
         proto: HTTP/2.0
@@ -715,7 +715,7 @@ interactions:
         trailer: {}
         content_length: 571
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.825840Z","description":"","environment_variables":{},"error_message":null,"id":"e08913fd-9b67-4c8e-b68b-779c58433459","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdataxaockfy1","registry_namespace_id":"b5145ab0-aaf4-4061-921e-db1774b44571","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:09.775268Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.489089Z","description":"","environment_variables":{},"error_message":null,"id":"efe72a18-22cb-47eb-87a2-6fcfbcd372d0","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdatalej38wa2","registry_namespace_id":"49637118-d193-4756-89fb-c88c8a8b9ce3","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:00.571528Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "571"
@@ -724,9 +724,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:13 GMT
+                - Fri, 03 Jul 2026 15:02:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -734,10 +734,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2e5f3d39-61b1-4367-bf5a-a1d2173e7f20
+                - ceebdf67-2288-48b3-8e48-adc87ff2916e
         status: 200 OK
         code: 200
-        duration: 28.584551ms
+        duration: 35.250364ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -754,7 +754,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e08913fd-9b67-4c8e-b68b-779c58433459
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/efe72a18-22cb-47eb-87a2-6fcfbcd372d0
         method: GET
       response:
         proto: HTTP/2.0
@@ -764,7 +764,7 @@ interactions:
         trailer: {}
         content_length: 571
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.825840Z","description":"","environment_variables":{},"error_message":null,"id":"e08913fd-9b67-4c8e-b68b-779c58433459","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdataxaockfy1","registry_namespace_id":"b5145ab0-aaf4-4061-921e-db1774b44571","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:09.775268Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.489089Z","description":"","environment_variables":{},"error_message":null,"id":"efe72a18-22cb-47eb-87a2-6fcfbcd372d0","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdatalej38wa2","registry_namespace_id":"49637118-d193-4756-89fb-c88c8a8b9ce3","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:00.571528Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "571"
@@ -773,9 +773,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:13 GMT
+                - Fri, 03 Jul 2026 15:02:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -783,10 +783,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4301b5b6-5dcf-42c5-9007-f1b199df25a9
+                - 4067ea93-bc0f-48a6-8ed2-0243291e08bb
         status: 200 OK
         code: 200
-        duration: 36.55203ms
+        duration: 62.707592ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -803,7 +803,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e08913fd-9b67-4c8e-b68b-779c58433459
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/efe72a18-22cb-47eb-87a2-6fcfbcd372d0
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -813,7 +813,7 @@ interactions:
         trailer: {}
         content_length: 577
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.825840Z","description":"","environment_variables":{},"error_message":null,"id":"e08913fd-9b67-4c8e-b68b-779c58433459","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdataxaockfy1","registry_namespace_id":"b5145ab0-aaf4-4061-921e-db1774b44571","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-05-04T12:39:13.871062062Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.489089Z","description":"","environment_variables":{},"error_message":null,"id":"efe72a18-22cb-47eb-87a2-6fcfbcd372d0","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdatalej38wa2","registry_namespace_id":"49637118-d193-4756-89fb-c88c8a8b9ce3","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-07-03T15:02:03.993330756Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "577"
@@ -822,9 +822,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:14 GMT
+                - Fri, 03 Jul 2026 15:02:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -832,10 +832,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b32143cb-76d1-4edc-b923-c9fa69f0edfb
+                - 2ee0c9b5-6a53-4e50-8bda-99c17afe0d65
         status: 200 OK
         code: 200
-        duration: 500.032002ms
+        duration: 1.577075225s
     - id: 17
       request:
         proto: HTTP/1.1
@@ -852,7 +852,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e08913fd-9b67-4c8e-b68b-779c58433459
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/efe72a18-22cb-47eb-87a2-6fcfbcd372d0
         method: GET
       response:
         proto: HTTP/2.0
@@ -862,7 +862,7 @@ interactions:
         trailer: {}
         content_length: 574
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.825840Z","description":"","environment_variables":{},"error_message":null,"id":"e08913fd-9b67-4c8e-b68b-779c58433459","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdataxaockfy1","registry_namespace_id":"b5145ab0-aaf4-4061-921e-db1774b44571","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-05-04T12:39:13.871062Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.489089Z","description":"","environment_variables":{},"error_message":null,"id":"efe72a18-22cb-47eb-87a2-6fcfbcd372d0","name":"test-cr-data","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrdatalej38wa2","registry_namespace_id":"49637118-d193-4756-89fb-c88c8a8b9ce3","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-07-03T15:02:03.993331Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "574"
@@ -871,9 +871,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:14 GMT
+                - Fri, 03 Jul 2026 15:02:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -881,10 +881,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5cec53bf-8c07-4d81-9d0a-433857d06fe6
+                - 24684225-2183-4387-9fc6-e09690de0386
         status: 200 OK
         code: 200
-        duration: 36.182836ms
+        duration: 30.414891ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -901,7 +901,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e08913fd-9b67-4c8e-b68b-779c58433459
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/efe72a18-22cb-47eb-87a2-6fcfbcd372d0
         method: GET
       response:
         proto: HTTP/2.0
@@ -920,9 +920,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:19 GMT
+                - Fri, 03 Jul 2026 15:02:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -930,10 +930,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6f61abdb-d5db-4ea5-b85a-11ece5f9b823
+                - 3ce6b81b-92e1-4bda-98a0-38d2fa1ba6ae
         status: 404 Not Found
         code: 404
-        duration: 25.492174ms
+        duration: 32.755613ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -950,7 +950,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e08913fd-9b67-4c8e-b68b-779c58433459
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/efe72a18-22cb-47eb-87a2-6fcfbcd372d0
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -969,9 +969,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:19 GMT
+                - Fri, 03 Jul 2026 15:02:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -979,10 +979,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 73fe45c9-bdae-447a-9dea-c06f19ff28c0
+                - f264e18c-5000-4d27-9c94-935dc1334430
         status: 404 Not Found
         code: 404
-        duration: 31.533309ms
+        duration: 20.090984ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -999,7 +999,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e08913fd-9b67-4c8e-b68b-779c58433459
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/efe72a18-22cb-47eb-87a2-6fcfbcd372d0
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1018,9 +1018,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:19 GMT
+                - Fri, 03 Jul 2026 15:02:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1028,10 +1028,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 62f23bd5-c4ba-4ace-96da-f15ee05363a6
+                - f1e2c3e4-18be-4dfc-af96-90c9dca36d82
         status: 404 Not Found
         code: 404
-        duration: 26.19219ms
+        duration: 26.159628ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1048,7 +1048,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e08913fd-9b67-4c8e-b68b-779c58433459
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/efe72a18-22cb-47eb-87a2-6fcfbcd372d0
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1067,9 +1067,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:19 GMT
+                - Fri, 03 Jul 2026 15:02:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1077,7 +1077,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 41bbf6c8-18be-4604-aa21-4173efb7d71e
+                - ac2c7d66-6040-4158-8de3-a1d455e2c255
         status: 404 Not Found
         code: 404
-        duration: 364.709674ms
+        duration: 23.285182ms

--- a/internal/services/function/testdata/function-basic.cassette.yaml
+++ b/internal/services/function/testdata/function-basic.cassette.yaml
@@ -6,13 +6,13 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 159
+        content_length: 158
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-func-musing-einstein","environment_variables":{},"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","secret_environment_variables":[],"tags":null}'
+        body: '{"name":"tf-func-pensive-cannon","environment_variables":{},"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","secret_environment_variables":[],"tags":null}'
         form: {}
         headers:
             Content-Type:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 509
+        content_length: 508
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.974139758Z","description":"","environment_variables":{},"error_message":null,"id":"5ef5c8b8-44cf-42f1-8d95-60f61e2cd8d8","name":"tf-func-musing-einstein","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-05-04T12:38:57.974139758Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.373197412Z","description":"","environment_variables":{},"error_message":null,"id":"a46033d8-84b5-4a1c-987a-6ec8314ce8e3","name":"tf-func-pensive-cannon","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-07-03T15:01:47.373197412Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "509"
+                - "508"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:38:57 GMT
+                - Fri, 03 Jul 2026 15:01:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 30d33315-f837-4bcc-9c6d-116526be1833
+                - 25430f75-0210-4243-9b10-c3c7a5d857bd
         status: 200 OK
         code: 200
-        duration: 1.96273951s
+        duration: 7.901493148s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -68,7 +68,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5ef5c8b8-44cf-42f1-8d95-60f61e2cd8d8
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a46033d8-84b5-4a1c-987a-6ec8314ce8e3
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 503
+        content_length: 502
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.974140Z","description":"","environment_variables":{},"error_message":null,"id":"5ef5c8b8-44cf-42f1-8d95-60f61e2cd8d8","name":"tf-func-musing-einstein","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-05-04T12:38:57.974140Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.373197Z","description":"","environment_variables":{},"error_message":null,"id":"a46033d8-84b5-4a1c-987a-6ec8314ce8e3","name":"tf-func-pensive-cannon","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-07-03T15:01:47.373197Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "503"
+                - "502"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:38:58 GMT
+                - Fri, 03 Jul 2026 15:01:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 12cef476-a0c2-4e7c-9b5f-a1f571cd7557
+                - 1f234973-d152-435e-8fe9-d2d2f5343e68
         status: 200 OK
         code: 200
-        duration: 47.2061ms
+        duration: 34.59914ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -117,7 +117,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5ef5c8b8-44cf-42f1-8d95-60f61e2cd8d8
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a46033d8-84b5-4a1c-987a-6ec8314ce8e3
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,20 +125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 592
+        content_length: 590
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.974140Z","description":"","environment_variables":{},"error_message":null,"id":"5ef5c8b8-44cf-42f1-8d95-60f61e2cd8d8","name":"tf-func-musing-einstein","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncmusingeinsteinsz1emc1w","registry_namespace_id":"7e2c1ca0-59f5-49ec-af0e-dbc904e240f3","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:13.757766Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.373197Z","description":"","environment_variables":{},"error_message":null,"id":"a46033d8-84b5-4a1c-987a-6ec8314ce8e3","name":"tf-func-pensive-cannon","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncpensivecannonbwrvlsec","registry_namespace_id":"afcaf03d-b50b-4c39-a718-f1b4f3154975","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:02.055683Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "592"
+                - "590"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:18 GMT
+                - Fri, 03 Jul 2026 15:02:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 56b39c75-00ce-4932-b352-b4a130898b3d
+                - 693dec3c-4b93-47fc-b113-fc7bbb2ffe33
         status: 200 OK
         code: 200
-        duration: 170.072096ms
+        duration: 35.207955ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -166,7 +166,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5ef5c8b8-44cf-42f1-8d95-60f61e2cd8d8
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a46033d8-84b5-4a1c-987a-6ec8314ce8e3
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,20 +174,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 592
+        content_length: 590
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.974140Z","description":"","environment_variables":{},"error_message":null,"id":"5ef5c8b8-44cf-42f1-8d95-60f61e2cd8d8","name":"tf-func-musing-einstein","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncmusingeinsteinsz1emc1w","registry_namespace_id":"7e2c1ca0-59f5-49ec-af0e-dbc904e240f3","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:13.757766Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.373197Z","description":"","environment_variables":{},"error_message":null,"id":"a46033d8-84b5-4a1c-987a-6ec8314ce8e3","name":"tf-func-pensive-cannon","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncpensivecannonbwrvlsec","registry_namespace_id":"afcaf03d-b50b-4c39-a718-f1b4f3154975","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:02.055683Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "592"
+                - "590"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:18 GMT
+                - Fri, 03 Jul 2026 15:02:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,10 +195,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f6872505-4257-40d6-b004-f530ad9301f5
+                - 7fe9f758-5f88-45f0-9b48-8ff9d68fd210
         status: 200 OK
         code: 200
-        duration: 60.198111ms
+        duration: 33.964426ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -210,7 +210,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"foobar","namespace_id":"5ef5c8b8-44cf-42f1-8d95-60f61e2cd8d8","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node22","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox","tags":["tag1","tag2"]}'
+        body: '{"name":"foobar","namespace_id":"a46033d8-84b5-4a1c-987a-6ec8314ce8e3","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node26","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox","tags":["tag1","tag2"]}'
         form: {}
         headers:
             Content-Type:
@@ -225,20 +225,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 719
+        content_length: 718
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:18.454743869Z","description":"","domain_name":"tffuncmusingeinsteinsz1emc1w-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"7d3d792e-7cdd-454b-ae25-7f6935494a7c","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5ef5c8b8-44cf-42f1-8d95-60f61e2cd8d8","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":["tag1","tag2"],"timeout":"300s","updated_at":"2026-05-04T12:39:18.454743869Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:02.663406634Z","description":"","domain_name":"tffuncpensivecannonbwrvlsec-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"b8707337-0911-4249-9ca8-a112de7c217d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"a46033d8-84b5-4a1c-987a-6ec8314ce8e3","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":["tag1","tag2"],"timeout":"300s","updated_at":"2026-07-03T15:02:02.663406634Z"}'
         headers:
             Content-Length:
-                - "719"
+                - "718"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:18 GMT
+                - Fri, 03 Jul 2026 15:02:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -246,10 +246,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 16d5a647-205c-4984-a786-c7bd81008235
+                - 374a28d0-0c9e-4f66-bb67-602086b5ac1d
         status: 200 OK
         code: 200
-        duration: 75.472159ms
+        duration: 120.71731ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -266,7 +266,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7d3d792e-7cdd-454b-ae25-7f6935494a7c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/b8707337-0911-4249-9ca8-a112de7c217d
         method: GET
       response:
         proto: HTTP/2.0
@@ -274,20 +274,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 713
+        content_length: 712
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:18.454744Z","description":"","domain_name":"tffuncmusingeinsteinsz1emc1w-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"7d3d792e-7cdd-454b-ae25-7f6935494a7c","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5ef5c8b8-44cf-42f1-8d95-60f61e2cd8d8","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":["tag1","tag2"],"timeout":"300s","updated_at":"2026-05-04T12:39:18.454744Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:02.663407Z","description":"","domain_name":"tffuncpensivecannonbwrvlsec-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"b8707337-0911-4249-9ca8-a112de7c217d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"a46033d8-84b5-4a1c-987a-6ec8314ce8e3","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":["tag1","tag2"],"timeout":"300s","updated_at":"2026-07-03T15:02:02.663407Z"}'
         headers:
             Content-Length:
-                - "713"
+                - "712"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:18 GMT
+                - Fri, 03 Jul 2026 15:02:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -295,10 +295,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2c87b185-9ee4-476a-88ee-2f9aa2aecbca
+                - 258cf51c-b591-4701-aa0d-920e51248abe
         status: 200 OK
         code: 200
-        duration: 39.605377ms
+        duration: 40.341099ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -315,7 +315,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7d3d792e-7cdd-454b-ae25-7f6935494a7c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/b8707337-0911-4249-9ca8-a112de7c217d
         method: GET
       response:
         proto: HTTP/2.0
@@ -323,20 +323,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 713
+        content_length: 712
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:18.454744Z","description":"","domain_name":"tffuncmusingeinsteinsz1emc1w-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"7d3d792e-7cdd-454b-ae25-7f6935494a7c","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5ef5c8b8-44cf-42f1-8d95-60f61e2cd8d8","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":["tag1","tag2"],"timeout":"300s","updated_at":"2026-05-04T12:39:18.454744Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:02.663407Z","description":"","domain_name":"tffuncpensivecannonbwrvlsec-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"b8707337-0911-4249-9ca8-a112de7c217d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"a46033d8-84b5-4a1c-987a-6ec8314ce8e3","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":["tag1","tag2"],"timeout":"300s","updated_at":"2026-07-03T15:02:02.663407Z"}'
         headers:
             Content-Length:
-                - "713"
+                - "712"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:18 GMT
+                - Fri, 03 Jul 2026 15:02:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -344,10 +344,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 662d4a65-5efc-4db6-8de9-fc90809eff6f
+                - b3fc6642-87f6-4c11-9010-a3dd31007d0f
         status: 200 OK
         code: 200
-        duration: 34.309903ms
+        duration: 46.616801ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -364,7 +364,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7d3d792e-7cdd-454b-ae25-7f6935494a7c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/b8707337-0911-4249-9ca8-a112de7c217d
         method: GET
       response:
         proto: HTTP/2.0
@@ -372,20 +372,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 713
+        content_length: 712
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:18.454744Z","description":"","domain_name":"tffuncmusingeinsteinsz1emc1w-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"7d3d792e-7cdd-454b-ae25-7f6935494a7c","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5ef5c8b8-44cf-42f1-8d95-60f61e2cd8d8","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":["tag1","tag2"],"timeout":"300s","updated_at":"2026-05-04T12:39:18.454744Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:02.663407Z","description":"","domain_name":"tffuncpensivecannonbwrvlsec-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"b8707337-0911-4249-9ca8-a112de7c217d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"a46033d8-84b5-4a1c-987a-6ec8314ce8e3","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":["tag1","tag2"],"timeout":"300s","updated_at":"2026-07-03T15:02:02.663407Z"}'
         headers:
             Content-Length:
-                - "713"
+                - "712"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:18 GMT
+                - Fri, 03 Jul 2026 15:02:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -393,10 +393,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 09a55978-a176-4ab7-91e3-6c5e720e04f1
+                - 343f0b5f-78d1-4145-b61a-24c959695a89
         status: 200 OK
         code: 200
-        duration: 43.596476ms
+        duration: 47.405154ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -413,7 +413,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5ef5c8b8-44cf-42f1-8d95-60f61e2cd8d8
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a46033d8-84b5-4a1c-987a-6ec8314ce8e3
         method: GET
       response:
         proto: HTTP/2.0
@@ -421,20 +421,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 592
+        content_length: 590
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.974140Z","description":"","environment_variables":{},"error_message":null,"id":"5ef5c8b8-44cf-42f1-8d95-60f61e2cd8d8","name":"tf-func-musing-einstein","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncmusingeinsteinsz1emc1w","registry_namespace_id":"7e2c1ca0-59f5-49ec-af0e-dbc904e240f3","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:13.757766Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.373197Z","description":"","environment_variables":{},"error_message":null,"id":"a46033d8-84b5-4a1c-987a-6ec8314ce8e3","name":"tf-func-pensive-cannon","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncpensivecannonbwrvlsec","registry_namespace_id":"afcaf03d-b50b-4c39-a718-f1b4f3154975","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:02.055683Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "592"
+                - "590"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:18 GMT
+                - Fri, 03 Jul 2026 15:02:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -442,10 +442,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f67d39b0-f86e-412d-962b-4e36ee4f8b13
+                - d1d5dd22-cbc0-48a6-aff3-e63329492f1a
         status: 200 OK
         code: 200
-        duration: 35.040247ms
+        duration: 40.311844ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -462,7 +462,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7d3d792e-7cdd-454b-ae25-7f6935494a7c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/b8707337-0911-4249-9ca8-a112de7c217d
         method: GET
       response:
         proto: HTTP/2.0
@@ -470,20 +470,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 713
+        content_length: 712
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:18.454744Z","description":"","domain_name":"tffuncmusingeinsteinsz1emc1w-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"7d3d792e-7cdd-454b-ae25-7f6935494a7c","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5ef5c8b8-44cf-42f1-8d95-60f61e2cd8d8","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":["tag1","tag2"],"timeout":"300s","updated_at":"2026-05-04T12:39:18.454744Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:02.663407Z","description":"","domain_name":"tffuncpensivecannonbwrvlsec-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"b8707337-0911-4249-9ca8-a112de7c217d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"a46033d8-84b5-4a1c-987a-6ec8314ce8e3","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":["tag1","tag2"],"timeout":"300s","updated_at":"2026-07-03T15:02:02.663407Z"}'
         headers:
             Content-Length:
-                - "713"
+                - "712"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:19 GMT
+                - Fri, 03 Jul 2026 15:02:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -491,10 +491,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2f9cb46e-521f-4af7-b6e7-d79a62971234
+                - 4fc03849-80bc-44c5-b7e0-40b3d761d84d
         status: 200 OK
         code: 200
-        duration: 38.315059ms
+        duration: 44.832686ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -511,7 +511,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7d3d792e-7cdd-454b-ae25-7f6935494a7c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/b8707337-0911-4249-9ca8-a112de7c217d
         method: GET
       response:
         proto: HTTP/2.0
@@ -519,20 +519,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 713
+        content_length: 712
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:18.454744Z","description":"","domain_name":"tffuncmusingeinsteinsz1emc1w-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"7d3d792e-7cdd-454b-ae25-7f6935494a7c","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5ef5c8b8-44cf-42f1-8d95-60f61e2cd8d8","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":["tag1","tag2"],"timeout":"300s","updated_at":"2026-05-04T12:39:18.454744Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:02.663407Z","description":"","domain_name":"tffuncpensivecannonbwrvlsec-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"b8707337-0911-4249-9ca8-a112de7c217d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"a46033d8-84b5-4a1c-987a-6ec8314ce8e3","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":["tag1","tag2"],"timeout":"300s","updated_at":"2026-07-03T15:02:02.663407Z"}'
         headers:
             Content-Length:
-                - "713"
+                - "712"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:19 GMT
+                - Fri, 03 Jul 2026 15:02:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -540,10 +540,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 801fbb7c-c2a3-4859-b6b6-d5d42e05c553
+                - bb6a4ff4-2d44-464c-a0fd-b98f79c5087b
         status: 200 OK
         code: 200
-        duration: 35.565656ms
+        duration: 120.318861ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -560,7 +560,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7d3d792e-7cdd-454b-ae25-7f6935494a7c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/b8707337-0911-4249-9ca8-a112de7c217d
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -568,20 +568,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 717
+        content_length: 716
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:18.454744Z","description":"","domain_name":"tffuncmusingeinsteinsz1emc1w-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"7d3d792e-7cdd-454b-ae25-7f6935494a7c","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"5ef5c8b8-44cf-42f1-8d95-60f61e2cd8d8","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","tags":["tag1","tag2"],"timeout":"300s","updated_at":"2026-05-04T12:39:19.345747587Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:02.663407Z","description":"","domain_name":"tffuncpensivecannonbwrvlsec-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"b8707337-0911-4249-9ca8-a112de7c217d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"a46033d8-84b5-4a1c-987a-6ec8314ce8e3","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","tags":["tag1","tag2"],"timeout":"300s","updated_at":"2026-07-03T15:02:03.745811458Z"}'
         headers:
             Content-Length:
-                - "717"
+                - "716"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:19 GMT
+                - Fri, 03 Jul 2026 15:02:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -589,10 +589,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9731c527-5a9b-44f8-8ae1-c7da720f215b
+                - f8908470-1e75-462d-b27f-40aaf25b00b5
         status: 200 OK
         code: 200
-        duration: 144.395898ms
+        duration: 315.860271ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -609,7 +609,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5ef5c8b8-44cf-42f1-8d95-60f61e2cd8d8
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a46033d8-84b5-4a1c-987a-6ec8314ce8e3
         method: GET
       response:
         proto: HTTP/2.0
@@ -617,20 +617,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 592
+        content_length: 590
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.974140Z","description":"","environment_variables":{},"error_message":null,"id":"5ef5c8b8-44cf-42f1-8d95-60f61e2cd8d8","name":"tf-func-musing-einstein","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncmusingeinsteinsz1emc1w","registry_namespace_id":"7e2c1ca0-59f5-49ec-af0e-dbc904e240f3","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:13.757766Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.373197Z","description":"","environment_variables":{},"error_message":null,"id":"a46033d8-84b5-4a1c-987a-6ec8314ce8e3","name":"tf-func-pensive-cannon","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncpensivecannonbwrvlsec","registry_namespace_id":"afcaf03d-b50b-4c39-a718-f1b4f3154975","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:02.055683Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "592"
+                - "590"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:19 GMT
+                - Fri, 03 Jul 2026 15:02:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -638,10 +638,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bd3f7d7f-7c6f-4b9d-b1fb-5f7ee2836033
+                - c5f162ea-7463-4983-b55a-9b5c35c71c20
         status: 200 OK
         code: 200
-        duration: 402.151791ms
+        duration: 32.217ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -658,7 +658,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5ef5c8b8-44cf-42f1-8d95-60f61e2cd8d8
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a46033d8-84b5-4a1c-987a-6ec8314ce8e3
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -666,20 +666,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 598
+        content_length: 596
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.974140Z","description":"","environment_variables":{},"error_message":null,"id":"5ef5c8b8-44cf-42f1-8d95-60f61e2cd8d8","name":"tf-func-musing-einstein","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncmusingeinsteinsz1emc1w","registry_namespace_id":"7e2c1ca0-59f5-49ec-af0e-dbc904e240f3","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-05-04T12:39:19.926416240Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.373197Z","description":"","environment_variables":{},"error_message":null,"id":"a46033d8-84b5-4a1c-987a-6ec8314ce8e3","name":"tf-func-pensive-cannon","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncpensivecannonbwrvlsec","registry_namespace_id":"afcaf03d-b50b-4c39-a718-f1b4f3154975","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-07-03T15:02:04.078652236Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "598"
+                - "596"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:20 GMT
+                - Fri, 03 Jul 2026 15:02:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -687,10 +687,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 98245c48-66ed-4a13-846e-2033d4e2311c
+                - 8d0a9f88-b090-46d0-bb3d-f3366bc350a2
         status: 200 OK
         code: 200
-        duration: 618.504848ms
+        duration: 1.37786192s
     - id: 14
       request:
         proto: HTTP/1.1
@@ -707,7 +707,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5ef5c8b8-44cf-42f1-8d95-60f61e2cd8d8
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a46033d8-84b5-4a1c-987a-6ec8314ce8e3
         method: GET
       response:
         proto: HTTP/2.0
@@ -715,20 +715,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 595
+        content_length: 593
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.974140Z","description":"","environment_variables":{},"error_message":null,"id":"5ef5c8b8-44cf-42f1-8d95-60f61e2cd8d8","name":"tf-func-musing-einstein","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncmusingeinsteinsz1emc1w","registry_namespace_id":"7e2c1ca0-59f5-49ec-af0e-dbc904e240f3","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-05-04T12:39:19.926416Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.373197Z","description":"","environment_variables":{},"error_message":null,"id":"a46033d8-84b5-4a1c-987a-6ec8314ce8e3","name":"tf-func-pensive-cannon","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncpensivecannonbwrvlsec","registry_namespace_id":"afcaf03d-b50b-4c39-a718-f1b4f3154975","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-07-03T15:02:04.078652Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "595"
+                - "593"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:20 GMT
+                - Fri, 03 Jul 2026 15:02:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -736,10 +736,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0463b553-27f5-4fb0-a35a-1f7c355a2978
+                - 87849a52-b93b-476a-9ba8-a4d1d999c346
         status: 200 OK
         code: 200
-        duration: 43.260754ms
+        duration: 30.378532ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -756,7 +756,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5ef5c8b8-44cf-42f1-8d95-60f61e2cd8d8
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a46033d8-84b5-4a1c-987a-6ec8314ce8e3
         method: GET
       response:
         proto: HTTP/2.0
@@ -775,9 +775,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:25 GMT
+                - Fri, 03 Jul 2026 15:02:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -785,10 +785,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4913df47-d1c2-4249-9dba-d93758f01ad1
+                - 0cd3ae12-5802-4666-bb7d-9344efe614cf
         status: 404 Not Found
         code: 404
-        duration: 23.47038ms
+        duration: 27.103423ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -805,7 +805,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7d3d792e-7cdd-454b-ae25-7f6935494a7c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/b8707337-0911-4249-9ca8-a112de7c217d
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -824,9 +824,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:25 GMT
+                - Fri, 03 Jul 2026 15:02:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -834,7 +834,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b17edcd1-239b-4085-84df-f746f7988dff
+                - b6eb7c95-662f-4aa1-8fff-2ab7a2e6da32
         status: 404 Not Found
         code: 404
-        duration: 23.396571ms
+        duration: 27.198952ms

--- a/internal/services/function/testdata/function-cron-basic.cassette.yaml
+++ b/internal/services/function/testdata/function-cron-basic.cassette.yaml
@@ -29,7 +29,7 @@ interactions:
         trailer: {}
         content_length: 514
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.932003069Z","description":"","environment_variables":{},"error_message":null,"id":"37410ade-e486-414a-83ab-e0ac75c35d36","name":"tf-tests-function-cron-basic","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-05-04T12:38:57.932003069Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.510399434Z","description":"","environment_variables":{},"error_message":null,"id":"00b950c3-7956-46a5-8710-523e345fd594","name":"tf-tests-function-cron-basic","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-07-03T15:01:47.510399434Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "514"
@@ -38,9 +38,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:38:57 GMT
+                - Fri, 03 Jul 2026 15:01:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 77dd54b1-82f7-4f8b-afa2-4c733525d689
+                - 36157d2d-590d-47f2-9e62-5ab51b4ff6a1
         status: 200 OK
         code: 200
-        duration: 1.920762618s
+        duration: 8.040070657s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -68,7 +68,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/37410ade-e486-414a-83ab-e0ac75c35d36
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/00b950c3-7956-46a5-8710-523e345fd594
         method: GET
       response:
         proto: HTTP/2.0
@@ -78,7 +78,7 @@ interactions:
         trailer: {}
         content_length: 508
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.932003Z","description":"","environment_variables":{},"error_message":null,"id":"37410ade-e486-414a-83ab-e0ac75c35d36","name":"tf-tests-function-cron-basic","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-05-04T12:38:57.932003Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.510399Z","description":"","environment_variables":{},"error_message":null,"id":"00b950c3-7956-46a5-8710-523e345fd594","name":"tf-tests-function-cron-basic","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-07-03T15:01:47.510399Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "508"
@@ -87,9 +87,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:38:57 GMT
+                - Fri, 03 Jul 2026 15:01:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8c46fa33-e478-42cd-9126-633d6a423524
+                - 1addf13e-3cc2-4a98-9fc2-5c4910942855
         status: 200 OK
         code: 200
-        duration: 47.088478ms
+        duration: 31.702582ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -117,7 +117,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/37410ade-e486-414a-83ab-e0ac75c35d36
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/00b950c3-7956-46a5-8710-523e345fd594
         method: GET
       response:
         proto: HTTP/2.0
@@ -127,7 +127,7 @@ interactions:
         trailer: {}
         content_length: 597
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.932003Z","description":"","environment_variables":{},"error_message":null,"id":"37410ade-e486-414a-83ab-e0ac75c35d36","name":"tf-tests-function-cron-basic","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronbinxym0x2","registry_namespace_id":"95ba88c8-6b24-4a93-8b6c-2242544b6544","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:09.850349Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.510399Z","description":"","environment_variables":{},"error_message":null,"id":"00b950c3-7956-46a5-8710-523e345fd594","name":"tf-tests-function-cron-basic","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronbevbaclj5","registry_namespace_id":"0e11baa3-1864-4fab-86d0-4f6b3a004d24","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:05.774743Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "597"
@@ -136,9 +136,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:13 GMT
+                - Fri, 03 Jul 2026 15:02:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e7a823ca-98a9-4e03-b9ce-cea19a6f9b14
+                - 3524dc36-1060-4f6c-ae6f-7ab2bcaa0312
         status: 200 OK
         code: 200
-        duration: 34.541378ms
+        duration: 35.625349ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -166,7 +166,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/37410ade-e486-414a-83ab-e0ac75c35d36
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/00b950c3-7956-46a5-8710-523e345fd594
         method: GET
       response:
         proto: HTTP/2.0
@@ -176,7 +176,7 @@ interactions:
         trailer: {}
         content_length: 597
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.932003Z","description":"","environment_variables":{},"error_message":null,"id":"37410ade-e486-414a-83ab-e0ac75c35d36","name":"tf-tests-function-cron-basic","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronbinxym0x2","registry_namespace_id":"95ba88c8-6b24-4a93-8b6c-2242544b6544","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:09.850349Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.510399Z","description":"","environment_variables":{},"error_message":null,"id":"00b950c3-7956-46a5-8710-523e345fd594","name":"tf-tests-function-cron-basic","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronbevbaclj5","registry_namespace_id":"0e11baa3-1864-4fab-86d0-4f6b3a004d24","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:05.774743Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "597"
@@ -185,9 +185,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:13 GMT
+                - Fri, 03 Jul 2026 15:02:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,10 +195,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d7c7ec09-7466-49df-9caf-8cd15f9d71df
+                - 808618ff-26af-4ef0-9a24-0a8c8645f43b
         status: 200 OK
         code: 200
-        duration: 27.846291ms
+        duration: 37.413793ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -210,7 +210,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-tests-cron-basic","namespace_id":"37410ade-e486-414a-83ab-e0ac75c35d36","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node20","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox","tags":null}'
+        body: '{"name":"tf-tests-cron-basic","namespace_id":"00b950c3-7956-46a5-8710-523e345fd594","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node26","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox","tags":null}'
         form: {}
         headers:
             Content-Type:
@@ -227,7 +227,7 @@ interactions:
         trailer: {}
         content_length: 732
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:13.211448913Z","description":"","domain_name":"tftestsfunctioncronbinxym0x2-tf-tests-cron-basic.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"95d72d7f-018d-466a-8164-d20b7b13674b","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-basic","namespace_id":"37410ade-e486-414a-83ab-e0ac75c35d36","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:13.211448913Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:07.804018701Z","description":"","domain_name":"tftestsfunctioncronbevbaclj5-tf-tests-cron-basic.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"ee67efb0-ee5f-486a-85be-8af33324bdfd","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-basic","namespace_id":"00b950c3-7956-46a5-8710-523e345fd594","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:07.804018701Z"}'
         headers:
             Content-Length:
                 - "732"
@@ -236,9 +236,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:13 GMT
+                - Fri, 03 Jul 2026 15:02:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -246,10 +246,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c859a871-d8f6-4686-a677-67c322ad75f7
+                - 85377b12-80cd-4dc3-bbff-8e4ac9d7b7d9
         status: 200 OK
         code: 200
-        duration: 103.855438ms
+        duration: 84.847812ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -266,7 +266,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/95d72d7f-018d-466a-8164-d20b7b13674b
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/ee67efb0-ee5f-486a-85be-8af33324bdfd
         method: GET
       response:
         proto: HTTP/2.0
@@ -276,7 +276,7 @@ interactions:
         trailer: {}
         content_length: 726
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:13.211449Z","description":"","domain_name":"tftestsfunctioncronbinxym0x2-tf-tests-cron-basic.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"95d72d7f-018d-466a-8164-d20b7b13674b","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-basic","namespace_id":"37410ade-e486-414a-83ab-e0ac75c35d36","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:13.211449Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:07.804019Z","description":"","domain_name":"tftestsfunctioncronbevbaclj5-tf-tests-cron-basic.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"ee67efb0-ee5f-486a-85be-8af33324bdfd","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-basic","namespace_id":"00b950c3-7956-46a5-8710-523e345fd594","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:07.804019Z"}'
         headers:
             Content-Length:
                 - "726"
@@ -285,9 +285,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:13 GMT
+                - Fri, 03 Jul 2026 15:02:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -295,10 +295,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 07cc5188-f306-4b35-a890-f6911e7e68a6
+                - cf165bef-778d-4896-aff0-ec71c446b2de
         status: 200 OK
         code: 200
-        duration: 47.975343ms
+        duration: 41.270927ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -315,7 +315,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/95d72d7f-018d-466a-8164-d20b7b13674b
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/ee67efb0-ee5f-486a-85be-8af33324bdfd
         method: GET
       response:
         proto: HTTP/2.0
@@ -325,7 +325,7 @@ interactions:
         trailer: {}
         content_length: 726
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:13.211449Z","description":"","domain_name":"tftestsfunctioncronbinxym0x2-tf-tests-cron-basic.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"95d72d7f-018d-466a-8164-d20b7b13674b","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-basic","namespace_id":"37410ade-e486-414a-83ab-e0ac75c35d36","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:13.211449Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:07.804019Z","description":"","domain_name":"tftestsfunctioncronbevbaclj5-tf-tests-cron-basic.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"ee67efb0-ee5f-486a-85be-8af33324bdfd","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-basic","namespace_id":"00b950c3-7956-46a5-8710-523e345fd594","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:07.804019Z"}'
         headers:
             Content-Length:
                 - "726"
@@ -334,9 +334,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:13 GMT
+                - Fri, 03 Jul 2026 15:02:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -344,10 +344,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 267d7c42-17f3-4b56-bd07-aea39c3064e7
+                - fa016d8b-392b-4d3d-8b82-8b9b1fa384cd
         status: 200 OK
         code: 200
-        duration: 49.901366ms
+        duration: 41.673023ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -364,7 +364,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/95d72d7f-018d-466a-8164-d20b7b13674b
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/ee67efb0-ee5f-486a-85be-8af33324bdfd
         method: GET
       response:
         proto: HTTP/2.0
@@ -374,7 +374,7 @@ interactions:
         trailer: {}
         content_length: 726
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:13.211449Z","description":"","domain_name":"tftestsfunctioncronbinxym0x2-tf-tests-cron-basic.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"95d72d7f-018d-466a-8164-d20b7b13674b","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-basic","namespace_id":"37410ade-e486-414a-83ab-e0ac75c35d36","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:13.211449Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:07.804019Z","description":"","domain_name":"tftestsfunctioncronbevbaclj5-tf-tests-cron-basic.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"ee67efb0-ee5f-486a-85be-8af33324bdfd","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-basic","namespace_id":"00b950c3-7956-46a5-8710-523e345fd594","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:07.804019Z"}'
         headers:
             Content-Length:
                 - "726"
@@ -383,9 +383,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:13 GMT
+                - Fri, 03 Jul 2026 15:02:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -393,10 +393,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 22189d17-836f-4c79-a79a-32c217eb6a90
+                - 5d9df52f-eb58-4f7c-ae69-79622aead6f1
         status: 200 OK
         code: 200
-        duration: 43.22227ms
+        duration: 55.858692ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -408,7 +408,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"function_id":"95d72d7f-018d-466a-8164-d20b7b13674b","schedule":"0 0 * * *","args":{},"name":"tf-tests-cron-basic"}'
+        body: '{"function_id":"ee67efb0-ee5f-486a-85be-8af33324bdfd","schedule":"0 0 * * *","args":{},"name":"tf-tests-cron-basic"}'
         form: {}
         headers:
             Content-Type:
@@ -425,7 +425,7 @@ interactions:
         trailer: {}
         content_length: 179
         uncompressed: false
-        body: '{"args":{},"function_id":"95d72d7f-018d-466a-8164-d20b7b13674b","id":"4ddfe3c8-ebdd-4327-858a-507314735d8b","name":"tf-tests-cron-basic","schedule":"0 0 * * *","status":"pending"}'
+        body: '{"args":{},"function_id":"ee67efb0-ee5f-486a-85be-8af33324bdfd","id":"3491a386-4654-4d84-85e1-a9a0dbdb5e68","name":"tf-tests-cron-basic","schedule":"0 0 * * *","status":"pending"}'
         headers:
             Content-Length:
                 - "179"
@@ -434,9 +434,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:13 GMT
+                - Fri, 03 Jul 2026 15:02:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -444,10 +444,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 411b25fa-96bf-4fee-8ffb-6c0052159cd5
+                - 844c36a4-7dea-4389-b188-6fbfa2758afe
         status: 200 OK
         code: 200
-        duration: 73.591858ms
+        duration: 120.949927ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -464,7 +464,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/4ddfe3c8-ebdd-4327-858a-507314735d8b
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/3491a386-4654-4d84-85e1-a9a0dbdb5e68
         method: GET
       response:
         proto: HTTP/2.0
@@ -474,7 +474,7 @@ interactions:
         trailer: {}
         content_length: 179
         uncompressed: false
-        body: '{"args":{},"function_id":"95d72d7f-018d-466a-8164-d20b7b13674b","id":"4ddfe3c8-ebdd-4327-858a-507314735d8b","name":"tf-tests-cron-basic","schedule":"0 0 * * *","status":"pending"}'
+        body: '{"args":{},"function_id":"ee67efb0-ee5f-486a-85be-8af33324bdfd","id":"3491a386-4654-4d84-85e1-a9a0dbdb5e68","name":"tf-tests-cron-basic","schedule":"0 0 * * *","status":"pending"}'
         headers:
             Content-Length:
                 - "179"
@@ -483,9 +483,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:13 GMT
+                - Fri, 03 Jul 2026 15:02:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -493,10 +493,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 735f61e5-34ae-4b70-9a57-3513de4dff22
+                - eadc8b6f-a76f-4206-878f-a6df4eaea1fc
         status: 200 OK
         code: 200
-        duration: 48.905994ms
+        duration: 52.764153ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -513,7 +513,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/4ddfe3c8-ebdd-4327-858a-507314735d8b
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/3491a386-4654-4d84-85e1-a9a0dbdb5e68
         method: GET
       response:
         proto: HTTP/2.0
@@ -523,7 +523,7 @@ interactions:
         trailer: {}
         content_length: 177
         uncompressed: false
-        body: '{"args":{},"function_id":"95d72d7f-018d-466a-8164-d20b7b13674b","id":"4ddfe3c8-ebdd-4327-858a-507314735d8b","name":"tf-tests-cron-basic","schedule":"0 0 * * *","status":"ready"}'
+        body: '{"args":{},"function_id":"ee67efb0-ee5f-486a-85be-8af33324bdfd","id":"3491a386-4654-4d84-85e1-a9a0dbdb5e68","name":"tf-tests-cron-basic","schedule":"0 0 * * *","status":"ready"}'
         headers:
             Content-Length:
                 - "177"
@@ -532,9 +532,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:18 GMT
+                - Fri, 03 Jul 2026 15:02:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -542,10 +542,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1606209c-05c5-40a3-a816-6e7a2f262903
+                - 021a4c28-1e71-45eb-b04d-ddd27db52ce1
         status: 200 OK
         code: 200
-        duration: 49.111121ms
+        duration: 76.368214ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -562,7 +562,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/4ddfe3c8-ebdd-4327-858a-507314735d8b
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/3491a386-4654-4d84-85e1-a9a0dbdb5e68
         method: GET
       response:
         proto: HTTP/2.0
@@ -572,7 +572,7 @@ interactions:
         trailer: {}
         content_length: 177
         uncompressed: false
-        body: '{"args":{},"function_id":"95d72d7f-018d-466a-8164-d20b7b13674b","id":"4ddfe3c8-ebdd-4327-858a-507314735d8b","name":"tf-tests-cron-basic","schedule":"0 0 * * *","status":"ready"}'
+        body: '{"args":{},"function_id":"ee67efb0-ee5f-486a-85be-8af33324bdfd","id":"3491a386-4654-4d84-85e1-a9a0dbdb5e68","name":"tf-tests-cron-basic","schedule":"0 0 * * *","status":"ready"}'
         headers:
             Content-Length:
                 - "177"
@@ -581,9 +581,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:18 GMT
+                - Fri, 03 Jul 2026 15:02:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -591,10 +591,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d78d1551-e6c3-40c9-a1f2-6507e51f28a4
+                - 45d1c977-c235-4a87-8769-674b00ec8971
         status: 200 OK
         code: 200
-        duration: 91.989345ms
+        duration: 229.318894ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -611,7 +611,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/4ddfe3c8-ebdd-4327-858a-507314735d8b
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/3491a386-4654-4d84-85e1-a9a0dbdb5e68
         method: GET
       response:
         proto: HTTP/2.0
@@ -621,7 +621,7 @@ interactions:
         trailer: {}
         content_length: 177
         uncompressed: false
-        body: '{"args":{},"function_id":"95d72d7f-018d-466a-8164-d20b7b13674b","id":"4ddfe3c8-ebdd-4327-858a-507314735d8b","name":"tf-tests-cron-basic","schedule":"0 0 * * *","status":"ready"}'
+        body: '{"args":{},"function_id":"ee67efb0-ee5f-486a-85be-8af33324bdfd","id":"3491a386-4654-4d84-85e1-a9a0dbdb5e68","name":"tf-tests-cron-basic","schedule":"0 0 * * *","status":"ready"}'
         headers:
             Content-Length:
                 - "177"
@@ -630,9 +630,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:18 GMT
+                - Fri, 03 Jul 2026 15:02:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -640,10 +640,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6c6f9b9c-d976-495f-9bb4-a47191b53509
+                - 38c3a735-ab1f-4e9a-b8d3-6c498ad7fc1a
         status: 200 OK
         code: 200
-        duration: 53.964713ms
+        duration: 45.481696ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -660,7 +660,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/37410ade-e486-414a-83ab-e0ac75c35d36
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/00b950c3-7956-46a5-8710-523e345fd594
         method: GET
       response:
         proto: HTTP/2.0
@@ -670,7 +670,7 @@ interactions:
         trailer: {}
         content_length: 597
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.932003Z","description":"","environment_variables":{},"error_message":null,"id":"37410ade-e486-414a-83ab-e0ac75c35d36","name":"tf-tests-function-cron-basic","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronbinxym0x2","registry_namespace_id":"95ba88c8-6b24-4a93-8b6c-2242544b6544","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:09.850349Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.510399Z","description":"","environment_variables":{},"error_message":null,"id":"00b950c3-7956-46a5-8710-523e345fd594","name":"tf-tests-function-cron-basic","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronbevbaclj5","registry_namespace_id":"0e11baa3-1864-4fab-86d0-4f6b3a004d24","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:05.774743Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "597"
@@ -679,9 +679,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:19 GMT
+                - Fri, 03 Jul 2026 15:02:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -689,10 +689,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3f715797-e435-4f53-a881-f62985d6fe10
+                - f7866723-93a3-4c32-8f0f-b79013fc9e10
         status: 200 OK
         code: 200
-        duration: 39.849947ms
+        duration: 33.165213ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -709,7 +709,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/95d72d7f-018d-466a-8164-d20b7b13674b
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/ee67efb0-ee5f-486a-85be-8af33324bdfd
         method: GET
       response:
         proto: HTTP/2.0
@@ -719,7 +719,7 @@ interactions:
         trailer: {}
         content_length: 726
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:13.211449Z","description":"","domain_name":"tftestsfunctioncronbinxym0x2-tf-tests-cron-basic.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"95d72d7f-018d-466a-8164-d20b7b13674b","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-basic","namespace_id":"37410ade-e486-414a-83ab-e0ac75c35d36","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:13.211449Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:07.804019Z","description":"","domain_name":"tftestsfunctioncronbevbaclj5-tf-tests-cron-basic.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"ee67efb0-ee5f-486a-85be-8af33324bdfd","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-basic","namespace_id":"00b950c3-7956-46a5-8710-523e345fd594","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:07.804019Z"}'
         headers:
             Content-Length:
                 - "726"
@@ -728,9 +728,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:19 GMT
+                - Fri, 03 Jul 2026 15:02:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -738,10 +738,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e061e696-1e38-4cc7-9ef7-d0a7312ae964
+                - 48c3c6eb-b463-4494-99b7-3f2fa1e6e4cb
         status: 200 OK
         code: 200
-        duration: 45.928253ms
+        duration: 45.235844ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -758,7 +758,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/4ddfe3c8-ebdd-4327-858a-507314735d8b
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/3491a386-4654-4d84-85e1-a9a0dbdb5e68
         method: GET
       response:
         proto: HTTP/2.0
@@ -768,7 +768,7 @@ interactions:
         trailer: {}
         content_length: 177
         uncompressed: false
-        body: '{"args":{},"function_id":"95d72d7f-018d-466a-8164-d20b7b13674b","id":"4ddfe3c8-ebdd-4327-858a-507314735d8b","name":"tf-tests-cron-basic","schedule":"0 0 * * *","status":"ready"}'
+        body: '{"args":{},"function_id":"ee67efb0-ee5f-486a-85be-8af33324bdfd","id":"3491a386-4654-4d84-85e1-a9a0dbdb5e68","name":"tf-tests-cron-basic","schedule":"0 0 * * *","status":"ready"}'
         headers:
             Content-Length:
                 - "177"
@@ -777,9 +777,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:19 GMT
+                - Fri, 03 Jul 2026 15:02:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -787,10 +787,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 95c2686a-b58d-4cb1-a152-e7e22a38fb82
+                - e54f079f-68af-4022-ace6-7a82ff398091
         status: 200 OK
         code: 200
-        duration: 91.602989ms
+        duration: 46.454256ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -807,7 +807,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/4ddfe3c8-ebdd-4327-858a-507314735d8b
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/3491a386-4654-4d84-85e1-a9a0dbdb5e68
         method: GET
       response:
         proto: HTTP/2.0
@@ -817,7 +817,7 @@ interactions:
         trailer: {}
         content_length: 177
         uncompressed: false
-        body: '{"args":{},"function_id":"95d72d7f-018d-466a-8164-d20b7b13674b","id":"4ddfe3c8-ebdd-4327-858a-507314735d8b","name":"tf-tests-cron-basic","schedule":"0 0 * * *","status":"ready"}'
+        body: '{"args":{},"function_id":"ee67efb0-ee5f-486a-85be-8af33324bdfd","id":"3491a386-4654-4d84-85e1-a9a0dbdb5e68","name":"tf-tests-cron-basic","schedule":"0 0 * * *","status":"ready"}'
         headers:
             Content-Length:
                 - "177"
@@ -826,9 +826,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:19 GMT
+                - Fri, 03 Jul 2026 15:02:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -836,10 +836,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8af77032-b9b9-40d7-93ad-f04516208196
+                - c29c00a6-b4da-4364-a2e0-de21622bb66e
         status: 200 OK
         code: 200
-        duration: 268.387836ms
+        duration: 37.328322ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -856,7 +856,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/4ddfe3c8-ebdd-4327-858a-507314735d8b
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/3491a386-4654-4d84-85e1-a9a0dbdb5e68
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -866,7 +866,7 @@ interactions:
         trailer: {}
         content_length: 180
         uncompressed: false
-        body: '{"args":{},"function_id":"95d72d7f-018d-466a-8164-d20b7b13674b","id":"4ddfe3c8-ebdd-4327-858a-507314735d8b","name":"tf-tests-cron-basic","schedule":"0 0 * * *","status":"deleting"}'
+        body: '{"args":{},"function_id":"ee67efb0-ee5f-486a-85be-8af33324bdfd","id":"3491a386-4654-4d84-85e1-a9a0dbdb5e68","name":"tf-tests-cron-basic","schedule":"0 0 * * *","status":"deleting"}'
         headers:
             Content-Length:
                 - "180"
@@ -875,9 +875,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:19 GMT
+                - Fri, 03 Jul 2026 15:02:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -885,10 +885,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - deab102c-2a78-4ab3-8129-bd4c5942a3e5
+                - 5518aa18-a1ee-4059-8790-7d18fcb6b91c
         status: 200 OK
         code: 200
-        duration: 105.053647ms
+        duration: 64.82755ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -905,7 +905,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/95d72d7f-018d-466a-8164-d20b7b13674b
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/ee67efb0-ee5f-486a-85be-8af33324bdfd
         method: GET
       response:
         proto: HTTP/2.0
@@ -915,7 +915,7 @@ interactions:
         trailer: {}
         content_length: 726
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:13.211449Z","description":"","domain_name":"tftestsfunctioncronbinxym0x2-tf-tests-cron-basic.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"95d72d7f-018d-466a-8164-d20b7b13674b","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-basic","namespace_id":"37410ade-e486-414a-83ab-e0ac75c35d36","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:13.211449Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:07.804019Z","description":"","domain_name":"tftestsfunctioncronbevbaclj5-tf-tests-cron-basic.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"ee67efb0-ee5f-486a-85be-8af33324bdfd","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-basic","namespace_id":"00b950c3-7956-46a5-8710-523e345fd594","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:07.804019Z"}'
         headers:
             Content-Length:
                 - "726"
@@ -924,9 +924,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:20 GMT
+                - Fri, 03 Jul 2026 15:02:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -934,10 +934,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b05c95eb-de72-48dc-990a-37d02182ae71
+                - c5db7825-f2c4-4fe5-94fb-66882aeb09c2
         status: 200 OK
         code: 200
-        duration: 613.893903ms
+        duration: 46.687083ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -954,7 +954,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/95d72d7f-018d-466a-8164-d20b7b13674b
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/ee67efb0-ee5f-486a-85be-8af33324bdfd
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -964,7 +964,7 @@ interactions:
         trailer: {}
         content_length: 730
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:13.211449Z","description":"","domain_name":"tftestsfunctioncronbinxym0x2-tf-tests-cron-basic.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"95d72d7f-018d-466a-8164-d20b7b13674b","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-basic","namespace_id":"37410ade-e486-414a-83ab-e0ac75c35d36","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:20.538454245Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:07.804019Z","description":"","domain_name":"tftestsfunctioncronbevbaclj5-tf-tests-cron-basic.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"ee67efb0-ee5f-486a-85be-8af33324bdfd","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-basic","namespace_id":"00b950c3-7956-46a5-8710-523e345fd594","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:14.475467614Z"}'
         headers:
             Content-Length:
                 - "730"
@@ -973,9 +973,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:20 GMT
+                - Fri, 03 Jul 2026 15:02:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -983,10 +983,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 67a49e6e-4a3d-4c3b-877e-c46420d2bad3
+                - 9f98fcdb-4941-49b9-a2c2-6768c751097c
         status: 200 OK
         code: 200
-        duration: 156.110059ms
+        duration: 587.733556ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1003,7 +1003,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/37410ade-e486-414a-83ab-e0ac75c35d36
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/00b950c3-7956-46a5-8710-523e345fd594
         method: GET
       response:
         proto: HTTP/2.0
@@ -1013,7 +1013,7 @@ interactions:
         trailer: {}
         content_length: 597
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.932003Z","description":"","environment_variables":{},"error_message":null,"id":"37410ade-e486-414a-83ab-e0ac75c35d36","name":"tf-tests-function-cron-basic","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronbinxym0x2","registry_namespace_id":"95ba88c8-6b24-4a93-8b6c-2242544b6544","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:09.850349Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.510399Z","description":"","environment_variables":{},"error_message":null,"id":"00b950c3-7956-46a5-8710-523e345fd594","name":"tf-tests-function-cron-basic","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronbevbaclj5","registry_namespace_id":"0e11baa3-1864-4fab-86d0-4f6b3a004d24","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:05.774743Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "597"
@@ -1022,9 +1022,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:20 GMT
+                - Fri, 03 Jul 2026 15:02:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1032,10 +1032,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b22c323d-952d-4138-aff2-ae344fa3c300
+                - 3170e6b1-363b-49c1-b531-9fe56f35f772
         status: 200 OK
         code: 200
-        duration: 33.362761ms
+        duration: 31.50483ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1052,7 +1052,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/37410ade-e486-414a-83ab-e0ac75c35d36
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/00b950c3-7956-46a5-8710-523e345fd594
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1062,7 +1062,7 @@ interactions:
         trailer: {}
         content_length: 603
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.932003Z","description":"","environment_variables":{},"error_message":null,"id":"37410ade-e486-414a-83ab-e0ac75c35d36","name":"tf-tests-function-cron-basic","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronbinxym0x2","registry_namespace_id":"95ba88c8-6b24-4a93-8b6c-2242544b6544","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-05-04T12:39:20.728505381Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.510399Z","description":"","environment_variables":{},"error_message":null,"id":"00b950c3-7956-46a5-8710-523e345fd594","name":"tf-tests-function-cron-basic","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronbevbaclj5","registry_namespace_id":"0e11baa3-1864-4fab-86d0-4f6b3a004d24","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-07-03T15:02:15.090534148Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "603"
@@ -1071,9 +1071,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:21 GMT
+                - Fri, 03 Jul 2026 15:02:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1081,10 +1081,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 49ecbdaa-d7ec-46ff-886b-61766a0e1106
+                - 7a77b679-ef08-4fec-b6ee-a89c90888cff
         status: 200 OK
         code: 200
-        duration: 331.83294ms
+        duration: 1.593291967s
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1101,7 +1101,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/37410ade-e486-414a-83ab-e0ac75c35d36
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/00b950c3-7956-46a5-8710-523e345fd594
         method: GET
       response:
         proto: HTTP/2.0
@@ -1111,7 +1111,7 @@ interactions:
         trailer: {}
         content_length: 600
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.932003Z","description":"","environment_variables":{},"error_message":null,"id":"37410ade-e486-414a-83ab-e0ac75c35d36","name":"tf-tests-function-cron-basic","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronbinxym0x2","registry_namespace_id":"95ba88c8-6b24-4a93-8b6c-2242544b6544","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-05-04T12:39:20.728505Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.510399Z","description":"","environment_variables":{},"error_message":null,"id":"00b950c3-7956-46a5-8710-523e345fd594","name":"tf-tests-function-cron-basic","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronbevbaclj5","registry_namespace_id":"0e11baa3-1864-4fab-86d0-4f6b3a004d24","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-07-03T15:02:15.090534Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "600"
@@ -1120,9 +1120,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:21 GMT
+                - Fri, 03 Jul 2026 15:02:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1130,10 +1130,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9beb3732-caa6-4872-a0c6-3f30ff7cee5a
+                - 95cdfa78-5da7-4b56-8e32-7bbeaddeabea
         status: 200 OK
         code: 200
-        duration: 31.165148ms
+        duration: 33.87583ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1150,7 +1150,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/37410ade-e486-414a-83ab-e0ac75c35d36
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/00b950c3-7956-46a5-8710-523e345fd594
         method: GET
       response:
         proto: HTTP/2.0
@@ -1169,9 +1169,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:51 GMT
+                - Fri, 03 Jul 2026 15:02:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1179,10 +1179,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dc66e701-a4bd-4656-b9df-5a88bcc22f4c
+                - e49cc7e8-db51-48c7-8017-78866366d064
         status: 404 Not Found
         code: 404
-        duration: 34.973229ms
+        duration: 23.475059ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1199,7 +1199,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/4ddfe3c8-ebdd-4327-858a-507314735d8b
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/3491a386-4654-4d84-85e1-a9a0dbdb5e68
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1218,9 +1218,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:51 GMT
+                - Fri, 03 Jul 2026 15:02:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1228,7 +1228,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4bcfc30a-723a-4264-8a4c-cad7ad48605f
+                - c070476b-4aea-4c34-9189-41ba1d7337fd
         status: 404 Not Found
         code: 404
-        duration: 23.880346ms
+        duration: 22.99703ms

--- a/internal/services/function/testdata/function-cron-name-update.cassette.yaml
+++ b/internal/services/function/testdata/function-cron-name-update.cassette.yaml
@@ -29,7 +29,7 @@ interactions:
         trailer: {}
         content_length: 520
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:39:34.668976212Z","description":"","environment_variables":{},"error_message":null,"id":"c2a45bfc-b13c-4d64-b2cc-b73c25df408a","name":"tf-tests-function-cron-name-update","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-05-04T12:39:34.668976212Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:02:14.892208930Z","description":"","environment_variables":{},"error_message":null,"id":"dc97e3d6-d1d8-4a3e-b964-50116b830b4a","name":"tf-tests-function-cron-name-update","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-07-03T15:02:14.892208930Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "520"
@@ -38,9 +38,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:34 GMT
+                - Fri, 03 Jul 2026 15:02:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4e06eea8-ea5c-4457-8473-0772b68d41c5
+                - a3a563c3-b7bf-430b-8df8-0c0de404a80b
         status: 200 OK
         code: 200
-        duration: 349.31198ms
+        duration: 4.062471382s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -68,7 +68,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/c2a45bfc-b13c-4d64-b2cc-b73c25df408a
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/dc97e3d6-d1d8-4a3e-b964-50116b830b4a
         method: GET
       response:
         proto: HTTP/2.0
@@ -78,7 +78,7 @@ interactions:
         trailer: {}
         content_length: 514
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:39:34.668976Z","description":"","environment_variables":{},"error_message":null,"id":"c2a45bfc-b13c-4d64-b2cc-b73c25df408a","name":"tf-tests-function-cron-name-update","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-05-04T12:39:34.668976Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:02:14.892209Z","description":"","environment_variables":{},"error_message":null,"id":"dc97e3d6-d1d8-4a3e-b964-50116b830b4a","name":"tf-tests-function-cron-name-update","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-07-03T15:02:14.892209Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "514"
@@ -87,9 +87,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:34 GMT
+                - Fri, 03 Jul 2026 15:02:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7253f2ec-d381-4619-805d-8a0ebee6ab8d
+                - 80165025-59b8-4ea1-a1ea-2eb80064405a
         status: 200 OK
         code: 200
-        duration: 28.171637ms
+        duration: 131.536267ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -117,7 +117,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/c2a45bfc-b13c-4d64-b2cc-b73c25df408a
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/dc97e3d6-d1d8-4a3e-b964-50116b830b4a
         method: GET
       response:
         proto: HTTP/2.0
@@ -127,7 +127,7 @@ interactions:
         trailer: {}
         content_length: 603
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:39:34.668976Z","description":"","environment_variables":{},"error_message":null,"id":"c2a45bfc-b13c-4d64-b2cc-b73c25df408a","name":"tf-tests-function-cron-name-update","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronni7agz2hj","registry_namespace_id":"87c298ca-0eb6-4880-9f35-5aa06ce09fcb","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:36.683912Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:02:14.892209Z","description":"","environment_variables":{},"error_message":null,"id":"dc97e3d6-d1d8-4a3e-b964-50116b830b4a","name":"tf-tests-function-cron-name-update","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronn3w3kv4iy","registry_namespace_id":"189769f1-513c-4e58-8fa8-dbe466b40faf","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:16.405360Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "603"
@@ -136,9 +136,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:39 GMT
+                - Fri, 03 Jul 2026 15:02:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d7bc31fd-8432-419f-bbb9-02d86be15d0d
+                - 1f37771e-7742-4cb7-bbd1-6a93205f464b
         status: 200 OK
         code: 200
-        duration: 98.166061ms
+        duration: 30.23908ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -166,7 +166,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/c2a45bfc-b13c-4d64-b2cc-b73c25df408a
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/dc97e3d6-d1d8-4a3e-b964-50116b830b4a
         method: GET
       response:
         proto: HTTP/2.0
@@ -176,7 +176,7 @@ interactions:
         trailer: {}
         content_length: 603
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:39:34.668976Z","description":"","environment_variables":{},"error_message":null,"id":"c2a45bfc-b13c-4d64-b2cc-b73c25df408a","name":"tf-tests-function-cron-name-update","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronni7agz2hj","registry_namespace_id":"87c298ca-0eb6-4880-9f35-5aa06ce09fcb","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:36.683912Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:02:14.892209Z","description":"","environment_variables":{},"error_message":null,"id":"dc97e3d6-d1d8-4a3e-b964-50116b830b4a","name":"tf-tests-function-cron-name-update","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronn3w3kv4iy","registry_namespace_id":"189769f1-513c-4e58-8fa8-dbe466b40faf","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:16.405360Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "603"
@@ -185,9 +185,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:39 GMT
+                - Fri, 03 Jul 2026 15:02:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,10 +195,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ed1ce86a-91bc-4cbe-8de5-b0f6be93577e
+                - 18947d11-4167-4dce-adc0-aa76a7c91be7
         status: 200 OK
         code: 200
-        duration: 43.406394ms
+        duration: 34.623315ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -210,7 +210,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-tests-function-cron-name-update","namespace_id":"c2a45bfc-b13c-4d64-b2cc-b73c25df408a","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node20","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox","tags":null}'
+        body: '{"name":"tf-tests-function-cron-name-update","namespace_id":"dc97e3d6-d1d8-4a3e-b964-50116b830b4a","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node26","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox","tags":null}'
         form: {}
         headers:
             Content-Type:
@@ -227,7 +227,7 @@ interactions:
         trailer: {}
         content_length: 762
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:39.948862439Z","description":"","domain_name":"tftestsfunctioncronni7agz2hj-tf-tests-function-cron-name-update.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"3acccd6e-64e7-44b7-868b-11bfc5dfef4d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-function-cron-name-update","namespace_id":"c2a45bfc-b13c-4d64-b2cc-b73c25df408a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:39.948862439Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:20.236933995Z","description":"","domain_name":"tftestsfunctioncronn3w3kv4iy-tf-tests-function-cron-name-update.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0d31b7cf-e6c0-49f7-924a-41a1288dc615","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-function-cron-name-update","namespace_id":"dc97e3d6-d1d8-4a3e-b964-50116b830b4a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:20.236933995Z"}'
         headers:
             Content-Length:
                 - "762"
@@ -236,9 +236,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:39 GMT
+                - Fri, 03 Jul 2026 15:02:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -246,10 +246,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 269f65cc-0794-403c-ade3-d6532ac4e7b2
+                - 889ed2a1-7527-45f3-b8e1-6162737e4752
         status: 200 OK
         code: 200
-        duration: 167.815906ms
+        duration: 129.887646ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -266,7 +266,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/3acccd6e-64e7-44b7-868b-11bfc5dfef4d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0d31b7cf-e6c0-49f7-924a-41a1288dc615
         method: GET
       response:
         proto: HTTP/2.0
@@ -276,7 +276,7 @@ interactions:
         trailer: {}
         content_length: 756
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:39.948862Z","description":"","domain_name":"tftestsfunctioncronni7agz2hj-tf-tests-function-cron-name-update.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"3acccd6e-64e7-44b7-868b-11bfc5dfef4d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-function-cron-name-update","namespace_id":"c2a45bfc-b13c-4d64-b2cc-b73c25df408a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:39.948862Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:20.236934Z","description":"","domain_name":"tftestsfunctioncronn3w3kv4iy-tf-tests-function-cron-name-update.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0d31b7cf-e6c0-49f7-924a-41a1288dc615","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-function-cron-name-update","namespace_id":"dc97e3d6-d1d8-4a3e-b964-50116b830b4a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:20.236934Z"}'
         headers:
             Content-Length:
                 - "756"
@@ -285,9 +285,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:40 GMT
+                - Fri, 03 Jul 2026 15:02:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -295,10 +295,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7f2de200-9bb8-4e2c-adfb-5da52e81d43a
+                - 4ce4837b-cabe-4781-b302-fcc6cc35b3b5
         status: 200 OK
         code: 200
-        duration: 208.125133ms
+        duration: 46.68007ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -315,7 +315,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/3acccd6e-64e7-44b7-868b-11bfc5dfef4d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0d31b7cf-e6c0-49f7-924a-41a1288dc615
         method: GET
       response:
         proto: HTTP/2.0
@@ -325,7 +325,7 @@ interactions:
         trailer: {}
         content_length: 756
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:39.948862Z","description":"","domain_name":"tftestsfunctioncronni7agz2hj-tf-tests-function-cron-name-update.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"3acccd6e-64e7-44b7-868b-11bfc5dfef4d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-function-cron-name-update","namespace_id":"c2a45bfc-b13c-4d64-b2cc-b73c25df408a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:39.948862Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:20.236934Z","description":"","domain_name":"tftestsfunctioncronn3w3kv4iy-tf-tests-function-cron-name-update.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0d31b7cf-e6c0-49f7-924a-41a1288dc615","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-function-cron-name-update","namespace_id":"dc97e3d6-d1d8-4a3e-b964-50116b830b4a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:20.236934Z"}'
         headers:
             Content-Length:
                 - "756"
@@ -334,9 +334,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:40 GMT
+                - Fri, 03 Jul 2026 15:02:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -344,10 +344,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5259531a-1ff0-43bd-9a4e-5348cb0693e9
+                - 7056ef50-7301-4f96-83f6-5a7155ad9792
         status: 200 OK
         code: 200
-        duration: 44.085623ms
+        duration: 48.371391ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -364,7 +364,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/3acccd6e-64e7-44b7-868b-11bfc5dfef4d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0d31b7cf-e6c0-49f7-924a-41a1288dc615
         method: GET
       response:
         proto: HTTP/2.0
@@ -374,7 +374,7 @@ interactions:
         trailer: {}
         content_length: 756
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:39.948862Z","description":"","domain_name":"tftestsfunctioncronni7agz2hj-tf-tests-function-cron-name-update.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"3acccd6e-64e7-44b7-868b-11bfc5dfef4d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-function-cron-name-update","namespace_id":"c2a45bfc-b13c-4d64-b2cc-b73c25df408a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:39.948862Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:20.236934Z","description":"","domain_name":"tftestsfunctioncronn3w3kv4iy-tf-tests-function-cron-name-update.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0d31b7cf-e6c0-49f7-924a-41a1288dc615","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-function-cron-name-update","namespace_id":"dc97e3d6-d1d8-4a3e-b964-50116b830b4a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:20.236934Z"}'
         headers:
             Content-Length:
                 - "756"
@@ -383,9 +383,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:40 GMT
+                - Fri, 03 Jul 2026 15:02:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -393,10 +393,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1e2063ce-7503-4096-9ae2-60a2f062cb87
+                - 8fe6f933-6626-43ad-9437-4e0df88f4d09
         status: 200 OK
         code: 200
-        duration: 207.801163ms
+        duration: 45.064171ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -408,7 +408,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"function_id":"3acccd6e-64e7-44b7-868b-11bfc5dfef4d","schedule":"0 0 * * *","args":{},"name":"tf-tests-function-cron-name-update"}'
+        body: '{"function_id":"0d31b7cf-e6c0-49f7-924a-41a1288dc615","schedule":"0 0 * * *","args":{},"name":"tf-tests-function-cron-name-update"}'
         form: {}
         headers:
             Content-Type:
@@ -425,7 +425,7 @@ interactions:
         trailer: {}
         content_length: 194
         uncompressed: false
-        body: '{"args":{},"function_id":"3acccd6e-64e7-44b7-868b-11bfc5dfef4d","id":"d2a35a16-f329-4747-bef8-550b6f2232eb","name":"tf-tests-function-cron-name-update","schedule":"0 0 * * *","status":"pending"}'
+        body: '{"args":{},"function_id":"0d31b7cf-e6c0-49f7-924a-41a1288dc615","id":"f620b8e2-61aa-44ef-ae6c-1c6b55e74cf5","name":"tf-tests-function-cron-name-update","schedule":"0 0 * * *","status":"pending"}'
         headers:
             Content-Length:
                 - "194"
@@ -434,9 +434,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:40 GMT
+                - Fri, 03 Jul 2026 15:02:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -444,10 +444,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1950ad10-398a-4a64-bfb5-253921d92b6c
+                - 922b0b0b-ae1d-49cd-95dd-0c1447e65394
         status: 200 OK
         code: 200
-        duration: 77.777137ms
+        duration: 100.12862ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -464,7 +464,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/d2a35a16-f329-4747-bef8-550b6f2232eb
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/f620b8e2-61aa-44ef-ae6c-1c6b55e74cf5
         method: GET
       response:
         proto: HTTP/2.0
@@ -474,7 +474,7 @@ interactions:
         trailer: {}
         content_length: 192
         uncompressed: false
-        body: '{"args":{},"function_id":"3acccd6e-64e7-44b7-868b-11bfc5dfef4d","id":"d2a35a16-f329-4747-bef8-550b6f2232eb","name":"tf-tests-function-cron-name-update","schedule":"0 0 * * *","status":"ready"}'
+        body: '{"args":{},"function_id":"0d31b7cf-e6c0-49f7-924a-41a1288dc615","id":"f620b8e2-61aa-44ef-ae6c-1c6b55e74cf5","name":"tf-tests-function-cron-name-update","schedule":"0 0 * * *","status":"ready"}'
         headers:
             Content-Length:
                 - "192"
@@ -483,9 +483,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:40 GMT
+                - Fri, 03 Jul 2026 15:02:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -493,10 +493,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0407a3a6-f7cd-4c9c-b2c2-9a767d56980a
+                - fc99d45a-46bd-423e-ab50-aff841016611
         status: 200 OK
         code: 200
-        duration: 65.447428ms
+        duration: 60.521481ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -513,7 +513,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/d2a35a16-f329-4747-bef8-550b6f2232eb
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/f620b8e2-61aa-44ef-ae6c-1c6b55e74cf5
         method: GET
       response:
         proto: HTTP/2.0
@@ -523,7 +523,7 @@ interactions:
         trailer: {}
         content_length: 192
         uncompressed: false
-        body: '{"args":{},"function_id":"3acccd6e-64e7-44b7-868b-11bfc5dfef4d","id":"d2a35a16-f329-4747-bef8-550b6f2232eb","name":"tf-tests-function-cron-name-update","schedule":"0 0 * * *","status":"ready"}'
+        body: '{"args":{},"function_id":"0d31b7cf-e6c0-49f7-924a-41a1288dc615","id":"f620b8e2-61aa-44ef-ae6c-1c6b55e74cf5","name":"tf-tests-function-cron-name-update","schedule":"0 0 * * *","status":"ready"}'
         headers:
             Content-Length:
                 - "192"
@@ -532,9 +532,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:40 GMT
+                - Fri, 03 Jul 2026 15:02:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -542,10 +542,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3cbd5db7-fdac-4c9b-9fbc-00701ece3905
+                - f22eb772-2b5e-48e7-bf46-4b3df5d54cbf
         status: 200 OK
         code: 200
-        duration: 103.86225ms
+        duration: 49.511886ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -562,7 +562,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/d2a35a16-f329-4747-bef8-550b6f2232eb
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/f620b8e2-61aa-44ef-ae6c-1c6b55e74cf5
         method: GET
       response:
         proto: HTTP/2.0
@@ -572,7 +572,7 @@ interactions:
         trailer: {}
         content_length: 192
         uncompressed: false
-        body: '{"args":{},"function_id":"3acccd6e-64e7-44b7-868b-11bfc5dfef4d","id":"d2a35a16-f329-4747-bef8-550b6f2232eb","name":"tf-tests-function-cron-name-update","schedule":"0 0 * * *","status":"ready"}'
+        body: '{"args":{},"function_id":"0d31b7cf-e6c0-49f7-924a-41a1288dc615","id":"f620b8e2-61aa-44ef-ae6c-1c6b55e74cf5","name":"tf-tests-function-cron-name-update","schedule":"0 0 * * *","status":"ready"}'
         headers:
             Content-Length:
                 - "192"
@@ -581,9 +581,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:40 GMT
+                - Fri, 03 Jul 2026 15:02:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -591,10 +591,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8aa3bd79-0146-4a27-83a0-4f5630cdfd67
+                - a8d545a7-83c1-4a40-804a-3afbc841dee0
         status: 200 OK
         code: 200
-        duration: 126.31612ms
+        duration: 61.734082ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -611,7 +611,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/c2a45bfc-b13c-4d64-b2cc-b73c25df408a
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/dc97e3d6-d1d8-4a3e-b964-50116b830b4a
         method: GET
       response:
         proto: HTTP/2.0
@@ -621,7 +621,7 @@ interactions:
         trailer: {}
         content_length: 603
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:39:34.668976Z","description":"","environment_variables":{},"error_message":null,"id":"c2a45bfc-b13c-4d64-b2cc-b73c25df408a","name":"tf-tests-function-cron-name-update","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronni7agz2hj","registry_namespace_id":"87c298ca-0eb6-4880-9f35-5aa06ce09fcb","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:36.683912Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:02:14.892209Z","description":"","environment_variables":{},"error_message":null,"id":"dc97e3d6-d1d8-4a3e-b964-50116b830b4a","name":"tf-tests-function-cron-name-update","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronn3w3kv4iy","registry_namespace_id":"189769f1-513c-4e58-8fa8-dbe466b40faf","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:16.405360Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "603"
@@ -630,9 +630,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:41 GMT
+                - Fri, 03 Jul 2026 15:02:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -640,10 +640,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c7ddce95-d6da-4935-9ec4-69629def05c8
+                - f82e6ec4-f4d4-4831-90a4-0a9051f3f0c4
         status: 200 OK
         code: 200
-        duration: 100.358728ms
+        duration: 31.756324ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -660,7 +660,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/3acccd6e-64e7-44b7-868b-11bfc5dfef4d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0d31b7cf-e6c0-49f7-924a-41a1288dc615
         method: GET
       response:
         proto: HTTP/2.0
@@ -670,7 +670,7 @@ interactions:
         trailer: {}
         content_length: 756
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:39.948862Z","description":"","domain_name":"tftestsfunctioncronni7agz2hj-tf-tests-function-cron-name-update.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"3acccd6e-64e7-44b7-868b-11bfc5dfef4d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-function-cron-name-update","namespace_id":"c2a45bfc-b13c-4d64-b2cc-b73c25df408a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:39.948862Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:20.236934Z","description":"","domain_name":"tftestsfunctioncronn3w3kv4iy-tf-tests-function-cron-name-update.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0d31b7cf-e6c0-49f7-924a-41a1288dc615","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-function-cron-name-update","namespace_id":"dc97e3d6-d1d8-4a3e-b964-50116b830b4a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:20.236934Z"}'
         headers:
             Content-Length:
                 - "756"
@@ -679,9 +679,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:41 GMT
+                - Fri, 03 Jul 2026 15:02:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -689,10 +689,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3caa184f-7023-4d71-a873-8f1d9e3812dc
+                - fb9a374c-33e6-46d4-ba22-f6abc2b96a60
         status: 200 OK
         code: 200
-        duration: 46.912572ms
+        duration: 38.138846ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -709,7 +709,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/d2a35a16-f329-4747-bef8-550b6f2232eb
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/f620b8e2-61aa-44ef-ae6c-1c6b55e74cf5
         method: GET
       response:
         proto: HTTP/2.0
@@ -719,7 +719,7 @@ interactions:
         trailer: {}
         content_length: 192
         uncompressed: false
-        body: '{"args":{},"function_id":"3acccd6e-64e7-44b7-868b-11bfc5dfef4d","id":"d2a35a16-f329-4747-bef8-550b6f2232eb","name":"tf-tests-function-cron-name-update","schedule":"0 0 * * *","status":"ready"}'
+        body: '{"args":{},"function_id":"0d31b7cf-e6c0-49f7-924a-41a1288dc615","id":"f620b8e2-61aa-44ef-ae6c-1c6b55e74cf5","name":"tf-tests-function-cron-name-update","schedule":"0 0 * * *","status":"ready"}'
         headers:
             Content-Length:
                 - "192"
@@ -728,9 +728,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:41 GMT
+                - Fri, 03 Jul 2026 15:02:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -738,10 +738,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a3ba6180-8680-4f84-97ab-e6268c94c3ea
+                - 8ae6ca5f-9c27-4800-872b-069a8db31294
         status: 200 OK
         code: 200
-        duration: 128.105728ms
+        duration: 51.430304ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -758,7 +758,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/c2a45bfc-b13c-4d64-b2cc-b73c25df408a
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/dc97e3d6-d1d8-4a3e-b964-50116b830b4a
         method: GET
       response:
         proto: HTTP/2.0
@@ -768,7 +768,7 @@ interactions:
         trailer: {}
         content_length: 603
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:39:34.668976Z","description":"","environment_variables":{},"error_message":null,"id":"c2a45bfc-b13c-4d64-b2cc-b73c25df408a","name":"tf-tests-function-cron-name-update","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronni7agz2hj","registry_namespace_id":"87c298ca-0eb6-4880-9f35-5aa06ce09fcb","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:36.683912Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:02:14.892209Z","description":"","environment_variables":{},"error_message":null,"id":"dc97e3d6-d1d8-4a3e-b964-50116b830b4a","name":"tf-tests-function-cron-name-update","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronn3w3kv4iy","registry_namespace_id":"189769f1-513c-4e58-8fa8-dbe466b40faf","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:16.405360Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "603"
@@ -777,9 +777,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:41 GMT
+                - Fri, 03 Jul 2026 15:02:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -787,10 +787,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 916d7b83-5833-4a38-9615-6e3b7cc3313d
+                - 8a9b32d1-bca0-401e-b88f-c7be2c0ae4fd
         status: 200 OK
         code: 200
-        duration: 29.322715ms
+        duration: 37.805771ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -807,7 +807,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/3acccd6e-64e7-44b7-868b-11bfc5dfef4d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0d31b7cf-e6c0-49f7-924a-41a1288dc615
         method: GET
       response:
         proto: HTTP/2.0
@@ -817,7 +817,7 @@ interactions:
         trailer: {}
         content_length: 756
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:39.948862Z","description":"","domain_name":"tftestsfunctioncronni7agz2hj-tf-tests-function-cron-name-update.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"3acccd6e-64e7-44b7-868b-11bfc5dfef4d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-function-cron-name-update","namespace_id":"c2a45bfc-b13c-4d64-b2cc-b73c25df408a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:39.948862Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:20.236934Z","description":"","domain_name":"tftestsfunctioncronn3w3kv4iy-tf-tests-function-cron-name-update.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0d31b7cf-e6c0-49f7-924a-41a1288dc615","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-function-cron-name-update","namespace_id":"dc97e3d6-d1d8-4a3e-b964-50116b830b4a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:20.236934Z"}'
         headers:
             Content-Length:
                 - "756"
@@ -826,9 +826,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:41 GMT
+                - Fri, 03 Jul 2026 15:02:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -836,10 +836,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e3c24330-d25d-4ea2-9afd-888f70b2d7c6
+                - 16c6e4c9-b176-4c5f-a69c-fac3fca9e079
         status: 200 OK
         code: 200
-        duration: 38.949448ms
+        duration: 38.901351ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -856,7 +856,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/d2a35a16-f329-4747-bef8-550b6f2232eb
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/f620b8e2-61aa-44ef-ae6c-1c6b55e74cf5
         method: GET
       response:
         proto: HTTP/2.0
@@ -866,7 +866,7 @@ interactions:
         trailer: {}
         content_length: 192
         uncompressed: false
-        body: '{"args":{},"function_id":"3acccd6e-64e7-44b7-868b-11bfc5dfef4d","id":"d2a35a16-f329-4747-bef8-550b6f2232eb","name":"tf-tests-function-cron-name-update","schedule":"0 0 * * *","status":"ready"}'
+        body: '{"args":{},"function_id":"0d31b7cf-e6c0-49f7-924a-41a1288dc615","id":"f620b8e2-61aa-44ef-ae6c-1c6b55e74cf5","name":"tf-tests-function-cron-name-update","schedule":"0 0 * * *","status":"ready"}'
         headers:
             Content-Length:
                 - "192"
@@ -875,9 +875,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:41 GMT
+                - Fri, 03 Jul 2026 15:02:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -885,10 +885,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - af4124f2-6127-44ba-afa1-12d3a0ff4343
+                - 661592eb-fb00-41dc-91dc-20ec543e27eb
         status: 200 OK
         code: 200
-        duration: 92.397458ms
+        duration: 61.202261ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -905,7 +905,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/d2a35a16-f329-4747-bef8-550b6f2232eb
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/f620b8e2-61aa-44ef-ae6c-1c6b55e74cf5
         method: GET
       response:
         proto: HTTP/2.0
@@ -915,7 +915,7 @@ interactions:
         trailer: {}
         content_length: 192
         uncompressed: false
-        body: '{"args":{},"function_id":"3acccd6e-64e7-44b7-868b-11bfc5dfef4d","id":"d2a35a16-f329-4747-bef8-550b6f2232eb","name":"tf-tests-function-cron-name-update","schedule":"0 0 * * *","status":"ready"}'
+        body: '{"args":{},"function_id":"0d31b7cf-e6c0-49f7-924a-41a1288dc615","id":"f620b8e2-61aa-44ef-ae6c-1c6b55e74cf5","name":"tf-tests-function-cron-name-update","schedule":"0 0 * * *","status":"ready"}'
         headers:
             Content-Length:
                 - "192"
@@ -924,9 +924,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:41 GMT
+                - Fri, 03 Jul 2026 15:02:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -934,10 +934,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9feb2470-f0dd-4a2d-ac4e-66f80972c3c4
+                - c6a67dbf-27cb-461f-8161-ad321bcad046
         status: 200 OK
         code: 200
-        duration: 44.72669ms
+        duration: 46.080592ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -956,7 +956,7 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/d2a35a16-f329-4747-bef8-550b6f2232eb
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/f620b8e2-61aa-44ef-ae6c-1c6b55e74cf5
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -966,7 +966,7 @@ interactions:
         trailer: {}
         content_length: 184
         uncompressed: false
-        body: '{"args":{"test":"scw"},"function_id":"3acccd6e-64e7-44b7-868b-11bfc5dfef4d","id":"d2a35a16-f329-4747-bef8-550b6f2232eb","name":"name-changed","schedule":"0 0 * * *","status":"pending"}'
+        body: '{"args":{"test":"scw"},"function_id":"0d31b7cf-e6c0-49f7-924a-41a1288dc615","id":"f620b8e2-61aa-44ef-ae6c-1c6b55e74cf5","name":"name-changed","schedule":"0 0 * * *","status":"pending"}'
         headers:
             Content-Length:
                 - "184"
@@ -975,9 +975,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:42 GMT
+                - Fri, 03 Jul 2026 15:02:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -985,10 +985,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - edc0fce8-48c2-4ef5-a220-ca398d1a5266
+                - 29c08d94-887e-4d18-a2b9-0703e413f192
         status: 200 OK
         code: 200
-        duration: 121.411653ms
+        duration: 96.161709ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1005,7 +1005,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/d2a35a16-f329-4747-bef8-550b6f2232eb
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/f620b8e2-61aa-44ef-ae6c-1c6b55e74cf5
         method: GET
       response:
         proto: HTTP/2.0
@@ -1015,7 +1015,7 @@ interactions:
         trailer: {}
         content_length: 182
         uncompressed: false
-        body: '{"args":{"test":"scw"},"function_id":"3acccd6e-64e7-44b7-868b-11bfc5dfef4d","id":"d2a35a16-f329-4747-bef8-550b6f2232eb","name":"name-changed","schedule":"0 0 * * *","status":"ready"}'
+        body: '{"args":{"test":"scw"},"function_id":"0d31b7cf-e6c0-49f7-924a-41a1288dc615","id":"f620b8e2-61aa-44ef-ae6c-1c6b55e74cf5","name":"name-changed","schedule":"0 0 * * *","status":"ready"}'
         headers:
             Content-Length:
                 - "182"
@@ -1024,9 +1024,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:42 GMT
+                - Fri, 03 Jul 2026 15:02:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1034,10 +1034,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5373d1b9-0be5-4fb2-8240-35b8835cd663
+                - 6203e33d-0477-4af8-a802-8d0940f23bd8
         status: 200 OK
         code: 200
-        duration: 116.501263ms
+        duration: 38.213157ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1054,7 +1054,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/d2a35a16-f329-4747-bef8-550b6f2232eb
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/f620b8e2-61aa-44ef-ae6c-1c6b55e74cf5
         method: GET
       response:
         proto: HTTP/2.0
@@ -1064,7 +1064,7 @@ interactions:
         trailer: {}
         content_length: 182
         uncompressed: false
-        body: '{"args":{"test":"scw"},"function_id":"3acccd6e-64e7-44b7-868b-11bfc5dfef4d","id":"d2a35a16-f329-4747-bef8-550b6f2232eb","name":"name-changed","schedule":"0 0 * * *","status":"ready"}'
+        body: '{"args":{"test":"scw"},"function_id":"0d31b7cf-e6c0-49f7-924a-41a1288dc615","id":"f620b8e2-61aa-44ef-ae6c-1c6b55e74cf5","name":"name-changed","schedule":"0 0 * * *","status":"ready"}'
         headers:
             Content-Length:
                 - "182"
@@ -1073,9 +1073,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:42 GMT
+                - Fri, 03 Jul 2026 15:02:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1083,10 +1083,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e8d71201-207c-4d15-81ca-1b665b8e922a
+                - 8f434409-80f2-48fd-9928-5b4f111f955c
         status: 200 OK
         code: 200
-        duration: 108.737394ms
+        duration: 86.483218ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1103,7 +1103,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/c2a45bfc-b13c-4d64-b2cc-b73c25df408a
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/dc97e3d6-d1d8-4a3e-b964-50116b830b4a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1113,7 +1113,7 @@ interactions:
         trailer: {}
         content_length: 603
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:39:34.668976Z","description":"","environment_variables":{},"error_message":null,"id":"c2a45bfc-b13c-4d64-b2cc-b73c25df408a","name":"tf-tests-function-cron-name-update","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronni7agz2hj","registry_namespace_id":"87c298ca-0eb6-4880-9f35-5aa06ce09fcb","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:36.683912Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:02:14.892209Z","description":"","environment_variables":{},"error_message":null,"id":"dc97e3d6-d1d8-4a3e-b964-50116b830b4a","name":"tf-tests-function-cron-name-update","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronn3w3kv4iy","registry_namespace_id":"189769f1-513c-4e58-8fa8-dbe466b40faf","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:16.405360Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "603"
@@ -1122,9 +1122,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:42 GMT
+                - Fri, 03 Jul 2026 15:02:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1132,10 +1132,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b06a9932-72eb-4658-ab87-8e221dc15f93
+                - fe96f0dc-753e-4207-8078-0d7a4bffd18b
         status: 200 OK
         code: 200
-        duration: 101.164255ms
+        duration: 38.372807ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1152,7 +1152,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/3acccd6e-64e7-44b7-868b-11bfc5dfef4d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0d31b7cf-e6c0-49f7-924a-41a1288dc615
         method: GET
       response:
         proto: HTTP/2.0
@@ -1162,7 +1162,7 @@ interactions:
         trailer: {}
         content_length: 756
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:39.948862Z","description":"","domain_name":"tftestsfunctioncronni7agz2hj-tf-tests-function-cron-name-update.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"3acccd6e-64e7-44b7-868b-11bfc5dfef4d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-function-cron-name-update","namespace_id":"c2a45bfc-b13c-4d64-b2cc-b73c25df408a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:39.948862Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:20.236934Z","description":"","domain_name":"tftestsfunctioncronn3w3kv4iy-tf-tests-function-cron-name-update.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0d31b7cf-e6c0-49f7-924a-41a1288dc615","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-function-cron-name-update","namespace_id":"dc97e3d6-d1d8-4a3e-b964-50116b830b4a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:20.236934Z"}'
         headers:
             Content-Length:
                 - "756"
@@ -1171,9 +1171,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:42 GMT
+                - Fri, 03 Jul 2026 15:02:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1181,10 +1181,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0ca61b6d-ddc7-4a15-a94b-09f2b2460466
+                - 941adc49-f71c-4bae-a86f-c79d10f8d35f
         status: 200 OK
         code: 200
-        duration: 111.283836ms
+        duration: 48.303503ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1201,7 +1201,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/d2a35a16-f329-4747-bef8-550b6f2232eb
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/f620b8e2-61aa-44ef-ae6c-1c6b55e74cf5
         method: GET
       response:
         proto: HTTP/2.0
@@ -1211,7 +1211,7 @@ interactions:
         trailer: {}
         content_length: 182
         uncompressed: false
-        body: '{"args":{"test":"scw"},"function_id":"3acccd6e-64e7-44b7-868b-11bfc5dfef4d","id":"d2a35a16-f329-4747-bef8-550b6f2232eb","name":"name-changed","schedule":"0 0 * * *","status":"ready"}'
+        body: '{"args":{"test":"scw"},"function_id":"0d31b7cf-e6c0-49f7-924a-41a1288dc615","id":"f620b8e2-61aa-44ef-ae6c-1c6b55e74cf5","name":"name-changed","schedule":"0 0 * * *","status":"ready"}'
         headers:
             Content-Length:
                 - "182"
@@ -1220,9 +1220,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:42 GMT
+                - Fri, 03 Jul 2026 15:02:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1230,10 +1230,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ffb6bf8f-d014-477a-866e-2d7a0c19f838
+                - a2c8a602-9b93-4cb5-9630-be5f7a759747
         status: 200 OK
         code: 200
-        duration: 64.348771ms
+        duration: 57.694725ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1250,7 +1250,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/d2a35a16-f329-4747-bef8-550b6f2232eb
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/f620b8e2-61aa-44ef-ae6c-1c6b55e74cf5
         method: GET
       response:
         proto: HTTP/2.0
@@ -1260,7 +1260,7 @@ interactions:
         trailer: {}
         content_length: 182
         uncompressed: false
-        body: '{"args":{"test":"scw"},"function_id":"3acccd6e-64e7-44b7-868b-11bfc5dfef4d","id":"d2a35a16-f329-4747-bef8-550b6f2232eb","name":"name-changed","schedule":"0 0 * * *","status":"ready"}'
+        body: '{"args":{"test":"scw"},"function_id":"0d31b7cf-e6c0-49f7-924a-41a1288dc615","id":"f620b8e2-61aa-44ef-ae6c-1c6b55e74cf5","name":"name-changed","schedule":"0 0 * * *","status":"ready"}'
         headers:
             Content-Length:
                 - "182"
@@ -1269,9 +1269,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:43 GMT
+                - Fri, 03 Jul 2026 15:02:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1279,10 +1279,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 90112f4e-baaf-4273-a6d9-8bde6fd89c62
+                - 86148234-ec32-4000-9f85-5a2719068c9e
         status: 200 OK
         code: 200
-        duration: 79.230754ms
+        duration: 44.26066ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1299,7 +1299,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/d2a35a16-f329-4747-bef8-550b6f2232eb
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/f620b8e2-61aa-44ef-ae6c-1c6b55e74cf5
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1309,7 +1309,7 @@ interactions:
         trailer: {}
         content_length: 185
         uncompressed: false
-        body: '{"args":{"test":"scw"},"function_id":"3acccd6e-64e7-44b7-868b-11bfc5dfef4d","id":"d2a35a16-f329-4747-bef8-550b6f2232eb","name":"name-changed","schedule":"0 0 * * *","status":"deleting"}'
+        body: '{"args":{"test":"scw"},"function_id":"0d31b7cf-e6c0-49f7-924a-41a1288dc615","id":"f620b8e2-61aa-44ef-ae6c-1c6b55e74cf5","name":"name-changed","schedule":"0 0 * * *","status":"deleting"}'
         headers:
             Content-Length:
                 - "185"
@@ -1318,9 +1318,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:43 GMT
+                - Fri, 03 Jul 2026 15:02:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1328,10 +1328,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 20781716-34ed-4c0b-a24b-5e94a1873beb
+                - 1232463f-78e0-4e09-a8a5-e51ae8d26b71
         status: 200 OK
         code: 200
-        duration: 148.486419ms
+        duration: 92.977521ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1348,7 +1348,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/3acccd6e-64e7-44b7-868b-11bfc5dfef4d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0d31b7cf-e6c0-49f7-924a-41a1288dc615
         method: GET
       response:
         proto: HTTP/2.0
@@ -1358,7 +1358,7 @@ interactions:
         trailer: {}
         content_length: 756
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:39.948862Z","description":"","domain_name":"tftestsfunctioncronni7agz2hj-tf-tests-function-cron-name-update.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"3acccd6e-64e7-44b7-868b-11bfc5dfef4d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-function-cron-name-update","namespace_id":"c2a45bfc-b13c-4d64-b2cc-b73c25df408a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:39.948862Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:20.236934Z","description":"","domain_name":"tftestsfunctioncronn3w3kv4iy-tf-tests-function-cron-name-update.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0d31b7cf-e6c0-49f7-924a-41a1288dc615","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-function-cron-name-update","namespace_id":"dc97e3d6-d1d8-4a3e-b964-50116b830b4a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:20.236934Z"}'
         headers:
             Content-Length:
                 - "756"
@@ -1367,9 +1367,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:43 GMT
+                - Fri, 03 Jul 2026 15:02:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1377,10 +1377,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 54d1d9fd-bcbb-4b55-a89f-e1f6c0caf3f8
+                - 9197ebe9-1855-4595-b0b2-53d720e49106
         status: 200 OK
         code: 200
-        duration: 103.92002ms
+        duration: 37.796664ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1397,7 +1397,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/3acccd6e-64e7-44b7-868b-11bfc5dfef4d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0d31b7cf-e6c0-49f7-924a-41a1288dc615
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1407,7 +1407,7 @@ interactions:
         trailer: {}
         content_length: 760
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:39.948862Z","description":"","domain_name":"tftestsfunctioncronni7agz2hj-tf-tests-function-cron-name-update.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"3acccd6e-64e7-44b7-868b-11bfc5dfef4d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-function-cron-name-update","namespace_id":"c2a45bfc-b13c-4d64-b2cc-b73c25df408a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:43.502399791Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:20.236934Z","description":"","domain_name":"tftestsfunctioncronn3w3kv4iy-tf-tests-function-cron-name-update.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0d31b7cf-e6c0-49f7-924a-41a1288dc615","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-function-cron-name-update","namespace_id":"dc97e3d6-d1d8-4a3e-b964-50116b830b4a","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:22.835287811Z"}'
         headers:
             Content-Length:
                 - "760"
@@ -1416,9 +1416,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:43 GMT
+                - Fri, 03 Jul 2026 15:02:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1426,10 +1426,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7032e4b3-b8c2-400e-9cee-6a166849fce5
+                - 299f0550-054d-4994-bae1-578391637c9a
         status: 200 OK
         code: 200
-        duration: 146.042981ms
+        duration: 208.989763ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1446,7 +1446,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/c2a45bfc-b13c-4d64-b2cc-b73c25df408a
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/dc97e3d6-d1d8-4a3e-b964-50116b830b4a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1456,7 +1456,7 @@ interactions:
         trailer: {}
         content_length: 603
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:39:34.668976Z","description":"","environment_variables":{},"error_message":null,"id":"c2a45bfc-b13c-4d64-b2cc-b73c25df408a","name":"tf-tests-function-cron-name-update","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronni7agz2hj","registry_namespace_id":"87c298ca-0eb6-4880-9f35-5aa06ce09fcb","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:36.683912Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:02:14.892209Z","description":"","environment_variables":{},"error_message":null,"id":"dc97e3d6-d1d8-4a3e-b964-50116b830b4a","name":"tf-tests-function-cron-name-update","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronn3w3kv4iy","registry_namespace_id":"189769f1-513c-4e58-8fa8-dbe466b40faf","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:16.405360Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "603"
@@ -1465,9 +1465,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:43 GMT
+                - Fri, 03 Jul 2026 15:02:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1475,10 +1475,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1f21e69a-ddc2-4ca5-b74f-cb6e79dec587
+                - 8b80e6b3-2fbb-4904-aae8-bdfead00cc84
         status: 200 OK
         code: 200
-        duration: 33.921989ms
+        duration: 29.404771ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1495,7 +1495,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/c2a45bfc-b13c-4d64-b2cc-b73c25df408a
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/dc97e3d6-d1d8-4a3e-b964-50116b830b4a
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1505,7 +1505,7 @@ interactions:
         trailer: {}
         content_length: 609
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:39:34.668976Z","description":"","environment_variables":{},"error_message":null,"id":"c2a45bfc-b13c-4d64-b2cc-b73c25df408a","name":"tf-tests-function-cron-name-update","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronni7agz2hj","registry_namespace_id":"87c298ca-0eb6-4880-9f35-5aa06ce09fcb","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-05-04T12:39:43.657853036Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:02:14.892209Z","description":"","environment_variables":{},"error_message":null,"id":"dc97e3d6-d1d8-4a3e-b964-50116b830b4a","name":"tf-tests-function-cron-name-update","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronn3w3kv4iy","registry_namespace_id":"189769f1-513c-4e58-8fa8-dbe466b40faf","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-07-03T15:02:23.074065620Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "609"
@@ -1514,9 +1514,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:43 GMT
+                - Fri, 03 Jul 2026 15:02:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1524,10 +1524,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 30732766-3213-414a-b12a-750476369453
+                - b5d97f6a-e3ef-424a-ac43-d6a206953fb0
         status: 200 OK
         code: 200
-        duration: 277.274381ms
+        duration: 471.059792ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1544,7 +1544,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/c2a45bfc-b13c-4d64-b2cc-b73c25df408a
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/dc97e3d6-d1d8-4a3e-b964-50116b830b4a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1554,7 +1554,7 @@ interactions:
         trailer: {}
         content_length: 606
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:39:34.668976Z","description":"","environment_variables":{},"error_message":null,"id":"c2a45bfc-b13c-4d64-b2cc-b73c25df408a","name":"tf-tests-function-cron-name-update","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronni7agz2hj","registry_namespace_id":"87c298ca-0eb6-4880-9f35-5aa06ce09fcb","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-05-04T12:39:43.657853Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:02:14.892209Z","description":"","environment_variables":{},"error_message":null,"id":"dc97e3d6-d1d8-4a3e-b964-50116b830b4a","name":"tf-tests-function-cron-name-update","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronn3w3kv4iy","registry_namespace_id":"189769f1-513c-4e58-8fa8-dbe466b40faf","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-07-03T15:02:23.074066Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "606"
@@ -1563,9 +1563,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:43 GMT
+                - Fri, 03 Jul 2026 15:02:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1573,10 +1573,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1f3c7679-bb16-416b-a56e-724f0e7f4df2
+                - b1fcb87a-eeab-47c6-9331-02852cee0ba5
         status: 200 OK
         code: 200
-        duration: 33.469698ms
+        duration: 40.84731ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1593,7 +1593,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/c2a45bfc-b13c-4d64-b2cc-b73c25df408a
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/dc97e3d6-d1d8-4a3e-b964-50116b830b4a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1612,9 +1612,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:40:14 GMT
+                - Fri, 03 Jul 2026 15:02:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1622,10 +1622,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 84bb586e-e62e-4fe2-8651-4725f9913df9
+                - ca387122-91fc-4805-b356-50e87d40d0d2
         status: 404 Not Found
         code: 404
-        duration: 23.610742ms
+        duration: 19.934661ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1642,7 +1642,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/d2a35a16-f329-4747-bef8-550b6f2232eb
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/f620b8e2-61aa-44ef-ae6c-1c6b55e74cf5
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1661,9 +1661,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:40:14 GMT
+                - Fri, 03 Jul 2026 15:02:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1671,7 +1671,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 53da2632-af91-4115-9513-42ae44395c15
+                - 599c2d60-acaf-47bf-9808-5e9039821492
         status: 404 Not Found
         code: 404
-        duration: 23.864329ms
+        duration: 21.139157ms

--- a/internal/services/function/testdata/function-cron-with-args.cassette.yaml
+++ b/internal/services/function/testdata/function-cron-with-args.cassette.yaml
@@ -29,7 +29,7 @@ interactions:
         trailer: {}
         content_length: 518
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:39:32.345197257Z","description":"","environment_variables":{},"error_message":null,"id":"94f3c030-9f00-490d-8d01-4735d65d6d26","name":"tf-tests-function-cron-with-args","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-05-04T12:39:32.345197257Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:02:07.544676220Z","description":"","environment_variables":{},"error_message":null,"id":"9f871acd-c56f-4663-8a23-b79310918c18","name":"tf-tests-function-cron-with-args","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-07-03T15:02:07.544676220Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "518"
@@ -38,9 +38,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:32 GMT
+                - Fri, 03 Jul 2026 15:02:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6085234d-4d0d-4d5a-9267-c866daf1c160
+                - b847de70-4e43-4d3d-8db6-d1a511ceb68b
         status: 200 OK
         code: 200
-        duration: 492.266073ms
+        duration: 4.028791827s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -68,7 +68,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/94f3c030-9f00-490d-8d01-4735d65d6d26
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9f871acd-c56f-4663-8a23-b79310918c18
         method: GET
       response:
         proto: HTTP/2.0
@@ -78,7 +78,7 @@ interactions:
         trailer: {}
         content_length: 512
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:39:32.345197Z","description":"","environment_variables":{},"error_message":null,"id":"94f3c030-9f00-490d-8d01-4735d65d6d26","name":"tf-tests-function-cron-with-args","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-05-04T12:39:32.345197Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:02:07.544676Z","description":"","environment_variables":{},"error_message":null,"id":"9f871acd-c56f-4663-8a23-b79310918c18","name":"tf-tests-function-cron-with-args","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-07-03T15:02:07.544676Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "512"
@@ -87,9 +87,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:32 GMT
+                - Fri, 03 Jul 2026 15:02:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5f913fe2-ae88-4f44-8191-cf3a0b9cf1e2
+                - f8a53670-0858-40c9-8124-d4d113d82136
         status: 200 OK
         code: 200
-        duration: 30.396924ms
+        duration: 33.282594ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -117,7 +117,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/94f3c030-9f00-490d-8d01-4735d65d6d26
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9f871acd-c56f-4663-8a23-b79310918c18
         method: GET
       response:
         proto: HTTP/2.0
@@ -127,7 +127,7 @@ interactions:
         trailer: {}
         content_length: 601
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:39:32.345197Z","description":"","environment_variables":{},"error_message":null,"id":"94f3c030-9f00-490d-8d01-4735d65d6d26","name":"tf-tests-function-cron-with-args","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronwtoz7caz0","registry_namespace_id":"ee501a0c-0128-4a7f-a65c-0d88ff88da3b","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:34.089914Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:02:07.544676Z","description":"","environment_variables":{},"error_message":null,"id":"9f871acd-c56f-4663-8a23-b79310918c18","name":"tf-tests-function-cron-with-args","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronwmbjfcuvt","registry_namespace_id":"13d56771-dc24-499c-956e-861f3d39aeba","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:10.577321Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "601"
@@ -136,9 +136,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:37 GMT
+                - Fri, 03 Jul 2026 15:02:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 688d4695-02d1-435e-b469-33adef6a86b0
+                - 49340931-52b6-45ea-805a-fd7c3d74f5e8
         status: 200 OK
         code: 200
-        duration: 142.759497ms
+        duration: 32.76498ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -166,7 +166,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/94f3c030-9f00-490d-8d01-4735d65d6d26
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9f871acd-c56f-4663-8a23-b79310918c18
         method: GET
       response:
         proto: HTTP/2.0
@@ -176,7 +176,7 @@ interactions:
         trailer: {}
         content_length: 601
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:39:32.345197Z","description":"","environment_variables":{},"error_message":null,"id":"94f3c030-9f00-490d-8d01-4735d65d6d26","name":"tf-tests-function-cron-with-args","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronwtoz7caz0","registry_namespace_id":"ee501a0c-0128-4a7f-a65c-0d88ff88da3b","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:34.089914Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:02:07.544676Z","description":"","environment_variables":{},"error_message":null,"id":"9f871acd-c56f-4663-8a23-b79310918c18","name":"tf-tests-function-cron-with-args","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronwmbjfcuvt","registry_namespace_id":"13d56771-dc24-499c-956e-861f3d39aeba","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:10.577321Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "601"
@@ -185,9 +185,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:37 GMT
+                - Fri, 03 Jul 2026 15:02:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,10 +195,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f36a8f2a-f99f-4b46-bc64-b298d358e0c9
+                - 0317c57b-8e75-4ad7-b3c1-2be63924cea6
         status: 200 OK
         code: 200
-        duration: 31.471247ms
+        duration: 36.397633ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -210,7 +210,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-tests-cron-with-args","namespace_id":"94f3c030-9f00-490d-8d01-4735d65d6d26","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node20","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox","tags":null}'
+        body: '{"name":"tf-tests-cron-with-args","namespace_id":"9f871acd-c56f-4663-8a23-b79310918c18","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node26","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox","tags":null}'
         form: {}
         headers:
             Content-Type:
@@ -227,7 +227,7 @@ interactions:
         trailer: {}
         content_length: 740
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:37.780674477Z","description":"","domain_name":"tftestsfunctioncronwtoz7caz0-tf-tests-cron-with-args.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"1d7ae86d-8c35-439d-b762-11ddf9dd16a7","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-with-args","namespace_id":"94f3c030-9f00-490d-8d01-4735d65d6d26","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:37.780674477Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:12.943158137Z","description":"","domain_name":"tftestsfunctioncronwmbjfcuvt-tf-tests-cron-with-args.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"41037afc-4532-49f4-9f8e-8a255c3fff17","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-with-args","namespace_id":"9f871acd-c56f-4663-8a23-b79310918c18","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:12.943158137Z"}'
         headers:
             Content-Length:
                 - "740"
@@ -236,9 +236,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:37 GMT
+                - Fri, 03 Jul 2026 15:02:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -246,10 +246,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 637f050e-5b61-40f8-9ee6-049c368ddffa
+                - f131f0bf-be46-420c-b296-502890eaf637
         status: 200 OK
         code: 200
-        duration: 197.425978ms
+        duration: 197.703667ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -266,7 +266,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/1d7ae86d-8c35-439d-b762-11ddf9dd16a7
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/41037afc-4532-49f4-9f8e-8a255c3fff17
         method: GET
       response:
         proto: HTTP/2.0
@@ -276,7 +276,7 @@ interactions:
         trailer: {}
         content_length: 734
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:37.780674Z","description":"","domain_name":"tftestsfunctioncronwtoz7caz0-tf-tests-cron-with-args.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"1d7ae86d-8c35-439d-b762-11ddf9dd16a7","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-with-args","namespace_id":"94f3c030-9f00-490d-8d01-4735d65d6d26","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:37.780674Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:12.943158Z","description":"","domain_name":"tftestsfunctioncronwmbjfcuvt-tf-tests-cron-with-args.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"41037afc-4532-49f4-9f8e-8a255c3fff17","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-with-args","namespace_id":"9f871acd-c56f-4663-8a23-b79310918c18","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:12.943158Z"}'
         headers:
             Content-Length:
                 - "734"
@@ -285,9 +285,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:37 GMT
+                - Fri, 03 Jul 2026 15:02:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -295,10 +295,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2e695ed0-832f-4da0-8582-1cf284716ec1
+                - 88f61194-b24f-4f48-b60e-2952d951ab66
         status: 200 OK
         code: 200
-        duration: 43.23957ms
+        duration: 81.007078ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -315,7 +315,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/1d7ae86d-8c35-439d-b762-11ddf9dd16a7
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/41037afc-4532-49f4-9f8e-8a255c3fff17
         method: GET
       response:
         proto: HTTP/2.0
@@ -325,7 +325,7 @@ interactions:
         trailer: {}
         content_length: 734
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:37.780674Z","description":"","domain_name":"tftestsfunctioncronwtoz7caz0-tf-tests-cron-with-args.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"1d7ae86d-8c35-439d-b762-11ddf9dd16a7","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-with-args","namespace_id":"94f3c030-9f00-490d-8d01-4735d65d6d26","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:37.780674Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:12.943158Z","description":"","domain_name":"tftestsfunctioncronwmbjfcuvt-tf-tests-cron-with-args.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"41037afc-4532-49f4-9f8e-8a255c3fff17","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-with-args","namespace_id":"9f871acd-c56f-4663-8a23-b79310918c18","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:12.943158Z"}'
         headers:
             Content-Length:
                 - "734"
@@ -334,9 +334,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:37 GMT
+                - Fri, 03 Jul 2026 15:02:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -344,10 +344,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6741c5b1-af53-46b7-8db8-f80c692125aa
+                - a3b7115f-a939-4ea1-9ac8-520f2f811b4e
         status: 200 OK
         code: 200
-        duration: 42.501441ms
+        duration: 42.34103ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -364,7 +364,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/1d7ae86d-8c35-439d-b762-11ddf9dd16a7
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/41037afc-4532-49f4-9f8e-8a255c3fff17
         method: GET
       response:
         proto: HTTP/2.0
@@ -374,7 +374,7 @@ interactions:
         trailer: {}
         content_length: 734
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:37.780674Z","description":"","domain_name":"tftestsfunctioncronwtoz7caz0-tf-tests-cron-with-args.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"1d7ae86d-8c35-439d-b762-11ddf9dd16a7","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-with-args","namespace_id":"94f3c030-9f00-490d-8d01-4735d65d6d26","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:37.780674Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:12.943158Z","description":"","domain_name":"tftestsfunctioncronwmbjfcuvt-tf-tests-cron-with-args.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"41037afc-4532-49f4-9f8e-8a255c3fff17","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-with-args","namespace_id":"9f871acd-c56f-4663-8a23-b79310918c18","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:12.943158Z"}'
         headers:
             Content-Length:
                 - "734"
@@ -383,9 +383,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:38 GMT
+                - Fri, 03 Jul 2026 15:02:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -393,10 +393,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 068403d3-ec0f-41d7-974b-9480f536d1f1
+                - 75260061-954b-4460-9695-0db47a156181
         status: 200 OK
         code: 200
-        duration: 147.406171ms
+        duration: 43.307748ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -408,7 +408,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"function_id":"1d7ae86d-8c35-439d-b762-11ddf9dd16a7","schedule":"0 0 * * *","args":{"test":"scw"},"name":"tf-tests-cron-with-args"}'
+        body: '{"function_id":"41037afc-4532-49f4-9f8e-8a255c3fff17","schedule":"0 0 * * *","args":{"test":"scw"},"name":"tf-tests-cron-with-args"}'
         form: {}
         headers:
             Content-Type:
@@ -425,7 +425,7 @@ interactions:
         trailer: {}
         content_length: 195
         uncompressed: false
-        body: '{"args":{"test":"scw"},"function_id":"1d7ae86d-8c35-439d-b762-11ddf9dd16a7","id":"746050e8-85fa-4bd2-90c0-6c4f289cb0cf","name":"tf-tests-cron-with-args","schedule":"0 0 * * *","status":"pending"}'
+        body: '{"args":{"test":"scw"},"function_id":"41037afc-4532-49f4-9f8e-8a255c3fff17","id":"04a8c004-3cef-4e10-9ab9-ed1550d8ea4e","name":"tf-tests-cron-with-args","schedule":"0 0 * * *","status":"pending"}'
         headers:
             Content-Length:
                 - "195"
@@ -434,9 +434,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:38 GMT
+                - Fri, 03 Jul 2026 15:02:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -444,10 +444,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 82d6e92c-663b-41eb-addb-a27264c589b0
+                - 26e247b1-4bc8-48b4-a8d8-07bd2d3eaffa
         status: 200 OK
         code: 200
-        duration: 82.10532ms
+        duration: 109.332048ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -464,7 +464,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/746050e8-85fa-4bd2-90c0-6c4f289cb0cf
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/04a8c004-3cef-4e10-9ab9-ed1550d8ea4e
         method: GET
       response:
         proto: HTTP/2.0
@@ -472,20 +472,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 195
+        content_length: 193
         uncompressed: false
-        body: '{"args":{"test":"scw"},"function_id":"1d7ae86d-8c35-439d-b762-11ddf9dd16a7","id":"746050e8-85fa-4bd2-90c0-6c4f289cb0cf","name":"tf-tests-cron-with-args","schedule":"0 0 * * *","status":"pending"}'
+        body: '{"args":{"test":"scw"},"function_id":"41037afc-4532-49f4-9f8e-8a255c3fff17","id":"04a8c004-3cef-4e10-9ab9-ed1550d8ea4e","name":"tf-tests-cron-with-args","schedule":"0 0 * * *","status":"ready"}'
         headers:
             Content-Length:
-                - "195"
+                - "193"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:38 GMT
+                - Fri, 03 Jul 2026 15:02:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -493,10 +493,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 813adb5d-a488-4a3e-a893-0bbd6f4ed597
+                - a30b2a21-7c6b-4035-89e9-c225c585f632
         status: 200 OK
         code: 200
-        duration: 182.553064ms
+        duration: 227.56712ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -513,7 +513,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/746050e8-85fa-4bd2-90c0-6c4f289cb0cf
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/04a8c004-3cef-4e10-9ab9-ed1550d8ea4e
         method: GET
       response:
         proto: HTTP/2.0
@@ -523,7 +523,7 @@ interactions:
         trailer: {}
         content_length: 193
         uncompressed: false
-        body: '{"args":{"test":"scw"},"function_id":"1d7ae86d-8c35-439d-b762-11ddf9dd16a7","id":"746050e8-85fa-4bd2-90c0-6c4f289cb0cf","name":"tf-tests-cron-with-args","schedule":"0 0 * * *","status":"ready"}'
+        body: '{"args":{"test":"scw"},"function_id":"41037afc-4532-49f4-9f8e-8a255c3fff17","id":"04a8c004-3cef-4e10-9ab9-ed1550d8ea4e","name":"tf-tests-cron-with-args","schedule":"0 0 * * *","status":"ready"}'
         headers:
             Content-Length:
                 - "193"
@@ -532,9 +532,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:43 GMT
+                - Fri, 03 Jul 2026 15:02:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -542,10 +542,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fb4207ff-935e-463e-80f2-f410566ab389
+                - c66dee56-dea1-4f3d-b83e-108cdf1a8494
         status: 200 OK
         code: 200
-        duration: 127.685369ms
+        duration: 56.369282ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -562,7 +562,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/746050e8-85fa-4bd2-90c0-6c4f289cb0cf
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/04a8c004-3cef-4e10-9ab9-ed1550d8ea4e
         method: GET
       response:
         proto: HTTP/2.0
@@ -572,7 +572,7 @@ interactions:
         trailer: {}
         content_length: 193
         uncompressed: false
-        body: '{"args":{"test":"scw"},"function_id":"1d7ae86d-8c35-439d-b762-11ddf9dd16a7","id":"746050e8-85fa-4bd2-90c0-6c4f289cb0cf","name":"tf-tests-cron-with-args","schedule":"0 0 * * *","status":"ready"}'
+        body: '{"args":{"test":"scw"},"function_id":"41037afc-4532-49f4-9f8e-8a255c3fff17","id":"04a8c004-3cef-4e10-9ab9-ed1550d8ea4e","name":"tf-tests-cron-with-args","schedule":"0 0 * * *","status":"ready"}'
         headers:
             Content-Length:
                 - "193"
@@ -581,9 +581,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:43 GMT
+                - Fri, 03 Jul 2026 15:02:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -591,10 +591,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 72520388-43b3-4750-b355-8a602622b565
+                - 682cca08-f2a7-4cf4-b92a-12dbed930af0
         status: 200 OK
         code: 200
-        duration: 55.861171ms
+        duration: 54.488966ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -611,7 +611,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/746050e8-85fa-4bd2-90c0-6c4f289cb0cf
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9f871acd-c56f-4663-8a23-b79310918c18
         method: GET
       response:
         proto: HTTP/2.0
@@ -619,20 +619,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 193
+        content_length: 601
         uncompressed: false
-        body: '{"args":{"test":"scw"},"function_id":"1d7ae86d-8c35-439d-b762-11ddf9dd16a7","id":"746050e8-85fa-4bd2-90c0-6c4f289cb0cf","name":"tf-tests-cron-with-args","schedule":"0 0 * * *","status":"ready"}'
+        body: '{"created_at":"2026-07-03T15:02:07.544676Z","description":"","environment_variables":{},"error_message":null,"id":"9f871acd-c56f-4663-8a23-b79310918c18","name":"tf-tests-function-cron-with-args","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronwmbjfcuvt","registry_namespace_id":"13d56771-dc24-499c-956e-861f3d39aeba","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:10.577321Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "193"
+                - "601"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:43 GMT
+                - Fri, 03 Jul 2026 15:02:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -640,10 +640,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ec916ed2-7acc-467a-85cb-d89dad158df6
+                - dc9bd7fb-3d65-4823-9f1e-0bf57e1f0d03
         status: 200 OK
         code: 200
-        duration: 179.106555ms
+        duration: 38.05012ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -660,7 +660,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/94f3c030-9f00-490d-8d01-4735d65d6d26
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/41037afc-4532-49f4-9f8e-8a255c3fff17
         method: GET
       response:
         proto: HTTP/2.0
@@ -668,20 +668,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 601
+        content_length: 734
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:39:32.345197Z","description":"","environment_variables":{},"error_message":null,"id":"94f3c030-9f00-490d-8d01-4735d65d6d26","name":"tf-tests-function-cron-with-args","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronwtoz7caz0","registry_namespace_id":"ee501a0c-0128-4a7f-a65c-0d88ff88da3b","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:34.089914Z","vpc_integration_activated":false}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:12.943158Z","description":"","domain_name":"tftestsfunctioncronwmbjfcuvt-tf-tests-cron-with-args.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"41037afc-4532-49f4-9f8e-8a255c3fff17","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-with-args","namespace_id":"9f871acd-c56f-4663-8a23-b79310918c18","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:12.943158Z"}'
         headers:
             Content-Length:
-                - "601"
+                - "734"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:44 GMT
+                - Fri, 03 Jul 2026 15:02:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -689,10 +689,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2a715754-3ceb-48fc-99f5-5405408d4631
+                - f9ecc5ff-e429-40ac-bc95-60b4651d48da
         status: 200 OK
         code: 200
-        duration: 47.400311ms
+        duration: 31.878613ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -709,7 +709,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/1d7ae86d-8c35-439d-b762-11ddf9dd16a7
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/04a8c004-3cef-4e10-9ab9-ed1550d8ea4e
         method: GET
       response:
         proto: HTTP/2.0
@@ -717,20 +717,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 734
+        content_length: 193
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:37.780674Z","description":"","domain_name":"tftestsfunctioncronwtoz7caz0-tf-tests-cron-with-args.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"1d7ae86d-8c35-439d-b762-11ddf9dd16a7","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-with-args","namespace_id":"94f3c030-9f00-490d-8d01-4735d65d6d26","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:37.780674Z"}'
+        body: '{"args":{"test":"scw"},"function_id":"41037afc-4532-49f4-9f8e-8a255c3fff17","id":"04a8c004-3cef-4e10-9ab9-ed1550d8ea4e","name":"tf-tests-cron-with-args","schedule":"0 0 * * *","status":"ready"}'
         headers:
             Content-Length:
-                - "734"
+                - "193"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:44 GMT
+                - Fri, 03 Jul 2026 15:02:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -738,10 +738,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a44d8c9d-61b6-41ac-9223-48c1197d4030
+                - 391e2535-7eec-42ee-b047-41be97a1cea3
         status: 200 OK
         code: 200
-        duration: 39.933682ms
+        duration: 57.396084ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -758,7 +758,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/746050e8-85fa-4bd2-90c0-6c4f289cb0cf
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/04a8c004-3cef-4e10-9ab9-ed1550d8ea4e
         method: GET
       response:
         proto: HTTP/2.0
@@ -768,7 +768,7 @@ interactions:
         trailer: {}
         content_length: 193
         uncompressed: false
-        body: '{"args":{"test":"scw"},"function_id":"1d7ae86d-8c35-439d-b762-11ddf9dd16a7","id":"746050e8-85fa-4bd2-90c0-6c4f289cb0cf","name":"tf-tests-cron-with-args","schedule":"0 0 * * *","status":"ready"}'
+        body: '{"args":{"test":"scw"},"function_id":"41037afc-4532-49f4-9f8e-8a255c3fff17","id":"04a8c004-3cef-4e10-9ab9-ed1550d8ea4e","name":"tf-tests-cron-with-args","schedule":"0 0 * * *","status":"ready"}'
         headers:
             Content-Length:
                 - "193"
@@ -777,9 +777,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:44 GMT
+                - Fri, 03 Jul 2026 15:02:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -787,10 +787,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5261b859-2e20-43f8-95df-c2fadf8549d6
+                - e66f07f7-2695-47d1-8568-87842f1760cb
         status: 200 OK
         code: 200
-        duration: 59.370925ms
+        duration: 55.237334ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -807,28 +807,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/746050e8-85fa-4bd2-90c0-6c4f289cb0cf
-        method: GET
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/04a8c004-3cef-4e10-9ab9-ed1550d8ea4e
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 193
+        content_length: 196
         uncompressed: false
-        body: '{"args":{"test":"scw"},"function_id":"1d7ae86d-8c35-439d-b762-11ddf9dd16a7","id":"746050e8-85fa-4bd2-90c0-6c4f289cb0cf","name":"tf-tests-cron-with-args","schedule":"0 0 * * *","status":"ready"}'
+        body: '{"args":{"test":"scw"},"function_id":"41037afc-4532-49f4-9f8e-8a255c3fff17","id":"04a8c004-3cef-4e10-9ab9-ed1550d8ea4e","name":"tf-tests-cron-with-args","schedule":"0 0 * * *","status":"deleting"}'
         headers:
             Content-Length:
-                - "193"
+                - "196"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:44 GMT
+                - Fri, 03 Jul 2026 15:02:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -836,10 +836,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 03129468-6755-42af-b65a-8c8ed6657129
+                - 74fc7a9a-35c2-48a0-af35-e737c9c10fb7
         status: 200 OK
         code: 200
-        duration: 63.650879ms
+        duration: 70.877237ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -856,28 +856,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/746050e8-85fa-4bd2-90c0-6c4f289cb0cf
-        method: DELETE
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/41037afc-4532-49f4-9f8e-8a255c3fff17
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 196
+        content_length: 734
         uncompressed: false
-        body: '{"args":{"test":"scw"},"function_id":"1d7ae86d-8c35-439d-b762-11ddf9dd16a7","id":"746050e8-85fa-4bd2-90c0-6c4f289cb0cf","name":"tf-tests-cron-with-args","schedule":"0 0 * * *","status":"deleting"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:12.943158Z","description":"","domain_name":"tftestsfunctioncronwmbjfcuvt-tf-tests-cron-with-args.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"41037afc-4532-49f4-9f8e-8a255c3fff17","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-with-args","namespace_id":"9f871acd-c56f-4663-8a23-b79310918c18","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:12.943158Z"}'
         headers:
             Content-Length:
-                - "196"
+                - "734"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:44 GMT
+                - Fri, 03 Jul 2026 15:02:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -885,10 +885,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 020f2b29-f27d-4ff1-a4a4-85c875acb6b5
+                - 00ac9f57-2a5d-4cac-93f0-2bb01c52ba33
         status: 200 OK
         code: 200
-        duration: 73.963874ms
+        duration: 38.323995ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -905,28 +905,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/1d7ae86d-8c35-439d-b762-11ddf9dd16a7
-        method: GET
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/41037afc-4532-49f4-9f8e-8a255c3fff17
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 734
+        content_length: 738
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:37.780674Z","description":"","domain_name":"tftestsfunctioncronwtoz7caz0-tf-tests-cron-with-args.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"1d7ae86d-8c35-439d-b762-11ddf9dd16a7","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-with-args","namespace_id":"94f3c030-9f00-490d-8d01-4735d65d6d26","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:37.780674Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:12.943158Z","description":"","domain_name":"tftestsfunctioncronwmbjfcuvt-tf-tests-cron-with-args.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"41037afc-4532-49f4-9f8e-8a255c3fff17","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-with-args","namespace_id":"9f871acd-c56f-4663-8a23-b79310918c18","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:14.531373633Z"}'
         headers:
             Content-Length:
-                - "734"
+                - "738"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:44 GMT
+                - Fri, 03 Jul 2026 15:02:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -934,10 +934,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 567954ba-b9eb-42c7-88ae-afa4c0e01238
+                - 4600f885-4d41-4118-8b54-4c380ae45c4f
         status: 200 OK
         code: 200
-        duration: 44.459107ms
+        duration: 492.356363ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -954,28 +954,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/1d7ae86d-8c35-439d-b762-11ddf9dd16a7
-        method: DELETE
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9f871acd-c56f-4663-8a23-b79310918c18
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 738
+        content_length: 601
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:37.780674Z","description":"","domain_name":"tftestsfunctioncronwtoz7caz0-tf-tests-cron-with-args.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"1d7ae86d-8c35-439d-b762-11ddf9dd16a7","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-tests-cron-with-args","namespace_id":"94f3c030-9f00-490d-8d01-4735d65d6d26","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node20","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:44.670196023Z"}'
+        body: '{"created_at":"2026-07-03T15:02:07.544676Z","description":"","environment_variables":{},"error_message":null,"id":"9f871acd-c56f-4663-8a23-b79310918c18","name":"tf-tests-function-cron-with-args","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronwmbjfcuvt","registry_namespace_id":"13d56771-dc24-499c-956e-861f3d39aeba","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:10.577321Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "738"
+                - "601"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:44 GMT
+                - Fri, 03 Jul 2026 15:02:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -983,10 +983,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 204a024f-8aa7-436d-8e6c-0a23aafe7942
+                - 727d9e43-5d9e-464b-8280-23013eff64f2
         status: 200 OK
         code: 200
-        duration: 197.638476ms
+        duration: 41.479389ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1003,28 +1003,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/94f3c030-9f00-490d-8d01-4735d65d6d26
-        method: GET
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9f871acd-c56f-4663-8a23-b79310918c18
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 601
+        content_length: 607
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:39:32.345197Z","description":"","environment_variables":{},"error_message":null,"id":"94f3c030-9f00-490d-8d01-4735d65d6d26","name":"tf-tests-function-cron-with-args","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronwtoz7caz0","registry_namespace_id":"ee501a0c-0128-4a7f-a65c-0d88ff88da3b","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:34.089914Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:02:07.544676Z","description":"","environment_variables":{},"error_message":null,"id":"9f871acd-c56f-4663-8a23-b79310918c18","name":"tf-tests-function-cron-with-args","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronwmbjfcuvt","registry_namespace_id":"13d56771-dc24-499c-956e-861f3d39aeba","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-07-03T15:02:15.089239904Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "601"
+                - "607"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:44 GMT
+                - Fri, 03 Jul 2026 15:02:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1032,10 +1032,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e0831663-a97c-43a8-ba4f-f327437d4ecb
+                - 2eb6d79a-5aa9-4337-8d93-dfbf889537f2
         status: 200 OK
         code: 200
-        duration: 43.74898ms
+        duration: 1.616785591s
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1052,28 +1052,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/94f3c030-9f00-490d-8d01-4735d65d6d26
-        method: DELETE
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9f871acd-c56f-4663-8a23-b79310918c18
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 607
+        content_length: 604
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:39:32.345197Z","description":"","environment_variables":{},"error_message":null,"id":"94f3c030-9f00-490d-8d01-4735d65d6d26","name":"tf-tests-function-cron-with-args","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronwtoz7caz0","registry_namespace_id":"ee501a0c-0128-4a7f-a65c-0d88ff88da3b","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-05-04T12:39:44.903166441Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:02:07.544676Z","description":"","environment_variables":{},"error_message":null,"id":"9f871acd-c56f-4663-8a23-b79310918c18","name":"tf-tests-function-cron-with-args","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronwmbjfcuvt","registry_namespace_id":"13d56771-dc24-499c-956e-861f3d39aeba","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-07-03T15:02:15.089240Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "607"
+                - "604"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:45 GMT
+                - Fri, 03 Jul 2026 15:02:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1081,10 +1081,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d6ce9493-74dc-40fb-8da0-8f425ddc137f
+                - 60303fe4-56da-4b2f-8612-5f2224c9d8df
         status: 200 OK
         code: 200
-        duration: 328.416318ms
+        duration: 40.511619ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1101,56 +1101,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/94f3c030-9f00-490d-8d01-4735d65d6d26
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 604
-        uncompressed: false
-        body: '{"created_at":"2026-05-04T12:39:32.345197Z","description":"","environment_variables":{},"error_message":null,"id":"94f3c030-9f00-490d-8d01-4735d65d6d26","name":"tf-tests-function-cron-with-args","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtftestsfunctioncronwtoz7caz0","registry_namespace_id":"ee501a0c-0128-4a7f-a65c-0d88ff88da3b","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-05-04T12:39:44.903166Z","vpc_integration_activated":false}'
-        headers:
-            Content-Length:
-                - "604"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 04 May 2026 12:39:45 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 3b29aec0-9c73-4c8f-956e-25cf4ab11b33
-        status: 200 OK
-        code: 200
-        duration: 32.339671ms
-    - id: 23
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/94f3c030-9f00-490d-8d01-4735d65d6d26
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/9f871acd-c56f-4663-8a23-b79310918c18
         method: GET
       response:
         proto: HTTP/2.0
@@ -1169,9 +1120,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:50 GMT
+                - Fri, 03 Jul 2026 15:02:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1179,11 +1130,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8c5d9ca7-d488-4e14-bb67-01078e09a05c
+                - 5e9aeb5f-c444-4ba5-a94a-6f257ac8c07e
         status: 404 Not Found
         code: 404
-        duration: 219.842656ms
-    - id: 24
+        duration: 20.459528ms
+    - id: 23
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1199,7 +1150,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/746050e8-85fa-4bd2-90c0-6c4f289cb0cf
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/crons/04a8c004-3cef-4e10-9ab9-ed1550d8ea4e
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1218,9 +1169,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:50 GMT
+                - Fri, 03 Jul 2026 15:02:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1228,7 +1179,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4241173e-d1b8-4d69-b08a-dd8c1a20069f
+                - 99f4a88a-9143-45d8-bf1d-cb813c468501
         status: 404 Not Found
         code: 404
-        duration: 22.622639ms
+        duration: 43.949255ms

--- a/internal/services/function/testdata/function-deploy.cassette.yaml
+++ b/internal/services/function/testdata/function-deploy.cassette.yaml
@@ -6,13 +6,13 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 152
+        content_length: 160
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-func-goofy-tu","environment_variables":{},"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","secret_environment_variables":[],"tags":null}'
+        body: '{"name":"tf-func-objective-panini","environment_variables":{},"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","secret_environment_variables":[],"tags":null}'
         form: {}
         headers:
             Content-Type:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 502
+        content_length: 510
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:56.466566572Z","description":"","environment_variables":{},"error_message":null,"id":"b4b999b9-68c2-4cb5-b96e-0c610bfb09c7","name":"tf-func-goofy-tu","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-05-04T12:38:56.466566572Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:02:15.432935994Z","description":"","environment_variables":{},"error_message":null,"id":"a674b2b7-ae7c-4dec-886d-7a33637219d7","name":"tf-func-objective-panini","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-07-03T15:02:15.432935994Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "502"
+                - "510"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:38:56 GMT
+                - Fri, 03 Jul 2026 15:02:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 84d41c0f-5991-4b37-90f8-52e2aa6a2752
+                - 11808f5a-8bee-4248-bf78-c2505771b1fa
         status: 200 OK
         code: 200
-        duration: 1.071578884s
+        duration: 4.487183338s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -68,7 +68,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b4b999b9-68c2-4cb5-b96e-0c610bfb09c7
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a674b2b7-ae7c-4dec-886d-7a33637219d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 496
+        content_length: 504
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:56.466567Z","description":"","environment_variables":{},"error_message":null,"id":"b4b999b9-68c2-4cb5-b96e-0c610bfb09c7","name":"tf-func-goofy-tu","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-05-04T12:38:56.466567Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:02:15.432936Z","description":"","environment_variables":{},"error_message":null,"id":"a674b2b7-ae7c-4dec-886d-7a33637219d7","name":"tf-func-objective-panini","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-07-03T15:02:15.432936Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "496"
+                - "504"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:38:56 GMT
+                - Fri, 03 Jul 2026 15:02:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f8ab38dc-ceee-4af0-8f83-9db83f789a0a
+                - 0a1a0024-bfc3-48da-98bd-50266f700a45
         status: 200 OK
         code: 200
-        duration: 57.37505ms
+        duration: 33.094079ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -117,7 +117,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b4b999b9-68c2-4cb5-b96e-0c610bfb09c7
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a674b2b7-ae7c-4dec-886d-7a33637219d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,20 +125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 578
+        content_length: 593
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:56.466567Z","description":"","environment_variables":{},"error_message":null,"id":"b4b999b9-68c2-4cb5-b96e-0c610bfb09c7","name":"tf-func-goofy-tu","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgoofytunkwwj3pf","registry_namespace_id":"e84886a7-a947-4b67-839f-7ce5c12ba894","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:38:57.912638Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:02:15.432936Z","description":"","environment_variables":{},"error_message":null,"id":"a674b2b7-ae7c-4dec-886d-7a33637219d7","name":"tf-func-objective-panini","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncobjectivepanin5v8b6jly","registry_namespace_id":"99054410-2716-4202-a100-d34cf34043c4","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:16.940550Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "578"
+                - "593"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:01 GMT
+                - Fri, 03 Jul 2026 15:02:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4edc8a84-1f1a-4831-b8af-51ef028b67c3
+                - e439f3fc-235e-45fe-95e1-faa5e3194bd3
         status: 200 OK
         code: 200
-        duration: 145.688962ms
+        duration: 36.709128ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -166,7 +166,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b4b999b9-68c2-4cb5-b96e-0c610bfb09c7
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a674b2b7-ae7c-4dec-886d-7a33637219d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,20 +174,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 578
+        content_length: 593
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:56.466567Z","description":"","environment_variables":{},"error_message":null,"id":"b4b999b9-68c2-4cb5-b96e-0c610bfb09c7","name":"tf-func-goofy-tu","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgoofytunkwwj3pf","registry_namespace_id":"e84886a7-a947-4b67-839f-7ce5c12ba894","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:38:57.912638Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:02:15.432936Z","description":"","environment_variables":{},"error_message":null,"id":"a674b2b7-ae7c-4dec-886d-7a33637219d7","name":"tf-func-objective-panini","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncobjectivepanin5v8b6jly","registry_namespace_id":"99054410-2716-4202-a100-d34cf34043c4","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:16.940550Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "578"
+                - "593"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:01 GMT
+                - Fri, 03 Jul 2026 15:02:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,10 +195,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f70b2e6c-8163-47e4-80c1-635f08599541
+                - e23db3b9-72dc-4b58-b85c-88cdf1424a1f
         status: 200 OK
         code: 200
-        duration: 43.356429ms
+        duration: 35.973485ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -210,7 +210,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"foobar","namespace_id":"b4b999b9-68c2-4cb5-b96e-0c610bfb09c7","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"go122","memory_limit":256,"handler":"Handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox","tags":null}'
+        body: '{"name":"foobar","namespace_id":"a674b2b7-ae7c-4dec-886d-7a33637219d7","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"go126","memory_limit":256,"handler":"Handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox","tags":null}'
         form: {}
         headers:
             Content-Type:
@@ -225,20 +225,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 690
+        content_length: 697
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:01.833924084Z","description":"","domain_name":"tffuncgoofytunkwwj3pf-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"922e4b58-aedd-4f24-914f-f92b9e421083","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"b4b999b9-68c2-4cb5-b96e-0c610bfb09c7","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:01.833924084Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:20.650308455Z","description":"","domain_name":"tffuncobjectivepanin5v8b6jly-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"7bf8ff79-a842-430d-b873-92e485b66552","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"a674b2b7-ae7c-4dec-886d-7a33637219d7","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:20.650308455Z"}'
         headers:
             Content-Length:
-                - "690"
+                - "697"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:01 GMT
+                - Fri, 03 Jul 2026 15:02:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -246,10 +246,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4bb7714f-dd9c-467b-8a50-8235d881108e
+                - 96b22d85-2cca-47ba-88b7-296e0951f15d
         status: 200 OK
         code: 200
-        duration: 111.685179ms
+        duration: 107.10531ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -266,7 +266,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/922e4b58-aedd-4f24-914f-f92b9e421083/upload-url?content_length=780
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7bf8ff79-a842-430d-b873-92e485b66552/upload-url?content_length=780
         method: GET
       response:
         proto: HTTP/2.0
@@ -276,7 +276,7 @@ interactions:
         trailer: {}
         content_length: 510
         uncompressed: false
-        body: '{"headers":{"content-length":["780"],"content-type":["application/octet-stream"]},"url":"https://s3.fr-par.scw.cloud/serverless-functions-code-prod-fr-par/uploads/function-922e4b58-aedd-4f24-914f-f92b9e421083.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=SCW0KAMQFQV1YYSZK2PF%2F20260504%2Ffr-par%2Fs3%2Faws4_request\u0026X-Amz-Date=20260504T123901Z\u0026X-Amz-Expires=3600\u0026X-Amz-SignedHeaders=content-length%3Bcontent-type%3Bhost\u0026X-Amz-Signature=78473c2748e8b1ec4c06bafafa25ee09b9f401543680be5b4331435c71274d39"}'
+        body: '{"headers":{"content-length":["780"],"content-type":["application/octet-stream"]},"url":"https://s3.fr-par.scw.cloud/serverless-functions-code-prod-fr-par/uploads/function-7bf8ff79-a842-430d-b873-92e485b66552.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=SCW0KAMQFQV1YYSZK2PF%2F20260703%2Ffr-par%2Fs3%2Faws4_request\u0026X-Amz-Date=20260703T150220Z\u0026X-Amz-Expires=3600\u0026X-Amz-SignedHeaders=content-length%3Bcontent-type%3Bhost\u0026X-Amz-Signature=e055e7f79375b84b0a693e855c893bfb8f0c3a812a274b11609072f5cff0325e"}'
         headers:
             Content-Length:
                 - "510"
@@ -285,9 +285,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:01 GMT
+                - Fri, 03 Jul 2026 15:02:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -295,10 +295,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b63bb457-35ed-4341-8742-6289ce3f5796
+                - 0ef531b7-315c-458c-9a4b-301e5c770bd5
         status: 200 OK
         code: 200
-        duration: 54.05646ms
+        duration: 60.082075ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -332,7 +332,7 @@ interactions:
                 - "780"
             Content-Type:
                 - application/octet-stream
-        url: https://s3.fr-par.scw.cloud/serverless-functions-code-prod-fr-par/uploads/function-922e4b58-aedd-4f24-914f-f92b9e421083.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=SCW0KAMQFQV1YYSZK2PF%2F20260504%2Ffr-par%2Fs3%2Faws4_request&X-Amz-Date=20260504T123901Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=content-length%3Bcontent-type%3Bhost&X-Amz-Signature=78473c2748e8b1ec4c06bafafa25ee09b9f401543680be5b4331435c71274d39
+        url: https://s3.fr-par.scw.cloud/serverless-functions-code-prod-fr-par/uploads/function-7bf8ff79-a842-430d-b873-92e485b66552.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=SCW0KAMQFQV1YYSZK2PF%2F20260703%2Ffr-par%2Fs3%2Faws4_request&X-Amz-Date=20260703T150220Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=content-length%3Bcontent-type%3Bhost&X-Amz-Signature=e055e7f79375b84b0a693e855c893bfb8f0c3a812a274b11609072f5cff0325e
         method: PUT
       response:
         proto: HTTP/2.0
@@ -347,16 +347,16 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 04 May 2026 12:39:01 GMT
+                - Fri, 03 Jul 2026 15:02:20 GMT
             Etag:
                 - '"10633bf7a5ff211d8f3eee3856a28101"'
             X-Amz-Id-2:
-                - txg80a48e5cddde44c5a20e-0069f89365
+                - txg2bc65bb6a5234258a5be-006a47cefc
             X-Amz-Request-Id:
-                - txg80a48e5cddde44c5a20e-0069f89365
+                - txg2bc65bb6a5234258a5be-006a47cefc
         status: 200 OK
         code: 200
-        duration: 173.858459ms
+        duration: 334.459871ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -375,7 +375,7 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/922e4b58-aedd-4f24-914f-f92b9e421083/deploy
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7bf8ff79-a842-430d-b873-92e485b66552/deploy
         method: POST
       response:
         proto: HTTP/2.0
@@ -383,20 +383,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 687
+        content_length: 694
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:01.833924Z","description":"","domain_name":"tffuncgoofytunkwwj3pf-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"922e4b58-aedd-4f24-914f-f92b9e421083","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"b4b999b9-68c2-4cb5-b96e-0c610bfb09c7","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:02.152058202Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:20.650308Z","description":"","domain_name":"tffuncobjectivepanin5v8b6jly-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"7bf8ff79-a842-430d-b873-92e485b66552","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"a674b2b7-ae7c-4dec-886d-7a33637219d7","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:21.137056306Z"}'
         headers:
             Content-Length:
-                - "687"
+                - "694"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:02 GMT
+                - Fri, 03 Jul 2026 15:02:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -404,10 +404,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5e740ea6-fee2-4c8d-91bb-e706816e3ab4
+                - 66fd1ee7-2394-492e-ac5b-dcb9c0d727c9
         status: 200 OK
         code: 200
-        duration: 76.523479ms
+        duration: 94.077489ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -424,7 +424,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/922e4b58-aedd-4f24-914f-f92b9e421083
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7bf8ff79-a842-430d-b873-92e485b66552
         method: GET
       response:
         proto: HTTP/2.0
@@ -432,20 +432,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 684
+        content_length: 691
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:01.833924Z","description":"","domain_name":"tffuncgoofytunkwwj3pf-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"922e4b58-aedd-4f24-914f-f92b9e421083","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"b4b999b9-68c2-4cb5-b96e-0c610bfb09c7","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:02.152058Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:20.650308Z","description":"","domain_name":"tffuncobjectivepanin5v8b6jly-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"7bf8ff79-a842-430d-b873-92e485b66552","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"a674b2b7-ae7c-4dec-886d-7a33637219d7","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:21.137056Z"}'
         headers:
             Content-Length:
-                - "684"
+                - "691"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:02 GMT
+                - Fri, 03 Jul 2026 15:02:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -453,10 +453,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ebf5c999-9476-4026-b057-5d72dfc0e2a4
+                - 1c642437-7905-4cf0-86b8-78ca2ebee3db
         status: 200 OK
         code: 200
-        duration: 54.187637ms
+        duration: 31.916204ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -473,7 +473,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/922e4b58-aedd-4f24-914f-f92b9e421083
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7bf8ff79-a842-430d-b873-92e485b66552
         method: GET
       response:
         proto: HTTP/2.0
@@ -481,20 +481,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 707
+        content_length: 714
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:01.833924Z","description":"","domain_name":"tffuncgoofytunkwwj3pf-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"922e4b58-aedd-4f24-914f-f92b9e421083","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"b4b999b9-68c2-4cb5-b96e-0c610bfb09c7","privacy":"private","private_network_id":null,"ready_at":"2026-05-04T12:40:36.585914Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:40:36.600030Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:20.650308Z","description":"","domain_name":"tffuncobjectivepanin5v8b6jly-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"7bf8ff79-a842-430d-b873-92e485b66552","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"a674b2b7-ae7c-4dec-886d-7a33637219d7","privacy":"private","private_network_id":null,"ready_at":"2026-07-03T15:03:49.134526Z","region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:03:49.139300Z"}'
         headers:
             Content-Length:
-                - "707"
+                - "714"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:40:38 GMT
+                - Fri, 03 Jul 2026 15:03:52 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -502,10 +502,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 24365a68-749e-4405-b0ef-5977d28f9d53
+                - 26cad48b-8ee8-49ba-b039-b894c91b2c5c
         status: 200 OK
         code: 200
-        duration: 39.247553ms
+        duration: 35.404088ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -522,7 +522,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/922e4b58-aedd-4f24-914f-f92b9e421083
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7bf8ff79-a842-430d-b873-92e485b66552
         method: GET
       response:
         proto: HTTP/2.0
@@ -530,20 +530,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 707
+        content_length: 714
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:01.833924Z","description":"","domain_name":"tffuncgoofytunkwwj3pf-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"922e4b58-aedd-4f24-914f-f92b9e421083","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"b4b999b9-68c2-4cb5-b96e-0c610bfb09c7","privacy":"private","private_network_id":null,"ready_at":"2026-05-04T12:40:36.585914Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:40:36.600030Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:20.650308Z","description":"","domain_name":"tffuncobjectivepanin5v8b6jly-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"7bf8ff79-a842-430d-b873-92e485b66552","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"a674b2b7-ae7c-4dec-886d-7a33637219d7","privacy":"private","private_network_id":null,"ready_at":"2026-07-03T15:03:49.134526Z","region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:03:49.139300Z"}'
         headers:
             Content-Length:
-                - "707"
+                - "714"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:40:38 GMT
+                - Fri, 03 Jul 2026 15:03:52 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -551,10 +551,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d0e1b018-e6c9-4ce4-9cd2-65768bf5735b
+                - 37bf45c6-7b17-4daf-ab7f-69a33103d137
         status: 200 OK
         code: 200
-        duration: 39.355126ms
+        duration: 44.063589ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -571,7 +571,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/922e4b58-aedd-4f24-914f-f92b9e421083
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7bf8ff79-a842-430d-b873-92e485b66552
         method: GET
       response:
         proto: HTTP/2.0
@@ -579,20 +579,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 707
+        content_length: 714
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:01.833924Z","description":"","domain_name":"tffuncgoofytunkwwj3pf-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"922e4b58-aedd-4f24-914f-f92b9e421083","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"b4b999b9-68c2-4cb5-b96e-0c610bfb09c7","privacy":"private","private_network_id":null,"ready_at":"2026-05-04T12:40:36.585914Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:40:36.600030Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:20.650308Z","description":"","domain_name":"tffuncobjectivepanin5v8b6jly-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"7bf8ff79-a842-430d-b873-92e485b66552","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"a674b2b7-ae7c-4dec-886d-7a33637219d7","privacy":"private","private_network_id":null,"ready_at":"2026-07-03T15:03:49.134526Z","region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:03:49.139300Z"}'
         headers:
             Content-Length:
-                - "707"
+                - "714"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:40:39 GMT
+                - Fri, 03 Jul 2026 15:03:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -600,10 +600,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f3affcf6-07e0-437a-bdf9-20a0bbbde516
+                - 204a8195-8cc8-4856-9e28-e2d601e1ab25
         status: 200 OK
         code: 200
-        duration: 40.502455ms
+        duration: 40.15211ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -620,7 +620,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b4b999b9-68c2-4cb5-b96e-0c610bfb09c7
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a674b2b7-ae7c-4dec-886d-7a33637219d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -628,20 +628,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 578
+        content_length: 593
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:56.466567Z","description":"","environment_variables":{},"error_message":null,"id":"b4b999b9-68c2-4cb5-b96e-0c610bfb09c7","name":"tf-func-goofy-tu","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgoofytunkwwj3pf","registry_namespace_id":"e84886a7-a947-4b67-839f-7ce5c12ba894","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:38:57.912638Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:02:15.432936Z","description":"","environment_variables":{},"error_message":null,"id":"a674b2b7-ae7c-4dec-886d-7a33637219d7","name":"tf-func-objective-panini","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncobjectivepanin5v8b6jly","registry_namespace_id":"99054410-2716-4202-a100-d34cf34043c4","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:16.940550Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "578"
+                - "593"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:40:39 GMT
+                - Fri, 03 Jul 2026 15:03:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -649,10 +649,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6189577c-ff39-4ecc-b86b-182ce6d9e53f
+                - 629bcef7-79aa-4fd3-bb25-56162dc79a29
         status: 200 OK
         code: 200
-        duration: 34.625495ms
+        duration: 34.928726ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -669,7 +669,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/922e4b58-aedd-4f24-914f-f92b9e421083
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7bf8ff79-a842-430d-b873-92e485b66552
         method: GET
       response:
         proto: HTTP/2.0
@@ -677,20 +677,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 707
+        content_length: 714
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:01.833924Z","description":"","domain_name":"tffuncgoofytunkwwj3pf-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"922e4b58-aedd-4f24-914f-f92b9e421083","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"b4b999b9-68c2-4cb5-b96e-0c610bfb09c7","privacy":"private","private_network_id":null,"ready_at":"2026-05-04T12:40:36.585914Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:40:36.600030Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:20.650308Z","description":"","domain_name":"tffuncobjectivepanin5v8b6jly-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"7bf8ff79-a842-430d-b873-92e485b66552","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"a674b2b7-ae7c-4dec-886d-7a33637219d7","privacy":"private","private_network_id":null,"ready_at":"2026-07-03T15:03:49.134526Z","region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:03:49.139300Z"}'
         headers:
             Content-Length:
-                - "707"
+                - "714"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:40:39 GMT
+                - Fri, 03 Jul 2026 15:03:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -698,10 +698,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c0657cc9-7568-46b2-bf12-5ad6d37bf89c
+                - 182ccc9e-377d-4f69-9587-34b0da87f833
         status: 200 OK
         code: 200
-        duration: 47.575578ms
+        duration: 51.347164ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -718,7 +718,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b4b999b9-68c2-4cb5-b96e-0c610bfb09c7
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a674b2b7-ae7c-4dec-886d-7a33637219d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -726,20 +726,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 578
+        content_length: 593
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:56.466567Z","description":"","environment_variables":{},"error_message":null,"id":"b4b999b9-68c2-4cb5-b96e-0c610bfb09c7","name":"tf-func-goofy-tu","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgoofytunkwwj3pf","registry_namespace_id":"e84886a7-a947-4b67-839f-7ce5c12ba894","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:38:57.912638Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:02:15.432936Z","description":"","environment_variables":{},"error_message":null,"id":"a674b2b7-ae7c-4dec-886d-7a33637219d7","name":"tf-func-objective-panini","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncobjectivepanin5v8b6jly","registry_namespace_id":"99054410-2716-4202-a100-d34cf34043c4","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:16.940550Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "578"
+                - "593"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:40:39 GMT
+                - Fri, 03 Jul 2026 15:03:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -747,10 +747,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 18528c03-4664-4734-b49a-876f7b4444b9
+                - 1959746d-edd9-4e28-a90b-6c45ab5ea789
         status: 200 OK
         code: 200
-        duration: 34.434155ms
+        duration: 38.894407ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -767,7 +767,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/922e4b58-aedd-4f24-914f-f92b9e421083
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7bf8ff79-a842-430d-b873-92e485b66552
         method: GET
       response:
         proto: HTTP/2.0
@@ -775,20 +775,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 707
+        content_length: 714
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:01.833924Z","description":"","domain_name":"tffuncgoofytunkwwj3pf-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"922e4b58-aedd-4f24-914f-f92b9e421083","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"b4b999b9-68c2-4cb5-b96e-0c610bfb09c7","privacy":"private","private_network_id":null,"ready_at":"2026-05-04T12:40:36.585914Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:40:36.600030Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:20.650308Z","description":"","domain_name":"tffuncobjectivepanin5v8b6jly-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"7bf8ff79-a842-430d-b873-92e485b66552","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"a674b2b7-ae7c-4dec-886d-7a33637219d7","privacy":"private","private_network_id":null,"ready_at":"2026-07-03T15:03:49.134526Z","region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:03:49.139300Z"}'
         headers:
             Content-Length:
-                - "707"
+                - "714"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:40:39 GMT
+                - Fri, 03 Jul 2026 15:03:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -796,10 +796,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8f31614b-95e6-4116-be86-baa476afcbbf
+                - 1049e32f-b968-45dc-a3d9-c52fd92fbfcf
         status: 200 OK
         code: 200
-        duration: 48.340807ms
+        duration: 44.615126ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -816,7 +816,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/922e4b58-aedd-4f24-914f-f92b9e421083
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7bf8ff79-a842-430d-b873-92e485b66552
         method: GET
       response:
         proto: HTTP/2.0
@@ -824,20 +824,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 707
+        content_length: 714
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:01.833924Z","description":"","domain_name":"tffuncgoofytunkwwj3pf-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"922e4b58-aedd-4f24-914f-f92b9e421083","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"b4b999b9-68c2-4cb5-b96e-0c610bfb09c7","privacy":"private","private_network_id":null,"ready_at":"2026-05-04T12:40:36.585914Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:40:36.600030Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:20.650308Z","description":"","domain_name":"tffuncobjectivepanin5v8b6jly-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"7bf8ff79-a842-430d-b873-92e485b66552","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"a674b2b7-ae7c-4dec-886d-7a33637219d7","privacy":"private","private_network_id":null,"ready_at":"2026-07-03T15:03:49.134526Z","region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:03:49.139300Z"}'
         headers:
             Content-Length:
-                - "707"
+                - "714"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:40:39 GMT
+                - Fri, 03 Jul 2026 15:03:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -845,10 +845,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 131509a8-4440-46c5-8160-346b7289ce80
+                - 0ee925a2-a6ce-4d0a-8d80-8edd139820af
         status: 200 OK
         code: 200
-        duration: 43.90518ms
+        duration: 41.358697ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -865,7 +865,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/922e4b58-aedd-4f24-914f-f92b9e421083/upload-url?content_length=780
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7bf8ff79-a842-430d-b873-92e485b66552/upload-url?content_length=780
         method: GET
       response:
         proto: HTTP/2.0
@@ -875,7 +875,7 @@ interactions:
         trailer: {}
         content_length: 510
         uncompressed: false
-        body: '{"headers":{"content-length":["780"],"content-type":["application/octet-stream"]},"url":"https://s3.fr-par.scw.cloud/serverless-functions-code-prod-fr-par/uploads/function-922e4b58-aedd-4f24-914f-f92b9e421083.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=SCW0KAMQFQV1YYSZK2PF%2F20260504%2Ffr-par%2Fs3%2Faws4_request\u0026X-Amz-Date=20260504T124039Z\u0026X-Amz-Expires=3600\u0026X-Amz-SignedHeaders=content-length%3Bcontent-type%3Bhost\u0026X-Amz-Signature=560324ea5e4c9b29c32d9202b7794d511f7a0285d5fb997721829a946e121ff3"}'
+        body: '{"headers":{"content-length":["780"],"content-type":["application/octet-stream"]},"url":"https://s3.fr-par.scw.cloud/serverless-functions-code-prod-fr-par/uploads/function-7bf8ff79-a842-430d-b873-92e485b66552.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=SCW0KAMQFQV1YYSZK2PF%2F20260703%2Ffr-par%2Fs3%2Faws4_request\u0026X-Amz-Date=20260703T150353Z\u0026X-Amz-Expires=3600\u0026X-Amz-SignedHeaders=content-length%3Bcontent-type%3Bhost\u0026X-Amz-Signature=74feb99df0c5afa3d0cc51609eea717c9e4d57693f6c7aea1e22ad7a218b99cf"}'
         headers:
             Content-Length:
                 - "510"
@@ -884,9 +884,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:40:39 GMT
+                - Fri, 03 Jul 2026 15:03:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -894,10 +894,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2a47ad26-a6ac-4d1b-8bd2-5db4c8ff05d0
+                - 1a721e0f-d37f-4a9b-91ac-3cc22185cd64
         status: 200 OK
         code: 200
-        duration: 56.470387ms
+        duration: 55.7303ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -931,7 +931,7 @@ interactions:
                 - "780"
             Content-Type:
                 - application/octet-stream
-        url: https://s3.fr-par.scw.cloud/serverless-functions-code-prod-fr-par/uploads/function-922e4b58-aedd-4f24-914f-f92b9e421083.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=SCW0KAMQFQV1YYSZK2PF%2F20260504%2Ffr-par%2Fs3%2Faws4_request&X-Amz-Date=20260504T124039Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=content-length%3Bcontent-type%3Bhost&X-Amz-Signature=560324ea5e4c9b29c32d9202b7794d511f7a0285d5fb997721829a946e121ff3
+        url: https://s3.fr-par.scw.cloud/serverless-functions-code-prod-fr-par/uploads/function-7bf8ff79-a842-430d-b873-92e485b66552.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=SCW0KAMQFQV1YYSZK2PF%2F20260703%2Ffr-par%2Fs3%2Faws4_request&X-Amz-Date=20260703T150353Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=content-length%3Bcontent-type%3Bhost&X-Amz-Signature=74feb99df0c5afa3d0cc51609eea717c9e4d57693f6c7aea1e22ad7a218b99cf
         method: PUT
       response:
         proto: HTTP/2.0
@@ -946,16 +946,16 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 04 May 2026 12:40:39 GMT
+                - Fri, 03 Jul 2026 15:03:53 GMT
             Etag:
                 - '"10633bf7a5ff211d8f3eee3856a28101"'
             X-Amz-Id-2:
-                - txg705cfe5e7bb145ec86c5-0069f893c7
+                - txg717e2419a54e40dba29a-006a47cf59
             X-Amz-Request-Id:
-                - txg705cfe5e7bb145ec86c5-0069f893c7
+                - txg717e2419a54e40dba29a-006a47cf59
         status: 200 OK
         code: 200
-        duration: 232.201074ms
+        duration: 102.211691ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -972,7 +972,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/922e4b58-aedd-4f24-914f-f92b9e421083
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7bf8ff79-a842-430d-b873-92e485b66552
         method: GET
       response:
         proto: HTTP/2.0
@@ -980,20 +980,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 707
+        content_length: 714
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:01.833924Z","description":"","domain_name":"tffuncgoofytunkwwj3pf-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"922e4b58-aedd-4f24-914f-f92b9e421083","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"b4b999b9-68c2-4cb5-b96e-0c610bfb09c7","privacy":"private","private_network_id":null,"ready_at":"2026-05-04T12:40:36.585914Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:40:36.600030Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:20.650308Z","description":"","domain_name":"tffuncobjectivepanin5v8b6jly-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"7bf8ff79-a842-430d-b873-92e485b66552","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"a674b2b7-ae7c-4dec-886d-7a33637219d7","privacy":"private","private_network_id":null,"ready_at":"2026-07-03T15:03:49.134526Z","region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:03:49.139300Z"}'
         headers:
             Content-Length:
-                - "707"
+                - "714"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:40:40 GMT
+                - Fri, 03 Jul 2026 15:03:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1001,10 +1001,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 695857de-de67-41eb-afb3-b9654f3887e0
+                - 49467f3c-3032-4863-b61d-abf080ee3ff4
         status: 200 OK
         code: 200
-        duration: 37.737182ms
+        duration: 51.030138ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1023,7 +1023,7 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/922e4b58-aedd-4f24-914f-f92b9e421083/deploy
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7bf8ff79-a842-430d-b873-92e485b66552/deploy
         method: POST
       response:
         proto: HTTP/2.0
@@ -1031,20 +1031,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 712
+        content_length: 719
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:01.833924Z","description":"","domain_name":"tffuncgoofytunkwwj3pf-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"922e4b58-aedd-4f24-914f-f92b9e421083","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"b4b999b9-68c2-4cb5-b96e-0c610bfb09c7","privacy":"private","private_network_id":null,"ready_at":"2026-05-04T12:40:36.585914Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:40:40.208862667Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:20.650308Z","description":"","domain_name":"tffuncobjectivepanin5v8b6jly-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"7bf8ff79-a842-430d-b873-92e485b66552","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"a674b2b7-ae7c-4dec-886d-7a33637219d7","privacy":"private","private_network_id":null,"ready_at":"2026-07-03T15:03:49.134526Z","region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:03:54.151585440Z"}'
         headers:
             Content-Length:
-                - "712"
+                - "719"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:40:40 GMT
+                - Fri, 03 Jul 2026 15:03:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1052,10 +1052,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9ffed8a8-48fb-4bbb-9b32-4d0417c964da
+                - ff479e8c-a217-4ea6-adf3-9bdd2d696f9a
         status: 200 OK
         code: 200
-        duration: 81.887993ms
+        duration: 72.278221ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1072,7 +1072,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/922e4b58-aedd-4f24-914f-f92b9e421083
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7bf8ff79-a842-430d-b873-92e485b66552
         method: GET
       response:
         proto: HTTP/2.0
@@ -1080,20 +1080,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 709
+        content_length: 716
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:01.833924Z","description":"","domain_name":"tffuncgoofytunkwwj3pf-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"922e4b58-aedd-4f24-914f-f92b9e421083","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"b4b999b9-68c2-4cb5-b96e-0c610bfb09c7","privacy":"private","private_network_id":null,"ready_at":"2026-05-04T12:40:36.585914Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:40:40.208863Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:20.650308Z","description":"","domain_name":"tffuncobjectivepanin5v8b6jly-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"7bf8ff79-a842-430d-b873-92e485b66552","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"a674b2b7-ae7c-4dec-886d-7a33637219d7","privacy":"private","private_network_id":null,"ready_at":"2026-07-03T15:03:49.134526Z","region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:03:54.151585Z"}'
         headers:
             Content-Length:
-                - "709"
+                - "716"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:40:40 GMT
+                - Fri, 03 Jul 2026 15:03:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1101,10 +1101,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2a364cfe-b745-429c-9bdb-364c24205710
+                - f14036f4-7777-46ca-bbd5-bc1bca23b624
         status: 200 OK
         code: 200
-        duration: 38.409668ms
+        duration: 40.830205ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1121,7 +1121,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/922e4b58-aedd-4f24-914f-f92b9e421083
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7bf8ff79-a842-430d-b873-92e485b66552
         method: GET
       response:
         proto: HTTP/2.0
@@ -1129,20 +1129,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 707
+        content_length: 714
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:01.833924Z","description":"","domain_name":"tffuncgoofytunkwwj3pf-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"922e4b58-aedd-4f24-914f-f92b9e421083","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"b4b999b9-68c2-4cb5-b96e-0c610bfb09c7","privacy":"private","private_network_id":null,"ready_at":"2026-05-04T12:40:36.585914Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:42:07.971480Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:20.650308Z","description":"","domain_name":"tffuncobjectivepanin5v8b6jly-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"7bf8ff79-a842-430d-b873-92e485b66552","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"a674b2b7-ae7c-4dec-886d-7a33637219d7","privacy":"private","private_network_id":null,"ready_at":"2026-07-03T15:03:49.134526Z","region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:07:13.770721Z"}'
         headers:
             Content-Length:
-                - "707"
+                - "714"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:42:11 GMT
+                - Fri, 03 Jul 2026 15:07:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1150,10 +1150,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b02b82a4-ae96-4396-baf0-18d2d3b945c8
+                - c280d96e-f197-4e60-a0c8-39a44dad4d92
         status: 200 OK
         code: 200
-        duration: 65.301862ms
+        duration: 53.467867ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1170,7 +1170,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/922e4b58-aedd-4f24-914f-f92b9e421083
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7bf8ff79-a842-430d-b873-92e485b66552
         method: GET
       response:
         proto: HTTP/2.0
@@ -1178,20 +1178,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 707
+        content_length: 714
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:01.833924Z","description":"","domain_name":"tffuncgoofytunkwwj3pf-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"922e4b58-aedd-4f24-914f-f92b9e421083","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"b4b999b9-68c2-4cb5-b96e-0c610bfb09c7","privacy":"private","private_network_id":null,"ready_at":"2026-05-04T12:40:36.585914Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:42:07.971480Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:20.650308Z","description":"","domain_name":"tffuncobjectivepanin5v8b6jly-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"7bf8ff79-a842-430d-b873-92e485b66552","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"a674b2b7-ae7c-4dec-886d-7a33637219d7","privacy":"private","private_network_id":null,"ready_at":"2026-07-03T15:03:49.134526Z","region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:07:13.770721Z"}'
         headers:
             Content-Length:
-                - "707"
+                - "714"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:42:11 GMT
+                - Fri, 03 Jul 2026 15:07:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1199,10 +1199,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e7638b11-9818-4f67-9ea7-635acd229963
+                - fbc6fc8d-5da7-4b6d-ae5c-10e47f635a0e
         status: 200 OK
         code: 200
-        duration: 63.757083ms
+        duration: 57.018902ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1219,7 +1219,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b4b999b9-68c2-4cb5-b96e-0c610bfb09c7
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a674b2b7-ae7c-4dec-886d-7a33637219d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1227,20 +1227,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 578
+        content_length: 593
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:56.466567Z","description":"","environment_variables":{},"error_message":null,"id":"b4b999b9-68c2-4cb5-b96e-0c610bfb09c7","name":"tf-func-goofy-tu","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgoofytunkwwj3pf","registry_namespace_id":"e84886a7-a947-4b67-839f-7ce5c12ba894","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:38:57.912638Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:02:15.432936Z","description":"","environment_variables":{},"error_message":null,"id":"a674b2b7-ae7c-4dec-886d-7a33637219d7","name":"tf-func-objective-panini","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncobjectivepanin5v8b6jly","registry_namespace_id":"99054410-2716-4202-a100-d34cf34043c4","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:16.940550Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "578"
+                - "593"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:42:11 GMT
+                - Fri, 03 Jul 2026 15:07:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1248,10 +1248,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7cf2a9cf-3f57-4e15-afab-7ca2a8dac97b
+                - c67ce4fa-b86b-4b12-ab7b-3940495592f1
         status: 200 OK
         code: 200
-        duration: 47.984ms
+        duration: 44.628486ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1268,7 +1268,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/922e4b58-aedd-4f24-914f-f92b9e421083
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7bf8ff79-a842-430d-b873-92e485b66552
         method: GET
       response:
         proto: HTTP/2.0
@@ -1276,20 +1276,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 707
+        content_length: 714
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:01.833924Z","description":"","domain_name":"tffuncgoofytunkwwj3pf-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"922e4b58-aedd-4f24-914f-f92b9e421083","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"b4b999b9-68c2-4cb5-b96e-0c610bfb09c7","privacy":"private","private_network_id":null,"ready_at":"2026-05-04T12:40:36.585914Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:42:07.971480Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:20.650308Z","description":"","domain_name":"tffuncobjectivepanin5v8b6jly-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"7bf8ff79-a842-430d-b873-92e485b66552","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"a674b2b7-ae7c-4dec-886d-7a33637219d7","privacy":"private","private_network_id":null,"ready_at":"2026-07-03T15:03:49.134526Z","region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:07:13.770721Z"}'
         headers:
             Content-Length:
-                - "707"
+                - "714"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:42:11 GMT
+                - Fri, 03 Jul 2026 15:07:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1297,10 +1297,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3ce45efe-bb49-4234-9a78-13aa8c769c4c
+                - bff6a09b-51f8-4871-84e2-4264aac3c249
         status: 200 OK
         code: 200
-        duration: 57.969258ms
+        duration: 57.106006ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1317,7 +1317,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/922e4b58-aedd-4f24-914f-f92b9e421083
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7bf8ff79-a842-430d-b873-92e485b66552
         method: GET
       response:
         proto: HTTP/2.0
@@ -1325,20 +1325,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 707
+        content_length: 714
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:01.833924Z","description":"","domain_name":"tffuncgoofytunkwwj3pf-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"922e4b58-aedd-4f24-914f-f92b9e421083","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"b4b999b9-68c2-4cb5-b96e-0c610bfb09c7","privacy":"private","private_network_id":null,"ready_at":"2026-05-04T12:40:36.585914Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:42:07.971480Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:20.650308Z","description":"","domain_name":"tffuncobjectivepanin5v8b6jly-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"7bf8ff79-a842-430d-b873-92e485b66552","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"a674b2b7-ae7c-4dec-886d-7a33637219d7","privacy":"private","private_network_id":null,"ready_at":"2026-07-03T15:03:49.134526Z","region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:07:13.770721Z"}'
         headers:
             Content-Length:
-                - "707"
+                - "714"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:42:11 GMT
+                - Fri, 03 Jul 2026 15:07:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1346,10 +1346,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9d283858-1f50-49f4-ab87-92fb809f8af4
+                - 58f1d37d-f62e-49ad-9e34-fb7eb8a04b4f
         status: 200 OK
         code: 200
-        duration: 53.08873ms
+        duration: 46.638143ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1366,7 +1366,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/922e4b58-aedd-4f24-914f-f92b9e421083
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7bf8ff79-a842-430d-b873-92e485b66552
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1374,20 +1374,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 713
+        content_length: 720
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:01.833924Z","description":"","domain_name":"tffuncgoofytunkwwj3pf-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"922e4b58-aedd-4f24-914f-f92b9e421083","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"b4b999b9-68c2-4cb5-b96e-0c610bfb09c7","privacy":"private","private_network_id":null,"ready_at":"2026-05-04T12:40:36.585914Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:42:12.034404004Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:20.650308Z","description":"","domain_name":"tffuncobjectivepanin5v8b6jly-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"7bf8ff79-a842-430d-b873-92e485b66552","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"a674b2b7-ae7c-4dec-886d-7a33637219d7","privacy":"private","private_network_id":null,"ready_at":"2026-07-03T15:03:49.134526Z","region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:07:17.624717144Z"}'
         headers:
             Content-Length:
-                - "713"
+                - "720"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:42:12 GMT
+                - Fri, 03 Jul 2026 15:07:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1395,10 +1395,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 68a3717f-9f19-4b09-81bd-a6b68b4b4e2e
+                - e2f7c67c-455d-4153-b2c1-86ece3c134f9
         status: 200 OK
         code: 200
-        duration: 152.958206ms
+        duration: 309.328728ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1415,7 +1415,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b4b999b9-68c2-4cb5-b96e-0c610bfb09c7
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a674b2b7-ae7c-4dec-886d-7a33637219d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1423,20 +1423,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 578
+        content_length: 593
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:56.466567Z","description":"","environment_variables":{},"error_message":null,"id":"b4b999b9-68c2-4cb5-b96e-0c610bfb09c7","name":"tf-func-goofy-tu","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgoofytunkwwj3pf","registry_namespace_id":"e84886a7-a947-4b67-839f-7ce5c12ba894","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:38:57.912638Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:02:15.432936Z","description":"","environment_variables":{},"error_message":null,"id":"a674b2b7-ae7c-4dec-886d-7a33637219d7","name":"tf-func-objective-panini","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncobjectivepanin5v8b6jly","registry_namespace_id":"99054410-2716-4202-a100-d34cf34043c4","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:16.940550Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "578"
+                - "593"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:42:12 GMT
+                - Fri, 03 Jul 2026 15:07:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1444,10 +1444,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c3a2b3f1-a9c3-45eb-8bfd-a557d9da4270
+                - cfd124b3-cae5-49ab-90e8-4e290e9afa29
         status: 200 OK
         code: 200
-        duration: 48.540768ms
+        duration: 43.697956ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1464,7 +1464,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b4b999b9-68c2-4cb5-b96e-0c610bfb09c7
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a674b2b7-ae7c-4dec-886d-7a33637219d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1472,20 +1472,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 584
+        content_length: 599
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:56.466567Z","description":"","environment_variables":{},"error_message":null,"id":"b4b999b9-68c2-4cb5-b96e-0c610bfb09c7","name":"tf-func-goofy-tu","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgoofytunkwwj3pf","registry_namespace_id":"e84886a7-a947-4b67-839f-7ce5c12ba894","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-05-04T12:42:12.250373896Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:02:15.432936Z","description":"","environment_variables":{},"error_message":null,"id":"a674b2b7-ae7c-4dec-886d-7a33637219d7","name":"tf-func-objective-panini","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncobjectivepanin5v8b6jly","registry_namespace_id":"99054410-2716-4202-a100-d34cf34043c4","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-07-03T15:07:17.970979341Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "584"
+                - "599"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:42:12 GMT
+                - Fri, 03 Jul 2026 15:07:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1493,10 +1493,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 444d5f72-fa5d-4987-acb6-13558ecb4ecf
+                - 208844e0-5df9-406d-a3fe-c16eef24d2f2
         status: 200 OK
         code: 200
-        duration: 341.417623ms
+        duration: 435.70445ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1513,7 +1513,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b4b999b9-68c2-4cb5-b96e-0c610bfb09c7
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a674b2b7-ae7c-4dec-886d-7a33637219d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1521,20 +1521,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 581
+        content_length: 596
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:56.466567Z","description":"","environment_variables":{},"error_message":null,"id":"b4b999b9-68c2-4cb5-b96e-0c610bfb09c7","name":"tf-func-goofy-tu","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgoofytunkwwj3pf","registry_namespace_id":"e84886a7-a947-4b67-839f-7ce5c12ba894","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-05-04T12:42:12.250374Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:02:15.432936Z","description":"","environment_variables":{},"error_message":null,"id":"a674b2b7-ae7c-4dec-886d-7a33637219d7","name":"tf-func-objective-panini","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncobjectivepanin5v8b6jly","registry_namespace_id":"99054410-2716-4202-a100-d34cf34043c4","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-07-03T15:07:17.970979Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "581"
+                - "596"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:42:12 GMT
+                - Fri, 03 Jul 2026 15:07:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1542,10 +1542,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 50074438-3b95-468f-b577-fd6b2022eaad
+                - efa60517-e738-40ec-94ee-4ea6c14aff5e
         status: 200 OK
         code: 200
-        duration: 29.820498ms
+        duration: 45.834362ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1562,7 +1562,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b4b999b9-68c2-4cb5-b96e-0c610bfb09c7
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a674b2b7-ae7c-4dec-886d-7a33637219d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1581,9 +1581,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:42:58 GMT
+                - Fri, 03 Jul 2026 15:07:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1591,10 +1591,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 86986ba9-ef4d-45f7-b778-0176e7c6b310
+                - 63651c18-4288-4406-b700-6959c0ed1beb
         status: 404 Not Found
         code: 404
-        duration: 23.53447ms
+        duration: 33.125801ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1611,7 +1611,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/922e4b58-aedd-4f24-914f-f92b9e421083
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7bf8ff79-a842-430d-b873-92e485b66552
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1630,9 +1630,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:42:58 GMT
+                - Fri, 03 Jul 2026 15:07:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1640,7 +1640,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7ad1b676-75c3-4298-b90e-cc959e85a827
+                - 6cd798f7-6733-4143-b1bf-917e561bf62f
         status: 404 Not Found
         code: 404
-        duration: 24.389679ms
+        duration: 40.38832ms

--- a/internal/services/function/testdata/function-domain-basic.cassette.yaml
+++ b/internal/services/function/testdata/function-domain-basic.cassette.yaml
@@ -6,13 +6,13 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 155
+        content_length: 156
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-func-quirky-boyd","environment_variables":{},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","secret_environment_variables":[],"tags":null}'
+        body: '{"name":"tf-func-serene-hertz","environment_variables":{},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","secret_environment_variables":[],"tags":null}'
         form: {}
         headers:
             Content-Type:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 505
+        content_length: 506
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:44:57.318329736Z","description":"","environment_variables":{},"error_message":null,"id":"94f80183-9a88-48c4-87ab-f1ef6cae7aac","name":"tf-func-quirky-boyd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-05-04T12:44:57.318329736Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:08:44.488095210Z","description":"","environment_variables":{},"error_message":null,"id":"56bcac67-2ff8-4f23-bac0-2deda7732309","name":"tf-func-serene-hertz","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-07-03T15:08:44.488095210Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "505"
+                - "506"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:44:57 GMT
+                - Fri, 03 Jul 2026 15:08:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3b2546d0-a9fb-41ea-94ff-b0048d2ce7d9
+                - 160e2c5e-9562-4811-a45f-1ec20e2ca7c3
         status: 200 OK
         code: 200
-        duration: 855.077257ms
+        duration: 7.754002182s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -68,7 +68,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/94f80183-9a88-48c4-87ab-f1ef6cae7aac
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/56bcac67-2ff8-4f23-bac0-2deda7732309
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 499
+        content_length: 500
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:44:57.318330Z","description":"","environment_variables":{},"error_message":null,"id":"94f80183-9a88-48c4-87ab-f1ef6cae7aac","name":"tf-func-quirky-boyd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-05-04T12:44:57.318330Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:08:44.488095Z","description":"","environment_variables":{},"error_message":null,"id":"56bcac67-2ff8-4f23-bac0-2deda7732309","name":"tf-func-serene-hertz","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-07-03T15:08:44.488095Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "499"
+                - "500"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:44:57 GMT
+                - Fri, 03 Jul 2026 15:08:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fd352c58-417d-4624-89bf-298a5c0df6f0
+                - d0ee95f4-d0ac-4d6b-887d-e333f74bf4bd
         status: 200 OK
         code: 200
-        duration: 107.575619ms
+        duration: 134.471049ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -117,7 +117,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/94f80183-9a88-48c4-87ab-f1ef6cae7aac
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/56bcac67-2ff8-4f23-bac0-2deda7732309
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,20 +125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 584
+        content_length: 586
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:44:57.318330Z","description":"","environment_variables":{},"error_message":null,"id":"94f80183-9a88-48c4-87ab-f1ef6cae7aac","name":"tf-func-quirky-boyd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncquirkyboyd4fvnzpue","registry_namespace_id":"81155c5a-bb48-4b00-9e5a-c153d442241b","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:44:58.616344Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:08:44.488095Z","description":"","environment_variables":{},"error_message":null,"id":"56bcac67-2ff8-4f23-bac0-2deda7732309","name":"tf-func-serene-hertz","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncserenehertztyjm4www","registry_namespace_id":"7690f4f6-6007-4d42-aac4-c7bb35f5f7ff","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:08:46.093725Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "584"
+                - "586"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:45:02 GMT
+                - Fri, 03 Jul 2026 15:08:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2f938f49-0f8e-48b4-b1c7-6be8fb477a3f
+                - 9afee554-d381-4ae4-b9ac-da68a1aa3d4f
         status: 200 OK
         code: 200
-        duration: 112.516666ms
+        duration: 388.097237ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -166,7 +166,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/94f80183-9a88-48c4-87ab-f1ef6cae7aac
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/56bcac67-2ff8-4f23-bac0-2deda7732309
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,20 +174,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 584
+        content_length: 586
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:44:57.318330Z","description":"","environment_variables":{},"error_message":null,"id":"94f80183-9a88-48c4-87ab-f1ef6cae7aac","name":"tf-func-quirky-boyd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncquirkyboyd4fvnzpue","registry_namespace_id":"81155c5a-bb48-4b00-9e5a-c153d442241b","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:44:58.616344Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:08:44.488095Z","description":"","environment_variables":{},"error_message":null,"id":"56bcac67-2ff8-4f23-bac0-2deda7732309","name":"tf-func-serene-hertz","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncserenehertztyjm4www","registry_namespace_id":"7690f4f6-6007-4d42-aac4-c7bb35f5f7ff","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:08:46.093725Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "584"
+                - "586"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:45:02 GMT
+                - Fri, 03 Jul 2026 15:08:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,22 +195,22 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 56e52653-55d0-46d4-813d-61cec0e93feb
+                - ad89cedd-cf74-4930-9729-14219cefb1ac
         status: 200 OK
         code: 200
-        duration: 110.019293ms
+        duration: 612.308215ms
     - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 318
+        content_length: 321
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-func-objective-kirch","namespace_id":"94f80183-9a88-48c4-87ab-f1ef6cae7aac","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"go122","memory_limit":256,"handler":"Handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox","tags":null}'
+        body: '{"name":"tf-func-competent-meninsky","namespace_id":"56bcac67-2ff8-4f23-bac0-2deda7732309","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"go126","memory_limit":256,"handler":"Handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox","tags":null}'
         form: {}
         headers:
             Content-Type:
@@ -225,20 +225,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 727
+        content_length: 734
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:45:03.164191499Z","description":"","domain_name":"tffuncquirkyboyd4fvnzpue-tf-func-objective-kirch.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"c93918f3-103e-4113-9009-0da3e62070b9","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-objective-kirch","namespace_id":"94f80183-9a88-48c4-87ab-f1ef6cae7aac","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:45:03.164191499Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:08:53.432063632Z","description":"","domain_name":"tffuncserenehertztyjm4www-tf-func-competent-meninsky.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"b61b16c2-2ab3-4c2a-ab39-6d55014e2a58","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-competent-meninsky","namespace_id":"56bcac67-2ff8-4f23-bac0-2deda7732309","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:08:53.432063632Z"}'
         headers:
             Content-Length:
-                - "727"
+                - "734"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:45:03 GMT
+                - Fri, 03 Jul 2026 15:08:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -246,10 +246,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 75a73bc8-a7d7-4c45-9575-49752651d74b
+                - 0486ce26-120d-4880-80a3-67d5114fd266
         status: 200 OK
         code: 200
-        duration: 502.729019ms
+        duration: 2.643860298s
     - id: 5
       request:
         proto: HTTP/1.1
@@ -266,7 +266,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/c93918f3-103e-4113-9009-0da3e62070b9/upload-url?content_length=780
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/b61b16c2-2ab3-4c2a-ab39-6d55014e2a58/upload-url?content_length=780
         method: GET
       response:
         proto: HTTP/2.0
@@ -276,7 +276,7 @@ interactions:
         trailer: {}
         content_length: 510
         uncompressed: false
-        body: '{"headers":{"content-length":["780"],"content-type":["application/octet-stream"]},"url":"https://s3.fr-par.scw.cloud/serverless-functions-code-prod-fr-par/uploads/function-c93918f3-103e-4113-9009-0da3e62070b9.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=SCW0KAMQFQV1YYSZK2PF%2F20260504%2Ffr-par%2Fs3%2Faws4_request\u0026X-Amz-Date=20260504T124503Z\u0026X-Amz-Expires=3600\u0026X-Amz-SignedHeaders=content-length%3Bcontent-type%3Bhost\u0026X-Amz-Signature=17ca21e23b2d3555485901982924323c65a9b351784b75989ca3968d810ec578"}'
+        body: '{"headers":{"content-length":["780"],"content-type":["application/octet-stream"]},"url":"https://s3.fr-par.scw.cloud/serverless-functions-code-prod-fr-par/uploads/function-b61b16c2-2ab3-4c2a-ab39-6d55014e2a58.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=SCW0KAMQFQV1YYSZK2PF%2F20260703%2Ffr-par%2Fs3%2Faws4_request\u0026X-Amz-Date=20260703T150853Z\u0026X-Amz-Expires=3600\u0026X-Amz-SignedHeaders=content-length%3Bcontent-type%3Bhost\u0026X-Amz-Signature=25658a5c455bd15b88c250821f2eed0b4767853156251d8a221033740775c823"}'
         headers:
             Content-Length:
                 - "510"
@@ -285,9 +285,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:45:03 GMT
+                - Fri, 03 Jul 2026 15:08:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -295,10 +295,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d9ee7423-54a3-4ca4-b0db-9a84c44ddf5a
+                - eb9d30ea-fd21-4bc4-8f93-e236b9a9fd2e
         status: 200 OK
         code: 200
-        duration: 100.911901ms
+        duration: 154.469291ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -332,7 +332,7 @@ interactions:
                 - "780"
             Content-Type:
                 - application/octet-stream
-        url: https://s3.fr-par.scw.cloud/serverless-functions-code-prod-fr-par/uploads/function-c93918f3-103e-4113-9009-0da3e62070b9.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=SCW0KAMQFQV1YYSZK2PF%2F20260504%2Ffr-par%2Fs3%2Faws4_request&X-Amz-Date=20260504T124503Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=content-length%3Bcontent-type%3Bhost&X-Amz-Signature=17ca21e23b2d3555485901982924323c65a9b351784b75989ca3968d810ec578
+        url: https://s3.fr-par.scw.cloud/serverless-functions-code-prod-fr-par/uploads/function-b61b16c2-2ab3-4c2a-ab39-6d55014e2a58.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=SCW0KAMQFQV1YYSZK2PF%2F20260703%2Ffr-par%2Fs3%2Faws4_request&X-Amz-Date=20260703T150853Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=content-length%3Bcontent-type%3Bhost&X-Amz-Signature=25658a5c455bd15b88c250821f2eed0b4767853156251d8a221033740775c823
         method: PUT
       response:
         proto: HTTP/2.0
@@ -347,16 +347,16 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 04 May 2026 12:45:03 GMT
+                - Fri, 03 Jul 2026 15:08:53 GMT
             Etag:
                 - '"10633bf7a5ff211d8f3eee3856a28101"'
             X-Amz-Id-2:
-                - txg2b0554cbc4ca42f08cd8-0069f894cf
+                - txg0d0aa12a9efc46dfaf43-006a47d085
             X-Amz-Request-Id:
-                - txg2b0554cbc4ca42f08cd8-0069f894cf
+                - txg0d0aa12a9efc46dfaf43-006a47d085
         status: 200 OK
         code: 200
-        duration: 457.675504ms
+        duration: 300.419891ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -375,7 +375,7 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/c93918f3-103e-4113-9009-0da3e62070b9/deploy
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/b61b16c2-2ab3-4c2a-ab39-6d55014e2a58/deploy
         method: POST
       response:
         proto: HTTP/2.0
@@ -383,20 +383,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 724
+        content_length: 731
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:45:03.164191Z","description":"","domain_name":"tffuncquirkyboyd4fvnzpue-tf-func-objective-kirch.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"c93918f3-103e-4113-9009-0da3e62070b9","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-objective-kirch","namespace_id":"94f80183-9a88-48c4-87ab-f1ef6cae7aac","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:45:03.850579490Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:08:53.432064Z","description":"","domain_name":"tffuncserenehertztyjm4www-tf-func-competent-meninsky.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"b61b16c2-2ab3-4c2a-ab39-6d55014e2a58","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-competent-meninsky","namespace_id":"56bcac67-2ff8-4f23-bac0-2deda7732309","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:08:54.048962320Z"}'
         headers:
             Content-Length:
-                - "724"
+                - "731"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:45:03 GMT
+                - Fri, 03 Jul 2026 15:08:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -404,10 +404,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - acf8ad50-229e-4c96-b7f4-40b585268336
+                - 3ca43b54-c10b-41c8-9362-efb58e4b3ea0
         status: 200 OK
         code: 200
-        duration: 111.743781ms
+        duration: 156.650951ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -424,7 +424,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/c93918f3-103e-4113-9009-0da3e62070b9
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/b61b16c2-2ab3-4c2a-ab39-6d55014e2a58
         method: GET
       response:
         proto: HTTP/2.0
@@ -432,20 +432,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 721
+        content_length: 728
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:45:03.164191Z","description":"","domain_name":"tffuncquirkyboyd4fvnzpue-tf-func-objective-kirch.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"c93918f3-103e-4113-9009-0da3e62070b9","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-objective-kirch","namespace_id":"94f80183-9a88-48c4-87ab-f1ef6cae7aac","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:45:03.850579Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:08:53.432064Z","description":"","domain_name":"tffuncserenehertztyjm4www-tf-func-competent-meninsky.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"b61b16c2-2ab3-4c2a-ab39-6d55014e2a58","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-competent-meninsky","namespace_id":"56bcac67-2ff8-4f23-bac0-2deda7732309","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:08:54.048962Z"}'
         headers:
             Content-Length:
-                - "721"
+                - "728"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:45:03 GMT
+                - Fri, 03 Jul 2026 15:08:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -453,10 +453,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dedeaba4-1479-42e0-bad0-00f41e3bd07c
+                - c9599691-6266-44da-afdc-959df4a07beb
         status: 200 OK
         code: 200
-        duration: 121.962465ms
+        duration: 139.222634ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -473,7 +473,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/c93918f3-103e-4113-9009-0da3e62070b9
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/b61b16c2-2ab3-4c2a-ab39-6d55014e2a58
         method: GET
       response:
         proto: HTTP/2.0
@@ -481,20 +481,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 744
+        content_length: 738
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:45:03.164191Z","description":"","domain_name":"tffuncquirkyboyd4fvnzpue-tf-func-objective-kirch.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"c93918f3-103e-4113-9009-0da3e62070b9","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-objective-kirch","namespace_id":"94f80183-9a88-48c4-87ab-f1ef6cae7aac","privacy":"private","private_network_id":null,"ready_at":"2026-05-04T12:46:21.869829Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:46:21.880234Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:08:53.432064Z","description":"","domain_name":"tffuncserenehertztyjm4www-tf-func-competent-meninsky.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"Handle","http_option":"enabled","id":"b61b16c2-2ab3-4c2a-ab39-6d55014e2a58","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-competent-meninsky","namespace_id":"56bcac67-2ff8-4f23-bac0-2deda7732309","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:10:06.449378Z"}'
         headers:
             Content-Length:
-                - "744"
+                - "738"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:46:25 GMT
+                - Fri, 03 Jul 2026 15:10:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -502,10 +502,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a6bb6a00-6a94-47dd-af0b-6ccb422fb21a
+                - 885e7c5f-0379-4c0a-b747-08a6bb1dbc90
         status: 200 OK
         code: 200
-        duration: 108.147777ms
+        duration: 142.080855ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -522,7 +522,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/c93918f3-103e-4113-9009-0da3e62070b9
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/b61b16c2-2ab3-4c2a-ab39-6d55014e2a58
         method: GET
       response:
         proto: HTTP/2.0
@@ -530,20 +530,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 744
+        content_length: 738
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:45:03.164191Z","description":"","domain_name":"tffuncquirkyboyd4fvnzpue-tf-func-objective-kirch.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"c93918f3-103e-4113-9009-0da3e62070b9","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-objective-kirch","namespace_id":"94f80183-9a88-48c4-87ab-f1ef6cae7aac","privacy":"private","private_network_id":null,"ready_at":"2026-05-04T12:46:21.869829Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:46:21.880234Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:08:53.432064Z","description":"","domain_name":"tffuncserenehertztyjm4www-tf-func-competent-meninsky.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"Handle","http_option":"enabled","id":"b61b16c2-2ab3-4c2a-ab39-6d55014e2a58","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-competent-meninsky","namespace_id":"56bcac67-2ff8-4f23-bac0-2deda7732309","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:10:06.449378Z"}'
         headers:
             Content-Length:
-                - "744"
+                - "738"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:46:25 GMT
+                - Fri, 03 Jul 2026 15:10:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -551,22 +551,22 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3e91926e-4cc8-4b7d-8998-bf7a3f67b44f
+                - 30843b06-ef40-430c-90e8-a4fa562958c0
         status: 200 OK
         code: 200
-        duration: 108.522383ms
+        duration: 160.45837ms
     - id: 11
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 285
+        content_length: 289
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"changes":[{"add":{"records":[{"data":"tffuncquirkyboyd4fvnzpue-tf-func-objective-kirch.functions.fnc.fr-par.scw.cloud.","name":"function","priority":0,"ttl":60,"type":"CNAME","comment":null,"id":"","updated_at":null}]}}],"return_all_records":false,"disallow_new_zone_creation":false}'
+        body: '{"changes":[{"add":{"records":[{"data":"tffuncserenehertztyjm4www-tf-func-competent-meninsky.functions.fnc.fr-par.scw.cloud.","name":"function","priority":0,"ttl":60,"type":"CNAME","comment":null,"id":"","updated_at":null}]}}],"return_all_records":false,"disallow_new_zone_creation":false}'
         form: {}
         headers:
             Content-Type:
@@ -581,20 +581,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 255
+        content_length: 259
         uncompressed: false
-        body: '{"records":[{"comment":null,"data":"tffuncquirkyboyd4fvnzpue-tf-func-objective-kirch.functions.fnc.fr-par.scw.cloud.","id":"8b474635-3d45-4096-829b-3333812ab18d","name":"function","priority":0,"ttl":60,"type":"CNAME","updated_at":"2026-05-04T12:46:26Z"}]}'
+        body: '{"records":[{"comment":null,"data":"tffuncserenehertztyjm4www-tf-func-competent-meninsky.functions.fnc.fr-par.scw.cloud.","id":"24f216d6-4725-4cd3-9be7-9b23e96f9950","name":"function","priority":0,"ttl":60,"type":"CNAME","updated_at":"2026-07-03T15:10:11Z"}]}'
         headers:
             Content-Length:
-                - "255"
+                - "259"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:46:26 GMT
+                - Fri, 03 Jul 2026 15:10:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -602,10 +602,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 83194431-4318-422e-af13-776c4be8d981
+                - e5966c4d-eb79-4bdd-bdcf-e164187288a8
         status: 200 OK
         code: 200
-        duration: 160.648815ms
+        duration: 258.633573ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -630,20 +630,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 271
+        content_length: 275
         uncompressed: false
-        body: '{"records":[{"comment":null,"data":"tffuncquirkyboyd4fvnzpue-tf-func-objective-kirch.functions.fnc.fr-par.scw.cloud.","id":"8b474635-3d45-4096-829b-3333812ab18d","name":"function","priority":0,"ttl":60,"type":"CNAME","updated_at":"2026-05-04T12:46:26Z"}],"total_count":1}'
+        body: '{"records":[{"comment":null,"data":"tffuncserenehertztyjm4www-tf-func-competent-meninsky.functions.fnc.fr-par.scw.cloud.","id":"24f216d6-4725-4cd3-9be7-9b23e96f9950","name":"function","priority":0,"ttl":60,"type":"CNAME","updated_at":"2026-07-03T15:10:11Z"}],"total_count":1}'
         headers:
             Content-Length:
-                - "271"
+                - "275"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:46:26 GMT
+                - Fri, 03 Jul 2026 15:10:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -651,10 +651,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d1500136-77aa-4f41-a65d-9593cde605de
+                - 64773c49-084e-4619-bb9a-48db7d7f11a4
         status: 200 OK
         code: 200
-        duration: 102.66952ms
+        duration: 192.550905ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -679,20 +679,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 271
+        content_length: 275
         uncompressed: false
-        body: '{"records":[{"comment":null,"data":"tffuncquirkyboyd4fvnzpue-tf-func-objective-kirch.functions.fnc.fr-par.scw.cloud.","id":"8b474635-3d45-4096-829b-3333812ab18d","name":"function","priority":0,"ttl":60,"type":"CNAME","updated_at":"2026-05-04T12:46:26Z"}],"total_count":1}'
+        body: '{"records":[{"comment":null,"data":"tffuncserenehertztyjm4www-tf-func-competent-meninsky.functions.fnc.fr-par.scw.cloud.","id":"24f216d6-4725-4cd3-9be7-9b23e96f9950","name":"function","priority":0,"ttl":60,"type":"CNAME","updated_at":"2026-07-03T15:10:11Z"}],"total_count":1}'
         headers:
             Content-Length:
-                - "271"
+                - "275"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:46:26 GMT
+                - Fri, 03 Jul 2026 15:10:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -700,10 +700,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1e7864e1-e41d-4ba8-b4a1-52766c5cf0d1
+                - ea83c4ab-bcdf-4d9f-a12a-46634aaa2613
         status: 200 OK
         code: 200
-        duration: 94.703215ms
+        duration: 180.100872ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -720,7 +720,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/domain/v2beta1/dns-zones/function-basic.scaleway-terraform.com/records?id=8b474635-3d45-4096-829b-3333812ab18d&name=&order_by=name_asc&page=1&type=unknown
+        url: https://api.scaleway.com/domain/v2beta1/dns-zones/function-basic.scaleway-terraform.com/records?id=24f216d6-4725-4cd3-9be7-9b23e96f9950&name=&order_by=name_asc&page=1&type=unknown
         method: GET
       response:
         proto: HTTP/2.0
@@ -728,20 +728,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 271
+        content_length: 275
         uncompressed: false
-        body: '{"records":[{"comment":null,"data":"tffuncquirkyboyd4fvnzpue-tf-func-objective-kirch.functions.fnc.fr-par.scw.cloud.","id":"8b474635-3d45-4096-829b-3333812ab18d","name":"function","priority":0,"ttl":60,"type":"CNAME","updated_at":"2026-05-04T12:46:26Z"}],"total_count":1}'
+        body: '{"records":[{"comment":null,"data":"tffuncserenehertztyjm4www-tf-func-competent-meninsky.functions.fnc.fr-par.scw.cloud.","id":"24f216d6-4725-4cd3-9be7-9b23e96f9950","name":"function","priority":0,"ttl":60,"type":"CNAME","updated_at":"2026-07-03T15:10:11Z"}],"total_count":1}'
         headers:
             Content-Length:
-                - "271"
+                - "275"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:46:26 GMT
+                - Fri, 03 Jul 2026 15:10:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -749,10 +749,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e167514d-f398-4c32-bed9-64eacc17eb0a
+                - 81fc8734-ee76-4122-98a3-22f161e39290
         status: 200 OK
         code: 200
-        duration: 95.888648ms
+        duration: 176.093831ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -779,7 +779,7 @@ interactions:
         trailer: {}
         content_length: 356
         uncompressed: false
-        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"function-basic","updated_at":"2026-05-04T12:46:26Z"}],"total_count":1}'
+        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"function-basic","updated_at":"2026-07-03T15:10:12Z"}],"total_count":1}'
         headers:
             Content-Length:
                 - "356"
@@ -788,9 +788,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:46:26 GMT
+                - Fri, 03 Jul 2026 15:10:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -798,10 +798,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5fe130dc-7953-4523-820c-3da220e726d9
+                - 4137a829-266f-4d75-a51d-32a43a8ed9ef
         status: 200 OK
         code: 200
-        duration: 91.088296ms
+        duration: 168.553096ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -818,7 +818,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/c93918f3-103e-4113-9009-0da3e62070b9
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/b61b16c2-2ab3-4c2a-ab39-6d55014e2a58
         method: GET
       response:
         proto: HTTP/2.0
@@ -826,20 +826,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 744
+        content_length: 738
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:45:03.164191Z","description":"","domain_name":"tffuncquirkyboyd4fvnzpue-tf-func-objective-kirch.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"c93918f3-103e-4113-9009-0da3e62070b9","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-objective-kirch","namespace_id":"94f80183-9a88-48c4-87ab-f1ef6cae7aac","privacy":"private","private_network_id":null,"ready_at":"2026-05-04T12:46:21.869829Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:46:21.880234Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:08:53.432064Z","description":"","domain_name":"tffuncserenehertztyjm4www-tf-func-competent-meninsky.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"Handle","http_option":"enabled","id":"b61b16c2-2ab3-4c2a-ab39-6d55014e2a58","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-competent-meninsky","namespace_id":"56bcac67-2ff8-4f23-bac0-2deda7732309","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:10:06.449378Z"}'
         headers:
             Content-Length:
-                - "744"
+                - "738"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:46:26 GMT
+                - Fri, 03 Jul 2026 15:10:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -847,10 +847,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3c27b05e-029e-4dd6-9e3f-056f34362d01
+                - c46d49e0-8173-4d6e-b3a2-4a41231b4357
         status: 200 OK
         code: 200
-        duration: 114.72707ms
+        duration: 147.554724ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -862,7 +862,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"hostname":"function.function-basic.scaleway-terraform.com","function_id":"c93918f3-103e-4113-9009-0da3e62070b9"}'
+        body: '{"hostname":"function.function-basic.scaleway-terraform.com","function_id":"b61b16c2-2ab3-4c2a-ab39-6d55014e2a58"}'
         form: {}
         headers:
             Content-Type:
@@ -879,7 +879,7 @@ interactions:
         trailer: {}
         content_length: 207
         uncompressed: false
-        body: '{"error_message":null,"function_id":"c93918f3-103e-4113-9009-0da3e62070b9","hostname":"function.function-basic.scaleway-terraform.com","id":"0e859484-53dc-418e-b055-473631f300f1","status":"pending","url":""}'
+        body: '{"error_message":null,"function_id":"b61b16c2-2ab3-4c2a-ab39-6d55014e2a58","hostname":"function.function-basic.scaleway-terraform.com","id":"c80299ac-de8b-4ef5-86d5-6bcb064dafe2","status":"pending","url":""}'
         headers:
             Content-Length:
                 - "207"
@@ -888,9 +888,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:46:31 GMT
+                - Fri, 03 Jul 2026 15:10:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -898,10 +898,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1ad6b338-8ba0-4e55-8931-1824f314f625
+                - e7fb907c-bf6b-49d7-9b7f-1c86c5f3a98e
         status: 200 OK
         code: 200
-        duration: 143.948792ms
+        duration: 166.978488ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -918,7 +918,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/0e859484-53dc-418e-b055-473631f300f1
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/c80299ac-de8b-4ef5-86d5-6bcb064dafe2
         method: GET
       response:
         proto: HTTP/2.0
@@ -928,7 +928,7 @@ interactions:
         trailer: {}
         content_length: 207
         uncompressed: false
-        body: '{"error_message":null,"function_id":"c93918f3-103e-4113-9009-0da3e62070b9","hostname":"function.function-basic.scaleway-terraform.com","id":"0e859484-53dc-418e-b055-473631f300f1","status":"pending","url":""}'
+        body: '{"error_message":null,"function_id":"b61b16c2-2ab3-4c2a-ab39-6d55014e2a58","hostname":"function.function-basic.scaleway-terraform.com","id":"c80299ac-de8b-4ef5-86d5-6bcb064dafe2","status":"pending","url":""}'
         headers:
             Content-Length:
                 - "207"
@@ -937,9 +937,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:46:31 GMT
+                - Fri, 03 Jul 2026 15:10:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -947,10 +947,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ccd8b54b-5ae3-42d9-9e55-d7f80bece46d
+                - dedf435e-b909-4da5-99c7-cbdfadece3e5
         status: 200 OK
         code: 200
-        duration: 126.265996ms
+        duration: 176.383407ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -967,7 +967,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/0e859484-53dc-418e-b055-473631f300f1
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/c80299ac-de8b-4ef5-86d5-6bcb064dafe2
         method: GET
       response:
         proto: HTTP/2.0
@@ -977,7 +977,7 @@ interactions:
         trailer: {}
         content_length: 259
         uncompressed: false
-        body: '{"error_message":null,"function_id":"c93918f3-103e-4113-9009-0da3e62070b9","hostname":"function.function-basic.scaleway-terraform.com","id":"0e859484-53dc-418e-b055-473631f300f1","status":"ready","url":"https://function.function-basic.scaleway-terraform.com"}'
+        body: '{"error_message":null,"function_id":"b61b16c2-2ab3-4c2a-ab39-6d55014e2a58","hostname":"function.function-basic.scaleway-terraform.com","id":"c80299ac-de8b-4ef5-86d5-6bcb064dafe2","status":"ready","url":"https://function.function-basic.scaleway-terraform.com"}'
         headers:
             Content-Length:
                 - "259"
@@ -986,9 +986,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:46:42 GMT
+                - Fri, 03 Jul 2026 15:10:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -996,10 +996,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 36a649be-f1ca-460f-9628-132f78fb68a3
+                - f05e51b6-762f-4b2a-8d61-9b5c31356f3c
         status: 200 OK
         code: 200
-        duration: 347.574671ms
+        duration: 129.08517ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1016,7 +1016,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/0e859484-53dc-418e-b055-473631f300f1
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/c80299ac-de8b-4ef5-86d5-6bcb064dafe2
         method: GET
       response:
         proto: HTTP/2.0
@@ -1026,7 +1026,7 @@ interactions:
         trailer: {}
         content_length: 259
         uncompressed: false
-        body: '{"error_message":null,"function_id":"c93918f3-103e-4113-9009-0da3e62070b9","hostname":"function.function-basic.scaleway-terraform.com","id":"0e859484-53dc-418e-b055-473631f300f1","status":"ready","url":"https://function.function-basic.scaleway-terraform.com"}'
+        body: '{"error_message":null,"function_id":"b61b16c2-2ab3-4c2a-ab39-6d55014e2a58","hostname":"function.function-basic.scaleway-terraform.com","id":"c80299ac-de8b-4ef5-86d5-6bcb064dafe2","status":"ready","url":"https://function.function-basic.scaleway-terraform.com"}'
         headers:
             Content-Length:
                 - "259"
@@ -1035,9 +1035,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:46:42 GMT
+                - Fri, 03 Jul 2026 15:10:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1045,10 +1045,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - eba2b468-bc27-4296-b238-74f3e7e4e7f0
+                - 4101a1e8-a890-46be-988b-445ba5e68f51
         status: 200 OK
         code: 200
-        duration: 107.220006ms
+        duration: 135.788229ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1065,7 +1065,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/0e859484-53dc-418e-b055-473631f300f1
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/c80299ac-de8b-4ef5-86d5-6bcb064dafe2
         method: GET
       response:
         proto: HTTP/2.0
@@ -1075,7 +1075,7 @@ interactions:
         trailer: {}
         content_length: 259
         uncompressed: false
-        body: '{"error_message":null,"function_id":"c93918f3-103e-4113-9009-0da3e62070b9","hostname":"function.function-basic.scaleway-terraform.com","id":"0e859484-53dc-418e-b055-473631f300f1","status":"ready","url":"https://function.function-basic.scaleway-terraform.com"}'
+        body: '{"error_message":null,"function_id":"b61b16c2-2ab3-4c2a-ab39-6d55014e2a58","hostname":"function.function-basic.scaleway-terraform.com","id":"c80299ac-de8b-4ef5-86d5-6bcb064dafe2","status":"ready","url":"https://function.function-basic.scaleway-terraform.com"}'
         headers:
             Content-Length:
                 - "259"
@@ -1084,9 +1084,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:46:42 GMT
+                - Fri, 03 Jul 2026 15:10:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1094,10 +1094,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 80d9aab3-1a7b-4bd4-8ade-24d8a2697fcb
+                - 4e548756-aade-420a-9d5a-16a8a2687eea
         status: 200 OK
         code: 200
-        duration: 48.013647ms
+        duration: 142.98075ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1114,7 +1114,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/94f80183-9a88-48c4-87ab-f1ef6cae7aac
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/56bcac67-2ff8-4f23-bac0-2deda7732309
         method: GET
       response:
         proto: HTTP/2.0
@@ -1122,20 +1122,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 584
+        content_length: 586
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:44:57.318330Z","description":"","environment_variables":{},"error_message":null,"id":"94f80183-9a88-48c4-87ab-f1ef6cae7aac","name":"tf-func-quirky-boyd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncquirkyboyd4fvnzpue","registry_namespace_id":"81155c5a-bb48-4b00-9e5a-c153d442241b","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:44:58.616344Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:08:44.488095Z","description":"","environment_variables":{},"error_message":null,"id":"56bcac67-2ff8-4f23-bac0-2deda7732309","name":"tf-func-serene-hertz","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncserenehertztyjm4www","registry_namespace_id":"7690f4f6-6007-4d42-aac4-c7bb35f5f7ff","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:08:46.093725Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "584"
+                - "586"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:46:42 GMT
+                - Fri, 03 Jul 2026 15:10:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1143,10 +1143,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5b5ead2d-1915-4066-a6a5-7684ef7812e6
+                - 209f2e1c-24c9-44d0-a31a-d2abcf7fc7aa
         status: 200 OK
         code: 200
-        duration: 96.238452ms
+        duration: 124.794524ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1163,7 +1163,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/c93918f3-103e-4113-9009-0da3e62070b9
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/b61b16c2-2ab3-4c2a-ab39-6d55014e2a58
         method: GET
       response:
         proto: HTTP/2.0
@@ -1171,20 +1171,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 744
+        content_length: 738
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:45:03.164191Z","description":"","domain_name":"tffuncquirkyboyd4fvnzpue-tf-func-objective-kirch.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"c93918f3-103e-4113-9009-0da3e62070b9","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-objective-kirch","namespace_id":"94f80183-9a88-48c4-87ab-f1ef6cae7aac","privacy":"private","private_network_id":null,"ready_at":"2026-05-04T12:46:21.869829Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:46:21.880234Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:08:53.432064Z","description":"","domain_name":"tffuncserenehertztyjm4www-tf-func-competent-meninsky.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"Handle","http_option":"enabled","id":"b61b16c2-2ab3-4c2a-ab39-6d55014e2a58","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-competent-meninsky","namespace_id":"56bcac67-2ff8-4f23-bac0-2deda7732309","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:10:06.449378Z"}'
         headers:
             Content-Length:
-                - "744"
+                - "738"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:46:43 GMT
+                - Fri, 03 Jul 2026 15:10:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1192,10 +1192,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d009b6e0-f778-47c3-b1de-e600e509cdd5
+                - 977c8de1-a6b6-4dfb-9d3d-acc0779e5fa6
         status: 200 OK
         code: 200
-        duration: 89.053999ms
+        duration: 138.108571ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1212,7 +1212,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/domain/v2beta1/dns-zones/function-basic.scaleway-terraform.com/records?id=8b474635-3d45-4096-829b-3333812ab18d&name=&order_by=name_asc&page=1&type=unknown
+        url: https://api.scaleway.com/domain/v2beta1/dns-zones/function-basic.scaleway-terraform.com/records?id=24f216d6-4725-4cd3-9be7-9b23e96f9950&name=&order_by=name_asc&page=1&type=unknown
         method: GET
       response:
         proto: HTTP/2.0
@@ -1220,20 +1220,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 271
+        content_length: 275
         uncompressed: false
-        body: '{"records":[{"comment":null,"data":"tffuncquirkyboyd4fvnzpue-tf-func-objective-kirch.functions.fnc.fr-par.scw.cloud.","id":"8b474635-3d45-4096-829b-3333812ab18d","name":"function","priority":0,"ttl":60,"type":"CNAME","updated_at":"2026-05-04T12:46:26Z"}],"total_count":1}'
+        body: '{"records":[{"comment":null,"data":"tffuncserenehertztyjm4www-tf-func-competent-meninsky.functions.fnc.fr-par.scw.cloud.","id":"24f216d6-4725-4cd3-9be7-9b23e96f9950","name":"function","priority":0,"ttl":60,"type":"CNAME","updated_at":"2026-07-03T15:10:11Z"}],"total_count":1}'
         headers:
             Content-Length:
-                - "271"
+                - "275"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:46:43 GMT
+                - Fri, 03 Jul 2026 15:10:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1241,10 +1241,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a8ee6ddc-ba9a-48a1-a99f-c58ed7bd8b4e
+                - be819c20-6410-4ac3-88c5-c2b237e617c4
         status: 200 OK
         code: 200
-        duration: 102.447988ms
+        duration: 199.670393ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1271,7 +1271,7 @@ interactions:
         trailer: {}
         content_length: 355
         uncompressed: false
-        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"function-basic","updated_at":"2026-05-04T12:46:32Z"}],"total_count":1}'
+        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"function-basic","updated_at":"2026-07-03T15:10:19Z"}],"total_count":1}'
         headers:
             Content-Length:
                 - "355"
@@ -1280,9 +1280,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:46:43 GMT
+                - Fri, 03 Jul 2026 15:10:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1290,10 +1290,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 79d415ea-9c0b-40be-a03b-307bc273e1fe
+                - 31d53281-560b-4c34-8fd8-ce9fd678bf09
         status: 200 OK
         code: 200
-        duration: 119.759686ms
+        duration: 203.922546ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1310,7 +1310,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/0e859484-53dc-418e-b055-473631f300f1
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/c80299ac-de8b-4ef5-86d5-6bcb064dafe2
         method: GET
       response:
         proto: HTTP/2.0
@@ -1320,7 +1320,7 @@ interactions:
         trailer: {}
         content_length: 259
         uncompressed: false
-        body: '{"error_message":null,"function_id":"c93918f3-103e-4113-9009-0da3e62070b9","hostname":"function.function-basic.scaleway-terraform.com","id":"0e859484-53dc-418e-b055-473631f300f1","status":"ready","url":"https://function.function-basic.scaleway-terraform.com"}'
+        body: '{"error_message":null,"function_id":"b61b16c2-2ab3-4c2a-ab39-6d55014e2a58","hostname":"function.function-basic.scaleway-terraform.com","id":"c80299ac-de8b-4ef5-86d5-6bcb064dafe2","status":"ready","url":"https://function.function-basic.scaleway-terraform.com"}'
         headers:
             Content-Length:
                 - "259"
@@ -1329,9 +1329,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:46:43 GMT
+                - Fri, 03 Jul 2026 15:10:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1339,10 +1339,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 893acb29-96a1-48a2-a00b-041c2d2b4251
+                - 22371296-589d-4c29-9f9f-624490257327
         status: 200 OK
         code: 200
-        duration: 106.01697ms
+        duration: 180.549039ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1359,7 +1359,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/0e859484-53dc-418e-b055-473631f300f1
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/c80299ac-de8b-4ef5-86d5-6bcb064dafe2
         method: GET
       response:
         proto: HTTP/2.0
@@ -1369,7 +1369,7 @@ interactions:
         trailer: {}
         content_length: 259
         uncompressed: false
-        body: '{"error_message":null,"function_id":"c93918f3-103e-4113-9009-0da3e62070b9","hostname":"function.function-basic.scaleway-terraform.com","id":"0e859484-53dc-418e-b055-473631f300f1","status":"ready","url":"https://function.function-basic.scaleway-terraform.com"}'
+        body: '{"error_message":null,"function_id":"b61b16c2-2ab3-4c2a-ab39-6d55014e2a58","hostname":"function.function-basic.scaleway-terraform.com","id":"c80299ac-de8b-4ef5-86d5-6bcb064dafe2","status":"ready","url":"https://function.function-basic.scaleway-terraform.com"}'
         headers:
             Content-Length:
                 - "259"
@@ -1378,9 +1378,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:46:43 GMT
+                - Fri, 03 Jul 2026 15:10:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1388,10 +1388,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8492d7cd-c07d-480e-9250-5e8f26b84cae
+                - f55fd424-afd9-47ca-a428-807d6091ad71
         status: 200 OK
         code: 200
-        duration: 120.278073ms
+        duration: 167.752235ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1408,7 +1408,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/0e859484-53dc-418e-b055-473631f300f1
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/c80299ac-de8b-4ef5-86d5-6bcb064dafe2
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1418,7 +1418,7 @@ interactions:
         trailer: {}
         content_length: 262
         uncompressed: false
-        body: '{"error_message":null,"function_id":"c93918f3-103e-4113-9009-0da3e62070b9","hostname":"function.function-basic.scaleway-terraform.com","id":"0e859484-53dc-418e-b055-473631f300f1","status":"deleting","url":"https://function.function-basic.scaleway-terraform.com"}'
+        body: '{"error_message":null,"function_id":"b61b16c2-2ab3-4c2a-ab39-6d55014e2a58","hostname":"function.function-basic.scaleway-terraform.com","id":"c80299ac-de8b-4ef5-86d5-6bcb064dafe2","status":"deleting","url":"https://function.function-basic.scaleway-terraform.com"}'
         headers:
             Content-Length:
                 - "262"
@@ -1427,9 +1427,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:46:43 GMT
+                - Fri, 03 Jul 2026 15:10:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1437,10 +1437,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f0919abc-49a5-454d-8e58-90efc34a24d6
+                - 0a2379ff-94c6-47d9-9bd5-fdc1e7713a28
         status: 200 OK
         code: 200
-        duration: 118.352816ms
+        duration: 160.632611ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1457,7 +1457,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/0e859484-53dc-418e-b055-473631f300f1
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/c80299ac-de8b-4ef5-86d5-6bcb064dafe2
         method: GET
       response:
         proto: HTTP/2.0
@@ -1467,7 +1467,7 @@ interactions:
         trailer: {}
         content_length: 262
         uncompressed: false
-        body: '{"error_message":null,"function_id":"c93918f3-103e-4113-9009-0da3e62070b9","hostname":"function.function-basic.scaleway-terraform.com","id":"0e859484-53dc-418e-b055-473631f300f1","status":"deleting","url":"https://function.function-basic.scaleway-terraform.com"}'
+        body: '{"error_message":null,"function_id":"b61b16c2-2ab3-4c2a-ab39-6d55014e2a58","hostname":"function.function-basic.scaleway-terraform.com","id":"c80299ac-de8b-4ef5-86d5-6bcb064dafe2","status":"deleting","url":"https://function.function-basic.scaleway-terraform.com"}'
         headers:
             Content-Length:
                 - "262"
@@ -1476,9 +1476,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:46:43 GMT
+                - Fri, 03 Jul 2026 15:10:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1486,10 +1486,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6745ee8d-f5a9-4eb2-9be6-5b406ab4174e
+                - 07520eee-e83b-4cff-ad57-1a6d9af219a2
         status: 200 OK
         code: 200
-        duration: 51.442175ms
+        duration: 152.472161ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1506,7 +1506,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/0e859484-53dc-418e-b055-473631f300f1
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/c80299ac-de8b-4ef5-86d5-6bcb064dafe2
         method: GET
       response:
         proto: HTTP/2.0
@@ -1525,9 +1525,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:46:48 GMT
+                - Fri, 03 Jul 2026 15:10:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1535,10 +1535,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2879d8f5-a7a1-4cdd-a8b4-b8c2a89b2d70
+                - 8001cee7-656d-470f-95c2-0d96370a2a8c
         status: 404 Not Found
         code: 404
-        duration: 23.499082ms
+        duration: 21.75261ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1550,7 +1550,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"changes":[{"delete":{"id":"8b474635-3d45-4096-829b-3333812ab18d"}}],"return_all_records":false,"disallow_new_zone_creation":false}'
+        body: '{"changes":[{"delete":{"id":"24f216d6-4725-4cd3-9be7-9b23e96f9950"}}],"return_all_records":false,"disallow_new_zone_creation":false}'
         form: {}
         headers:
             Content-Type:
@@ -1576,9 +1576,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:46:49 GMT
+                - Fri, 03 Jul 2026 15:10:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1586,10 +1586,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e9c24834-d344-48ff-b303-8a113e7c89a8
+                - 617bbca6-242b-41e5-93df-1fa49aad77ef
         status: 200 OK
         code: 200
-        duration: 141.86226ms
+        duration: 181.407154ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1606,7 +1606,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/c93918f3-103e-4113-9009-0da3e62070b9
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/b61b16c2-2ab3-4c2a-ab39-6d55014e2a58
         method: GET
       response:
         proto: HTTP/2.0
@@ -1614,20 +1614,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 744
+        content_length: 738
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:45:03.164191Z","description":"","domain_name":"tffuncquirkyboyd4fvnzpue-tf-func-objective-kirch.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"c93918f3-103e-4113-9009-0da3e62070b9","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-objective-kirch","namespace_id":"94f80183-9a88-48c4-87ab-f1ef6cae7aac","privacy":"private","private_network_id":null,"ready_at":"2026-05-04T12:46:21.869829Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"ready","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:46:21.880234Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:08:53.432064Z","description":"","domain_name":"tffuncserenehertztyjm4www-tf-func-competent-meninsky.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"Handle","http_option":"enabled","id":"b61b16c2-2ab3-4c2a-ab39-6d55014e2a58","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-competent-meninsky","namespace_id":"56bcac67-2ff8-4f23-bac0-2deda7732309","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:10:06.449378Z"}'
         headers:
             Content-Length:
-                - "744"
+                - "738"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:46:49 GMT
+                - Fri, 03 Jul 2026 15:10:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1635,10 +1635,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 664a2d6e-ea91-4f80-8720-1279ae5737f1
+                - 6a3d4f57-ee55-48bf-ad3e-b37303a20466
         status: 200 OK
         code: 200
-        duration: 133.914089ms
+        duration: 131.569131ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1655,7 +1655,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/c93918f3-103e-4113-9009-0da3e62070b9
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/b61b16c2-2ab3-4c2a-ab39-6d55014e2a58
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1663,20 +1663,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 750
+        content_length: 732
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:45:03.164191Z","description":"","domain_name":"tffuncquirkyboyd4fvnzpue-tf-func-objective-kirch.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"c93918f3-103e-4113-9009-0da3e62070b9","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-objective-kirch","namespace_id":"94f80183-9a88-48c4-87ab-f1ef6cae7aac","privacy":"private","private_network_id":null,"ready_at":"2026-05-04T12:46:21.869829Z","region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:46:49.344828785Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:08:53.432064Z","description":"","domain_name":"tffuncserenehertztyjm4www-tf-func-competent-meninsky.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"b61b16c2-2ab3-4c2a-ab39-6d55014e2a58","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-competent-meninsky","namespace_id":"56bcac67-2ff8-4f23-bac0-2deda7732309","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:10:36.309668499Z"}'
         headers:
             Content-Length:
-                - "750"
+                - "732"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:46:49 GMT
+                - Fri, 03 Jul 2026 15:10:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1684,10 +1684,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f531fd7e-be9a-4283-bfb9-56c1c34d3c97
+                - 53b30b2e-6466-4957-b62e-e5deeed1df85
         status: 200 OK
         code: 200
-        duration: 266.411028ms
+        duration: 299.90227ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1704,7 +1704,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/94f80183-9a88-48c4-87ab-f1ef6cae7aac
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/56bcac67-2ff8-4f23-bac0-2deda7732309
         method: GET
       response:
         proto: HTTP/2.0
@@ -1712,20 +1712,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 584
+        content_length: 586
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:44:57.318330Z","description":"","environment_variables":{},"error_message":null,"id":"94f80183-9a88-48c4-87ab-f1ef6cae7aac","name":"tf-func-quirky-boyd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncquirkyboyd4fvnzpue","registry_namespace_id":"81155c5a-bb48-4b00-9e5a-c153d442241b","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:44:58.616344Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:08:44.488095Z","description":"","environment_variables":{},"error_message":null,"id":"56bcac67-2ff8-4f23-bac0-2deda7732309","name":"tf-func-serene-hertz","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncserenehertztyjm4www","registry_namespace_id":"7690f4f6-6007-4d42-aac4-c7bb35f5f7ff","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:08:46.093725Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "584"
+                - "586"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:46:49 GMT
+                - Fri, 03 Jul 2026 15:10:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1733,10 +1733,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - aecc0f8f-de2b-4601-bfc9-6b6c8f44dde3
+                - 78ba0613-54d0-4efa-9e42-a29a59a7408f
         status: 200 OK
         code: 200
-        duration: 102.381975ms
+        duration: 124.900415ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1753,7 +1753,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/94f80183-9a88-48c4-87ab-f1ef6cae7aac
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/56bcac67-2ff8-4f23-bac0-2deda7732309
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1761,20 +1761,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 590
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:44:57.318330Z","description":"","environment_variables":{},"error_message":null,"id":"94f80183-9a88-48c4-87ab-f1ef6cae7aac","name":"tf-func-quirky-boyd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncquirkyboyd4fvnzpue","registry_namespace_id":"81155c5a-bb48-4b00-9e5a-c153d442241b","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-05-04T12:46:49.688485882Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:08:44.488095Z","description":"","environment_variables":{},"error_message":null,"id":"56bcac67-2ff8-4f23-bac0-2deda7732309","name":"tf-func-serene-hertz","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncserenehertztyjm4www","registry_namespace_id":"7690f4f6-6007-4d42-aac4-c7bb35f5f7ff","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-07-03T15:10:36.710378870Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "590"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:46:50 GMT
+                - Fri, 03 Jul 2026 15:10:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1782,10 +1782,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 342379af-fe27-4d13-ad40-f48b651c4573
+                - 8b740214-1e78-4ec3-be0e-c7c5d223a64c
         status: 200 OK
         code: 200
-        duration: 444.946254ms
+        duration: 377.948257ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1802,7 +1802,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/94f80183-9a88-48c4-87ab-f1ef6cae7aac
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/56bcac67-2ff8-4f23-bac0-2deda7732309
         method: GET
       response:
         proto: HTTP/2.0
@@ -1810,20 +1810,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 587
+        content_length: 589
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:44:57.318330Z","description":"","environment_variables":{},"error_message":null,"id":"94f80183-9a88-48c4-87ab-f1ef6cae7aac","name":"tf-func-quirky-boyd","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncquirkyboyd4fvnzpue","registry_namespace_id":"81155c5a-bb48-4b00-9e5a-c153d442241b","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-05-04T12:46:49.688486Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:08:44.488095Z","description":"","environment_variables":{},"error_message":null,"id":"56bcac67-2ff8-4f23-bac0-2deda7732309","name":"tf-func-serene-hertz","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncserenehertztyjm4www","registry_namespace_id":"7690f4f6-6007-4d42-aac4-c7bb35f5f7ff","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-07-03T15:10:36.710379Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "587"
+                - "589"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:46:50 GMT
+                - Fri, 03 Jul 2026 15:10:37 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1831,10 +1831,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5fcbb2c5-6119-4d12-bf7f-d2c7d4ebd4dc
+                - 73070d23-48ff-4aba-9303-57c709832319
         status: 200 OK
         code: 200
-        duration: 101.657641ms
+        duration: 122.364698ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1851,7 +1851,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/94f80183-9a88-48c4-87ab-f1ef6cae7aac
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/56bcac67-2ff8-4f23-bac0-2deda7732309
         method: GET
       response:
         proto: HTTP/2.0
@@ -1870,9 +1870,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:47:30 GMT
+                - Fri, 03 Jul 2026 15:10:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1880,10 +1880,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 40ac5ff7-cb61-4f6e-b663-fa94e11f6f07
+                - 7d09ccbf-065d-46e1-9f3f-6a03063db7c2
         status: 404 Not Found
         code: 404
-        duration: 24.035636ms
+        duration: 37.061287ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1900,7 +1900,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/0e859484-53dc-418e-b055-473631f300f1
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/domains/c80299ac-de8b-4ef5-86d5-6bcb064dafe2
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1919,9 +1919,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:47:31 GMT
+                - Fri, 03 Jul 2026 15:10:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1929,7 +1929,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 50196eab-84bf-4f37-92ae-b5d541166f0b
+                - 5d4815ee-88b9-4054-bad5-a61542ff593e
         status: 404 Not Found
         code: 404
-        duration: 27.273796ms
+        duration: 23.880861ms

--- a/internal/services/function/testdata/function-environment-variables.cassette.yaml
+++ b/internal/services/function/testdata/function-environment-variables.cassette.yaml
@@ -6,13 +6,13 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 153
+        content_length: 160
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-func-epic-buck","environment_variables":{},"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","secret_environment_variables":[],"tags":null}'
+        body: '{"name":"tf-func-gracious-lamport","environment_variables":{},"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","secret_environment_variables":[],"tags":null}'
         form: {}
         headers:
             Content-Type:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 503
+        content_length: 510
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.540344094Z","description":"","environment_variables":{},"error_message":null,"id":"7ba41212-5ba5-42e0-b4c3-f3116ad20e53","name":"tf-func-epic-buck","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-05-04T12:38:57.540344094Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.231891054Z","description":"","environment_variables":{},"error_message":null,"id":"b2e1afd8-0ad2-4389-ad55-b6ad36a24e0c","name":"tf-func-gracious-lamport","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-07-03T15:01:47.231891054Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "503"
+                - "510"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:38:57 GMT
+                - Fri, 03 Jul 2026 15:01:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 952dace5-b8f0-4cd9-af98-99236aa21f37
+                - 92d07911-87d8-4e5e-aa47-76430b6ab300
         status: 200 OK
         code: 200
-        duration: 1.658495517s
+        duration: 7.775960223s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -68,7 +68,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7ba41212-5ba5-42e0-b4c3-f3116ad20e53
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b2e1afd8-0ad2-4389-ad55-b6ad36a24e0c
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 497
+        content_length: 504
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.540344Z","description":"","environment_variables":{},"error_message":null,"id":"7ba41212-5ba5-42e0-b4c3-f3116ad20e53","name":"tf-func-epic-buck","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-05-04T12:38:57.540344Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.231891Z","description":"","environment_variables":{},"error_message":null,"id":"b2e1afd8-0ad2-4389-ad55-b6ad36a24e0c","name":"tf-func-gracious-lamport","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-07-03T15:01:47.231891Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "497"
+                - "504"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:38:57 GMT
+                - Fri, 03 Jul 2026 15:01:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a1dc8bb1-2087-4395-a9dc-d54fff0ab2f4
+                - 9b2fcbc2-1955-4896-ad68-66a84c03a717
         status: 200 OK
         code: 200
-        duration: 73.789241ms
+        duration: 34.991157ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -117,7 +117,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7ba41212-5ba5-42e0-b4c3-f3116ad20e53
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b2e1afd8-0ad2-4389-ad55-b6ad36a24e0c
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,20 +125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 580
+        content_length: 593
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.540344Z","description":"","environment_variables":{},"error_message":null,"id":"7ba41212-5ba5-42e0-b4c3-f3116ad20e53","name":"tf-func-epic-buck","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncepicbuckrvfo7qzj","registry_namespace_id":"b6f103d7-e0a7-4c60-8395-cecd9a9f63ba","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:14.049926Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.231891Z","description":"","environment_variables":{},"error_message":null,"id":"b2e1afd8-0ad2-4389-ad55-b6ad36a24e0c","name":"tf-func-gracious-lamport","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgraciouslamporcoqeupqn","registry_namespace_id":"72cef781-ff1a-4612-8618-c191d6ad3a77","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:03.167021Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "580"
+                - "593"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:17 GMT
+                - Fri, 03 Jul 2026 15:02:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 899ee66c-c78a-4de8-9bca-a2349e4a81f0
+                - 8bda89ce-154d-4df4-b803-7c24cbcb0e31
         status: 200 OK
         code: 200
-        duration: 39.40006ms
+        duration: 43.035245ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -166,7 +166,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7ba41212-5ba5-42e0-b4c3-f3116ad20e53
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b2e1afd8-0ad2-4389-ad55-b6ad36a24e0c
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,20 +174,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 580
+        content_length: 593
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.540344Z","description":"","environment_variables":{},"error_message":null,"id":"7ba41212-5ba5-42e0-b4c3-f3116ad20e53","name":"tf-func-epic-buck","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncepicbuckrvfo7qzj","registry_namespace_id":"b6f103d7-e0a7-4c60-8395-cecd9a9f63ba","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:14.049926Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.231891Z","description":"","environment_variables":{},"error_message":null,"id":"b2e1afd8-0ad2-4389-ad55-b6ad36a24e0c","name":"tf-func-gracious-lamport","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgraciouslamporcoqeupqn","registry_namespace_id":"72cef781-ff1a-4612-8618-c191d6ad3a77","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:03.167021Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "580"
+                - "593"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:17 GMT
+                - Fri, 03 Jul 2026 15:02:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,10 +195,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e8c50729-72f0-4cf1-865e-d1e5aa00aef3
+                - 05a7316d-9c55-450e-8a18-b03b5ad40d34
         status: 200 OK
         code: 200
-        duration: 32.454542ms
+        duration: 30.551247ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -210,7 +210,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"foobar","namespace_id":"7ba41212-5ba5-42e0-b4c3-f3116ad20e53","environment_variables":{"test":"test"},"min_scale":0,"max_scale":20,"runtime":"node22","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[{"key":"test_secret","value":"test_secret"}],"http_option":"enabled","sandbox":"unknown_sandbox","tags":null}'
+        body: '{"name":"foobar","namespace_id":"b2e1afd8-0ad2-4389-ad55-b6ad36a24e0c","environment_variables":{"test":"test"},"min_scale":0,"max_scale":20,"runtime":"node26","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[{"key":"test_secret","value":"test_secret"}],"http_option":"enabled","sandbox":"unknown_sandbox","tags":null}'
         form: {}
         headers:
             Content-Type:
@@ -225,20 +225,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 849
+        content_length: 855
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:17.972668498Z","description":"","domain_name":"tffuncepicbuckrvfo7qzj-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"test":"test"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"4a5f5280-78f1-496f-a03c-ec0fa70b1ce8","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"7ba41212-5ba5-42e0-b4c3-f3116ad20e53","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$4U+OSdCYyAotxsuLOmkFJw$XDsAr3Bgl4+L0cuRwEjJlL3lSIcMYRtRXVTYn00L1iU","key":"test_secret"}],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:17.972668498Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:07.697497070Z","description":"","domain_name":"tffuncgraciouslamporcoqeupqn-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"test":"test"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"4e16b0e0-e7f1-4275-a174-43d74ade7d37","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"b2e1afd8-0ad2-4389-ad55-b6ad36a24e0c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$4kuBqfqA+e2BLdfbSao90g$inSY3TH/URuMK4LJaLm/s62flLH3nzYsgKJh9/bIXAI","key":"test_secret"}],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:07.697497070Z"}'
         headers:
             Content-Length:
-                - "849"
+                - "855"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:17 GMT
+                - Fri, 03 Jul 2026 15:02:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -246,10 +246,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 37ad77cf-8319-4786-8334-0cc2dd6f6cf1
+                - 459aaed0-cf4f-45fc-8d25-502ab564fa8c
         status: 200 OK
         code: 200
-        duration: 160.63022ms
+        duration: 240.391408ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -266,7 +266,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4a5f5280-78f1-496f-a03c-ec0fa70b1ce8
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4e16b0e0-e7f1-4275-a174-43d74ade7d37
         method: GET
       response:
         proto: HTTP/2.0
@@ -274,20 +274,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 843
+        content_length: 849
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:17.972668Z","description":"","domain_name":"tffuncepicbuckrvfo7qzj-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"test":"test"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"4a5f5280-78f1-496f-a03c-ec0fa70b1ce8","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"7ba41212-5ba5-42e0-b4c3-f3116ad20e53","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$4U+OSdCYyAotxsuLOmkFJw$XDsAr3Bgl4+L0cuRwEjJlL3lSIcMYRtRXVTYn00L1iU","key":"test_secret"}],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:17.972668Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:07.697497Z","description":"","domain_name":"tffuncgraciouslamporcoqeupqn-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"test":"test"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"4e16b0e0-e7f1-4275-a174-43d74ade7d37","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"b2e1afd8-0ad2-4389-ad55-b6ad36a24e0c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$4kuBqfqA+e2BLdfbSao90g$inSY3TH/URuMK4LJaLm/s62flLH3nzYsgKJh9/bIXAI","key":"test_secret"}],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:07.697497Z"}'
         headers:
             Content-Length:
-                - "843"
+                - "849"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:18 GMT
+                - Fri, 03 Jul 2026 15:02:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -295,10 +295,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e7d94876-d167-4fce-9740-b887d08c776f
+                - 06b8dc3b-bec2-4b84-8b85-38bce3dad60a
         status: 200 OK
         code: 200
-        duration: 78.768621ms
+        duration: 61.585052ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -315,7 +315,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4a5f5280-78f1-496f-a03c-ec0fa70b1ce8
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4e16b0e0-e7f1-4275-a174-43d74ade7d37
         method: GET
       response:
         proto: HTTP/2.0
@@ -323,20 +323,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 843
+        content_length: 849
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:17.972668Z","description":"","domain_name":"tffuncepicbuckrvfo7qzj-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"test":"test"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"4a5f5280-78f1-496f-a03c-ec0fa70b1ce8","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"7ba41212-5ba5-42e0-b4c3-f3116ad20e53","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$4U+OSdCYyAotxsuLOmkFJw$XDsAr3Bgl4+L0cuRwEjJlL3lSIcMYRtRXVTYn00L1iU","key":"test_secret"}],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:17.972668Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:07.697497Z","description":"","domain_name":"tffuncgraciouslamporcoqeupqn-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"test":"test"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"4e16b0e0-e7f1-4275-a174-43d74ade7d37","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"b2e1afd8-0ad2-4389-ad55-b6ad36a24e0c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$4kuBqfqA+e2BLdfbSao90g$inSY3TH/URuMK4LJaLm/s62flLH3nzYsgKJh9/bIXAI","key":"test_secret"}],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:07.697497Z"}'
         headers:
             Content-Length:
-                - "843"
+                - "849"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:18 GMT
+                - Fri, 03 Jul 2026 15:02:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -344,10 +344,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 975523ee-5258-4289-9549-0a26845085d3
+                - 02dbf5fe-7d61-48a4-85a1-3a8461c1a2c6
         status: 200 OK
         code: 200
-        duration: 56.414923ms
+        duration: 83.537938ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -364,7 +364,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4a5f5280-78f1-496f-a03c-ec0fa70b1ce8
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4e16b0e0-e7f1-4275-a174-43d74ade7d37
         method: GET
       response:
         proto: HTTP/2.0
@@ -372,20 +372,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 843
+        content_length: 849
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:17.972668Z","description":"","domain_name":"tffuncepicbuckrvfo7qzj-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"test":"test"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"4a5f5280-78f1-496f-a03c-ec0fa70b1ce8","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"7ba41212-5ba5-42e0-b4c3-f3116ad20e53","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$4U+OSdCYyAotxsuLOmkFJw$XDsAr3Bgl4+L0cuRwEjJlL3lSIcMYRtRXVTYn00L1iU","key":"test_secret"}],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:17.972668Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:07.697497Z","description":"","domain_name":"tffuncgraciouslamporcoqeupqn-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"test":"test"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"4e16b0e0-e7f1-4275-a174-43d74ade7d37","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"b2e1afd8-0ad2-4389-ad55-b6ad36a24e0c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$4kuBqfqA+e2BLdfbSao90g$inSY3TH/URuMK4LJaLm/s62flLH3nzYsgKJh9/bIXAI","key":"test_secret"}],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:07.697497Z"}'
         headers:
             Content-Length:
-                - "843"
+                - "849"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:18 GMT
+                - Fri, 03 Jul 2026 15:02:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -393,10 +393,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0e10e376-ecdd-4539-819f-4165602f8c40
+                - cb17f786-6540-4752-a5cc-d5eedd981eab
         status: 200 OK
         code: 200
-        duration: 181.557625ms
+        duration: 55.162051ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -413,7 +413,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7ba41212-5ba5-42e0-b4c3-f3116ad20e53
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b2e1afd8-0ad2-4389-ad55-b6ad36a24e0c
         method: GET
       response:
         proto: HTTP/2.0
@@ -421,20 +421,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 580
+        content_length: 593
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.540344Z","description":"","environment_variables":{},"error_message":null,"id":"7ba41212-5ba5-42e0-b4c3-f3116ad20e53","name":"tf-func-epic-buck","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncepicbuckrvfo7qzj","registry_namespace_id":"b6f103d7-e0a7-4c60-8395-cecd9a9f63ba","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:14.049926Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.231891Z","description":"","environment_variables":{},"error_message":null,"id":"b2e1afd8-0ad2-4389-ad55-b6ad36a24e0c","name":"tf-func-gracious-lamport","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgraciouslamporcoqeupqn","registry_namespace_id":"72cef781-ff1a-4612-8618-c191d6ad3a77","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:03.167021Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "580"
+                - "593"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:18 GMT
+                - Fri, 03 Jul 2026 15:02:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -442,10 +442,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8627c485-9332-4b08-a42d-06d3dedfd51a
+                - 2e3279b8-ddc9-43bb-ab16-92c3c0bc1751
         status: 200 OK
         code: 200
-        duration: 34.446179ms
+        duration: 33.060015ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -462,7 +462,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4a5f5280-78f1-496f-a03c-ec0fa70b1ce8
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4e16b0e0-e7f1-4275-a174-43d74ade7d37
         method: GET
       response:
         proto: HTTP/2.0
@@ -470,20 +470,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 843
+        content_length: 849
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:17.972668Z","description":"","domain_name":"tffuncepicbuckrvfo7qzj-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"test":"test"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"4a5f5280-78f1-496f-a03c-ec0fa70b1ce8","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"7ba41212-5ba5-42e0-b4c3-f3116ad20e53","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$4U+OSdCYyAotxsuLOmkFJw$XDsAr3Bgl4+L0cuRwEjJlL3lSIcMYRtRXVTYn00L1iU","key":"test_secret"}],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:17.972668Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:07.697497Z","description":"","domain_name":"tffuncgraciouslamporcoqeupqn-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"test":"test"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"4e16b0e0-e7f1-4275-a174-43d74ade7d37","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"b2e1afd8-0ad2-4389-ad55-b6ad36a24e0c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$4kuBqfqA+e2BLdfbSao90g$inSY3TH/URuMK4LJaLm/s62flLH3nzYsgKJh9/bIXAI","key":"test_secret"}],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:07.697497Z"}'
         headers:
             Content-Length:
-                - "843"
+                - "849"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:18 GMT
+                - Fri, 03 Jul 2026 15:02:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -491,10 +491,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 136c546b-d76d-4391-a2d0-4aa0587afa35
+                - 8e69908d-84b1-45dc-a811-5eb2751b4e8f
         status: 200 OK
         code: 200
-        duration: 34.277301ms
+        duration: 43.634653ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -511,7 +511,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7ba41212-5ba5-42e0-b4c3-f3116ad20e53
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b2e1afd8-0ad2-4389-ad55-b6ad36a24e0c
         method: GET
       response:
         proto: HTTP/2.0
@@ -519,20 +519,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 580
+        content_length: 593
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.540344Z","description":"","environment_variables":{},"error_message":null,"id":"7ba41212-5ba5-42e0-b4c3-f3116ad20e53","name":"tf-func-epic-buck","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncepicbuckrvfo7qzj","registry_namespace_id":"b6f103d7-e0a7-4c60-8395-cecd9a9f63ba","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:14.049926Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.231891Z","description":"","environment_variables":{},"error_message":null,"id":"b2e1afd8-0ad2-4389-ad55-b6ad36a24e0c","name":"tf-func-gracious-lamport","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgraciouslamporcoqeupqn","registry_namespace_id":"72cef781-ff1a-4612-8618-c191d6ad3a77","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:03.167021Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "580"
+                - "593"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:19 GMT
+                - Fri, 03 Jul 2026 15:02:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -540,10 +540,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a27b187d-dda9-4291-a9f8-8350d72e4eb7
+                - d92196b1-d6d4-41e3-a197-5ded3a56d4a3
         status: 200 OK
         code: 200
-        duration: 43.794519ms
+        duration: 39.137825ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -560,7 +560,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4a5f5280-78f1-496f-a03c-ec0fa70b1ce8
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4e16b0e0-e7f1-4275-a174-43d74ade7d37
         method: GET
       response:
         proto: HTTP/2.0
@@ -568,20 +568,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 843
+        content_length: 849
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:17.972668Z","description":"","domain_name":"tffuncepicbuckrvfo7qzj-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"test":"test"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"4a5f5280-78f1-496f-a03c-ec0fa70b1ce8","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"7ba41212-5ba5-42e0-b4c3-f3116ad20e53","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$4U+OSdCYyAotxsuLOmkFJw$XDsAr3Bgl4+L0cuRwEjJlL3lSIcMYRtRXVTYn00L1iU","key":"test_secret"}],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:17.972668Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:07.697497Z","description":"","domain_name":"tffuncgraciouslamporcoqeupqn-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"test":"test"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"4e16b0e0-e7f1-4275-a174-43d74ade7d37","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"b2e1afd8-0ad2-4389-ad55-b6ad36a24e0c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$4kuBqfqA+e2BLdfbSao90g$inSY3TH/URuMK4LJaLm/s62flLH3nzYsgKJh9/bIXAI","key":"test_secret"}],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:07.697497Z"}'
         headers:
             Content-Length:
-                - "843"
+                - "849"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:19 GMT
+                - Fri, 03 Jul 2026 15:02:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -589,10 +589,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c6c964f9-ac03-4f77-9eff-1761c113b4ca
+                - b0e60a62-148e-4b52-a00f-845bfd5aeecf
         status: 200 OK
         code: 200
-        duration: 55.113234ms
+        duration: 35.51969ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -609,7 +609,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4a5f5280-78f1-496f-a03c-ec0fa70b1ce8
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4e16b0e0-e7f1-4275-a174-43d74ade7d37
         method: GET
       response:
         proto: HTTP/2.0
@@ -617,20 +617,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 843
+        content_length: 849
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:17.972668Z","description":"","domain_name":"tffuncepicbuckrvfo7qzj-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"test":"test"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"4a5f5280-78f1-496f-a03c-ec0fa70b1ce8","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"7ba41212-5ba5-42e0-b4c3-f3116ad20e53","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$4U+OSdCYyAotxsuLOmkFJw$XDsAr3Bgl4+L0cuRwEjJlL3lSIcMYRtRXVTYn00L1iU","key":"test_secret"}],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:17.972668Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:07.697497Z","description":"","domain_name":"tffuncgraciouslamporcoqeupqn-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"test":"test"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"4e16b0e0-e7f1-4275-a174-43d74ade7d37","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"b2e1afd8-0ad2-4389-ad55-b6ad36a24e0c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$4kuBqfqA+e2BLdfbSao90g$inSY3TH/URuMK4LJaLm/s62flLH3nzYsgKJh9/bIXAI","key":"test_secret"}],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:07.697497Z"}'
         headers:
             Content-Length:
-                - "843"
+                - "849"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:19 GMT
+                - Fri, 03 Jul 2026 15:02:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -638,10 +638,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 766cd95a-7c6f-4cd8-9fdf-d8e71da5897d
+                - 8420e128-0640-401c-945e-52719a821d2e
         status: 200 OK
         code: 200
-        duration: 35.149824ms
+        duration: 42.576763ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -660,7 +660,7 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4a5f5280-78f1-496f-a03c-ec0fa70b1ce8
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4e16b0e0-e7f1-4275-a174-43d74ade7d37
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -668,20 +668,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 843
+        content_length: 849
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:17.972668Z","description":"","domain_name":"tffuncepicbuckrvfo7qzj-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"4a5f5280-78f1-496f-a03c-ec0fa70b1ce8","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"7ba41212-5ba5-42e0-b4c3-f3116ad20e53","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$tArYSsXR2cDXb6u0i+fOsA$AGJ2ockizVhqQsLOuycWRdNrGT3yBrmGPY7KnwIgAlo","key":"foo_secret"}],"status":"pending","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:20.090300298Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:07.697497Z","description":"","domain_name":"tffuncgraciouslamporcoqeupqn-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"4e16b0e0-e7f1-4275-a174-43d74ade7d37","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"b2e1afd8-0ad2-4389-ad55-b6ad36a24e0c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$ci+NHag6q1UvnAfF2K0TLw$o7Gglntxahxoi1LHF/zbhrEeUwezd2YC21dxwx10sOE","key":"foo_secret"}],"status":"pending","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:09.330295506Z"}'
         headers:
             Content-Length:
-                - "843"
+                - "849"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:20 GMT
+                - Fri, 03 Jul 2026 15:02:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -689,10 +689,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2c0783f6-58cb-4ab3-848b-bd61772e9893
+                - d39a1870-9e4f-46ac-8ba2-7dbb95393afd
         status: 200 OK
         code: 200
-        duration: 728.463841ms
+        duration: 379.014433ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -709,7 +709,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4a5f5280-78f1-496f-a03c-ec0fa70b1ce8
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4e16b0e0-e7f1-4275-a174-43d74ade7d37
         method: GET
       response:
         proto: HTTP/2.0
@@ -717,20 +717,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 840
+        content_length: 856
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:17.972668Z","description":"","domain_name":"tffuncepicbuckrvfo7qzj-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"4a5f5280-78f1-496f-a03c-ec0fa70b1ce8","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"7ba41212-5ba5-42e0-b4c3-f3116ad20e53","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$tArYSsXR2cDXb6u0i+fOsA$AGJ2ockizVhqQsLOuycWRdNrGT3yBrmGPY7KnwIgAlo","key":"foo_secret"}],"status":"pending","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:20.090300Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:07.697497Z","description":"","domain_name":"tffuncgraciouslamporcoqeupqn-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"4e16b0e0-e7f1-4275-a174-43d74ade7d37","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"b2e1afd8-0ad2-4389-ad55-b6ad36a24e0c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$ci+NHag6q1UvnAfF2K0TLw$o7Gglntxahxoi1LHF/zbhrEeUwezd2YC21dxwx10sOE","key":"foo_secret"}],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:09.957955Z"}'
         headers:
             Content-Length:
-                - "840"
+                - "856"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:21 GMT
+                - Fri, 03 Jul 2026 15:02:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -738,10 +738,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 21a159ad-4a92-418a-bd0d-140f2bc2168d
+                - 74ca1502-7bad-4a92-9427-eff179e44b62
         status: 200 OK
         code: 200
-        duration: 42.725287ms
+        duration: 50.467954ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -758,7 +758,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4a5f5280-78f1-496f-a03c-ec0fa70b1ce8
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4e16b0e0-e7f1-4275-a174-43d74ade7d37
         method: GET
       response:
         proto: HTTP/2.0
@@ -766,20 +766,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 850
+        content_length: 856
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:17.972668Z","description":"","domain_name":"tffuncepicbuckrvfo7qzj-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"4a5f5280-78f1-496f-a03c-ec0fa70b1ce8","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"7ba41212-5ba5-42e0-b4c3-f3116ad20e53","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$tArYSsXR2cDXb6u0i+fOsA$AGJ2ockizVhqQsLOuycWRdNrGT3yBrmGPY7KnwIgAlo","key":"foo_secret"}],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:21.390488Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:07.697497Z","description":"","domain_name":"tffuncgraciouslamporcoqeupqn-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"4e16b0e0-e7f1-4275-a174-43d74ade7d37","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"b2e1afd8-0ad2-4389-ad55-b6ad36a24e0c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$ci+NHag6q1UvnAfF2K0TLw$o7Gglntxahxoi1LHF/zbhrEeUwezd2YC21dxwx10sOE","key":"foo_secret"}],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:09.957955Z"}'
         headers:
             Content-Length:
-                - "850"
+                - "856"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:26 GMT
+                - Fri, 03 Jul 2026 15:02:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -787,10 +787,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c8b52f7c-b710-429b-afa6-0e5e9762cf24
+                - b620255a-2564-4312-a1c0-86e5818bdfa6
         status: 200 OK
         code: 200
-        duration: 53.226868ms
+        duration: 33.834963ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -807,7 +807,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4a5f5280-78f1-496f-a03c-ec0fa70b1ce8
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b2e1afd8-0ad2-4389-ad55-b6ad36a24e0c
         method: GET
       response:
         proto: HTTP/2.0
@@ -815,20 +815,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 850
+        content_length: 593
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:17.972668Z","description":"","domain_name":"tffuncepicbuckrvfo7qzj-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"4a5f5280-78f1-496f-a03c-ec0fa70b1ce8","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"7ba41212-5ba5-42e0-b4c3-f3116ad20e53","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$tArYSsXR2cDXb6u0i+fOsA$AGJ2ockizVhqQsLOuycWRdNrGT3yBrmGPY7KnwIgAlo","key":"foo_secret"}],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:21.390488Z"}'
+        body: '{"created_at":"2026-07-03T15:01:47.231891Z","description":"","environment_variables":{},"error_message":null,"id":"b2e1afd8-0ad2-4389-ad55-b6ad36a24e0c","name":"tf-func-gracious-lamport","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgraciouslamporcoqeupqn","registry_namespace_id":"72cef781-ff1a-4612-8618-c191d6ad3a77","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:03.167021Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "850"
+                - "593"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:26 GMT
+                - Fri, 03 Jul 2026 15:02:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -836,10 +836,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 07d814c0-d0c2-40e8-ae38-17c849424930
+                - 45852283-c7db-4fa9-8761-6a1cdc3e6da6
         status: 200 OK
         code: 200
-        duration: 40.927386ms
+        duration: 34.755454ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -856,7 +856,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7ba41212-5ba5-42e0-b4c3-f3116ad20e53
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4e16b0e0-e7f1-4275-a174-43d74ade7d37
         method: GET
       response:
         proto: HTTP/2.0
@@ -864,20 +864,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 580
+        content_length: 856
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.540344Z","description":"","environment_variables":{},"error_message":null,"id":"7ba41212-5ba5-42e0-b4c3-f3116ad20e53","name":"tf-func-epic-buck","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncepicbuckrvfo7qzj","registry_namespace_id":"b6f103d7-e0a7-4c60-8395-cecd9a9f63ba","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:14.049926Z","vpc_integration_activated":false}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:07.697497Z","description":"","domain_name":"tffuncgraciouslamporcoqeupqn-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"4e16b0e0-e7f1-4275-a174-43d74ade7d37","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"b2e1afd8-0ad2-4389-ad55-b6ad36a24e0c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$ci+NHag6q1UvnAfF2K0TLw$o7Gglntxahxoi1LHF/zbhrEeUwezd2YC21dxwx10sOE","key":"foo_secret"}],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:09.957955Z"}'
         headers:
             Content-Length:
-                - "580"
+                - "856"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:26 GMT
+                - Fri, 03 Jul 2026 15:02:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -885,10 +885,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 454b97d0-ec0c-4e7c-865f-ed032fecdaf3
+                - 1b9c7f26-4ae9-4543-9394-19a4f73570b5
         status: 200 OK
         code: 200
-        duration: 28.482641ms
+        duration: 77.213954ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -905,7 +905,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4a5f5280-78f1-496f-a03c-ec0fa70b1ce8
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4e16b0e0-e7f1-4275-a174-43d74ade7d37
         method: GET
       response:
         proto: HTTP/2.0
@@ -913,20 +913,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 850
+        content_length: 856
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:17.972668Z","description":"","domain_name":"tffuncepicbuckrvfo7qzj-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"4a5f5280-78f1-496f-a03c-ec0fa70b1ce8","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"7ba41212-5ba5-42e0-b4c3-f3116ad20e53","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$tArYSsXR2cDXb6u0i+fOsA$AGJ2ockizVhqQsLOuycWRdNrGT3yBrmGPY7KnwIgAlo","key":"foo_secret"}],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:21.390488Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:07.697497Z","description":"","domain_name":"tffuncgraciouslamporcoqeupqn-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"4e16b0e0-e7f1-4275-a174-43d74ade7d37","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"b2e1afd8-0ad2-4389-ad55-b6ad36a24e0c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$ci+NHag6q1UvnAfF2K0TLw$o7Gglntxahxoi1LHF/zbhrEeUwezd2YC21dxwx10sOE","key":"foo_secret"}],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:09.957955Z"}'
         headers:
             Content-Length:
-                - "850"
+                - "856"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:26 GMT
+                - Fri, 03 Jul 2026 15:02:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -934,10 +934,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3a63b476-0feb-4b59-afe1-365f9949dfd4
+                - 8851ebd5-4dec-4a76-bcf1-3546b139f9a2
         status: 200 OK
         code: 200
-        duration: 48.049176ms
+        duration: 59.987437ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -954,8 +954,8 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4a5f5280-78f1-496f-a03c-ec0fa70b1ce8
-        method: GET
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4e16b0e0-e7f1-4275-a174-43d74ade7d37
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
@@ -964,7 +964,7 @@ interactions:
         trailer: {}
         content_length: 850
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:17.972668Z","description":"","domain_name":"tffuncepicbuckrvfo7qzj-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"4a5f5280-78f1-496f-a03c-ec0fa70b1ce8","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"7ba41212-5ba5-42e0-b4c3-f3116ad20e53","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$tArYSsXR2cDXb6u0i+fOsA$AGJ2ockizVhqQsLOuycWRdNrGT3yBrmGPY7KnwIgAlo","key":"foo_secret"}],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:21.390488Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:07.697497Z","description":"","domain_name":"tffuncgraciouslamporcoqeupqn-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"4e16b0e0-e7f1-4275-a174-43d74ade7d37","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"b2e1afd8-0ad2-4389-ad55-b6ad36a24e0c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$ci+NHag6q1UvnAfF2K0TLw$o7Gglntxahxoi1LHF/zbhrEeUwezd2YC21dxwx10sOE","key":"foo_secret"}],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:11.386022686Z"}'
         headers:
             Content-Length:
                 - "850"
@@ -973,9 +973,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:27 GMT
+                - Fri, 03 Jul 2026 15:02:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -983,10 +983,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d5f1644b-c629-4d1b-8ba0-0d3934963dea
+                - bb1b57e3-eb1b-4830-b4c2-d0faa02b8201
         status: 200 OK
         code: 200
-        duration: 55.313264ms
+        duration: 360.430333ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1003,28 +1003,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4a5f5280-78f1-496f-a03c-ec0fa70b1ce8
-        method: DELETE
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b2e1afd8-0ad2-4389-ad55-b6ad36a24e0c
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 844
+        content_length: 593
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:17.972668Z","description":"","domain_name":"tffuncepicbuckrvfo7qzj-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{"foo":"bar"},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"4a5f5280-78f1-496f-a03c-ec0fa70b1ce8","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"7ba41212-5ba5-42e0-b4c3-f3116ad20e53","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$tArYSsXR2cDXb6u0i+fOsA$AGJ2ockizVhqQsLOuycWRdNrGT3yBrmGPY7KnwIgAlo","key":"foo_secret"}],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:27.105708652Z"}'
+        body: '{"created_at":"2026-07-03T15:01:47.231891Z","description":"","environment_variables":{},"error_message":null,"id":"b2e1afd8-0ad2-4389-ad55-b6ad36a24e0c","name":"tf-func-gracious-lamport","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgraciouslamporcoqeupqn","registry_namespace_id":"72cef781-ff1a-4612-8618-c191d6ad3a77","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:03.167021Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "844"
+                - "593"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:27 GMT
+                - Fri, 03 Jul 2026 15:02:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1032,10 +1032,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f09f3a0f-685a-461c-830a-0958b071160f
+                - 049e1bce-ce75-41db-999c-f8e8ab733f8b
         status: 200 OK
         code: 200
-        duration: 117.979673ms
+        duration: 31.947053ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1052,28 +1052,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7ba41212-5ba5-42e0-b4c3-f3116ad20e53
-        method: GET
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b2e1afd8-0ad2-4389-ad55-b6ad36a24e0c
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 580
+        content_length: 599
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.540344Z","description":"","environment_variables":{},"error_message":null,"id":"7ba41212-5ba5-42e0-b4c3-f3116ad20e53","name":"tf-func-epic-buck","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncepicbuckrvfo7qzj","registry_namespace_id":"b6f103d7-e0a7-4c60-8395-cecd9a9f63ba","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:14.049926Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.231891Z","description":"","environment_variables":{},"error_message":null,"id":"b2e1afd8-0ad2-4389-ad55-b6ad36a24e0c","name":"tf-func-gracious-lamport","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgraciouslamporcoqeupqn","registry_namespace_id":"72cef781-ff1a-4612-8618-c191d6ad3a77","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-07-03T15:02:11.758374182Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "580"
+                - "599"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:27 GMT
+                - Fri, 03 Jul 2026 15:02:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1081,10 +1081,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9cbc9577-a527-4008-bdf8-8e5ed502b07f
+                - 10c3a8b7-9aca-40ea-8c4e-95c32516c45b
         status: 200 OK
         code: 200
-        duration: 32.817087ms
+        duration: 910.897773ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1101,28 +1101,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7ba41212-5ba5-42e0-b4c3-f3116ad20e53
-        method: DELETE
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b2e1afd8-0ad2-4389-ad55-b6ad36a24e0c
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 586
+        content_length: 596
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.540344Z","description":"","environment_variables":{},"error_message":null,"id":"7ba41212-5ba5-42e0-b4c3-f3116ad20e53","name":"tf-func-epic-buck","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncepicbuckrvfo7qzj","registry_namespace_id":"b6f103d7-e0a7-4c60-8395-cecd9a9f63ba","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-05-04T12:39:27.257279256Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.231891Z","description":"","environment_variables":{},"error_message":null,"id":"b2e1afd8-0ad2-4389-ad55-b6ad36a24e0c","name":"tf-func-gracious-lamport","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgraciouslamporcoqeupqn","registry_namespace_id":"72cef781-ff1a-4612-8618-c191d6ad3a77","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-07-03T15:02:11.758374Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "586"
+                - "596"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:27 GMT
+                - Fri, 03 Jul 2026 15:02:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1130,10 +1130,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3c5186da-cdf5-4155-afb6-09f9691510fd
+                - 2a607f4f-edee-4d83-bdfd-e69fecc31150
         status: 200 OK
         code: 200
-        duration: 346.568672ms
+        duration: 93.518609ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1150,56 +1150,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7ba41212-5ba5-42e0-b4c3-f3116ad20e53
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 583
-        uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.540344Z","description":"","environment_variables":{},"error_message":null,"id":"7ba41212-5ba5-42e0-b4c3-f3116ad20e53","name":"tf-func-epic-buck","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncepicbuckrvfo7qzj","registry_namespace_id":"b6f103d7-e0a7-4c60-8395-cecd9a9f63ba","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-05-04T12:39:27.257279Z","vpc_integration_activated":false}'
-        headers:
-            Content-Length:
-                - "583"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 04 May 2026 12:39:27 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - b5b9098e-9517-4ac7-929d-8153da891087
-        status: 200 OK
-        code: 200
-        duration: 33.948095ms
-    - id: 24
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/7ba41212-5ba5-42e0-b4c3-f3116ad20e53
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b2e1afd8-0ad2-4389-ad55-b6ad36a24e0c
         method: GET
       response:
         proto: HTTP/2.0
@@ -1218,9 +1169,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:57 GMT
+                - Fri, 03 Jul 2026 15:02:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1228,11 +1179,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ed8f2d30-0ac9-4917-b126-482cd8e51d00
+                - 0587a835-af0c-42ca-91c2-7167fca4d795
         status: 404 Not Found
         code: 404
-        duration: 30.477509ms
-    - id: 25
+        duration: 23.233605ms
+    - id: 24
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1248,7 +1199,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4a5f5280-78f1-496f-a03c-ec0fa70b1ce8
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4e16b0e0-e7f1-4275-a174-43d74ade7d37
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1267,9 +1218,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:57 GMT
+                - Fri, 03 Jul 2026 15:02:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1277,7 +1228,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d316ea22-c418-4ccb-ad5b-242081f7c068
+                - 0b9f7781-b84a-417d-bba2-bd3ea2e8d9cf
         status: 404 Not Found
         code: 404
-        duration: 27.227816ms
+        duration: 22.705762ms

--- a/internal/services/function/testdata/function-http-option.cassette.yaml
+++ b/internal/services/function/testdata/function-http-option.cassette.yaml
@@ -6,13 +6,13 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 160
+        content_length: 157
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-func-friendly-taussig","environment_variables":{},"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","secret_environment_variables":[],"tags":null}'
+        body: '{"name":"tf-func-admiring-cerf","environment_variables":{},"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","secret_environment_variables":[],"tags":null}'
         form: {}
         headers:
             Content-Type:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 510
+        content_length: 507
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:56.381675356Z","description":"","environment_variables":{},"error_message":null,"id":"ed92dbf4-64ad-4341-bfb6-ad594976a8f1","name":"tf-func-friendly-taussig","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-05-04T12:38:56.381675356Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.217812594Z","description":"","environment_variables":{},"error_message":null,"id":"480530d7-bfe1-4399-931a-e6dfe716f585","name":"tf-func-admiring-cerf","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-07-03T15:01:47.217812594Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "510"
+                - "507"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:38:56 GMT
+                - Fri, 03 Jul 2026 15:01:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4bedd300-28ad-4426-a7dd-40ff70e9a733
+                - 83f5349f-6c7b-442b-a383-292014b9089c
         status: 200 OK
         code: 200
-        duration: 1.030922516s
+        duration: 7.72092512s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -68,7 +68,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ed92dbf4-64ad-4341-bfb6-ad594976a8f1
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/480530d7-bfe1-4399-931a-e6dfe716f585
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 504
+        content_length: 501
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:56.381675Z","description":"","environment_variables":{},"error_message":null,"id":"ed92dbf4-64ad-4341-bfb6-ad594976a8f1","name":"tf-func-friendly-taussig","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-05-04T12:38:56.381675Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.217813Z","description":"","environment_variables":{},"error_message":null,"id":"480530d7-bfe1-4399-931a-e6dfe716f585","name":"tf-func-admiring-cerf","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-07-03T15:01:47.217813Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "504"
+                - "501"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:38:56 GMT
+                - Fri, 03 Jul 2026 15:01:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5df54b0e-d330-4fbc-8c12-fec7727dcc94
+                - b1415b17-440d-4c3b-bad0-61ffda97351c
         status: 200 OK
         code: 200
-        duration: 42.806894ms
+        duration: 39.759715ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -117,7 +117,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ed92dbf4-64ad-4341-bfb6-ad594976a8f1
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/480530d7-bfe1-4399-931a-e6dfe716f585
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,20 +125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 593
+        content_length: 588
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:56.381675Z","description":"","environment_variables":{},"error_message":null,"id":"ed92dbf4-64ad-4341-bfb6-ad594976a8f1","name":"tf-func-friendly-taussig","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncfriendlytaussipjfz38or","registry_namespace_id":"24e228af-aeb2-4bed-ada9-4989895e4e5c","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:11.849613Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.217813Z","description":"","environment_variables":{},"error_message":null,"id":"480530d7-bfe1-4399-931a-e6dfe716f585","name":"tf-func-admiring-cerf","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncadmiringcerfaqp7bnro","registry_namespace_id":"92357de9-ffe1-4f2a-be0e-083a299f869d","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:01:57.073523Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "593"
+                - "588"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:16 GMT
+                - Fri, 03 Jul 2026 15:01:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9b24542d-c8e0-44a1-9e4f-5a0b699f2ea5
+                - e33c1475-c391-4942-be62-8b56d39aab6a
         status: 200 OK
         code: 200
-        duration: 390.878902ms
+        duration: 31.484442ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -166,7 +166,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ed92dbf4-64ad-4341-bfb6-ad594976a8f1
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/480530d7-bfe1-4399-931a-e6dfe716f585
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,20 +174,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 593
+        content_length: 588
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:56.381675Z","description":"","environment_variables":{},"error_message":null,"id":"ed92dbf4-64ad-4341-bfb6-ad594976a8f1","name":"tf-func-friendly-taussig","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncfriendlytaussipjfz38or","registry_namespace_id":"24e228af-aeb2-4bed-ada9-4989895e4e5c","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:11.849613Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.217813Z","description":"","environment_variables":{},"error_message":null,"id":"480530d7-bfe1-4399-931a-e6dfe716f585","name":"tf-func-admiring-cerf","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncadmiringcerfaqp7bnro","registry_namespace_id":"92357de9-ffe1-4f2a-be0e-083a299f869d","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:01:57.073523Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "593"
+                - "588"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:17 GMT
+                - Fri, 03 Jul 2026 15:01:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,10 +195,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7f05dec3-f590-43fa-8776-e4c6d3c1ec59
+                - 8c54d431-ccae-44a6-8e8f-50c8077c2aa7
         status: 200 OK
         code: 200
-        duration: 30.150096ms
+        duration: 31.918378ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -210,7 +210,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"foobar","namespace_id":"ed92dbf4-64ad-4341-bfb6-ad594976a8f1","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node22","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox","tags":null}'
+        body: '{"name":"foobar","namespace_id":"480530d7-bfe1-4399-931a-e6dfe716f585","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node26","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox","tags":null}'
         form: {}
         headers:
             Content-Type:
@@ -225,20 +225,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 706
+        content_length: 704
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:17.117806560Z","description":"","domain_name":"tffuncfriendlytaussipjfz38or-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"375e934f-6897-45e3-8795-1f013683b2e2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"ed92dbf4-64ad-4341-bfb6-ad594976a8f1","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:17.117806560Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:01:57.524800499Z","description":"","domain_name":"tffuncadmiringcerfaqp7bnro-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0013aa6b-414d-4149-8738-7023fdd52c81","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"480530d7-bfe1-4399-931a-e6dfe716f585","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:01:57.524800499Z"}'
         headers:
             Content-Length:
-                - "706"
+                - "704"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:17 GMT
+                - Fri, 03 Jul 2026 15:01:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -246,10 +246,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f846b000-a47f-422c-b7e2-4354d42b8917
+                - 7c908699-b4d1-43ec-9af4-7405577f70fd
         status: 200 OK
         code: 200
-        duration: 102.568369ms
+        duration: 154.888836ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -266,7 +266,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/375e934f-6897-45e3-8795-1f013683b2e2
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0013aa6b-414d-4149-8738-7023fdd52c81
         method: GET
       response:
         proto: HTTP/2.0
@@ -274,20 +274,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 700
+        content_length: 698
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:17.117807Z","description":"","domain_name":"tffuncfriendlytaussipjfz38or-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"375e934f-6897-45e3-8795-1f013683b2e2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"ed92dbf4-64ad-4341-bfb6-ad594976a8f1","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:17.117807Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:01:57.524800Z","description":"","domain_name":"tffuncadmiringcerfaqp7bnro-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0013aa6b-414d-4149-8738-7023fdd52c81","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"480530d7-bfe1-4399-931a-e6dfe716f585","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:01:57.524800Z"}'
         headers:
             Content-Length:
-                - "700"
+                - "698"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:17 GMT
+                - Fri, 03 Jul 2026 15:01:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -295,10 +295,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ba82fd16-2bb0-4fe0-abfb-a23344564755
+                - 822edd95-66cd-4214-a633-8efcd273898b
         status: 200 OK
         code: 200
-        duration: 50.247479ms
+        duration: 64.044948ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -315,7 +315,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/375e934f-6897-45e3-8795-1f013683b2e2
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0013aa6b-414d-4149-8738-7023fdd52c81
         method: GET
       response:
         proto: HTTP/2.0
@@ -323,20 +323,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 700
+        content_length: 698
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:17.117807Z","description":"","domain_name":"tffuncfriendlytaussipjfz38or-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"375e934f-6897-45e3-8795-1f013683b2e2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"ed92dbf4-64ad-4341-bfb6-ad594976a8f1","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:17.117807Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:01:57.524800Z","description":"","domain_name":"tffuncadmiringcerfaqp7bnro-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0013aa6b-414d-4149-8738-7023fdd52c81","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"480530d7-bfe1-4399-931a-e6dfe716f585","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:01:57.524800Z"}'
         headers:
             Content-Length:
-                - "700"
+                - "698"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:17 GMT
+                - Fri, 03 Jul 2026 15:01:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -344,10 +344,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bde0bee0-4433-4e17-a038-67932192d5b7
+                - fa8ba430-fc27-4893-9b18-673ad4bf27cb
         status: 200 OK
         code: 200
-        duration: 51.131102ms
+        duration: 59.61151ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -364,7 +364,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/375e934f-6897-45e3-8795-1f013683b2e2
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0013aa6b-414d-4149-8738-7023fdd52c81
         method: GET
       response:
         proto: HTTP/2.0
@@ -372,20 +372,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 700
+        content_length: 698
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:17.117807Z","description":"","domain_name":"tffuncfriendlytaussipjfz38or-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"375e934f-6897-45e3-8795-1f013683b2e2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"ed92dbf4-64ad-4341-bfb6-ad594976a8f1","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:17.117807Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:01:57.524800Z","description":"","domain_name":"tffuncadmiringcerfaqp7bnro-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0013aa6b-414d-4149-8738-7023fdd52c81","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"480530d7-bfe1-4399-931a-e6dfe716f585","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:01:57.524800Z"}'
         headers:
             Content-Length:
-                - "700"
+                - "698"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:17 GMT
+                - Fri, 03 Jul 2026 15:01:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -393,10 +393,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0c8738a4-3225-47fd-ac50-13d4ba6617e7
+                - cdd82435-1971-4bd7-960e-fa73f6810cc6
         status: 200 OK
         code: 200
-        duration: 42.860441ms
+        duration: 97.925656ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -413,7 +413,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ed92dbf4-64ad-4341-bfb6-ad594976a8f1
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/480530d7-bfe1-4399-931a-e6dfe716f585
         method: GET
       response:
         proto: HTTP/2.0
@@ -421,20 +421,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 593
+        content_length: 588
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:56.381675Z","description":"","environment_variables":{},"error_message":null,"id":"ed92dbf4-64ad-4341-bfb6-ad594976a8f1","name":"tf-func-friendly-taussig","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncfriendlytaussipjfz38or","registry_namespace_id":"24e228af-aeb2-4bed-ada9-4989895e4e5c","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:11.849613Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.217813Z","description":"","environment_variables":{},"error_message":null,"id":"480530d7-bfe1-4399-931a-e6dfe716f585","name":"tf-func-admiring-cerf","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncadmiringcerfaqp7bnro","registry_namespace_id":"92357de9-ffe1-4f2a-be0e-083a299f869d","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:01:57.073523Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "593"
+                - "588"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:17 GMT
+                - Fri, 03 Jul 2026 15:01:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -442,10 +442,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ae80a143-442b-4119-91b2-a9c169f92365
+                - 1d0dcf3f-2099-40e6-9de1-bfbe7cf1620a
         status: 200 OK
         code: 200
-        duration: 40.876117ms
+        duration: 34.899244ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -462,7 +462,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/375e934f-6897-45e3-8795-1f013683b2e2
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0013aa6b-414d-4149-8738-7023fdd52c81
         method: GET
       response:
         proto: HTTP/2.0
@@ -470,20 +470,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 700
+        content_length: 698
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:17.117807Z","description":"","domain_name":"tffuncfriendlytaussipjfz38or-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"375e934f-6897-45e3-8795-1f013683b2e2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"ed92dbf4-64ad-4341-bfb6-ad594976a8f1","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:17.117807Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:01:57.524800Z","description":"","domain_name":"tffuncadmiringcerfaqp7bnro-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0013aa6b-414d-4149-8738-7023fdd52c81","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"480530d7-bfe1-4399-931a-e6dfe716f585","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:01:57.524800Z"}'
         headers:
             Content-Length:
-                - "700"
+                - "698"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:17 GMT
+                - Fri, 03 Jul 2026 15:01:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -491,10 +491,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 168ec019-2350-4674-95e4-aa0c05087a2c
+                - 77833cfd-58d1-42af-af29-81f924f519d9
         status: 200 OK
         code: 200
-        duration: 38.47039ms
+        duration: 57.602231ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -511,7 +511,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ed92dbf4-64ad-4341-bfb6-ad594976a8f1
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/480530d7-bfe1-4399-931a-e6dfe716f585
         method: GET
       response:
         proto: HTTP/2.0
@@ -519,20 +519,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 593
+        content_length: 588
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:56.381675Z","description":"","environment_variables":{},"error_message":null,"id":"ed92dbf4-64ad-4341-bfb6-ad594976a8f1","name":"tf-func-friendly-taussig","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncfriendlytaussipjfz38or","registry_namespace_id":"24e228af-aeb2-4bed-ada9-4989895e4e5c","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:11.849613Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.217813Z","description":"","environment_variables":{},"error_message":null,"id":"480530d7-bfe1-4399-931a-e6dfe716f585","name":"tf-func-admiring-cerf","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncadmiringcerfaqp7bnro","registry_namespace_id":"92357de9-ffe1-4f2a-be0e-083a299f869d","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:01:57.073523Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "593"
+                - "588"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:17 GMT
+                - Fri, 03 Jul 2026 15:01:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -540,10 +540,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - af31ab13-eaf3-430a-a2fc-2472432df4f6
+                - a704c523-431f-496f-8cd8-941edcf8b8d2
         status: 200 OK
         code: 200
-        duration: 35.513307ms
+        duration: 96.77426ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -560,7 +560,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/375e934f-6897-45e3-8795-1f013683b2e2
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0013aa6b-414d-4149-8738-7023fdd52c81
         method: GET
       response:
         proto: HTTP/2.0
@@ -568,20 +568,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 700
+        content_length: 698
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:17.117807Z","description":"","domain_name":"tffuncfriendlytaussipjfz38or-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"375e934f-6897-45e3-8795-1f013683b2e2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"ed92dbf4-64ad-4341-bfb6-ad594976a8f1","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:17.117807Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:01:57.524800Z","description":"","domain_name":"tffuncadmiringcerfaqp7bnro-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0013aa6b-414d-4149-8738-7023fdd52c81","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"480530d7-bfe1-4399-931a-e6dfe716f585","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:01:57.524800Z"}'
         headers:
             Content-Length:
-                - "700"
+                - "698"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:17 GMT
+                - Fri, 03 Jul 2026 15:01:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -589,10 +589,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ff73bcfd-d387-4f2f-a453-7614e28dc7ce
+                - eac2597e-c48a-4796-b9f9-45199736bb27
         status: 200 OK
         code: 200
-        duration: 43.80124ms
+        duration: 49.73766ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -609,7 +609,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/375e934f-6897-45e3-8795-1f013683b2e2
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0013aa6b-414d-4149-8738-7023fdd52c81
         method: GET
       response:
         proto: HTTP/2.0
@@ -617,20 +617,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 700
+        content_length: 698
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:17.117807Z","description":"","domain_name":"tffuncfriendlytaussipjfz38or-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"375e934f-6897-45e3-8795-1f013683b2e2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"ed92dbf4-64ad-4341-bfb6-ad594976a8f1","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:17.117807Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:01:57.524800Z","description":"","domain_name":"tffuncadmiringcerfaqp7bnro-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0013aa6b-414d-4149-8738-7023fdd52c81","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"480530d7-bfe1-4399-931a-e6dfe716f585","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:01:57.524800Z"}'
         headers:
             Content-Length:
-                - "700"
+                - "698"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:18 GMT
+                - Fri, 03 Jul 2026 15:01:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -638,10 +638,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 91da6981-7c20-4b27-977b-228f7d248444
+                - 2177cc91-3be1-4f9f-9c4f-cdb4f2011920
         status: 200 OK
         code: 200
-        duration: 48.417626ms
+        duration: 46.916334ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -660,7 +660,7 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/375e934f-6897-45e3-8795-1f013683b2e2
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0013aa6b-414d-4149-8738-7023fdd52c81
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -668,20 +668,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 706
+        content_length: 704
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:17.117807Z","description":"","domain_name":"tffuncfriendlytaussipjfz38or-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"redirected","id":"375e934f-6897-45e3-8795-1f013683b2e2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"ed92dbf4-64ad-4341-bfb6-ad594976a8f1","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:18.170575036Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:01:57.524800Z","description":"","domain_name":"tffuncadmiringcerfaqp7bnro-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"redirected","id":"0013aa6b-414d-4149-8738-7023fdd52c81","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"480530d7-bfe1-4399-931a-e6dfe716f585","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:01:58.760345263Z"}'
         headers:
             Content-Length:
-                - "706"
+                - "704"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:18 GMT
+                - Fri, 03 Jul 2026 15:01:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -689,10 +689,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7d79337b-4bdc-4a25-bb7c-8cbe3d95bc87
+                - ae15db2e-9bb7-4daa-b712-7687e6bc6d4f
         status: 200 OK
         code: 200
-        duration: 275.688851ms
+        duration: 177.184185ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -709,7 +709,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/375e934f-6897-45e3-8795-1f013683b2e2
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0013aa6b-414d-4149-8738-7023fdd52c81
         method: GET
       response:
         proto: HTTP/2.0
@@ -717,20 +717,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 703
+        content_length: 701
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:17.117807Z","description":"","domain_name":"tffuncfriendlytaussipjfz38or-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"redirected","id":"375e934f-6897-45e3-8795-1f013683b2e2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"ed92dbf4-64ad-4341-bfb6-ad594976a8f1","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:18.170575Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:01:57.524800Z","description":"","domain_name":"tffuncadmiringcerfaqp7bnro-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"redirected","id":"0013aa6b-414d-4149-8738-7023fdd52c81","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"480530d7-bfe1-4399-931a-e6dfe716f585","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:01:58.760345Z"}'
         headers:
             Content-Length:
-                - "703"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:19 GMT
+                - Fri, 03 Jul 2026 15:01:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -738,10 +738,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 199cb000-58e9-4945-a4ff-a70147193f6a
+                - bcd5e3a3-1374-438f-8cc1-f0329415a4fd
         status: 200 OK
         code: 200
-        duration: 36.846466ms
+        duration: 49.257347ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -758,7 +758,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/375e934f-6897-45e3-8795-1f013683b2e2
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0013aa6b-414d-4149-8738-7023fdd52c81
         method: GET
       response:
         proto: HTTP/2.0
@@ -766,20 +766,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 713
+        content_length: 711
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:17.117807Z","description":"","domain_name":"tffuncfriendlytaussipjfz38or-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"redirected","id":"375e934f-6897-45e3-8795-1f013683b2e2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"ed92dbf4-64ad-4341-bfb6-ad594976a8f1","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:20.095112Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:01:57.524800Z","description":"","domain_name":"tffuncadmiringcerfaqp7bnro-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"redirected","id":"0013aa6b-414d-4149-8738-7023fdd52c81","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"480530d7-bfe1-4399-931a-e6dfe716f585","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:01:59.971272Z"}'
         headers:
             Content-Length:
-                - "713"
+                - "711"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:24 GMT
+                - Fri, 03 Jul 2026 15:02:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -787,10 +787,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 247d37e7-72b8-41a0-8f1f-d4f28c1899de
+                - cbb433eb-f4f3-43df-9516-2273404c4bf0
         status: 200 OK
         code: 200
-        duration: 71.838726ms
+        duration: 37.120611ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -807,7 +807,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/375e934f-6897-45e3-8795-1f013683b2e2
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0013aa6b-414d-4149-8738-7023fdd52c81
         method: GET
       response:
         proto: HTTP/2.0
@@ -815,20 +815,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 713
+        content_length: 711
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:17.117807Z","description":"","domain_name":"tffuncfriendlytaussipjfz38or-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"redirected","id":"375e934f-6897-45e3-8795-1f013683b2e2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"ed92dbf4-64ad-4341-bfb6-ad594976a8f1","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:20.095112Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:01:57.524800Z","description":"","domain_name":"tffuncadmiringcerfaqp7bnro-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"redirected","id":"0013aa6b-414d-4149-8738-7023fdd52c81","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"480530d7-bfe1-4399-931a-e6dfe716f585","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:01:59.971272Z"}'
         headers:
             Content-Length:
-                - "713"
+                - "711"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:24 GMT
+                - Fri, 03 Jul 2026 15:02:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -836,10 +836,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cc609544-4282-4e73-ac73-ab52c68aa518
+                - d2fbc173-fb9b-4824-85db-c2364080c3ab
         status: 200 OK
         code: 200
-        duration: 50.167071ms
+        duration: 39.809349ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -856,7 +856,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ed92dbf4-64ad-4341-bfb6-ad594976a8f1
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/480530d7-bfe1-4399-931a-e6dfe716f585
         method: GET
       response:
         proto: HTTP/2.0
@@ -864,20 +864,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 593
+        content_length: 588
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:56.381675Z","description":"","environment_variables":{},"error_message":null,"id":"ed92dbf4-64ad-4341-bfb6-ad594976a8f1","name":"tf-func-friendly-taussig","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncfriendlytaussipjfz38or","registry_namespace_id":"24e228af-aeb2-4bed-ada9-4989895e4e5c","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:11.849613Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.217813Z","description":"","environment_variables":{},"error_message":null,"id":"480530d7-bfe1-4399-931a-e6dfe716f585","name":"tf-func-admiring-cerf","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncadmiringcerfaqp7bnro","registry_namespace_id":"92357de9-ffe1-4f2a-be0e-083a299f869d","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:01:57.073523Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "593"
+                - "588"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:24 GMT
+                - Fri, 03 Jul 2026 15:02:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -885,10 +885,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bda14b06-eab6-4f52-ada0-cb129a441c47
+                - 33d430fa-143d-4c78-becb-7249ec702b79
         status: 200 OK
         code: 200
-        duration: 29.34323ms
+        duration: 34.573171ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -905,7 +905,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/375e934f-6897-45e3-8795-1f013683b2e2
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0013aa6b-414d-4149-8738-7023fdd52c81
         method: GET
       response:
         proto: HTTP/2.0
@@ -913,20 +913,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 713
+        content_length: 711
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:17.117807Z","description":"","domain_name":"tffuncfriendlytaussipjfz38or-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"redirected","id":"375e934f-6897-45e3-8795-1f013683b2e2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"ed92dbf4-64ad-4341-bfb6-ad594976a8f1","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:20.095112Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:01:57.524800Z","description":"","domain_name":"tffuncadmiringcerfaqp7bnro-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"redirected","id":"0013aa6b-414d-4149-8738-7023fdd52c81","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"480530d7-bfe1-4399-931a-e6dfe716f585","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:01:59.971272Z"}'
         headers:
             Content-Length:
-                - "713"
+                - "711"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:24 GMT
+                - Fri, 03 Jul 2026 15:02:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -934,10 +934,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - eb959456-f92a-4b1b-b719-52695441997f
+                - c19ceb39-f0a1-4a79-9df9-e454b019aa1d
         status: 200 OK
         code: 200
-        duration: 41.90264ms
+        duration: 45.162446ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -954,7 +954,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ed92dbf4-64ad-4341-bfb6-ad594976a8f1
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/480530d7-bfe1-4399-931a-e6dfe716f585
         method: GET
       response:
         proto: HTTP/2.0
@@ -962,20 +962,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 593
+        content_length: 588
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:56.381675Z","description":"","environment_variables":{},"error_message":null,"id":"ed92dbf4-64ad-4341-bfb6-ad594976a8f1","name":"tf-func-friendly-taussig","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncfriendlytaussipjfz38or","registry_namespace_id":"24e228af-aeb2-4bed-ada9-4989895e4e5c","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:11.849613Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.217813Z","description":"","environment_variables":{},"error_message":null,"id":"480530d7-bfe1-4399-931a-e6dfe716f585","name":"tf-func-admiring-cerf","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncadmiringcerfaqp7bnro","registry_namespace_id":"92357de9-ffe1-4f2a-be0e-083a299f869d","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:01:57.073523Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "593"
+                - "588"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:25 GMT
+                - Fri, 03 Jul 2026 15:02:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -983,10 +983,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 33608bb9-d949-44a7-9578-ac4f0048dbf9
+                - 737e388e-def3-422e-92ec-341b296ef7ad
         status: 200 OK
         code: 200
-        duration: 33.733741ms
+        duration: 29.95733ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1003,7 +1003,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/375e934f-6897-45e3-8795-1f013683b2e2
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0013aa6b-414d-4149-8738-7023fdd52c81
         method: GET
       response:
         proto: HTTP/2.0
@@ -1011,20 +1011,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 713
+        content_length: 711
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:17.117807Z","description":"","domain_name":"tffuncfriendlytaussipjfz38or-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"redirected","id":"375e934f-6897-45e3-8795-1f013683b2e2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"ed92dbf4-64ad-4341-bfb6-ad594976a8f1","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:20.095112Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:01:57.524800Z","description":"","domain_name":"tffuncadmiringcerfaqp7bnro-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"redirected","id":"0013aa6b-414d-4149-8738-7023fdd52c81","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"480530d7-bfe1-4399-931a-e6dfe716f585","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:01:59.971272Z"}'
         headers:
             Content-Length:
-                - "713"
+                - "711"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:25 GMT
+                - Fri, 03 Jul 2026 15:02:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1032,10 +1032,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7ce5d9cc-2c50-4857-b788-49ad0bba6ca5
+                - 15e25928-dd69-4614-b4d1-869dee4f88fa
         status: 200 OK
         code: 200
-        duration: 51.355897ms
+        duration: 33.640257ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1052,7 +1052,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/375e934f-6897-45e3-8795-1f013683b2e2
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0013aa6b-414d-4149-8738-7023fdd52c81
         method: GET
       response:
         proto: HTTP/2.0
@@ -1060,20 +1060,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 713
+        content_length: 711
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:17.117807Z","description":"","domain_name":"tffuncfriendlytaussipjfz38or-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"redirected","id":"375e934f-6897-45e3-8795-1f013683b2e2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"ed92dbf4-64ad-4341-bfb6-ad594976a8f1","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:20.095112Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:01:57.524800Z","description":"","domain_name":"tffuncadmiringcerfaqp7bnro-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"redirected","id":"0013aa6b-414d-4149-8738-7023fdd52c81","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"480530d7-bfe1-4399-931a-e6dfe716f585","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:01:59.971272Z"}'
         headers:
             Content-Length:
-                - "713"
+                - "711"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:25 GMT
+                - Fri, 03 Jul 2026 15:02:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1081,10 +1081,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cf2838dc-fab6-42cf-8697-cdec6ec1e9cc
+                - a6816967-1f15-4b37-bd28-28d95d4bc91c
         status: 200 OK
         code: 200
-        duration: 53.238249ms
+        duration: 50.824464ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1103,7 +1103,7 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/375e934f-6897-45e3-8795-1f013683b2e2
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0013aa6b-414d-4149-8738-7023fdd52c81
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -1111,20 +1111,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 703
+        content_length: 701
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:17.117807Z","description":"","domain_name":"tffuncfriendlytaussipjfz38or-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"375e934f-6897-45e3-8795-1f013683b2e2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"ed92dbf4-64ad-4341-bfb6-ad594976a8f1","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:25.305299206Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:01:57.524800Z","description":"","domain_name":"tffuncadmiringcerfaqp7bnro-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0013aa6b-414d-4149-8738-7023fdd52c81","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"480530d7-bfe1-4399-931a-e6dfe716f585","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:05.820647218Z"}'
         headers:
             Content-Length:
-                - "703"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:25 GMT
+                - Fri, 03 Jul 2026 15:02:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1132,10 +1132,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2928978b-9989-49d7-a9e1-bc172499977a
+                - ee78b0bb-3ea1-42b7-9de5-1dd793dc353d
         status: 200 OK
         code: 200
-        duration: 83.332382ms
+        duration: 41.786025ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1152,7 +1152,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/375e934f-6897-45e3-8795-1f013683b2e2
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0013aa6b-414d-4149-8738-7023fdd52c81
         method: GET
       response:
         proto: HTTP/2.0
@@ -1160,20 +1160,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 700
+        content_length: 698
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:17.117807Z","description":"","domain_name":"tffuncfriendlytaussipjfz38or-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"375e934f-6897-45e3-8795-1f013683b2e2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"ed92dbf4-64ad-4341-bfb6-ad594976a8f1","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:25.305299Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:01:57.524800Z","description":"","domain_name":"tffuncadmiringcerfaqp7bnro-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0013aa6b-414d-4149-8738-7023fdd52c81","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"480530d7-bfe1-4399-931a-e6dfe716f585","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:05.820647Z"}'
         headers:
             Content-Length:
-                - "700"
+                - "698"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:26 GMT
+                - Fri, 03 Jul 2026 15:02:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1181,10 +1181,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 280d76ff-76ab-4aa7-9461-5622962914d9
+                - 9ecc7a8c-2d9d-4f11-92a8-9c82515727b0
         status: 200 OK
         code: 200
-        duration: 37.445435ms
+        duration: 44.676703ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1201,7 +1201,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/375e934f-6897-45e3-8795-1f013683b2e2
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0013aa6b-414d-4149-8738-7023fdd52c81
         method: GET
       response:
         proto: HTTP/2.0
@@ -1209,20 +1209,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 710
+        content_length: 708
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:17.117807Z","description":"","domain_name":"tffuncfriendlytaussipjfz38or-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"375e934f-6897-45e3-8795-1f013683b2e2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"ed92dbf4-64ad-4341-bfb6-ad594976a8f1","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:31.009243Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:01:57.524800Z","description":"","domain_name":"tffuncadmiringcerfaqp7bnro-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"0013aa6b-414d-4149-8738-7023fdd52c81","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"480530d7-bfe1-4399-931a-e6dfe716f585","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:11.452835Z"}'
         headers:
             Content-Length:
-                - "710"
+                - "708"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:31 GMT
+                - Fri, 03 Jul 2026 15:02:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1230,10 +1230,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fa87a830-695a-4ad3-84d0-f9b6d062e5f9
+                - 7829d6ed-73fc-4cf3-baca-0519af50ea80
         status: 200 OK
         code: 200
-        duration: 35.238433ms
+        duration: 43.13866ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1250,7 +1250,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/375e934f-6897-45e3-8795-1f013683b2e2
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0013aa6b-414d-4149-8738-7023fdd52c81
         method: GET
       response:
         proto: HTTP/2.0
@@ -1258,20 +1258,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 710
+        content_length: 708
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:17.117807Z","description":"","domain_name":"tffuncfriendlytaussipjfz38or-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"375e934f-6897-45e3-8795-1f013683b2e2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"ed92dbf4-64ad-4341-bfb6-ad594976a8f1","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:31.009243Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:01:57.524800Z","description":"","domain_name":"tffuncadmiringcerfaqp7bnro-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"0013aa6b-414d-4149-8738-7023fdd52c81","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"480530d7-bfe1-4399-931a-e6dfe716f585","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:11.452835Z"}'
         headers:
             Content-Length:
-                - "710"
+                - "708"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:31 GMT
+                - Fri, 03 Jul 2026 15:02:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1279,10 +1279,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8f4f266b-e855-4670-9797-f37cd9543024
+                - 449db797-98a5-4d78-a720-a9b0caa2a773
         status: 200 OK
         code: 200
-        duration: 383.237335ms
+        duration: 42.044833ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1299,7 +1299,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ed92dbf4-64ad-4341-bfb6-ad594976a8f1
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/480530d7-bfe1-4399-931a-e6dfe716f585
         method: GET
       response:
         proto: HTTP/2.0
@@ -1307,20 +1307,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 593
+        content_length: 588
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:56.381675Z","description":"","environment_variables":{},"error_message":null,"id":"ed92dbf4-64ad-4341-bfb6-ad594976a8f1","name":"tf-func-friendly-taussig","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncfriendlytaussipjfz38or","registry_namespace_id":"24e228af-aeb2-4bed-ada9-4989895e4e5c","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:11.849613Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.217813Z","description":"","environment_variables":{},"error_message":null,"id":"480530d7-bfe1-4399-931a-e6dfe716f585","name":"tf-func-admiring-cerf","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncadmiringcerfaqp7bnro","registry_namespace_id":"92357de9-ffe1-4f2a-be0e-083a299f869d","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:01:57.073523Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "593"
+                - "588"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:32 GMT
+                - Fri, 03 Jul 2026 15:02:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1328,10 +1328,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 43c9985b-2271-497b-92f3-642f37eb8997
+                - 0f4a40f4-4ac3-4785-8da2-409dda03144d
         status: 200 OK
         code: 200
-        duration: 48.393316ms
+        duration: 25.491581ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1348,7 +1348,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/375e934f-6897-45e3-8795-1f013683b2e2
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0013aa6b-414d-4149-8738-7023fdd52c81
         method: GET
       response:
         proto: HTTP/2.0
@@ -1356,20 +1356,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 710
+        content_length: 708
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:17.117807Z","description":"","domain_name":"tffuncfriendlytaussipjfz38or-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"375e934f-6897-45e3-8795-1f013683b2e2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"ed92dbf4-64ad-4341-bfb6-ad594976a8f1","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:31.009243Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:01:57.524800Z","description":"","domain_name":"tffuncadmiringcerfaqp7bnro-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"0013aa6b-414d-4149-8738-7023fdd52c81","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"480530d7-bfe1-4399-931a-e6dfe716f585","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:11.452835Z"}'
         headers:
             Content-Length:
-                - "710"
+                - "708"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:32 GMT
+                - Fri, 03 Jul 2026 15:02:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1377,10 +1377,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ff53a282-4076-4034-b46c-2bee9fa16169
+                - 2144a7eb-700e-4e2e-9f32-99620f9ee2c1
         status: 200 OK
         code: 200
-        duration: 40.812041ms
+        duration: 48.325745ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1397,7 +1397,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/375e934f-6897-45e3-8795-1f013683b2e2
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0013aa6b-414d-4149-8738-7023fdd52c81
         method: GET
       response:
         proto: HTTP/2.0
@@ -1405,20 +1405,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 710
+        content_length: 708
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:17.117807Z","description":"","domain_name":"tffuncfriendlytaussipjfz38or-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"375e934f-6897-45e3-8795-1f013683b2e2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"ed92dbf4-64ad-4341-bfb6-ad594976a8f1","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:31.009243Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:01:57.524800Z","description":"","domain_name":"tffuncadmiringcerfaqp7bnro-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"0013aa6b-414d-4149-8738-7023fdd52c81","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"480530d7-bfe1-4399-931a-e6dfe716f585","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:11.452835Z"}'
         headers:
             Content-Length:
-                - "710"
+                - "708"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:32 GMT
+                - Fri, 03 Jul 2026 15:02:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1426,10 +1426,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 60594954-7b1f-4616-aae0-efa918e38112
+                - f418c870-8303-4d02-b2d3-39e077ea0b51
         status: 200 OK
         code: 200
-        duration: 110.249011ms
+        duration: 36.907972ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1446,7 +1446,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/375e934f-6897-45e3-8795-1f013683b2e2
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0013aa6b-414d-4149-8738-7023fdd52c81
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1454,20 +1454,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 704
+        content_length: 702
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:17.117807Z","description":"","domain_name":"tffuncfriendlytaussipjfz38or-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"375e934f-6897-45e3-8795-1f013683b2e2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"ed92dbf4-64ad-4341-bfb6-ad594976a8f1","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:32.541096983Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:01:57.524800Z","description":"","domain_name":"tffuncadmiringcerfaqp7bnro-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"0013aa6b-414d-4149-8738-7023fdd52c81","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"480530d7-bfe1-4399-931a-e6dfe716f585","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:12.670682357Z"}'
         headers:
             Content-Length:
-                - "704"
+                - "702"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:32 GMT
+                - Fri, 03 Jul 2026 15:02:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1475,10 +1475,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b0d93584-5144-4b69-a773-113ae390c021
+                - 2e39a0ee-e146-4d66-aedd-ad1dc5d73210
         status: 200 OK
         code: 200
-        duration: 128.863416ms
+        duration: 257.984054ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1495,7 +1495,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ed92dbf4-64ad-4341-bfb6-ad594976a8f1
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/480530d7-bfe1-4399-931a-e6dfe716f585
         method: GET
       response:
         proto: HTTP/2.0
@@ -1503,20 +1503,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 593
+        content_length: 588
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:56.381675Z","description":"","environment_variables":{},"error_message":null,"id":"ed92dbf4-64ad-4341-bfb6-ad594976a8f1","name":"tf-func-friendly-taussig","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncfriendlytaussipjfz38or","registry_namespace_id":"24e228af-aeb2-4bed-ada9-4989895e4e5c","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:11.849613Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.217813Z","description":"","environment_variables":{},"error_message":null,"id":"480530d7-bfe1-4399-931a-e6dfe716f585","name":"tf-func-admiring-cerf","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncadmiringcerfaqp7bnro","registry_namespace_id":"92357de9-ffe1-4f2a-be0e-083a299f869d","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:01:57.073523Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "593"
+                - "588"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:32 GMT
+                - Fri, 03 Jul 2026 15:02:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1524,10 +1524,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ec8c1c55-6af3-4454-b3af-172a014a617f
+                - ae762282-2cfa-4f9b-9931-4bb39015a73b
         status: 200 OK
         code: 200
-        duration: 32.340672ms
+        duration: 37.452476ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1544,7 +1544,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ed92dbf4-64ad-4341-bfb6-ad594976a8f1
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/480530d7-bfe1-4399-931a-e6dfe716f585
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1552,20 +1552,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 599
+        content_length: 594
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:56.381675Z","description":"","environment_variables":{},"error_message":null,"id":"ed92dbf4-64ad-4341-bfb6-ad594976a8f1","name":"tf-func-friendly-taussig","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncfriendlytaussipjfz38or","registry_namespace_id":"24e228af-aeb2-4bed-ada9-4989895e4e5c","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-05-04T12:39:32.700572213Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.217813Z","description":"","environment_variables":{},"error_message":null,"id":"480530d7-bfe1-4399-931a-e6dfe716f585","name":"tf-func-admiring-cerf","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncadmiringcerfaqp7bnro","registry_namespace_id":"92357de9-ffe1-4f2a-be0e-083a299f869d","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-07-03T15:02:12.958624203Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "599"
+                - "594"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:33 GMT
+                - Fri, 03 Jul 2026 15:02:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1573,10 +1573,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cc6e356a-98f8-4199-b440-5203c0c063cd
+                - 1b8ad809-4eb5-4aec-8039-1b3df502cb8b
         status: 200 OK
         code: 200
-        duration: 337.414459ms
+        duration: 976.835511ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1593,7 +1593,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ed92dbf4-64ad-4341-bfb6-ad594976a8f1
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/480530d7-bfe1-4399-931a-e6dfe716f585
         method: GET
       response:
         proto: HTTP/2.0
@@ -1601,20 +1601,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 596
+        content_length: 591
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:56.381675Z","description":"","environment_variables":{},"error_message":null,"id":"ed92dbf4-64ad-4341-bfb6-ad594976a8f1","name":"tf-func-friendly-taussig","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncfriendlytaussipjfz38or","registry_namespace_id":"24e228af-aeb2-4bed-ada9-4989895e4e5c","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-05-04T12:39:32.700572Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.217813Z","description":"","environment_variables":{},"error_message":null,"id":"480530d7-bfe1-4399-931a-e6dfe716f585","name":"tf-func-admiring-cerf","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncadmiringcerfaqp7bnro","registry_namespace_id":"92357de9-ffe1-4f2a-be0e-083a299f869d","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-07-03T15:02:12.958624Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "596"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:33 GMT
+                - Fri, 03 Jul 2026 15:02:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1622,10 +1622,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f5c15e80-2155-4005-b6dd-0abc81017394
+                - 77d1b4ab-3bac-4aec-a99a-b1d5f175b5ab
         status: 200 OK
         code: 200
-        duration: 34.637223ms
+        duration: 32.958794ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1642,7 +1642,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ed92dbf4-64ad-4341-bfb6-ad594976a8f1
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/480530d7-bfe1-4399-931a-e6dfe716f585
         method: GET
       response:
         proto: HTTP/2.0
@@ -1661,9 +1661,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:38 GMT
+                - Fri, 03 Jul 2026 15:02:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1671,10 +1671,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 780a1975-2b58-4179-a39c-087da70ea6d0
+                - 95b07728-5433-4703-b43b-0049ea34bbf4
         status: 404 Not Found
         code: 404
-        duration: 147.012811ms
+        duration: 25.63983ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1691,7 +1691,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/375e934f-6897-45e3-8795-1f013683b2e2
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/0013aa6b-414d-4149-8738-7023fdd52c81
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1710,9 +1710,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:38 GMT
+                - Fri, 03 Jul 2026 15:02:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1720,7 +1720,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9ec4e05f-2253-4e1a-83fb-fe65e5219fee
+                - 82853873-d71c-4894-9868-76c253f00fae
         status: 404 Not Found
         code: 404
-        duration: 24.210134ms
+        duration: 18.869277ms

--- a/internal/services/function/testdata/function-namespace-basic.cassette.yaml
+++ b/internal/services/function/testdata/function-namespace-basic.cassette.yaml
@@ -29,7 +29,7 @@ interactions:
         trailer: {}
         content_length: 512
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.930599964Z","description":"","environment_variables":{},"error_message":null,"id":"ef40d231-bc9d-413a-a79e-3f46ef17856d","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":["tag1","tag2"],"updated_at":"2026-05-04T12:38:57.930599964Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.200272178Z","description":"","environment_variables":{},"error_message":null,"id":"5c40676c-f3e6-4bc0-b8c5-c615d578cdda","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":["tag1","tag2"],"updated_at":"2026-07-03T15:01:47.200272178Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "512"
@@ -38,9 +38,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:38:57 GMT
+                - Fri, 03 Jul 2026 15:01:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5306394f-dca1-4487-a070-7c76eacb839f
+                - 207cb243-7e5e-4b96-9540-e4b26a60fc0c
         status: 200 OK
         code: 200
-        duration: 1.93571069s
+        duration: 7.727436946s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -68,7 +68,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ef40d231-bc9d-413a-a79e-3f46ef17856d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5c40676c-f3e6-4bc0-b8c5-c615d578cdda
         method: GET
       response:
         proto: HTTP/2.0
@@ -78,7 +78,7 @@ interactions:
         trailer: {}
         content_length: 506
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.930600Z","description":"","environment_variables":{},"error_message":null,"id":"ef40d231-bc9d-413a-a79e-3f46ef17856d","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":["tag1","tag2"],"updated_at":"2026-05-04T12:38:57.930600Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.200272Z","description":"","environment_variables":{},"error_message":null,"id":"5c40676c-f3e6-4bc0-b8c5-c615d578cdda","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":["tag1","tag2"],"updated_at":"2026-07-03T15:01:47.200272Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "506"
@@ -87,9 +87,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:38:57 GMT
+                - Fri, 03 Jul 2026 15:01:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a661958a-96b4-4e23-ad7d-6eb253228f78
+                - 664d05f1-5a1a-4053-ab61-fee59f419857
         status: 200 OK
         code: 200
-        duration: 50.468287ms
+        duration: 37.580927ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -117,7 +117,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ef40d231-bc9d-413a-a79e-3f46ef17856d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5c40676c-f3e6-4bc0-b8c5-c615d578cdda
         method: GET
       response:
         proto: HTTP/2.0
@@ -127,7 +127,7 @@ interactions:
         trailer: {}
         content_length: 585
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.930600Z","description":"","environment_variables":{},"error_message":null,"id":"ef40d231-bc9d-413a-a79e-3f46ef17856d","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01lolr1v6a","registry_namespace_id":"fe6c06b2-4118-4ad1-94dc-6fae37cf2f4a","secret_environment_variables":[],"status":"ready","tags":["tag1","tag2"],"updated_at":"2026-05-04T12:39:27.642300Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.200272Z","description":"","environment_variables":{},"error_message":null,"id":"5c40676c-f3e6-4bc0-b8c5-c615d578cdda","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01nxwiwc1p","registry_namespace_id":"a12aa44b-8cc5-4a39-bd61-a33e89fbe3f9","secret_environment_variables":[],"status":"ready","tags":["tag1","tag2"],"updated_at":"2026-07-03T15:01:58.777312Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "585"
@@ -136,9 +136,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:28 GMT
+                - Fri, 03 Jul 2026 15:02:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 63b15125-093e-4ad4-a523-10e1ca3089e4
+                - 871b0862-67dc-460e-87be-7b92962a1c87
         status: 200 OK
         code: 200
-        duration: 38.193743ms
+        duration: 55.019935ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -166,7 +166,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ef40d231-bc9d-413a-a79e-3f46ef17856d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5c40676c-f3e6-4bc0-b8c5-c615d578cdda
         method: GET
       response:
         proto: HTTP/2.0
@@ -176,7 +176,7 @@ interactions:
         trailer: {}
         content_length: 585
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.930600Z","description":"","environment_variables":{},"error_message":null,"id":"ef40d231-bc9d-413a-a79e-3f46ef17856d","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01lolr1v6a","registry_namespace_id":"fe6c06b2-4118-4ad1-94dc-6fae37cf2f4a","secret_environment_variables":[],"status":"ready","tags":["tag1","tag2"],"updated_at":"2026-05-04T12:39:27.642300Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.200272Z","description":"","environment_variables":{},"error_message":null,"id":"5c40676c-f3e6-4bc0-b8c5-c615d578cdda","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01nxwiwc1p","registry_namespace_id":"a12aa44b-8cc5-4a39-bd61-a33e89fbe3f9","secret_environment_variables":[],"status":"ready","tags":["tag1","tag2"],"updated_at":"2026-07-03T15:01:58.777312Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "585"
@@ -185,9 +185,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:28 GMT
+                - Fri, 03 Jul 2026 15:02:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,10 +195,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6c7bf7e2-83f0-4ed6-9aa9-68d31030b447
+                - 7d694c2e-8055-4684-8c67-df232ee4ef55
         status: 200 OK
         code: 200
-        duration: 38.728009ms
+        duration: 31.576325ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -215,7 +215,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ef40d231-bc9d-413a-a79e-3f46ef17856d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5c40676c-f3e6-4bc0-b8c5-c615d578cdda
         method: GET
       response:
         proto: HTTP/2.0
@@ -225,7 +225,7 @@ interactions:
         trailer: {}
         content_length: 585
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.930600Z","description":"","environment_variables":{},"error_message":null,"id":"ef40d231-bc9d-413a-a79e-3f46ef17856d","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01lolr1v6a","registry_namespace_id":"fe6c06b2-4118-4ad1-94dc-6fae37cf2f4a","secret_environment_variables":[],"status":"ready","tags":["tag1","tag2"],"updated_at":"2026-05-04T12:39:27.642300Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.200272Z","description":"","environment_variables":{},"error_message":null,"id":"5c40676c-f3e6-4bc0-b8c5-c615d578cdda","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01nxwiwc1p","registry_namespace_id":"a12aa44b-8cc5-4a39-bd61-a33e89fbe3f9","secret_environment_variables":[],"status":"ready","tags":["tag1","tag2"],"updated_at":"2026-07-03T15:01:58.777312Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "585"
@@ -234,9 +234,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:28 GMT
+                - Fri, 03 Jul 2026 15:02:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -244,10 +244,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2887ab8b-5762-4247-a3d5-ac3dd3bddc00
+                - d3b8f5aa-252a-4a95-8029-a9ee85ab3725
         status: 200 OK
         code: 200
-        duration: 42.516888ms
+        duration: 28.355727ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -264,7 +264,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ef40d231-bc9d-413a-a79e-3f46ef17856d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5c40676c-f3e6-4bc0-b8c5-c615d578cdda
         method: GET
       response:
         proto: HTTP/2.0
@@ -274,7 +274,7 @@ interactions:
         trailer: {}
         content_length: 585
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.930600Z","description":"","environment_variables":{},"error_message":null,"id":"ef40d231-bc9d-413a-a79e-3f46ef17856d","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01lolr1v6a","registry_namespace_id":"fe6c06b2-4118-4ad1-94dc-6fae37cf2f4a","secret_environment_variables":[],"status":"ready","tags":["tag1","tag2"],"updated_at":"2026-05-04T12:39:27.642300Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.200272Z","description":"","environment_variables":{},"error_message":null,"id":"5c40676c-f3e6-4bc0-b8c5-c615d578cdda","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01nxwiwc1p","registry_namespace_id":"a12aa44b-8cc5-4a39-bd61-a33e89fbe3f9","secret_environment_variables":[],"status":"ready","tags":["tag1","tag2"],"updated_at":"2026-07-03T15:01:58.777312Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "585"
@@ -283,9 +283,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:28 GMT
+                - Fri, 03 Jul 2026 15:02:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -293,10 +293,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - db8d709c-08f1-421d-98ee-53631a29e8aa
+                - 519f95a8-6d9e-4246-bcfd-6b27a4f8d92e
         status: 200 OK
         code: 200
-        duration: 34.74246ms
+        duration: 30.779927ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -313,7 +313,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ef40d231-bc9d-413a-a79e-3f46ef17856d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5c40676c-f3e6-4bc0-b8c5-c615d578cdda
         method: GET
       response:
         proto: HTTP/2.0
@@ -323,7 +323,7 @@ interactions:
         trailer: {}
         content_length: 585
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.930600Z","description":"","environment_variables":{},"error_message":null,"id":"ef40d231-bc9d-413a-a79e-3f46ef17856d","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01lolr1v6a","registry_namespace_id":"fe6c06b2-4118-4ad1-94dc-6fae37cf2f4a","secret_environment_variables":[],"status":"ready","tags":["tag1","tag2"],"updated_at":"2026-05-04T12:39:27.642300Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.200272Z","description":"","environment_variables":{},"error_message":null,"id":"5c40676c-f3e6-4bc0-b8c5-c615d578cdda","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01nxwiwc1p","registry_namespace_id":"a12aa44b-8cc5-4a39-bd61-a33e89fbe3f9","secret_environment_variables":[],"status":"ready","tags":["tag1","tag2"],"updated_at":"2026-07-03T15:01:58.777312Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "585"
@@ -332,9 +332,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:28 GMT
+                - Fri, 03 Jul 2026 15:02:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -342,10 +342,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3fd92da8-02f8-49d4-974f-0e0140742b3c
+                - 81f959ba-705d-4fb6-af10-f28cc6e32307
         status: 200 OK
         code: 200
-        duration: 35.270944ms
+        duration: 157.599694ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -362,7 +362,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ef40d231-bc9d-413a-a79e-3f46ef17856d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5c40676c-f3e6-4bc0-b8c5-c615d578cdda
         method: GET
       response:
         proto: HTTP/2.0
@@ -372,7 +372,7 @@ interactions:
         trailer: {}
         content_length: 585
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.930600Z","description":"","environment_variables":{},"error_message":null,"id":"ef40d231-bc9d-413a-a79e-3f46ef17856d","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01lolr1v6a","registry_namespace_id":"fe6c06b2-4118-4ad1-94dc-6fae37cf2f4a","secret_environment_variables":[],"status":"ready","tags":["tag1","tag2"],"updated_at":"2026-05-04T12:39:27.642300Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.200272Z","description":"","environment_variables":{},"error_message":null,"id":"5c40676c-f3e6-4bc0-b8c5-c615d578cdda","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01nxwiwc1p","registry_namespace_id":"a12aa44b-8cc5-4a39-bd61-a33e89fbe3f9","secret_environment_variables":[],"status":"ready","tags":["tag1","tag2"],"updated_at":"2026-07-03T15:01:58.777312Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "585"
@@ -381,9 +381,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:28 GMT
+                - Fri, 03 Jul 2026 15:02:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -391,10 +391,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - df90dea5-859f-4ffa-91b2-c4d2405406a9
+                - 1cdbe404-06b4-408d-a0ad-822626168d79
         status: 200 OK
         code: 200
-        duration: 31.855457ms
+        duration: 33.545217ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -413,7 +413,7 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ef40d231-bc9d-413a-a79e-3f46ef17856d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5c40676c-f3e6-4bc0-b8c5-c615d578cdda
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -423,7 +423,7 @@ interactions:
         trailer: {}
         content_length: 601
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.930600Z","description":"test function namespace 01","environment_variables":{},"error_message":null,"id":"ef40d231-bc9d-413a-a79e-3f46ef17856d","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01lolr1v6a","registry_namespace_id":"fe6c06b2-4118-4ad1-94dc-6fae37cf2f4a","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:29.017796246Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.200272Z","description":"test function namespace 01","environment_variables":{},"error_message":null,"id":"5c40676c-f3e6-4bc0-b8c5-c615d578cdda","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01nxwiwc1p","registry_namespace_id":"a12aa44b-8cc5-4a39-bd61-a33e89fbe3f9","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:03.405243626Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "601"
@@ -432,9 +432,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:29 GMT
+                - Fri, 03 Jul 2026 15:02:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -442,10 +442,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e496c984-4ba5-4b87-9698-fc9b6abf65c0
+                - f8721c1d-df63-4a6c-b4dd-0578552b9cd9
         status: 200 OK
         code: 200
-        duration: 60.186955ms
+        duration: 57.795365ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -462,7 +462,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ef40d231-bc9d-413a-a79e-3f46ef17856d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5c40676c-f3e6-4bc0-b8c5-c615d578cdda
         method: GET
       response:
         proto: HTTP/2.0
@@ -472,7 +472,7 @@ interactions:
         trailer: {}
         content_length: 598
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.930600Z","description":"test function namespace 01","environment_variables":{},"error_message":null,"id":"ef40d231-bc9d-413a-a79e-3f46ef17856d","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01lolr1v6a","registry_namespace_id":"fe6c06b2-4118-4ad1-94dc-6fae37cf2f4a","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:29.017796Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.200272Z","description":"test function namespace 01","environment_variables":{},"error_message":null,"id":"5c40676c-f3e6-4bc0-b8c5-c615d578cdda","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01nxwiwc1p","registry_namespace_id":"a12aa44b-8cc5-4a39-bd61-a33e89fbe3f9","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:03.405244Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "598"
@@ -481,9 +481,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:29 GMT
+                - Fri, 03 Jul 2026 15:02:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -491,10 +491,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bed72260-6d00-417c-a281-fcf144271001
+                - be284709-b379-4b59-8dce-fcbc2446e64a
         status: 200 OK
         code: 200
-        duration: 48.482422ms
+        duration: 32.825304ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -511,7 +511,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ef40d231-bc9d-413a-a79e-3f46ef17856d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5c40676c-f3e6-4bc0-b8c5-c615d578cdda
         method: GET
       response:
         proto: HTTP/2.0
@@ -521,7 +521,7 @@ interactions:
         trailer: {}
         content_length: 598
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.930600Z","description":"test function namespace 01","environment_variables":{},"error_message":null,"id":"ef40d231-bc9d-413a-a79e-3f46ef17856d","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01lolr1v6a","registry_namespace_id":"fe6c06b2-4118-4ad1-94dc-6fae37cf2f4a","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:29.017796Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.200272Z","description":"test function namespace 01","environment_variables":{},"error_message":null,"id":"5c40676c-f3e6-4bc0-b8c5-c615d578cdda","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01nxwiwc1p","registry_namespace_id":"a12aa44b-8cc5-4a39-bd61-a33e89fbe3f9","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:03.405244Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "598"
@@ -530,9 +530,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:29 GMT
+                - Fri, 03 Jul 2026 15:02:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -540,10 +540,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e16ba684-f65e-4c26-ac40-a8e758fa3754
+                - 41420f4a-1a1a-4c47-b1e1-2ba65450650b
         status: 200 OK
         code: 200
-        duration: 34.547362ms
+        duration: 36.175294ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -560,7 +560,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ef40d231-bc9d-413a-a79e-3f46ef17856d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5c40676c-f3e6-4bc0-b8c5-c615d578cdda
         method: GET
       response:
         proto: HTTP/2.0
@@ -570,7 +570,7 @@ interactions:
         trailer: {}
         content_length: 598
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.930600Z","description":"test function namespace 01","environment_variables":{},"error_message":null,"id":"ef40d231-bc9d-413a-a79e-3f46ef17856d","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01lolr1v6a","registry_namespace_id":"fe6c06b2-4118-4ad1-94dc-6fae37cf2f4a","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:29.017796Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.200272Z","description":"test function namespace 01","environment_variables":{},"error_message":null,"id":"5c40676c-f3e6-4bc0-b8c5-c615d578cdda","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01nxwiwc1p","registry_namespace_id":"a12aa44b-8cc5-4a39-bd61-a33e89fbe3f9","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:03.405244Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "598"
@@ -579,9 +579,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:29 GMT
+                - Fri, 03 Jul 2026 15:02:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -589,10 +589,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b9d68cac-be8a-4b3e-9da4-e0c56abd19ed
+                - 90dfa4de-de65-440b-80f7-76f0050f1391
         status: 200 OK
         code: 200
-        duration: 32.050956ms
+        duration: 123.838199ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -609,7 +609,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ef40d231-bc9d-413a-a79e-3f46ef17856d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5c40676c-f3e6-4bc0-b8c5-c615d578cdda
         method: GET
       response:
         proto: HTTP/2.0
@@ -619,7 +619,7 @@ interactions:
         trailer: {}
         content_length: 598
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.930600Z","description":"test function namespace 01","environment_variables":{},"error_message":null,"id":"ef40d231-bc9d-413a-a79e-3f46ef17856d","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01lolr1v6a","registry_namespace_id":"fe6c06b2-4118-4ad1-94dc-6fae37cf2f4a","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:29.017796Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.200272Z","description":"test function namespace 01","environment_variables":{},"error_message":null,"id":"5c40676c-f3e6-4bc0-b8c5-c615d578cdda","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01nxwiwc1p","registry_namespace_id":"a12aa44b-8cc5-4a39-bd61-a33e89fbe3f9","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:03.405244Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "598"
@@ -628,9 +628,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:29 GMT
+                - Fri, 03 Jul 2026 15:02:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -638,10 +638,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d9e4d400-b75a-4fb6-8da0-39201a96b6bb
+                - b5f66d64-0c85-4de8-ada1-d8016d783fbe
         status: 200 OK
         code: 200
-        duration: 34.966191ms
+        duration: 39.245127ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -658,7 +658,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ef40d231-bc9d-413a-a79e-3f46ef17856d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5c40676c-f3e6-4bc0-b8c5-c615d578cdda
         method: GET
       response:
         proto: HTTP/2.0
@@ -668,7 +668,7 @@ interactions:
         trailer: {}
         content_length: 598
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.930600Z","description":"test function namespace 01","environment_variables":{},"error_message":null,"id":"ef40d231-bc9d-413a-a79e-3f46ef17856d","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01lolr1v6a","registry_namespace_id":"fe6c06b2-4118-4ad1-94dc-6fae37cf2f4a","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:29.017796Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.200272Z","description":"test function namespace 01","environment_variables":{},"error_message":null,"id":"5c40676c-f3e6-4bc0-b8c5-c615d578cdda","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01nxwiwc1p","registry_namespace_id":"a12aa44b-8cc5-4a39-bd61-a33e89fbe3f9","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:03.405244Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "598"
@@ -677,9 +677,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:29 GMT
+                - Fri, 03 Jul 2026 15:02:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -687,10 +687,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b5baa20c-0eed-435e-9c59-5b53729dddf5
+                - 4eef1a09-e0a1-40a1-92f0-33895ad9ec42
         status: 200 OK
         code: 200
-        duration: 28.288105ms
+        duration: 31.16422ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -709,7 +709,7 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ef40d231-bc9d-413a-a79e-3f46ef17856d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5c40676c-f3e6-4bc0-b8c5-c615d578cdda
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -719,7 +719,7 @@ interactions:
         trailer: {}
         content_length: 726
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.930600Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"ef40d231-bc9d-413a-a79e-3f46ef17856d","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01lolr1v6a","registry_namespace_id":"fe6c06b2-4118-4ad1-94dc-6fae37cf2f4a","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$Y0uDlwpqWxfakU5v/dEcTA$+4RdR2EUApS5x4M8L7wU6N/TxdOJkszJRYNQVxlh61E","key":"test_secret"}],"status":"pending","tags":[],"updated_at":"2026-05-04T12:39:30.216749329Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.200272Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"5c40676c-f3e6-4bc0-b8c5-c615d578cdda","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01nxwiwc1p","registry_namespace_id":"a12aa44b-8cc5-4a39-bd61-a33e89fbe3f9","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$oWTUWA9nxYF5HKQmVptjhw$7DHqQpUKCkVlTTlcDbQNPUjGuiwB25Ddllq/WG/hQ64","key":"test_secret"}],"status":"pending","tags":[],"updated_at":"2026-07-03T15:02:04.620469797Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "726"
@@ -728,9 +728,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:30 GMT
+                - Fri, 03 Jul 2026 15:02:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -738,10 +738,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 70da6d53-3427-4726-96ad-27caf6211858
+                - bc1541f5-e6ae-406f-a9a2-487a3306e351
         status: 200 OK
         code: 200
-        duration: 479.521646ms
+        duration: 377.661539ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -758,7 +758,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ef40d231-bc9d-413a-a79e-3f46ef17856d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5c40676c-f3e6-4bc0-b8c5-c615d578cdda
         method: GET
       response:
         proto: HTTP/2.0
@@ -768,7 +768,7 @@ interactions:
         trailer: {}
         content_length: 723
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.930600Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"ef40d231-bc9d-413a-a79e-3f46ef17856d","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01lolr1v6a","registry_namespace_id":"fe6c06b2-4118-4ad1-94dc-6fae37cf2f4a","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$Y0uDlwpqWxfakU5v/dEcTA$+4RdR2EUApS5x4M8L7wU6N/TxdOJkszJRYNQVxlh61E","key":"test_secret"}],"status":"pending","tags":[],"updated_at":"2026-05-04T12:39:30.216749Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.200272Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"5c40676c-f3e6-4bc0-b8c5-c615d578cdda","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01nxwiwc1p","registry_namespace_id":"a12aa44b-8cc5-4a39-bd61-a33e89fbe3f9","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$oWTUWA9nxYF5HKQmVptjhw$7DHqQpUKCkVlTTlcDbQNPUjGuiwB25Ddllq/WG/hQ64","key":"test_secret"}],"status":"pending","tags":[],"updated_at":"2026-07-03T15:02:04.620470Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "723"
@@ -777,9 +777,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:30 GMT
+                - Fri, 03 Jul 2026 15:02:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -787,10 +787,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 177f8c76-99f3-4727-acf5-08c9d9a13467
+                - a84da149-f57b-4c69-a499-0571e13e4942
         status: 200 OK
         code: 200
-        duration: 27.176013ms
+        duration: 45.065142ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -807,7 +807,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ef40d231-bc9d-413a-a79e-3f46ef17856d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5c40676c-f3e6-4bc0-b8c5-c615d578cdda
         method: GET
       response:
         proto: HTTP/2.0
@@ -817,7 +817,7 @@ interactions:
         trailer: {}
         content_length: 721
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.930600Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"ef40d231-bc9d-413a-a79e-3f46ef17856d","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01lolr1v6a","registry_namespace_id":"fe6c06b2-4118-4ad1-94dc-6fae37cf2f4a","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$Y0uDlwpqWxfakU5v/dEcTA$+4RdR2EUApS5x4M8L7wU6N/TxdOJkszJRYNQVxlh61E","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:30.512424Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.200272Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"5c40676c-f3e6-4bc0-b8c5-c615d578cdda","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01nxwiwc1p","registry_namespace_id":"a12aa44b-8cc5-4a39-bd61-a33e89fbe3f9","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$oWTUWA9nxYF5HKQmVptjhw$7DHqQpUKCkVlTTlcDbQNPUjGuiwB25Ddllq/WG/hQ64","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:05.203901Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "721"
@@ -826,9 +826,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:35 GMT
+                - Fri, 03 Jul 2026 15:02:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -836,10 +836,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8957776f-e1c4-409c-904d-5fc0df36bec4
+                - cba8d13b-e453-4ca7-820d-2029c154b78f
         status: 200 OK
         code: 200
-        duration: 33.6575ms
+        duration: 30.20198ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -856,7 +856,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ef40d231-bc9d-413a-a79e-3f46ef17856d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5c40676c-f3e6-4bc0-b8c5-c615d578cdda
         method: GET
       response:
         proto: HTTP/2.0
@@ -866,7 +866,7 @@ interactions:
         trailer: {}
         content_length: 721
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.930600Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"ef40d231-bc9d-413a-a79e-3f46ef17856d","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01lolr1v6a","registry_namespace_id":"fe6c06b2-4118-4ad1-94dc-6fae37cf2f4a","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$Y0uDlwpqWxfakU5v/dEcTA$+4RdR2EUApS5x4M8L7wU6N/TxdOJkszJRYNQVxlh61E","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:30.512424Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.200272Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"5c40676c-f3e6-4bc0-b8c5-c615d578cdda","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01nxwiwc1p","registry_namespace_id":"a12aa44b-8cc5-4a39-bd61-a33e89fbe3f9","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$oWTUWA9nxYF5HKQmVptjhw$7DHqQpUKCkVlTTlcDbQNPUjGuiwB25Ddllq/WG/hQ64","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:05.203901Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "721"
@@ -875,9 +875,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:35 GMT
+                - Fri, 03 Jul 2026 15:02:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -885,10 +885,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e21bbdfe-08e7-44e5-8577-5df47ca84252
+                - 07a8663c-0098-4605-a4ff-8eebea8dd162
         status: 200 OK
         code: 200
-        duration: 28.117385ms
+        duration: 28.597933ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -905,7 +905,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ef40d231-bc9d-413a-a79e-3f46ef17856d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5c40676c-f3e6-4bc0-b8c5-c615d578cdda
         method: GET
       response:
         proto: HTTP/2.0
@@ -915,7 +915,7 @@ interactions:
         trailer: {}
         content_length: 721
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.930600Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"ef40d231-bc9d-413a-a79e-3f46ef17856d","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01lolr1v6a","registry_namespace_id":"fe6c06b2-4118-4ad1-94dc-6fae37cf2f4a","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$Y0uDlwpqWxfakU5v/dEcTA$+4RdR2EUApS5x4M8L7wU6N/TxdOJkszJRYNQVxlh61E","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:30.512424Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.200272Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"5c40676c-f3e6-4bc0-b8c5-c615d578cdda","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01nxwiwc1p","registry_namespace_id":"a12aa44b-8cc5-4a39-bd61-a33e89fbe3f9","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$oWTUWA9nxYF5HKQmVptjhw$7DHqQpUKCkVlTTlcDbQNPUjGuiwB25Ddllq/WG/hQ64","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:05.203901Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "721"
@@ -924,9 +924,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:35 GMT
+                - Fri, 03 Jul 2026 15:02:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -934,10 +934,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b469c351-b9d7-4740-870e-de4179c65f82
+                - 9ef2a069-c737-4fe2-ad87-c7e78cb40fd8
         status: 200 OK
         code: 200
-        duration: 61.324327ms
+        duration: 36.990787ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -954,7 +954,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ef40d231-bc9d-413a-a79e-3f46ef17856d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5c40676c-f3e6-4bc0-b8c5-c615d578cdda
         method: GET
       response:
         proto: HTTP/2.0
@@ -964,7 +964,7 @@ interactions:
         trailer: {}
         content_length: 721
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.930600Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"ef40d231-bc9d-413a-a79e-3f46ef17856d","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01lolr1v6a","registry_namespace_id":"fe6c06b2-4118-4ad1-94dc-6fae37cf2f4a","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$Y0uDlwpqWxfakU5v/dEcTA$+4RdR2EUApS5x4M8L7wU6N/TxdOJkszJRYNQVxlh61E","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:30.512424Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.200272Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"5c40676c-f3e6-4bc0-b8c5-c615d578cdda","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01nxwiwc1p","registry_namespace_id":"a12aa44b-8cc5-4a39-bd61-a33e89fbe3f9","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$oWTUWA9nxYF5HKQmVptjhw$7DHqQpUKCkVlTTlcDbQNPUjGuiwB25Ddllq/WG/hQ64","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:05.203901Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "721"
@@ -973,9 +973,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:35 GMT
+                - Fri, 03 Jul 2026 15:02:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -983,10 +983,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b32d5ef9-8f0f-4bea-a04d-38b2f0b83da2
+                - f12d6d72-1fdf-48f6-939c-bcd8766e3c69
         status: 200 OK
         code: 200
-        duration: 35.540613ms
+        duration: 35.107696ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1003,7 +1003,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ef40d231-bc9d-413a-a79e-3f46ef17856d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5c40676c-f3e6-4bc0-b8c5-c615d578cdda
         method: GET
       response:
         proto: HTTP/2.0
@@ -1013,7 +1013,7 @@ interactions:
         trailer: {}
         content_length: 721
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.930600Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"ef40d231-bc9d-413a-a79e-3f46ef17856d","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01lolr1v6a","registry_namespace_id":"fe6c06b2-4118-4ad1-94dc-6fae37cf2f4a","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$Y0uDlwpqWxfakU5v/dEcTA$+4RdR2EUApS5x4M8L7wU6N/TxdOJkszJRYNQVxlh61E","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:30.512424Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.200272Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"5c40676c-f3e6-4bc0-b8c5-c615d578cdda","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01nxwiwc1p","registry_namespace_id":"a12aa44b-8cc5-4a39-bd61-a33e89fbe3f9","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$oWTUWA9nxYF5HKQmVptjhw$7DHqQpUKCkVlTTlcDbQNPUjGuiwB25Ddllq/WG/hQ64","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:05.203901Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "721"
@@ -1022,9 +1022,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:36 GMT
+                - Fri, 03 Jul 2026 15:02:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1032,10 +1032,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4f9d827e-aa5f-4e19-b984-f849f1d11de6
+                - c7d02ba1-92f6-45d9-a0ba-1f4d527a681e
         status: 200 OK
         code: 200
-        duration: 47.888046ms
+        duration: 28.112019ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1054,7 +1054,7 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ef40d231-bc9d-413a-a79e-3f46ef17856d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5c40676c-f3e6-4bc0-b8c5-c615d578cdda
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -1064,7 +1064,7 @@ interactions:
         trailer: {}
         content_length: 737
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.930600Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"ef40d231-bc9d-413a-a79e-3f46ef17856d","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01lolr1v6a","registry_namespace_id":"fe6c06b2-4118-4ad1-94dc-6fae37cf2f4a","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$Y0uDlwpqWxfakU5v/dEcTA$+4RdR2EUApS5x4M8L7wU6N/TxdOJkszJRYNQVxlh61E","key":"test_secret"}],"status":"ready","tags":["tag1","tag2"],"updated_at":"2026-05-04T12:39:36.205108831Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.200272Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"5c40676c-f3e6-4bc0-b8c5-c615d578cdda","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01nxwiwc1p","registry_namespace_id":"a12aa44b-8cc5-4a39-bd61-a33e89fbe3f9","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$oWTUWA9nxYF5HKQmVptjhw$7DHqQpUKCkVlTTlcDbQNPUjGuiwB25Ddllq/WG/hQ64","key":"test_secret"}],"status":"ready","tags":["tag1","tag2"],"updated_at":"2026-07-03T15:02:10.623402357Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "737"
@@ -1073,9 +1073,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:36 GMT
+                - Fri, 03 Jul 2026 15:02:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1083,10 +1083,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ef9cb3c9-569d-410b-8788-ad4f896e3eb8
+                - b31f9206-0c98-4e89-a66f-6b073feda816
         status: 200 OK
         code: 200
-        duration: 82.062639ms
+        duration: 49.241538ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1103,7 +1103,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ef40d231-bc9d-413a-a79e-3f46ef17856d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5c40676c-f3e6-4bc0-b8c5-c615d578cdda
         method: GET
       response:
         proto: HTTP/2.0
@@ -1113,7 +1113,7 @@ interactions:
         trailer: {}
         content_length: 734
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.930600Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"ef40d231-bc9d-413a-a79e-3f46ef17856d","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01lolr1v6a","registry_namespace_id":"fe6c06b2-4118-4ad1-94dc-6fae37cf2f4a","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$Y0uDlwpqWxfakU5v/dEcTA$+4RdR2EUApS5x4M8L7wU6N/TxdOJkszJRYNQVxlh61E","key":"test_secret"}],"status":"ready","tags":["tag1","tag2"],"updated_at":"2026-05-04T12:39:36.205109Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.200272Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"5c40676c-f3e6-4bc0-b8c5-c615d578cdda","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01nxwiwc1p","registry_namespace_id":"a12aa44b-8cc5-4a39-bd61-a33e89fbe3f9","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$oWTUWA9nxYF5HKQmVptjhw$7DHqQpUKCkVlTTlcDbQNPUjGuiwB25Ddllq/WG/hQ64","key":"test_secret"}],"status":"ready","tags":["tag1","tag2"],"updated_at":"2026-07-03T15:02:10.623402Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "734"
@@ -1122,9 +1122,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:36 GMT
+                - Fri, 03 Jul 2026 15:02:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1132,10 +1132,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 944e38ed-fba0-4124-9acc-459c05e81535
+                - 3f09f2e9-e193-4cc6-97d9-b90517df8474
         status: 200 OK
         code: 200
-        duration: 104.290062ms
+        duration: 43.630464ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1152,7 +1152,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ef40d231-bc9d-413a-a79e-3f46ef17856d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5c40676c-f3e6-4bc0-b8c5-c615d578cdda
         method: GET
       response:
         proto: HTTP/2.0
@@ -1162,7 +1162,7 @@ interactions:
         trailer: {}
         content_length: 734
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.930600Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"ef40d231-bc9d-413a-a79e-3f46ef17856d","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01lolr1v6a","registry_namespace_id":"fe6c06b2-4118-4ad1-94dc-6fae37cf2f4a","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$Y0uDlwpqWxfakU5v/dEcTA$+4RdR2EUApS5x4M8L7wU6N/TxdOJkszJRYNQVxlh61E","key":"test_secret"}],"status":"ready","tags":["tag1","tag2"],"updated_at":"2026-05-04T12:39:36.205109Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.200272Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"5c40676c-f3e6-4bc0-b8c5-c615d578cdda","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01nxwiwc1p","registry_namespace_id":"a12aa44b-8cc5-4a39-bd61-a33e89fbe3f9","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$oWTUWA9nxYF5HKQmVptjhw$7DHqQpUKCkVlTTlcDbQNPUjGuiwB25Ddllq/WG/hQ64","key":"test_secret"}],"status":"ready","tags":["tag1","tag2"],"updated_at":"2026-07-03T15:02:10.623402Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "734"
@@ -1171,9 +1171,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:36 GMT
+                - Fri, 03 Jul 2026 15:02:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1181,10 +1181,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 224a150d-5287-40af-980a-ee14ecda0b1c
+                - f74a9102-fcdd-42f8-b54e-41f9246e125d
         status: 200 OK
         code: 200
-        duration: 63.816287ms
+        duration: 32.46674ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1201,7 +1201,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ef40d231-bc9d-413a-a79e-3f46ef17856d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5c40676c-f3e6-4bc0-b8c5-c615d578cdda
         method: GET
       response:
         proto: HTTP/2.0
@@ -1211,7 +1211,7 @@ interactions:
         trailer: {}
         content_length: 734
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.930600Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"ef40d231-bc9d-413a-a79e-3f46ef17856d","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01lolr1v6a","registry_namespace_id":"fe6c06b2-4118-4ad1-94dc-6fae37cf2f4a","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$Y0uDlwpqWxfakU5v/dEcTA$+4RdR2EUApS5x4M8L7wU6N/TxdOJkszJRYNQVxlh61E","key":"test_secret"}],"status":"ready","tags":["tag1","tag2"],"updated_at":"2026-05-04T12:39:36.205109Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.200272Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"5c40676c-f3e6-4bc0-b8c5-c615d578cdda","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01nxwiwc1p","registry_namespace_id":"a12aa44b-8cc5-4a39-bd61-a33e89fbe3f9","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$oWTUWA9nxYF5HKQmVptjhw$7DHqQpUKCkVlTTlcDbQNPUjGuiwB25Ddllq/WG/hQ64","key":"test_secret"}],"status":"ready","tags":["tag1","tag2"],"updated_at":"2026-07-03T15:02:10.623402Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "734"
@@ -1220,9 +1220,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:36 GMT
+                - Fri, 03 Jul 2026 15:02:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1230,10 +1230,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5014ff9d-8177-4c61-ab43-82a3d4f3020c
+                - 565bf7dd-a71f-42b2-9b1b-500c1ef9fc70
         status: 200 OK
         code: 200
-        duration: 78.978846ms
+        duration: 35.558013ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1250,7 +1250,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ef40d231-bc9d-413a-a79e-3f46ef17856d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5c40676c-f3e6-4bc0-b8c5-c615d578cdda
         method: GET
       response:
         proto: HTTP/2.0
@@ -1260,7 +1260,7 @@ interactions:
         trailer: {}
         content_length: 734
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.930600Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"ef40d231-bc9d-413a-a79e-3f46ef17856d","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01lolr1v6a","registry_namespace_id":"fe6c06b2-4118-4ad1-94dc-6fae37cf2f4a","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$Y0uDlwpqWxfakU5v/dEcTA$+4RdR2EUApS5x4M8L7wU6N/TxdOJkszJRYNQVxlh61E","key":"test_secret"}],"status":"ready","tags":["tag1","tag2"],"updated_at":"2026-05-04T12:39:36.205109Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.200272Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"5c40676c-f3e6-4bc0-b8c5-c615d578cdda","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01nxwiwc1p","registry_namespace_id":"a12aa44b-8cc5-4a39-bd61-a33e89fbe3f9","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$oWTUWA9nxYF5HKQmVptjhw$7DHqQpUKCkVlTTlcDbQNPUjGuiwB25Ddllq/WG/hQ64","key":"test_secret"}],"status":"ready","tags":["tag1","tag2"],"updated_at":"2026-07-03T15:02:10.623402Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "734"
@@ -1269,9 +1269,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:37 GMT
+                - Fri, 03 Jul 2026 15:02:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1279,10 +1279,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5ee4ff2d-b72c-41c0-9c13-ded8d7ab81a5
+                - cf840682-837c-43e4-bcd3-1aa2c6475fb8
         status: 200 OK
         code: 200
-        duration: 34.307102ms
+        duration: 110.950663ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1299,7 +1299,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ef40d231-bc9d-413a-a79e-3f46ef17856d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5c40676c-f3e6-4bc0-b8c5-c615d578cdda
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1309,7 +1309,7 @@ interactions:
         trailer: {}
         content_length: 740
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.930600Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"ef40d231-bc9d-413a-a79e-3f46ef17856d","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01lolr1v6a","registry_namespace_id":"fe6c06b2-4118-4ad1-94dc-6fae37cf2f4a","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$Y0uDlwpqWxfakU5v/dEcTA$+4RdR2EUApS5x4M8L7wU6N/TxdOJkszJRYNQVxlh61E","key":"test_secret"}],"status":"deleting","tags":["tag1","tag2"],"updated_at":"2026-05-04T12:39:37.189426132Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.200272Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"5c40676c-f3e6-4bc0-b8c5-c615d578cdda","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01nxwiwc1p","registry_namespace_id":"a12aa44b-8cc5-4a39-bd61-a33e89fbe3f9","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$oWTUWA9nxYF5HKQmVptjhw$7DHqQpUKCkVlTTlcDbQNPUjGuiwB25Ddllq/WG/hQ64","key":"test_secret"}],"status":"deleting","tags":["tag1","tag2"],"updated_at":"2026-07-03T15:02:11.550415633Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "740"
@@ -1318,9 +1318,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:37 GMT
+                - Fri, 03 Jul 2026 15:02:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1328,10 +1328,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 01525730-02ee-46f9-9fdb-48845c9bd263
+                - 7c2d6f56-62d8-4af9-b276-ed9cd9766ee4
         status: 200 OK
         code: 200
-        duration: 216.589075ms
+        duration: 1.125799895s
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1348,7 +1348,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ef40d231-bc9d-413a-a79e-3f46ef17856d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5c40676c-f3e6-4bc0-b8c5-c615d578cdda
         method: GET
       response:
         proto: HTTP/2.0
@@ -1358,7 +1358,7 @@ interactions:
         trailer: {}
         content_length: 737
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.930600Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"ef40d231-bc9d-413a-a79e-3f46ef17856d","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01lolr1v6a","registry_namespace_id":"fe6c06b2-4118-4ad1-94dc-6fae37cf2f4a","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$Y0uDlwpqWxfakU5v/dEcTA$+4RdR2EUApS5x4M8L7wU6N/TxdOJkszJRYNQVxlh61E","key":"test_secret"}],"status":"deleting","tags":["tag1","tag2"],"updated_at":"2026-05-04T12:39:37.189426Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.200272Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"5c40676c-f3e6-4bc0-b8c5-c615d578cdda","name":"test-cr-ns-01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01nxwiwc1p","registry_namespace_id":"a12aa44b-8cc5-4a39-bd61-a33e89fbe3f9","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$oWTUWA9nxYF5HKQmVptjhw$7DHqQpUKCkVlTTlcDbQNPUjGuiwB25Ddllq/WG/hQ64","key":"test_secret"}],"status":"deleting","tags":["tag1","tag2"],"updated_at":"2026-07-03T15:02:11.550416Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "737"
@@ -1367,9 +1367,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:37 GMT
+                - Fri, 03 Jul 2026 15:02:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1377,10 +1377,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - da04939b-c14e-4f05-a669-cdecf80713f3
+                - cb025d99-43c7-468e-9539-366a289957d7
         status: 200 OK
         code: 200
-        duration: 28.881754ms
+        duration: 35.265242ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1397,7 +1397,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ef40d231-bc9d-413a-a79e-3f46ef17856d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5c40676c-f3e6-4bc0-b8c5-c615d578cdda
         method: GET
       response:
         proto: HTTP/2.0
@@ -1416,9 +1416,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:42 GMT
+                - Fri, 03 Jul 2026 15:02:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1426,10 +1426,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 569f62f2-cf89-4dbe-9f1a-c688714fa12f
+                - 550466d2-d842-43d0-a81f-679131a78250
         status: 404 Not Found
         code: 404
-        duration: 111.102134ms
+        duration: 24.448179ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1446,7 +1446,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/ef40d231-bc9d-413a-a79e-3f46ef17856d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5c40676c-f3e6-4bc0-b8c5-c615d578cdda
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1465,9 +1465,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:42 GMT
+                - Fri, 03 Jul 2026 15:02:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1475,7 +1475,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 28852749-aab5-4d93-a8a4-8e9959d274de
+                - 0cd258e5-8624-4e50-9df9-f7a29fa78cfa
         status: 404 Not Found
         code: 404
-        duration: 21.493513ms
+        duration: 20.918001ms

--- a/internal/services/function/testdata/function-namespace-environment-variables.cassette.yaml
+++ b/internal/services/function/testdata/function-namespace-environment-variables.cassette.yaml
@@ -29,7 +29,7 @@ interactions:
         trailer: {}
         content_length: 646
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.985871392Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"0437243b-fa6d-4bf4-b45b-ee59ab3636d7","name":"tf-env-test","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$iiymTLmenWsw8otY1g7ZwQ$0T2xmtzqfty+xKRlSb5mRvWauDTyoXFL562X2c82jjE","key":"test_secret"}],"status":"pending","tags":[],"updated_at":"2026-05-04T12:38:57.985871392Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.243240681Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"d1262a81-6e4d-4987-947f-562facb100d3","name":"tf-env-test","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$S2VTFXE+LHaHryozLOClfA$LBJxqqHqN0h/bz1e08uuXJ+U6cM6RuMbGxD0ynAUK6s","key":"test_secret"}],"status":"pending","tags":[],"updated_at":"2026-07-03T15:01:47.243240681Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "646"
@@ -38,9 +38,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:38:57 GMT
+                - Fri, 03 Jul 2026 15:01:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5d9d472e-c200-4e67-a017-dcce9f73b244
+                - 9b19ffd2-69df-4922-8a86-dd74198350ef
         status: 200 OK
         code: 200
-        duration: 1.982165787s
+        duration: 7.774016116s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -68,7 +68,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0437243b-fa6d-4bf4-b45b-ee59ab3636d7
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d1262a81-6e4d-4987-947f-562facb100d3
         method: GET
       response:
         proto: HTTP/2.0
@@ -78,7 +78,7 @@ interactions:
         trailer: {}
         content_length: 640
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.985871Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"0437243b-fa6d-4bf4-b45b-ee59ab3636d7","name":"tf-env-test","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$iiymTLmenWsw8otY1g7ZwQ$0T2xmtzqfty+xKRlSb5mRvWauDTyoXFL562X2c82jjE","key":"test_secret"}],"status":"pending","tags":[],"updated_at":"2026-05-04T12:38:57.985871Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.243241Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"d1262a81-6e4d-4987-947f-562facb100d3","name":"tf-env-test","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$S2VTFXE+LHaHryozLOClfA$LBJxqqHqN0h/bz1e08uuXJ+U6cM6RuMbGxD0ynAUK6s","key":"test_secret"}],"status":"pending","tags":[],"updated_at":"2026-07-03T15:01:47.243241Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "640"
@@ -87,9 +87,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:38:58 GMT
+                - Fri, 03 Jul 2026 15:01:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ffa0659a-333d-46ba-a23d-b8f50ec9f800
+                - 8b71be7a-d0b3-4eae-a479-4a995d1bc7e0
         status: 200 OK
         code: 200
-        duration: 67.376457ms
+        duration: 38.225469ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -117,7 +117,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0437243b-fa6d-4bf4-b45b-ee59ab3636d7
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d1262a81-6e4d-4987-947f-562facb100d3
         method: GET
       response:
         proto: HTTP/2.0
@@ -127,7 +127,7 @@ interactions:
         trailer: {}
         content_length: 718
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.985871Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"0437243b-fa6d-4bf4-b45b-ee59ab3636d7","name":"tf-env-test","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestxc92rk0r","registry_namespace_id":"9cc78b9b-5a28-4399-8146-6695d4bdb863","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$iiymTLmenWsw8otY1g7ZwQ$0T2xmtzqfty+xKRlSb5mRvWauDTyoXFL562X2c82jjE","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:13.865504Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.243241Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"d1262a81-6e4d-4987-947f-562facb100d3","name":"tf-env-test","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvteste6yxx8dt","registry_namespace_id":"ecaea40a-798a-4fb4-9436-1bec0f1b9b21","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$S2VTFXE+LHaHryozLOClfA$LBJxqqHqN0h/bz1e08uuXJ+U6cM6RuMbGxD0ynAUK6s","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2026-07-03T15:01:59.466642Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "718"
@@ -136,9 +136,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:18 GMT
+                - Fri, 03 Jul 2026 15:02:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dc25e823-ccc4-4984-8fc3-d0ea7f3ca48e
+                - 040bb296-d561-4a4d-8309-e15795388e31
         status: 200 OK
         code: 200
-        duration: 158.492279ms
+        duration: 30.094738ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -166,7 +166,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0437243b-fa6d-4bf4-b45b-ee59ab3636d7
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d1262a81-6e4d-4987-947f-562facb100d3
         method: GET
       response:
         proto: HTTP/2.0
@@ -176,7 +176,7 @@ interactions:
         trailer: {}
         content_length: 718
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.985871Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"0437243b-fa6d-4bf4-b45b-ee59ab3636d7","name":"tf-env-test","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestxc92rk0r","registry_namespace_id":"9cc78b9b-5a28-4399-8146-6695d4bdb863","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$iiymTLmenWsw8otY1g7ZwQ$0T2xmtzqfty+xKRlSb5mRvWauDTyoXFL562X2c82jjE","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:13.865504Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.243241Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"d1262a81-6e4d-4987-947f-562facb100d3","name":"tf-env-test","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvteste6yxx8dt","registry_namespace_id":"ecaea40a-798a-4fb4-9436-1bec0f1b9b21","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$S2VTFXE+LHaHryozLOClfA$LBJxqqHqN0h/bz1e08uuXJ+U6cM6RuMbGxD0ynAUK6s","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2026-07-03T15:01:59.466642Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "718"
@@ -185,9 +185,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:18 GMT
+                - Fri, 03 Jul 2026 15:02:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,10 +195,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 82802745-4ffd-4961-8139-87c9c8901694
+                - ada7edb5-c064-4e6c-9a35-c18b45536021
         status: 200 OK
         code: 200
-        duration: 32.939656ms
+        duration: 33.492418ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -215,7 +215,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0437243b-fa6d-4bf4-b45b-ee59ab3636d7
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d1262a81-6e4d-4987-947f-562facb100d3
         method: GET
       response:
         proto: HTTP/2.0
@@ -225,7 +225,7 @@ interactions:
         trailer: {}
         content_length: 718
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.985871Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"0437243b-fa6d-4bf4-b45b-ee59ab3636d7","name":"tf-env-test","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestxc92rk0r","registry_namespace_id":"9cc78b9b-5a28-4399-8146-6695d4bdb863","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$iiymTLmenWsw8otY1g7ZwQ$0T2xmtzqfty+xKRlSb5mRvWauDTyoXFL562X2c82jjE","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:13.865504Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.243241Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"d1262a81-6e4d-4987-947f-562facb100d3","name":"tf-env-test","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvteste6yxx8dt","registry_namespace_id":"ecaea40a-798a-4fb4-9436-1bec0f1b9b21","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$S2VTFXE+LHaHryozLOClfA$LBJxqqHqN0h/bz1e08uuXJ+U6cM6RuMbGxD0ynAUK6s","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2026-07-03T15:01:59.466642Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "718"
@@ -234,9 +234,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:18 GMT
+                - Fri, 03 Jul 2026 15:02:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -244,10 +244,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 729b8039-37a0-4365-9f3c-5f7466244032
+                - 41a72e5c-c7ce-4d6a-8827-661dba976161
         status: 200 OK
         code: 200
-        duration: 29.167087ms
+        duration: 36.504303ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -264,7 +264,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0437243b-fa6d-4bf4-b45b-ee59ab3636d7
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d1262a81-6e4d-4987-947f-562facb100d3
         method: GET
       response:
         proto: HTTP/2.0
@@ -274,7 +274,7 @@ interactions:
         trailer: {}
         content_length: 718
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.985871Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"0437243b-fa6d-4bf4-b45b-ee59ab3636d7","name":"tf-env-test","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestxc92rk0r","registry_namespace_id":"9cc78b9b-5a28-4399-8146-6695d4bdb863","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$iiymTLmenWsw8otY1g7ZwQ$0T2xmtzqfty+xKRlSb5mRvWauDTyoXFL562X2c82jjE","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:13.865504Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.243241Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"d1262a81-6e4d-4987-947f-562facb100d3","name":"tf-env-test","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvteste6yxx8dt","registry_namespace_id":"ecaea40a-798a-4fb4-9436-1bec0f1b9b21","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$S2VTFXE+LHaHryozLOClfA$LBJxqqHqN0h/bz1e08uuXJ+U6cM6RuMbGxD0ynAUK6s","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2026-07-03T15:01:59.466642Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "718"
@@ -283,9 +283,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:18 GMT
+                - Fri, 03 Jul 2026 15:02:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -293,10 +293,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 79efb4b1-e6e6-461b-a655-46d383b8fe9a
+                - 4c94cc6d-d9f4-4cc2-b611-dfdb88c712c7
         status: 200 OK
         code: 200
-        duration: 30.165676ms
+        duration: 43.13327ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -313,7 +313,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0437243b-fa6d-4bf4-b45b-ee59ab3636d7
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d1262a81-6e4d-4987-947f-562facb100d3
         method: GET
       response:
         proto: HTTP/2.0
@@ -323,7 +323,7 @@ interactions:
         trailer: {}
         content_length: 718
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.985871Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"0437243b-fa6d-4bf4-b45b-ee59ab3636d7","name":"tf-env-test","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestxc92rk0r","registry_namespace_id":"9cc78b9b-5a28-4399-8146-6695d4bdb863","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$iiymTLmenWsw8otY1g7ZwQ$0T2xmtzqfty+xKRlSb5mRvWauDTyoXFL562X2c82jjE","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:13.865504Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.243241Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"d1262a81-6e4d-4987-947f-562facb100d3","name":"tf-env-test","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvteste6yxx8dt","registry_namespace_id":"ecaea40a-798a-4fb4-9436-1bec0f1b9b21","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$S2VTFXE+LHaHryozLOClfA$LBJxqqHqN0h/bz1e08uuXJ+U6cM6RuMbGxD0ynAUK6s","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2026-07-03T15:01:59.466642Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "718"
@@ -332,9 +332,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:19 GMT
+                - Fri, 03 Jul 2026 15:02:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -342,10 +342,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 50ba018e-4677-4896-be2c-307154233603
+                - 66c75215-c7b5-4ccd-9823-75f43d83c8e2
         status: 200 OK
         code: 200
-        duration: 40.966988ms
+        duration: 37.715591ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -362,7 +362,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0437243b-fa6d-4bf4-b45b-ee59ab3636d7
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d1262a81-6e4d-4987-947f-562facb100d3
         method: GET
       response:
         proto: HTTP/2.0
@@ -372,7 +372,7 @@ interactions:
         trailer: {}
         content_length: 718
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.985871Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"0437243b-fa6d-4bf4-b45b-ee59ab3636d7","name":"tf-env-test","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestxc92rk0r","registry_namespace_id":"9cc78b9b-5a28-4399-8146-6695d4bdb863","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$iiymTLmenWsw8otY1g7ZwQ$0T2xmtzqfty+xKRlSb5mRvWauDTyoXFL562X2c82jjE","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:13.865504Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.243241Z","description":"","environment_variables":{"test":"test"},"error_message":null,"id":"d1262a81-6e4d-4987-947f-562facb100d3","name":"tf-env-test","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvteste6yxx8dt","registry_namespace_id":"ecaea40a-798a-4fb4-9436-1bec0f1b9b21","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$S2VTFXE+LHaHryozLOClfA$LBJxqqHqN0h/bz1e08uuXJ+U6cM6RuMbGxD0ynAUK6s","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2026-07-03T15:01:59.466642Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "718"
@@ -381,9 +381,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:19 GMT
+                - Fri, 03 Jul 2026 15:02:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -391,10 +391,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3cd23ca3-01d2-4bb7-a09b-340adbd3b94e
+                - 915c1fc4-e689-48b2-9552-5ca7f25cbfaa
         status: 200 OK
         code: 200
-        duration: 300.33853ms
+        duration: 34.266514ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -413,7 +413,7 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0437243b-fa6d-4bf4-b45b-ee59ab3636d7
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d1262a81-6e4d-4987-947f-562facb100d3
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -423,7 +423,7 @@ interactions:
         trailer: {}
         content_length: 721
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.985871Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"0437243b-fa6d-4bf4-b45b-ee59ab3636d7","name":"tf-env-test","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestxc92rk0r","registry_namespace_id":"9cc78b9b-5a28-4399-8146-6695d4bdb863","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$HQUj20sSgmb79dtFSmHdCw$ZhLXuDDjoNscFoQUhrWf7M5JjA71/Lo+wGLLyHRKXp0","key":"test_secret"}],"status":"pending","tags":[],"updated_at":"2026-05-04T12:39:20.074255051Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.243241Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"d1262a81-6e4d-4987-947f-562facb100d3","name":"tf-env-test","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvteste6yxx8dt","registry_namespace_id":"ecaea40a-798a-4fb4-9436-1bec0f1b9b21","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$g7/b/fBQzTSgq8q5GFDY1g$4eEzzo2WmS8sMjRO7D4WcgGzDFHucPhpjw66HiLtaZM","key":"test_secret"}],"status":"pending","tags":[],"updated_at":"2026-07-03T15:02:03.917705973Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "721"
@@ -432,9 +432,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:20 GMT
+                - Fri, 03 Jul 2026 15:02:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -442,10 +442,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e4687318-5596-4d32-a89f-fba67d01658a
+                - 99000455-3747-4a16-ab25-5f7da463e3bf
         status: 200 OK
         code: 200
-        duration: 364.097292ms
+        duration: 357.439888ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -462,7 +462,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0437243b-fa6d-4bf4-b45b-ee59ab3636d7
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d1262a81-6e4d-4987-947f-562facb100d3
         method: GET
       response:
         proto: HTTP/2.0
@@ -472,7 +472,7 @@ interactions:
         trailer: {}
         content_length: 718
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.985871Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"0437243b-fa6d-4bf4-b45b-ee59ab3636d7","name":"tf-env-test","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestxc92rk0r","registry_namespace_id":"9cc78b9b-5a28-4399-8146-6695d4bdb863","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$HQUj20sSgmb79dtFSmHdCw$ZhLXuDDjoNscFoQUhrWf7M5JjA71/Lo+wGLLyHRKXp0","key":"test_secret"}],"status":"pending","tags":[],"updated_at":"2026-05-04T12:39:20.074255Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.243241Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"d1262a81-6e4d-4987-947f-562facb100d3","name":"tf-env-test","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvteste6yxx8dt","registry_namespace_id":"ecaea40a-798a-4fb4-9436-1bec0f1b9b21","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$g7/b/fBQzTSgq8q5GFDY1g$4eEzzo2WmS8sMjRO7D4WcgGzDFHucPhpjw66HiLtaZM","key":"test_secret"}],"status":"pending","tags":[],"updated_at":"2026-07-03T15:02:03.917706Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "718"
@@ -481,9 +481,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:20 GMT
+                - Fri, 03 Jul 2026 15:02:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -491,10 +491,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 217ebc1f-e06d-427d-9fc7-34dff3bb9ad2
+                - b549696c-9e5f-4a2d-b620-d5d032c0a4a7
         status: 200 OK
         code: 200
-        duration: 217.798205ms
+        duration: 28.60148ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -511,7 +511,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0437243b-fa6d-4bf4-b45b-ee59ab3636d7
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d1262a81-6e4d-4987-947f-562facb100d3
         method: GET
       response:
         proto: HTTP/2.0
@@ -521,7 +521,7 @@ interactions:
         trailer: {}
         content_length: 716
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.985871Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"0437243b-fa6d-4bf4-b45b-ee59ab3636d7","name":"tf-env-test","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestxc92rk0r","registry_namespace_id":"9cc78b9b-5a28-4399-8146-6695d4bdb863","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$HQUj20sSgmb79dtFSmHdCw$ZhLXuDDjoNscFoQUhrWf7M5JjA71/Lo+wGLLyHRKXp0","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:20.754403Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.243241Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"d1262a81-6e4d-4987-947f-562facb100d3","name":"tf-env-test","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvteste6yxx8dt","registry_namespace_id":"ecaea40a-798a-4fb4-9436-1bec0f1b9b21","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$g7/b/fBQzTSgq8q5GFDY1g$4eEzzo2WmS8sMjRO7D4WcgGzDFHucPhpjw66HiLtaZM","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:04.393449Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "716"
@@ -530,9 +530,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:25 GMT
+                - Fri, 03 Jul 2026 15:02:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -540,10 +540,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - eb6aff9f-bb21-4439-a097-acaf1d6c9045
+                - c30ed163-6cfa-4aa3-9f05-1039e114cbf2
         status: 200 OK
         code: 200
-        duration: 29.50788ms
+        duration: 42.650461ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -560,7 +560,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0437243b-fa6d-4bf4-b45b-ee59ab3636d7
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d1262a81-6e4d-4987-947f-562facb100d3
         method: GET
       response:
         proto: HTTP/2.0
@@ -570,7 +570,7 @@ interactions:
         trailer: {}
         content_length: 716
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.985871Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"0437243b-fa6d-4bf4-b45b-ee59ab3636d7","name":"tf-env-test","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestxc92rk0r","registry_namespace_id":"9cc78b9b-5a28-4399-8146-6695d4bdb863","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$HQUj20sSgmb79dtFSmHdCw$ZhLXuDDjoNscFoQUhrWf7M5JjA71/Lo+wGLLyHRKXp0","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:20.754403Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.243241Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"d1262a81-6e4d-4987-947f-562facb100d3","name":"tf-env-test","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvteste6yxx8dt","registry_namespace_id":"ecaea40a-798a-4fb4-9436-1bec0f1b9b21","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$g7/b/fBQzTSgq8q5GFDY1g$4eEzzo2WmS8sMjRO7D4WcgGzDFHucPhpjw66HiLtaZM","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:04.393449Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "716"
@@ -579,9 +579,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:25 GMT
+                - Fri, 03 Jul 2026 15:02:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -589,10 +589,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 67f2e914-97a1-494b-b27f-adff5e70eee6
+                - d27280cb-fa40-49bd-9363-306293883a31
         status: 200 OK
         code: 200
-        duration: 34.887221ms
+        duration: 102.403638ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -609,7 +609,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0437243b-fa6d-4bf4-b45b-ee59ab3636d7
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d1262a81-6e4d-4987-947f-562facb100d3
         method: GET
       response:
         proto: HTTP/2.0
@@ -619,7 +619,7 @@ interactions:
         trailer: {}
         content_length: 716
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.985871Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"0437243b-fa6d-4bf4-b45b-ee59ab3636d7","name":"tf-env-test","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestxc92rk0r","registry_namespace_id":"9cc78b9b-5a28-4399-8146-6695d4bdb863","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$HQUj20sSgmb79dtFSmHdCw$ZhLXuDDjoNscFoQUhrWf7M5JjA71/Lo+wGLLyHRKXp0","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:20.754403Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.243241Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"d1262a81-6e4d-4987-947f-562facb100d3","name":"tf-env-test","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvteste6yxx8dt","registry_namespace_id":"ecaea40a-798a-4fb4-9436-1bec0f1b9b21","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$g7/b/fBQzTSgq8q5GFDY1g$4eEzzo2WmS8sMjRO7D4WcgGzDFHucPhpjw66HiLtaZM","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:04.393449Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "716"
@@ -628,9 +628,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:25 GMT
+                - Fri, 03 Jul 2026 15:02:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -638,10 +638,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 340909d4-e471-44d5-bc1d-21e7176dbce0
+                - 349765aa-4c06-4b98-abe9-fe415bf0fa2f
         status: 200 OK
         code: 200
-        duration: 38.097631ms
+        duration: 37.18359ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -658,7 +658,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0437243b-fa6d-4bf4-b45b-ee59ab3636d7
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d1262a81-6e4d-4987-947f-562facb100d3
         method: GET
       response:
         proto: HTTP/2.0
@@ -668,7 +668,7 @@ interactions:
         trailer: {}
         content_length: 716
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.985871Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"0437243b-fa6d-4bf4-b45b-ee59ab3636d7","name":"tf-env-test","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestxc92rk0r","registry_namespace_id":"9cc78b9b-5a28-4399-8146-6695d4bdb863","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$HQUj20sSgmb79dtFSmHdCw$ZhLXuDDjoNscFoQUhrWf7M5JjA71/Lo+wGLLyHRKXp0","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:20.754403Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.243241Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"d1262a81-6e4d-4987-947f-562facb100d3","name":"tf-env-test","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvteste6yxx8dt","registry_namespace_id":"ecaea40a-798a-4fb4-9436-1bec0f1b9b21","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$g7/b/fBQzTSgq8q5GFDY1g$4eEzzo2WmS8sMjRO7D4WcgGzDFHucPhpjw66HiLtaZM","key":"test_secret"}],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:04.393449Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "716"
@@ -677,9 +677,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:26 GMT
+                - Fri, 03 Jul 2026 15:02:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -687,10 +687,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 57f861e5-38b6-4b70-965b-53cb1a2e9918
+                - 7b19d3cc-3f14-442a-b21a-7b71860e2cf6
         status: 200 OK
         code: 200
-        duration: 76.931419ms
+        duration: 34.813062ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -707,7 +707,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0437243b-fa6d-4bf4-b45b-ee59ab3636d7
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d1262a81-6e4d-4987-947f-562facb100d3
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -717,7 +717,7 @@ interactions:
         trailer: {}
         content_length: 722
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.985871Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"0437243b-fa6d-4bf4-b45b-ee59ab3636d7","name":"tf-env-test","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestxc92rk0r","registry_namespace_id":"9cc78b9b-5a28-4399-8146-6695d4bdb863","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$HQUj20sSgmb79dtFSmHdCw$ZhLXuDDjoNscFoQUhrWf7M5JjA71/Lo+wGLLyHRKXp0","key":"test_secret"}],"status":"deleting","tags":[],"updated_at":"2026-05-04T12:39:26.193657910Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.243241Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"d1262a81-6e4d-4987-947f-562facb100d3","name":"tf-env-test","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvteste6yxx8dt","registry_namespace_id":"ecaea40a-798a-4fb4-9436-1bec0f1b9b21","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$g7/b/fBQzTSgq8q5GFDY1g$4eEzzo2WmS8sMjRO7D4WcgGzDFHucPhpjw66HiLtaZM","key":"test_secret"}],"status":"deleting","tags":[],"updated_at":"2026-07-03T15:02:09.853367135Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "722"
@@ -726,9 +726,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:26 GMT
+                - Fri, 03 Jul 2026 15:02:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -736,10 +736,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2aa5c5ed-2bd8-4544-96f9-70c724239eb3
+                - c997cd40-fc68-4161-a6f3-bde9da4b659c
         status: 200 OK
         code: 200
-        duration: 254.098384ms
+        duration: 302.872475ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -756,7 +756,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0437243b-fa6d-4bf4-b45b-ee59ab3636d7
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d1262a81-6e4d-4987-947f-562facb100d3
         method: GET
       response:
         proto: HTTP/2.0
@@ -766,7 +766,7 @@ interactions:
         trailer: {}
         content_length: 719
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.985871Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"0437243b-fa6d-4bf4-b45b-ee59ab3636d7","name":"tf-env-test","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvtestxc92rk0r","registry_namespace_id":"9cc78b9b-5a28-4399-8146-6695d4bdb863","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$HQUj20sSgmb79dtFSmHdCw$ZhLXuDDjoNscFoQUhrWf7M5JjA71/Lo+wGLLyHRKXp0","key":"test_secret"}],"status":"deleting","tags":[],"updated_at":"2026-05-04T12:39:26.193658Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.243241Z","description":"","environment_variables":{"foo":"bar"},"error_message":null,"id":"d1262a81-6e4d-4987-947f-562facb100d3","name":"tf-env-test","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtfenvteste6yxx8dt","registry_namespace_id":"ecaea40a-798a-4fb4-9436-1bec0f1b9b21","secret_environment_variables":[{"hashed_value":"$argon2id$v=19$m=65536,t=1,p=2$g7/b/fBQzTSgq8q5GFDY1g$4eEzzo2WmS8sMjRO7D4WcgGzDFHucPhpjw66HiLtaZM","key":"test_secret"}],"status":"deleting","tags":[],"updated_at":"2026-07-03T15:02:09.853367Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "719"
@@ -775,9 +775,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:26 GMT
+                - Fri, 03 Jul 2026 15:02:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -785,10 +785,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ca6f14fd-5491-484f-bba2-b4afb3171474
+                - b4e7e8c1-851e-425d-8746-6870052556f1
         status: 200 OK
         code: 200
-        duration: 31.251932ms
+        duration: 34.943567ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -805,7 +805,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0437243b-fa6d-4bf4-b45b-ee59ab3636d7
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d1262a81-6e4d-4987-947f-562facb100d3
         method: GET
       response:
         proto: HTTP/2.0
@@ -824,9 +824,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:31 GMT
+                - Fri, 03 Jul 2026 15:02:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -834,10 +834,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 497b92d1-74c6-4dd4-bb09-b797da918c63
+                - b7959f4e-55f0-409f-b8fb-0a97ce008cd9
         status: 404 Not Found
         code: 404
-        duration: 25.312597ms
+        duration: 53.65087ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -854,7 +854,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0437243b-fa6d-4bf4-b45b-ee59ab3636d7
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d1262a81-6e4d-4987-947f-562facb100d3
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -873,9 +873,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:31 GMT
+                - Fri, 03 Jul 2026 15:02:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -883,7 +883,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0169a07d-5761-4954-8526-4b9a921b1ae7
+                - c4be2a2a-fc45-49a7-b4c2-4b5ba782f585
         status: 404 Not Found
         code: 404
-        duration: 241.865766ms
+        duration: 21.693078ms

--- a/internal/services/function/testdata/function-namespace-no-name.cassette.yaml
+++ b/internal/services/function/testdata/function-namespace-no-name.cassette.yaml
@@ -6,13 +6,13 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 157
+        content_length: 159
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-func-quirky-shtern","environment_variables":{},"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","secret_environment_variables":[],"tags":null}'
+        body: '{"name":"tf-func-naughty-mclaren","environment_variables":{},"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","secret_environment_variables":[],"tags":null}'
         form: {}
         headers:
             Content-Type:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 507
+        content_length: 509
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.715205290Z","description":"","environment_variables":{},"error_message":null,"id":"e1263401-2566-4dae-a339-78f5d9f3ada7","name":"tf-func-quirky-shtern","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-05-04T12:38:57.715205290Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.228295790Z","description":"","environment_variables":{},"error_message":null,"id":"0f86c7ce-d09b-4052-a80c-b3f0ea97677c","name":"tf-func-naughty-mclaren","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-07-03T15:01:47.228295790Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "507"
+                - "509"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:38:57 GMT
+                - Fri, 03 Jul 2026 15:01:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f5b4c4e7-73df-499e-bb9b-c230538537e1
+                - 2cdf521d-33eb-4bf0-af8e-a357a6bb2d9f
         status: 200 OK
         code: 200
-        duration: 1.757695666s
+        duration: 7.727216903s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -68,7 +68,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e1263401-2566-4dae-a339-78f5d9f3ada7
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0f86c7ce-d09b-4052-a80c-b3f0ea97677c
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 501
+        content_length: 503
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.715205Z","description":"","environment_variables":{},"error_message":null,"id":"e1263401-2566-4dae-a339-78f5d9f3ada7","name":"tf-func-quirky-shtern","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-05-04T12:38:57.715205Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.228296Z","description":"","environment_variables":{},"error_message":null,"id":"0f86c7ce-d09b-4052-a80c-b3f0ea97677c","name":"tf-func-naughty-mclaren","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-07-03T15:01:47.228296Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "501"
+                - "503"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:38:57 GMT
+                - Fri, 03 Jul 2026 15:01:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a95878dc-2ba6-477f-bbaa-f499c1429a28
+                - ebae4514-dba0-41d1-af0e-630ddea0dc1d
         status: 200 OK
         code: 200
-        duration: 49.277487ms
+        duration: 43.770518ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -117,7 +117,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e1263401-2566-4dae-a339-78f5d9f3ada7
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0f86c7ce-d09b-4052-a80c-b3f0ea97677c
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,20 +125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 588
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.715205Z","description":"","environment_variables":{},"error_message":null,"id":"e1263401-2566-4dae-a339-78f5d9f3ada7","name":"tf-func-quirky-shtern","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncquirkyshternw61ubrm6","registry_namespace_id":"bc87fb62-9df8-4f25-8faa-6fe1523f7c69","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:26.089551Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.228296Z","description":"","environment_variables":{},"error_message":null,"id":"0f86c7ce-d09b-4052-a80c-b3f0ea97677c","name":"tf-func-naughty-mclaren","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncnaughtymclarenquskalmu","registry_namespace_id":"fc55cd09-bff2-4df3-b4fa-bca10f843bee","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:06.418988Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "588"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:27 GMT
+                - Fri, 03 Jul 2026 15:02:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 976da9ba-6750-4238-a0a2-f696da3ffcea
+                - a5c6d046-5192-4feb-8c6a-da16a2831d41
         status: 200 OK
         code: 200
-        duration: 27.749652ms
+        duration: 24.323194ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -166,7 +166,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e1263401-2566-4dae-a339-78f5d9f3ada7
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0f86c7ce-d09b-4052-a80c-b3f0ea97677c
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,20 +174,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 588
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.715205Z","description":"","environment_variables":{},"error_message":null,"id":"e1263401-2566-4dae-a339-78f5d9f3ada7","name":"tf-func-quirky-shtern","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncquirkyshternw61ubrm6","registry_namespace_id":"bc87fb62-9df8-4f25-8faa-6fe1523f7c69","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:26.089551Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.228296Z","description":"","environment_variables":{},"error_message":null,"id":"0f86c7ce-d09b-4052-a80c-b3f0ea97677c","name":"tf-func-naughty-mclaren","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncnaughtymclarenquskalmu","registry_namespace_id":"fc55cd09-bff2-4df3-b4fa-bca10f843bee","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:06.418988Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "588"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:28 GMT
+                - Fri, 03 Jul 2026 15:02:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,10 +195,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 60bddd48-76d9-4442-a92f-415ccf74caa2
+                - 1d042d98-e511-4ef7-8746-b88e3933edfc
         status: 200 OK
         code: 200
-        duration: 73.965259ms
+        duration: 33.322048ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -215,7 +215,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e1263401-2566-4dae-a339-78f5d9f3ada7
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0f86c7ce-d09b-4052-a80c-b3f0ea97677c
         method: GET
       response:
         proto: HTTP/2.0
@@ -223,20 +223,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 588
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.715205Z","description":"","environment_variables":{},"error_message":null,"id":"e1263401-2566-4dae-a339-78f5d9f3ada7","name":"tf-func-quirky-shtern","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncquirkyshternw61ubrm6","registry_namespace_id":"bc87fb62-9df8-4f25-8faa-6fe1523f7c69","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:26.089551Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.228296Z","description":"","environment_variables":{},"error_message":null,"id":"0f86c7ce-d09b-4052-a80c-b3f0ea97677c","name":"tf-func-naughty-mclaren","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncnaughtymclarenquskalmu","registry_namespace_id":"fc55cd09-bff2-4df3-b4fa-bca10f843bee","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:06.418988Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "588"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:28 GMT
+                - Fri, 03 Jul 2026 15:02:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -244,10 +244,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 02a1a977-eff5-466e-b672-ce8294e0af72
+                - 3843b106-cb30-4998-9f6f-d2787b0977a2
         status: 200 OK
         code: 200
-        duration: 40.836065ms
+        duration: 101.553108ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -264,7 +264,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e1263401-2566-4dae-a339-78f5d9f3ada7
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0f86c7ce-d09b-4052-a80c-b3f0ea97677c
         method: GET
       response:
         proto: HTTP/2.0
@@ -272,20 +272,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 588
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.715205Z","description":"","environment_variables":{},"error_message":null,"id":"e1263401-2566-4dae-a339-78f5d9f3ada7","name":"tf-func-quirky-shtern","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncquirkyshternw61ubrm6","registry_namespace_id":"bc87fb62-9df8-4f25-8faa-6fe1523f7c69","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:26.089551Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.228296Z","description":"","environment_variables":{},"error_message":null,"id":"0f86c7ce-d09b-4052-a80c-b3f0ea97677c","name":"tf-func-naughty-mclaren","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncnaughtymclarenquskalmu","registry_namespace_id":"fc55cd09-bff2-4df3-b4fa-bca10f843bee","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:06.418988Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "588"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:28 GMT
+                - Fri, 03 Jul 2026 15:02:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -293,10 +293,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b9f98e6d-7dee-4477-a415-fb50db18b9c5
+                - 7f8a3227-a286-4da2-a38e-1511ed0b73b2
         status: 200 OK
         code: 200
-        duration: 38.164768ms
+        duration: 25.671399ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -313,7 +313,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e1263401-2566-4dae-a339-78f5d9f3ada7
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0f86c7ce-d09b-4052-a80c-b3f0ea97677c
         method: GET
       response:
         proto: HTTP/2.0
@@ -321,20 +321,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 588
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.715205Z","description":"","environment_variables":{},"error_message":null,"id":"e1263401-2566-4dae-a339-78f5d9f3ada7","name":"tf-func-quirky-shtern","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncquirkyshternw61ubrm6","registry_namespace_id":"bc87fb62-9df8-4f25-8faa-6fe1523f7c69","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:26.089551Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.228296Z","description":"","environment_variables":{},"error_message":null,"id":"0f86c7ce-d09b-4052-a80c-b3f0ea97677c","name":"tf-func-naughty-mclaren","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncnaughtymclarenquskalmu","registry_namespace_id":"fc55cd09-bff2-4df3-b4fa-bca10f843bee","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:06.418988Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "588"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:28 GMT
+                - Fri, 03 Jul 2026 15:02:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -342,10 +342,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 640af4a4-dc90-4735-8a5d-9a3c9401ac36
+                - 16238592-1ed6-49f4-a395-cbe9193c08d3
         status: 200 OK
         code: 200
-        duration: 40.205298ms
+        duration: 30.571785ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -362,7 +362,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e1263401-2566-4dae-a339-78f5d9f3ada7
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0f86c7ce-d09b-4052-a80c-b3f0ea97677c
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -370,20 +370,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 594
+        content_length: 598
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.715205Z","description":"","environment_variables":{},"error_message":null,"id":"e1263401-2566-4dae-a339-78f5d9f3ada7","name":"tf-func-quirky-shtern","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncquirkyshternw61ubrm6","registry_namespace_id":"bc87fb62-9df8-4f25-8faa-6fe1523f7c69","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-05-04T12:39:28.736641954Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.228296Z","description":"","environment_variables":{},"error_message":null,"id":"0f86c7ce-d09b-4052-a80c-b3f0ea97677c","name":"tf-func-naughty-mclaren","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncnaughtymclarenquskalmu","registry_namespace_id":"fc55cd09-bff2-4df3-b4fa-bca10f843bee","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-07-03T15:02:08.221931357Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "594"
+                - "598"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:28 GMT
+                - Fri, 03 Jul 2026 15:02:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -391,10 +391,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5bb7c26e-923a-44d6-8f9e-214cf51d2b2d
+                - bbc240e4-5bda-4d7c-b033-f68ef0c485b2
         status: 200 OK
         code: 200
-        duration: 264.553328ms
+        duration: 285.963515ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -411,7 +411,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e1263401-2566-4dae-a339-78f5d9f3ada7
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0f86c7ce-d09b-4052-a80c-b3f0ea97677c
         method: GET
       response:
         proto: HTTP/2.0
@@ -419,20 +419,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 591
+        content_length: 595
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.715205Z","description":"","environment_variables":{},"error_message":null,"id":"e1263401-2566-4dae-a339-78f5d9f3ada7","name":"tf-func-quirky-shtern","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncquirkyshternw61ubrm6","registry_namespace_id":"bc87fb62-9df8-4f25-8faa-6fe1523f7c69","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-05-04T12:39:28.736642Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.228296Z","description":"","environment_variables":{},"error_message":null,"id":"0f86c7ce-d09b-4052-a80c-b3f0ea97677c","name":"tf-func-naughty-mclaren","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncnaughtymclarenquskalmu","registry_namespace_id":"fc55cd09-bff2-4df3-b4fa-bca10f843bee","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-07-03T15:02:08.221931Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "591"
+                - "595"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:28 GMT
+                - Fri, 03 Jul 2026 15:02:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -440,10 +440,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d39fe624-a3e9-4826-95eb-d7ea16e721b3
+                - fe38d6ca-4580-401a-8e09-358a911ec235
         status: 200 OK
         code: 200
-        duration: 32.195608ms
+        duration: 32.639815ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -460,7 +460,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e1263401-2566-4dae-a339-78f5d9f3ada7
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0f86c7ce-d09b-4052-a80c-b3f0ea97677c
         method: GET
       response:
         proto: HTTP/2.0
@@ -479,9 +479,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:34 GMT
+                - Fri, 03 Jul 2026 15:02:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -489,10 +489,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cabb6b4d-a0bc-49cb-a572-0b7252351df4
+                - 5670c714-990b-4356-aae2-e195b147f057
         status: 404 Not Found
         code: 404
-        duration: 21.273568ms
+        duration: 25.035063ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -509,7 +509,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/e1263401-2566-4dae-a339-78f5d9f3ada7
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/0f86c7ce-d09b-4052-a80c-b3f0ea97677c
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -528,9 +528,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:34 GMT
+                - Fri, 03 Jul 2026 15:02:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -538,7 +538,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 785676ec-4e93-4367-93fe-6527033683d4
+                - e374c722-2654-402b-b2cd-90524c755ef5
         status: 404 Not Found
         code: 404
-        duration: 19.690599ms
+        duration: 32.197032ms

--- a/internal/services/function/testdata/function-no-name.cassette.yaml
+++ b/internal/services/function/testdata/function-no-name.cassette.yaml
@@ -6,13 +6,13 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 164
+        content_length: 158
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-func-charming-stonebraker","environment_variables":{},"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","secret_environment_variables":[],"tags":null}'
+        body: '{"name":"tf-func-gracious-booth","environment_variables":{},"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","secret_environment_variables":[],"tags":null}'
         form: {}
         headers:
             Content-Type:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 514
+        content_length: 508
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:39:20.710494694Z","description":"","environment_variables":{},"error_message":null,"id":"d8548e3c-2a09-4750-b9d8-3a25ea1e486c","name":"tf-func-charming-stonebraker","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-05-04T12:39:20.710494694Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.355342780Z","description":"","environment_variables":{},"error_message":null,"id":"52462b00-af16-46cd-bf49-5f3c84839e58","name":"tf-func-gracious-booth","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-07-03T15:01:47.355342780Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "514"
+                - "508"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:20 GMT
+                - Fri, 03 Jul 2026 15:01:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f930fcf6-16e7-4714-8c22-194f528df321
+                - d2a49dd0-1eb2-4bed-8fdb-8cf99cebfa50
         status: 200 OK
         code: 200
-        duration: 631.710725ms
+        duration: 7.865204061s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -68,7 +68,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d8548e3c-2a09-4750-b9d8-3a25ea1e486c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/52462b00-af16-46cd-bf49-5f3c84839e58
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 508
+        content_length: 502
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:39:20.710495Z","description":"","environment_variables":{},"error_message":null,"id":"d8548e3c-2a09-4750-b9d8-3a25ea1e486c","name":"tf-func-charming-stonebraker","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-05-04T12:39:20.710495Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.355343Z","description":"","environment_variables":{},"error_message":null,"id":"52462b00-af16-46cd-bf49-5f3c84839e58","name":"tf-func-gracious-booth","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-07-03T15:01:47.355343Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "508"
+                - "502"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:20 GMT
+                - Fri, 03 Jul 2026 15:01:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 52d327ae-52e6-4987-a475-7664c36edbad
+                - 8d3175bc-b0af-46d6-9ac7-2b0c8a8045d0
         status: 200 OK
         code: 200
-        duration: 30.813786ms
+        duration: 43.543281ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -117,7 +117,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d8548e3c-2a09-4750-b9d8-3a25ea1e486c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/52462b00-af16-46cd-bf49-5f3c84839e58
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,20 +125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 597
+        content_length: 590
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:39:20.710495Z","description":"","environment_variables":{},"error_message":null,"id":"d8548e3c-2a09-4750-b9d8-3a25ea1e486c","name":"tf-func-charming-stonebraker","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunccharmingstoneb0uufgfhv","registry_namespace_id":"3cb751ce-6ce2-41a2-a00d-ab9fffc5f2e9","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:21.811890Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.355343Z","description":"","environment_variables":{},"error_message":null,"id":"52462b00-af16-46cd-bf49-5f3c84839e58","name":"tf-func-gracious-booth","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgraciousbooth7dui2p4d","registry_namespace_id":"92860882-0244-4569-a43f-771ece366ab5","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:06.714267Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "597"
+                - "590"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:25 GMT
+                - Fri, 03 Jul 2026 15:02:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 32eee247-b8a9-48bf-a823-59395513bae6
+                - d32f9615-468b-4254-81b0-2ff42022e58d
         status: 200 OK
         code: 200
-        duration: 28.717433ms
+        duration: 135.232548ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -166,7 +166,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d8548e3c-2a09-4750-b9d8-3a25ea1e486c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/52462b00-af16-46cd-bf49-5f3c84839e58
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,20 +174,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 597
+        content_length: 590
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:39:20.710495Z","description":"","environment_variables":{},"error_message":null,"id":"d8548e3c-2a09-4750-b9d8-3a25ea1e486c","name":"tf-func-charming-stonebraker","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunccharmingstoneb0uufgfhv","registry_namespace_id":"3cb751ce-6ce2-41a2-a00d-ab9fffc5f2e9","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:21.811890Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.355343Z","description":"","environment_variables":{},"error_message":null,"id":"52462b00-af16-46cd-bf49-5f3c84839e58","name":"tf-func-gracious-booth","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgraciousbooth7dui2p4d","registry_namespace_id":"92860882-0244-4569-a43f-771ece366ab5","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:06.714267Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "597"
+                - "590"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:25 GMT
+                - Fri, 03 Jul 2026 15:02:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,10 +195,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6ac1e991-b7b3-4edc-adf6-32e5e40da81e
+                - ea7a476a-308e-437c-95fd-0ba6eed5d785
         status: 200 OK
         code: 200
-        duration: 36.13546ms
+        duration: 34.961341ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -210,7 +210,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-func-inspiring-cannon","namespace_id":"d8548e3c-2a09-4750-b9d8-3a25ea1e486c","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node22","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox","tags":null}'
+        body: '{"name":"tf-func-wonderful-bartik","namespace_id":"52462b00-af16-46cd-bf49-5f3c84839e58","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node26","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox","tags":null}'
         form: {}
         headers:
             Content-Type:
@@ -225,20 +225,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 742
+        content_length: 741
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:25.892625928Z","description":"","domain_name":"tffunccharmingstoneb0uufgfhv-tf-func-inspiring-cannon.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"b77dc556-e701-400e-b1ea-a748dbb21da9","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-inspiring-cannon","namespace_id":"d8548e3c-2a09-4750-b9d8-3a25ea1e486c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:25.892625928Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:07.778989320Z","description":"","domain_name":"tffuncgraciousbooth7dui2p4d-tf-func-wonderful-bartik.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e36f6269-4dff-494c-88a6-ad76ce1f5b4f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-wonderful-bartik","namespace_id":"52462b00-af16-46cd-bf49-5f3c84839e58","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:07.778989320Z"}'
         headers:
             Content-Length:
-                - "742"
+                - "741"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:25 GMT
+                - Fri, 03 Jul 2026 15:02:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -246,10 +246,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a54869b0-ea61-4887-91ff-15e7f83004b5
+                - e5ef6850-f89a-4a4e-bb7c-764f8068e1fb
         status: 200 OK
         code: 200
-        duration: 97.584939ms
+        duration: 94.867004ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -266,7 +266,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/b77dc556-e701-400e-b1ea-a748dbb21da9
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e36f6269-4dff-494c-88a6-ad76ce1f5b4f
         method: GET
       response:
         proto: HTTP/2.0
@@ -274,20 +274,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 736
+        content_length: 735
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:25.892626Z","description":"","domain_name":"tffunccharmingstoneb0uufgfhv-tf-func-inspiring-cannon.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"b77dc556-e701-400e-b1ea-a748dbb21da9","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-inspiring-cannon","namespace_id":"d8548e3c-2a09-4750-b9d8-3a25ea1e486c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:25.892626Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:07.778989Z","description":"","domain_name":"tffuncgraciousbooth7dui2p4d-tf-func-wonderful-bartik.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e36f6269-4dff-494c-88a6-ad76ce1f5b4f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-wonderful-bartik","namespace_id":"52462b00-af16-46cd-bf49-5f3c84839e58","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:07.778989Z"}'
         headers:
             Content-Length:
-                - "736"
+                - "735"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:25 GMT
+                - Fri, 03 Jul 2026 15:02:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -295,10 +295,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 99277aa5-0991-4f5e-a1a6-9243006193d0
+                - c1d9ccdf-5800-4ba5-bea0-3eb28129eb6c
         status: 200 OK
         code: 200
-        duration: 47.894023ms
+        duration: 46.636809ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -315,7 +315,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/b77dc556-e701-400e-b1ea-a748dbb21da9
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e36f6269-4dff-494c-88a6-ad76ce1f5b4f
         method: GET
       response:
         proto: HTTP/2.0
@@ -323,20 +323,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 736
+        content_length: 735
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:25.892626Z","description":"","domain_name":"tffunccharmingstoneb0uufgfhv-tf-func-inspiring-cannon.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"b77dc556-e701-400e-b1ea-a748dbb21da9","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-inspiring-cannon","namespace_id":"d8548e3c-2a09-4750-b9d8-3a25ea1e486c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:25.892626Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:07.778989Z","description":"","domain_name":"tffuncgraciousbooth7dui2p4d-tf-func-wonderful-bartik.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e36f6269-4dff-494c-88a6-ad76ce1f5b4f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-wonderful-bartik","namespace_id":"52462b00-af16-46cd-bf49-5f3c84839e58","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:07.778989Z"}'
         headers:
             Content-Length:
-                - "736"
+                - "735"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:26 GMT
+                - Fri, 03 Jul 2026 15:02:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -344,10 +344,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cf86e688-4ba4-4374-8214-a82cf0eda061
+                - 807f2f99-283d-4310-8310-33fd127e53bb
         status: 200 OK
         code: 200
-        duration: 37.100465ms
+        duration: 34.146859ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -364,7 +364,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/b77dc556-e701-400e-b1ea-a748dbb21da9
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e36f6269-4dff-494c-88a6-ad76ce1f5b4f
         method: GET
       response:
         proto: HTTP/2.0
@@ -372,20 +372,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 736
+        content_length: 735
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:25.892626Z","description":"","domain_name":"tffunccharmingstoneb0uufgfhv-tf-func-inspiring-cannon.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"b77dc556-e701-400e-b1ea-a748dbb21da9","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-inspiring-cannon","namespace_id":"d8548e3c-2a09-4750-b9d8-3a25ea1e486c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:25.892626Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:07.778989Z","description":"","domain_name":"tffuncgraciousbooth7dui2p4d-tf-func-wonderful-bartik.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e36f6269-4dff-494c-88a6-ad76ce1f5b4f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-wonderful-bartik","namespace_id":"52462b00-af16-46cd-bf49-5f3c84839e58","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:07.778989Z"}'
         headers:
             Content-Length:
-                - "736"
+                - "735"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:26 GMT
+                - Fri, 03 Jul 2026 15:02:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -393,10 +393,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 596b050a-a16b-4774-9c84-d7dd373e89c3
+                - e085c376-6fcf-46c5-89da-65e7fd19b4a3
         status: 200 OK
         code: 200
-        duration: 47.701231ms
+        duration: 35.293075ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -413,7 +413,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d8548e3c-2a09-4750-b9d8-3a25ea1e486c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/52462b00-af16-46cd-bf49-5f3c84839e58
         method: GET
       response:
         proto: HTTP/2.0
@@ -421,20 +421,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 597
+        content_length: 590
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:39:20.710495Z","description":"","environment_variables":{},"error_message":null,"id":"d8548e3c-2a09-4750-b9d8-3a25ea1e486c","name":"tf-func-charming-stonebraker","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunccharmingstoneb0uufgfhv","registry_namespace_id":"3cb751ce-6ce2-41a2-a00d-ab9fffc5f2e9","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:21.811890Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.355343Z","description":"","environment_variables":{},"error_message":null,"id":"52462b00-af16-46cd-bf49-5f3c84839e58","name":"tf-func-gracious-booth","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgraciousbooth7dui2p4d","registry_namespace_id":"92860882-0244-4569-a43f-771ece366ab5","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:06.714267Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "597"
+                - "590"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:26 GMT
+                - Fri, 03 Jul 2026 15:02:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -442,10 +442,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 81b338ac-6145-49cb-bb99-020aaa451fb2
+                - ede69eaa-970e-4512-b097-d20988377a4b
         status: 200 OK
         code: 200
-        duration: 30.332301ms
+        duration: 42.590869ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -462,7 +462,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/b77dc556-e701-400e-b1ea-a748dbb21da9
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e36f6269-4dff-494c-88a6-ad76ce1f5b4f
         method: GET
       response:
         proto: HTTP/2.0
@@ -470,20 +470,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 736
+        content_length: 735
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:25.892626Z","description":"","domain_name":"tffunccharmingstoneb0uufgfhv-tf-func-inspiring-cannon.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"b77dc556-e701-400e-b1ea-a748dbb21da9","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-inspiring-cannon","namespace_id":"d8548e3c-2a09-4750-b9d8-3a25ea1e486c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:25.892626Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:07.778989Z","description":"","domain_name":"tffuncgraciousbooth7dui2p4d-tf-func-wonderful-bartik.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e36f6269-4dff-494c-88a6-ad76ce1f5b4f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-wonderful-bartik","namespace_id":"52462b00-af16-46cd-bf49-5f3c84839e58","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:07.778989Z"}'
         headers:
             Content-Length:
-                - "736"
+                - "735"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:26 GMT
+                - Fri, 03 Jul 2026 15:02:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -491,10 +491,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 460cacc0-137e-44a3-96a1-4402f917b68a
+                - 002becc0-ddda-4f12-8f95-7a0e393936e1
         status: 200 OK
         code: 200
-        duration: 35.020753ms
+        duration: 35.020482ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -511,7 +511,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/b77dc556-e701-400e-b1ea-a748dbb21da9
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e36f6269-4dff-494c-88a6-ad76ce1f5b4f
         method: GET
       response:
         proto: HTTP/2.0
@@ -519,20 +519,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 736
+        content_length: 735
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:25.892626Z","description":"","domain_name":"tffunccharmingstoneb0uufgfhv-tf-func-inspiring-cannon.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"b77dc556-e701-400e-b1ea-a748dbb21da9","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-inspiring-cannon","namespace_id":"d8548e3c-2a09-4750-b9d8-3a25ea1e486c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:25.892626Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:07.778989Z","description":"","domain_name":"tffuncgraciousbooth7dui2p4d-tf-func-wonderful-bartik.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e36f6269-4dff-494c-88a6-ad76ce1f5b4f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-wonderful-bartik","namespace_id":"52462b00-af16-46cd-bf49-5f3c84839e58","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:07.778989Z"}'
         headers:
             Content-Length:
-                - "736"
+                - "735"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:26 GMT
+                - Fri, 03 Jul 2026 15:02:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -540,10 +540,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4bed6f75-a772-4d67-948d-f0e42ab47f5e
+                - 77c23e70-b98a-423c-8f64-8fe37c50c169
         status: 200 OK
         code: 200
-        duration: 37.142755ms
+        duration: 45.888491ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -560,7 +560,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/b77dc556-e701-400e-b1ea-a748dbb21da9
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e36f6269-4dff-494c-88a6-ad76ce1f5b4f
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -568,20 +568,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 740
+        content_length: 739
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:25.892626Z","description":"","domain_name":"tffunccharmingstoneb0uufgfhv-tf-func-inspiring-cannon.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"b77dc556-e701-400e-b1ea-a748dbb21da9","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-inspiring-cannon","namespace_id":"d8548e3c-2a09-4750-b9d8-3a25ea1e486c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:26.790896834Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:07.778989Z","description":"","domain_name":"tffuncgraciousbooth7dui2p4d-tf-func-wonderful-bartik.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"e36f6269-4dff-494c-88a6-ad76ce1f5b4f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-wonderful-bartik","namespace_id":"52462b00-af16-46cd-bf49-5f3c84839e58","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:08.663682972Z"}'
         headers:
             Content-Length:
-                - "740"
+                - "739"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:26 GMT
+                - Fri, 03 Jul 2026 15:02:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -589,10 +589,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1906dec6-4980-41e0-a5d3-ecc3ee979dba
+                - 2b1aa315-0e41-4b21-9bc0-053013a98988
         status: 200 OK
         code: 200
-        duration: 146.709338ms
+        duration: 129.733637ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -609,7 +609,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d8548e3c-2a09-4750-b9d8-3a25ea1e486c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/52462b00-af16-46cd-bf49-5f3c84839e58
         method: GET
       response:
         proto: HTTP/2.0
@@ -617,20 +617,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 597
+        content_length: 590
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:39:20.710495Z","description":"","environment_variables":{},"error_message":null,"id":"d8548e3c-2a09-4750-b9d8-3a25ea1e486c","name":"tf-func-charming-stonebraker","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunccharmingstoneb0uufgfhv","registry_namespace_id":"3cb751ce-6ce2-41a2-a00d-ab9fffc5f2e9","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:21.811890Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.355343Z","description":"","environment_variables":{},"error_message":null,"id":"52462b00-af16-46cd-bf49-5f3c84839e58","name":"tf-func-gracious-booth","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgraciousbooth7dui2p4d","registry_namespace_id":"92860882-0244-4569-a43f-771ece366ab5","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:06.714267Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "597"
+                - "590"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:26 GMT
+                - Fri, 03 Jul 2026 15:02:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -638,10 +638,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4321722f-bd64-4522-8dbe-c0d228664dc6
+                - 7cfd678f-51b1-4efe-8691-fc6ade10ded5
         status: 200 OK
         code: 200
-        duration: 29.458547ms
+        duration: 40.726083ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -658,7 +658,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d8548e3c-2a09-4750-b9d8-3a25ea1e486c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/52462b00-af16-46cd-bf49-5f3c84839e58
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -666,20 +666,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 603
+        content_length: 596
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:39:20.710495Z","description":"","environment_variables":{},"error_message":null,"id":"d8548e3c-2a09-4750-b9d8-3a25ea1e486c","name":"tf-func-charming-stonebraker","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunccharmingstoneb0uufgfhv","registry_namespace_id":"3cb751ce-6ce2-41a2-a00d-ab9fffc5f2e9","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-05-04T12:39:26.988716353Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.355343Z","description":"","environment_variables":{},"error_message":null,"id":"52462b00-af16-46cd-bf49-5f3c84839e58","name":"tf-func-gracious-booth","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgraciousbooth7dui2p4d","registry_namespace_id":"92860882-0244-4569-a43f-771ece366ab5","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-07-03T15:02:08.851428854Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "603"
+                - "596"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:27 GMT
+                - Fri, 03 Jul 2026 15:02:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -687,10 +687,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e5c10e15-0442-4684-ad61-c0961346473c
+                - 4753bb9f-1a81-4ba8-bedd-da3d14958889
         status: 200 OK
         code: 200
-        duration: 360.765162ms
+        duration: 259.39101ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -707,7 +707,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d8548e3c-2a09-4750-b9d8-3a25ea1e486c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/52462b00-af16-46cd-bf49-5f3c84839e58
         method: GET
       response:
         proto: HTTP/2.0
@@ -715,20 +715,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 600
+        content_length: 593
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:39:20.710495Z","description":"","environment_variables":{},"error_message":null,"id":"d8548e3c-2a09-4750-b9d8-3a25ea1e486c","name":"tf-func-charming-stonebraker","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunccharmingstoneb0uufgfhv","registry_namespace_id":"3cb751ce-6ce2-41a2-a00d-ab9fffc5f2e9","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-05-04T12:39:26.988716Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.355343Z","description":"","environment_variables":{},"error_message":null,"id":"52462b00-af16-46cd-bf49-5f3c84839e58","name":"tf-func-gracious-booth","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncgraciousbooth7dui2p4d","registry_namespace_id":"92860882-0244-4569-a43f-771ece366ab5","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-07-03T15:02:08.851429Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "600"
+                - "593"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:27 GMT
+                - Fri, 03 Jul 2026 15:02:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -736,10 +736,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5f2a2746-1796-4ad1-81bf-933d91dd4058
+                - e88217c0-193a-451f-bac4-389d88c3d4cf
         status: 200 OK
         code: 200
-        duration: 31.311413ms
+        duration: 38.842761ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -756,7 +756,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d8548e3c-2a09-4750-b9d8-3a25ea1e486c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/52462b00-af16-46cd-bf49-5f3c84839e58
         method: GET
       response:
         proto: HTTP/2.0
@@ -775,9 +775,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:57 GMT
+                - Fri, 03 Jul 2026 15:02:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -785,10 +785,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bd63443d-afc2-4204-a2ca-4d00c1d4ff98
+                - 36e03aa8-12dc-42b9-9a98-18b15878471e
         status: 404 Not Found
         code: 404
-        duration: 25.225488ms
+        duration: 25.131915ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -805,7 +805,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d8548e3c-2a09-4750-b9d8-3a25ea1e486c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/52462b00-af16-46cd-bf49-5f3c84839e58
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -824,9 +824,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:57 GMT
+                - Fri, 03 Jul 2026 15:02:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -834,7 +834,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - db93838e-594a-4c80-b92a-10c091c4e140
+                - 7f36ff8f-9639-43a8-8fcb-58b2a795ba86
         status: 404 Not Found
         code: 404
-        duration: 36.29643ms
+        duration: 25.444633ms

--- a/internal/services/function/testdata/function-private-network.cassette.yaml
+++ b/internal/services/function/testdata/function-private-network.cassette.yaml
@@ -6,13 +6,13 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 126
+        content_length: 154
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"TestAccFunction_PrivateNetwork","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"enable_routing":false}'
+        body: '{"name":"TestAccFunction_PrivateNetwork","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"enable_routing":false,"enable_transitivity":false}'
         form: {}
         headers:
             Content-Type:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 417
+        content_length: 446
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:55.544747Z","custom_routes_propagation_enabled":true,"id":"36d3c8ee-561c-47f5-95b1-973aa85443ef","is_default":false,"name":"TestAccFunction_PrivateNetwork","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_count":0,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","routing_enabled":true,"tags":[],"updated_at":"2026-05-04T12:38:55.544747Z"}'
+        body: '{"created_at":"2026-07-03T15:09:36.087385Z","custom_routes_propagation_enabled":true,"id":"6bb31d81-005b-4aea-adcf-add0bd121f33","is_default":false,"name":"TestAccFunction_PrivateNetwork","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_count":0,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","routing_enabled":true,"tags":[],"transitivity_enabled":false,"updated_at":"2026-07-03T15:09:36.087385Z"}'
         headers:
             Content-Length:
-                - "417"
+                - "446"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:38:55 GMT
+                - Fri, 03 Jul 2026 15:09:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b168f783-5b35-4fd0-89a1-b4f10a5b5cf5
+                - aca483d8-dcf6-401c-85e5-aa4d5238cf4d
         status: 200 OK
         code: 200
-        duration: 137.74481ms
+        duration: 118.365439ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -68,7 +68,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/36d3c8ee-561c-47f5-95b1-973aa85443ef
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/6bb31d81-005b-4aea-adcf-add0bd121f33
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 417
+        content_length: 446
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:55.544747Z","custom_routes_propagation_enabled":true,"id":"36d3c8ee-561c-47f5-95b1-973aa85443ef","is_default":false,"name":"TestAccFunction_PrivateNetwork","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_count":0,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","routing_enabled":true,"tags":[],"updated_at":"2026-05-04T12:38:55.544747Z"}'
+        body: '{"created_at":"2026-07-03T15:09:36.087385Z","custom_routes_propagation_enabled":true,"id":"6bb31d81-005b-4aea-adcf-add0bd121f33","is_default":false,"name":"TestAccFunction_PrivateNetwork","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_count":0,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","routing_enabled":true,"tags":[],"transitivity_enabled":false,"updated_at":"2026-07-03T15:09:36.087385Z"}'
         headers:
             Content-Length:
-                - "417"
+                - "446"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:38:55 GMT
+                - Fri, 03 Jul 2026 15:09:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a65b9d89-14a4-4619-86c5-a8fe6f8ff58b
+                - 36b1f676-6f57-461b-809a-75ad5e9de0d4
         status: 200 OK
         code: 200
-        duration: 79.027976ms
+        duration: 53.783716ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -112,7 +112,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"test-acc-function-pn-pn01","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"subnets":null,"vpc_id":"36d3c8ee-561c-47f5-95b1-973aa85443ef","default_route_propagation_enabled":false}'
+        body: '{"name":"test-acc-function-pn-pn01","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"subnets":null,"vpc_id":"6bb31d81-005b-4aea-adcf-add0bd121f33","default_route_propagation_enabled":false}'
         form: {}
         headers:
             Content-Type:
@@ -127,20 +127,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1070
+        content_length: 1107
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:55.688803Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"eeff176d-2ea9-4c03-bd41-675e65c0b176","name":"test-acc-function-pn-pn01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2026-05-04T12:38:55.688803Z","id":"d6a2cf65-6a4d-48e0-88b7-e779a952842a","private_network_id":"eeff176d-2ea9-4c03-bd41-675e65c0b176","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.0.0/22","updated_at":"2026-05-04T12:38:55.688803Z","vpc_id":"36d3c8ee-561c-47f5-95b1-973aa85443ef"},{"created_at":"2026-05-04T12:38:55.688803Z","id":"f5939756-132f-44dd-8f7d-8b9c679373e8","private_network_id":"eeff176d-2ea9-4c03-bd41-675e65c0b176","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:9c9b::/64","updated_at":"2026-05-04T12:38:55.688803Z","vpc_id":"36d3c8ee-561c-47f5-95b1-973aa85443ef"}],"tags":[],"updated_at":"2026-05-04T12:38:55.688803Z","vpc_id":"36d3c8ee-561c-47f5-95b1-973aa85443ef"}'
+        body: '{"created_at":"2026-07-03T15:09:36.236952Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"c46dd6b8-6100-4f5b-9abd-e63d17bccaf0","name":"test-acc-function-pn-pn01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2026-07-03T15:09:36.236952Z","id":"8eb6d00f-c872-4fec-99ea-d7da2e69b216","private_network_id":"c46dd6b8-6100-4f5b-9abd-e63d17bccaf0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnet":"172.16.64.0/22","updated_at":"2026-07-03T15:09:36.236952Z","vpc_id":"6bb31d81-005b-4aea-adcf-add0bd121f33"},{"created_at":"2026-07-03T15:09:36.236952Z","id":"b05f379d-6785-4c2e-a230-7b60778339f9","private_network_id":"c46dd6b8-6100-4f5b-9abd-e63d17bccaf0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnet":"fd63:256c:45f7:ad3f::/64","updated_at":"2026-07-03T15:09:36.236952Z","vpc_id":"6bb31d81-005b-4aea-adcf-add0bd121f33"}],"tags":[],"updated_at":"2026-07-03T15:09:36.236952Z","vpc_id":"6bb31d81-005b-4aea-adcf-add0bd121f33"}'
         headers:
             Content-Length:
-                - "1070"
+                - "1107"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:38:56 GMT
+                - Fri, 03 Jul 2026 15:09:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -148,10 +148,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8cc8b846-85cd-4c47-95ed-802a20753979
+                - 3dc26f3f-3cf2-4973-b009-55e51659a309
         status: 200 OK
         code: 200
-        duration: 688.462323ms
+        duration: 644.212803ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -168,7 +168,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/eeff176d-2ea9-4c03-bd41-675e65c0b176
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c46dd6b8-6100-4f5b-9abd-e63d17bccaf0
         method: GET
       response:
         proto: HTTP/2.0
@@ -176,20 +176,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1070
+        content_length: 1107
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:55.688803Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"eeff176d-2ea9-4c03-bd41-675e65c0b176","name":"test-acc-function-pn-pn01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2026-05-04T12:38:55.688803Z","id":"d6a2cf65-6a4d-48e0-88b7-e779a952842a","private_network_id":"eeff176d-2ea9-4c03-bd41-675e65c0b176","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.0.0/22","updated_at":"2026-05-04T12:38:55.688803Z","vpc_id":"36d3c8ee-561c-47f5-95b1-973aa85443ef"},{"created_at":"2026-05-04T12:38:55.688803Z","id":"f5939756-132f-44dd-8f7d-8b9c679373e8","private_network_id":"eeff176d-2ea9-4c03-bd41-675e65c0b176","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:9c9b::/64","updated_at":"2026-05-04T12:38:55.688803Z","vpc_id":"36d3c8ee-561c-47f5-95b1-973aa85443ef"}],"tags":[],"updated_at":"2026-05-04T12:38:55.688803Z","vpc_id":"36d3c8ee-561c-47f5-95b1-973aa85443ef"}'
+        body: '{"created_at":"2026-07-03T15:09:36.236952Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"c46dd6b8-6100-4f5b-9abd-e63d17bccaf0","name":"test-acc-function-pn-pn01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2026-07-03T15:09:36.236952Z","id":"8eb6d00f-c872-4fec-99ea-d7da2e69b216","private_network_id":"c46dd6b8-6100-4f5b-9abd-e63d17bccaf0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnet":"172.16.64.0/22","updated_at":"2026-07-03T15:09:36.236952Z","vpc_id":"6bb31d81-005b-4aea-adcf-add0bd121f33"},{"created_at":"2026-07-03T15:09:36.236952Z","id":"b05f379d-6785-4c2e-a230-7b60778339f9","private_network_id":"c46dd6b8-6100-4f5b-9abd-e63d17bccaf0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnet":"fd63:256c:45f7:ad3f::/64","updated_at":"2026-07-03T15:09:36.236952Z","vpc_id":"6bb31d81-005b-4aea-adcf-add0bd121f33"}],"tags":[],"updated_at":"2026-07-03T15:09:36.236952Z","vpc_id":"6bb31d81-005b-4aea-adcf-add0bd121f33"}'
         headers:
             Content-Length:
-                - "1070"
+                - "1107"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:38:56 GMT
+                - Fri, 03 Jul 2026 15:09:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -197,62 +197,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1b257c19-55a4-4e9b-bad2-54aeebbc0665
+                - 6e53a76f-d7d3-4fae-bc67-fa01b46cb0e6
         status: 200 OK
         code: 200
-        duration: 47.106993ms
+        duration: 26.727129ms
     - id: 4
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 156
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"name":"tf-func-elated-rubin","environment_variables":{},"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","secret_environment_variables":[],"tags":null}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 506
-        uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:56.371001061Z","description":"","environment_variables":{},"error_message":null,"id":"87948c6d-ea10-40ec-82b5-05977516bd00","name":"tf-func-elated-rubin","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-05-04T12:38:56.371001061Z","vpc_integration_activated":false}'
-        headers:
-            Content-Length:
-                - "506"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 04 May 2026 12:38:56 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 85c4d6b0-592c-46e6-9991-3737108964e2
-        status: 200 OK
-        code: 200
-        duration: 987.620481ms
-    - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -263,7 +212,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"test-acc-function-pn-pn00","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"subnets":null,"vpc_id":"36d3c8ee-561c-47f5-95b1-973aa85443ef","default_route_propagation_enabled":false}'
+        body: '{"name":"test-acc-function-pn-pn00","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"subnets":null,"vpc_id":"6bb31d81-005b-4aea-adcf-add0bd121f33","default_route_propagation_enabled":false}'
         form: {}
         headers:
             Content-Type:
@@ -278,20 +227,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1071
+        content_length: 1107
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:55.819981Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","name":"test-acc-function-pn-pn00","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2026-05-04T12:38:55.819981Z","id":"5f3c1582-5862-4175-80ab-9ca9aa98642b","private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.16.0/22","updated_at":"2026-05-04T12:38:55.819981Z","vpc_id":"36d3c8ee-561c-47f5-95b1-973aa85443ef"},{"created_at":"2026-05-04T12:38:55.819981Z","id":"03c23551-f7c3-4677-95e2-b3c06a282251","private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:8f19::/64","updated_at":"2026-05-04T12:38:55.819981Z","vpc_id":"36d3c8ee-561c-47f5-95b1-973aa85443ef"}],"tags":[],"updated_at":"2026-05-04T12:38:55.819981Z","vpc_id":"36d3c8ee-561c-47f5-95b1-973aa85443ef"}'
+        body: '{"created_at":"2026-07-03T15:09:36.386569Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"9c7ec006-9f9c-4337-acf3-2c7040516407","name":"test-acc-function-pn-pn00","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2026-07-03T15:09:36.386569Z","id":"9b301033-da29-4986-b09e-a1985e20cca8","private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnet":"172.16.76.0/22","updated_at":"2026-07-03T15:09:36.386569Z","vpc_id":"6bb31d81-005b-4aea-adcf-add0bd121f33"},{"created_at":"2026-07-03T15:09:36.386569Z","id":"982a3685-d413-4a51-9c3a-e9c29efb452b","private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnet":"fd63:256c:45f7:9f34::/64","updated_at":"2026-07-03T15:09:36.386569Z","vpc_id":"6bb31d81-005b-4aea-adcf-add0bd121f33"}],"tags":[],"updated_at":"2026-07-03T15:09:36.386569Z","vpc_id":"6bb31d81-005b-4aea-adcf-add0bd121f33"}'
         headers:
             Content-Length:
-                - "1071"
+                - "1107"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:38:56 GMT
+                - Fri, 03 Jul 2026 15:09:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -299,11 +248,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 74b22189-f6ad-4c8c-ad99-ca550b496ce0
+                - 76641adb-c709-43f7-8f30-b6a92e88bed0
         status: 200 OK
         code: 200
-        duration: 786.63719ms
-    - id: 6
+        duration: 679.91437ms
+    - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -319,7 +268,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/87948c6d-ea10-40ec-82b5-05977516bd00
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9c7ec006-9f9c-4337-acf3-2c7040516407
         method: GET
       response:
         proto: HTTP/2.0
@@ -327,20 +276,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 500
+        content_length: 1107
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:56.371001Z","description":"","environment_variables":{},"error_message":null,"id":"87948c6d-ea10-40ec-82b5-05977516bd00","name":"tf-func-elated-rubin","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-05-04T12:38:56.371001Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:09:36.386569Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"9c7ec006-9f9c-4337-acf3-2c7040516407","name":"test-acc-function-pn-pn00","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2026-07-03T15:09:36.386569Z","id":"9b301033-da29-4986-b09e-a1985e20cca8","private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnet":"172.16.76.0/22","updated_at":"2026-07-03T15:09:36.386569Z","vpc_id":"6bb31d81-005b-4aea-adcf-add0bd121f33"},{"created_at":"2026-07-03T15:09:36.386569Z","id":"982a3685-d413-4a51-9c3a-e9c29efb452b","private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnet":"fd63:256c:45f7:9f34::/64","updated_at":"2026-07-03T15:09:36.386569Z","vpc_id":"6bb31d81-005b-4aea-adcf-add0bd121f33"}],"tags":[],"updated_at":"2026-07-03T15:09:36.386569Z","vpc_id":"6bb31d81-005b-4aea-adcf-add0bd121f33"}'
         headers:
             Content-Length:
-                - "500"
+                - "1107"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:38:56 GMT
+                - Fri, 03 Jul 2026 15:09:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -348,10 +297,61 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 65ab42ff-651f-4817-98a2-8b0004a86dc7
+                - 182c105f-772b-4cf1-8d4a-6ea38bc19cd0
         status: 200 OK
         code: 200
-        duration: 47.809093ms
+        duration: 29.713912ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 160
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"tf-func-admiring-haslett","environment_variables":{},"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","secret_environment_variables":[],"tags":null}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 510
+        uncompressed: false
+        body: '{"created_at":"2026-07-03T15:09:40.800077693Z","description":"","environment_variables":{},"error_message":null,"id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","name":"tf-func-admiring-haslett","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-07-03T15:09:40.800077693Z","vpc_integration_activated":false}'
+        headers:
+            Content-Length:
+                - "510"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:09:40 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c4dbf4da-552c-4dd8-8d1a-e5b62bc3713a
+        status: 200 OK
+        code: 200
+        duration: 4.841485095s
     - id: 7
       request:
         proto: HTTP/1.1
@@ -368,7 +368,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/258f0f17-2b28-41a2-bba5-d15b6f0902f6
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8e8949ba-0f49-4761-ad34-e9a02d75bc55
         method: GET
       response:
         proto: HTTP/2.0
@@ -376,20 +376,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1071
+        content_length: 504
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:55.819981Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","name":"test-acc-function-pn-pn00","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2026-05-04T12:38:55.819981Z","id":"5f3c1582-5862-4175-80ab-9ca9aa98642b","private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.16.0/22","updated_at":"2026-05-04T12:38:55.819981Z","vpc_id":"36d3c8ee-561c-47f5-95b1-973aa85443ef"},{"created_at":"2026-05-04T12:38:55.819981Z","id":"03c23551-f7c3-4677-95e2-b3c06a282251","private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:8f19::/64","updated_at":"2026-05-04T12:38:55.819981Z","vpc_id":"36d3c8ee-561c-47f5-95b1-973aa85443ef"}],"tags":[],"updated_at":"2026-05-04T12:38:55.819981Z","vpc_id":"36d3c8ee-561c-47f5-95b1-973aa85443ef"}'
+        body: '{"created_at":"2026-07-03T15:09:40.800078Z","description":"","environment_variables":{},"error_message":null,"id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","name":"tf-func-admiring-haslett","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-07-03T15:09:40.800078Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "1071"
+                - "504"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:38:56 GMT
+                - Fri, 03 Jul 2026 15:09:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -397,10 +397,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4cd264ed-a5ec-4fb7-befb-3a906496c983
+                - 5027b18d-426d-411e-8b97-55534d2e297e
         status: 200 OK
         code: 200
-        duration: 45.731165ms
+        duration: 56.268887ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -417,7 +417,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/87948c6d-ea10-40ec-82b5-05977516bd00
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8e8949ba-0f49-4761-ad34-e9a02d75bc55
         method: GET
       response:
         proto: HTTP/2.0
@@ -425,20 +425,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 586
+        content_length: 593
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:56.371001Z","description":"","environment_variables":{},"error_message":null,"id":"87948c6d-ea10-40ec-82b5-05977516bd00","name":"tf-func-elated-rubin","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncelatedrubinryziaplj","registry_namespace_id":"0e89ad85-7b5a-48f1-9080-d79156d162ee","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:05.966803Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:09:40.800078Z","description":"","environment_variables":{},"error_message":null,"id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","name":"tf-func-admiring-haslett","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncadmiringhaslettwulbygg","registry_namespace_id":"29b67960-08ff-47ff-b909-a8a7819f1ee9","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:09:43.490527Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "586"
+                - "593"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:06 GMT
+                - Fri, 03 Jul 2026 15:09:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -446,10 +446,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a80161aa-5f9a-4d26-a82a-b482c21f196b
+                - 9e4f77d4-fb5a-41df-83f7-ac6e164be67c
         status: 200 OK
         code: 200
-        duration: 34.250539ms
+        duration: 44.612889ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -466,7 +466,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/87948c6d-ea10-40ec-82b5-05977516bd00
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8e8949ba-0f49-4761-ad34-e9a02d75bc55
         method: GET
       response:
         proto: HTTP/2.0
@@ -474,20 +474,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 586
+        content_length: 593
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:56.371001Z","description":"","environment_variables":{},"error_message":null,"id":"87948c6d-ea10-40ec-82b5-05977516bd00","name":"tf-func-elated-rubin","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncelatedrubinryziaplj","registry_namespace_id":"0e89ad85-7b5a-48f1-9080-d79156d162ee","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:05.966803Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:09:40.800078Z","description":"","environment_variables":{},"error_message":null,"id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","name":"tf-func-admiring-haslett","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncadmiringhaslettwulbygg","registry_namespace_id":"29b67960-08ff-47ff-b909-a8a7819f1ee9","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:09:43.490527Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "586"
+                - "593"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:06 GMT
+                - Fri, 03 Jul 2026 15:09:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -495,10 +495,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 38ff0a30-6ffd-4c56-ac7e-929e485fdcb4
+                - 660faeb8-6fe7-4f39-87a5-7b5c5cf7c829
         status: 200 OK
         code: 200
-        duration: 47.314227ms
+        duration: 47.865332ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -510,7 +510,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"test-acc-function-pn-00","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"go123","memory_limit":256,"handler":"Handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"v1","tags":null,"private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6"}'
+        body: '{"name":"test-acc-function-pn-00","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"go126","memory_limit":256,"handler":"Handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"v1","tags":null,"private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407"}'
         form: {}
         headers:
             Content-Type:
@@ -525,20 +525,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 762
+        content_length: 765
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:06.756020524Z","description":"","domain_name":"tffuncelatedrubinryziaplj-test-acc-function-pn-00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"89758c34-e02e-480b-bf6a-327e16c25282","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-00","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","privacy":"private","private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:06.756020524Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:09:46.188576636Z","description":"","domain_name":"tffuncadmiringhaslettwulbygg-test-acc-function-pn-00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"ccc47e98-2042-4072-8c5c-cfd01fe9ad17","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-00","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","privacy":"private","private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407","ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:09:46.188576636Z"}'
         headers:
             Content-Length:
-                - "762"
+                - "765"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:06 GMT
+                - Fri, 03 Jul 2026 15:09:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -546,10 +546,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5fd6bc37-85b6-4166-91d5-77e36fc9bc56
+                - b6ac7a50-5fd7-4e05-a1d6-b652d75072ce
         status: 200 OK
         code: 200
-        duration: 168.484716ms
+        duration: 208.716734ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -566,7 +566,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/89758c34-e02e-480b-bf6a-327e16c25282
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/ccc47e98-2042-4072-8c5c-cfd01fe9ad17
         method: GET
       response:
         proto: HTTP/2.0
@@ -574,20 +574,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 756
+        content_length: 759
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:06.756021Z","description":"","domain_name":"tffuncelatedrubinryziaplj-test-acc-function-pn-00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"89758c34-e02e-480b-bf6a-327e16c25282","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-00","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","privacy":"private","private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:06.756021Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:09:46.188577Z","description":"","domain_name":"tffuncadmiringhaslettwulbygg-test-acc-function-pn-00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"ccc47e98-2042-4072-8c5c-cfd01fe9ad17","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-00","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","privacy":"private","private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407","ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:09:46.188577Z"}'
         headers:
             Content-Length:
-                - "756"
+                - "759"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:06 GMT
+                - Fri, 03 Jul 2026 15:09:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -595,10 +595,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ed2eef42-e47b-45ec-a3b2-9a335f17d658
+                - 893057f9-42de-4177-86d1-1611127771a3
         status: 200 OK
         code: 200
-        duration: 61.510024ms
+        duration: 56.184409ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -615,7 +615,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/89758c34-e02e-480b-bf6a-327e16c25282
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/ccc47e98-2042-4072-8c5c-cfd01fe9ad17
         method: GET
       response:
         proto: HTTP/2.0
@@ -623,20 +623,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 756
+        content_length: 759
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:06.756021Z","description":"","domain_name":"tffuncelatedrubinryziaplj-test-acc-function-pn-00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"89758c34-e02e-480b-bf6a-327e16c25282","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-00","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","privacy":"private","private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:06.756021Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:09:46.188577Z","description":"","domain_name":"tffuncadmiringhaslettwulbygg-test-acc-function-pn-00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"ccc47e98-2042-4072-8c5c-cfd01fe9ad17","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-00","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","privacy":"private","private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407","ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:09:46.188577Z"}'
         headers:
             Content-Length:
-                - "756"
+                - "759"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:06 GMT
+                - Fri, 03 Jul 2026 15:09:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -644,10 +644,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 70c15a53-c070-4cfe-af68-5465fdaa52e9
+                - 1e2b5dde-3ae0-4aee-a07e-335746b71162
         status: 200 OK
         code: 200
-        duration: 48.143016ms
+        duration: 47.138736ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -664,7 +664,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/89758c34-e02e-480b-bf6a-327e16c25282
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/ccc47e98-2042-4072-8c5c-cfd01fe9ad17
         method: GET
       response:
         proto: HTTP/2.0
@@ -672,20 +672,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 756
+        content_length: 759
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:06.756021Z","description":"","domain_name":"tffuncelatedrubinryziaplj-test-acc-function-pn-00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"89758c34-e02e-480b-bf6a-327e16c25282","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-00","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","privacy":"private","private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:06.756021Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:09:46.188577Z","description":"","domain_name":"tffuncadmiringhaslettwulbygg-test-acc-function-pn-00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"ccc47e98-2042-4072-8c5c-cfd01fe9ad17","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-00","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","privacy":"private","private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407","ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:09:46.188577Z"}'
         headers:
             Content-Length:
-                - "756"
+                - "759"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:07 GMT
+                - Fri, 03 Jul 2026 15:09:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -693,10 +693,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c8e25c2e-305f-4db4-97c8-62eef866b3a7
+                - ae6eb318-5858-4601-a6f7-ec27f87602df
         status: 200 OK
         code: 200
-        duration: 479.50484ms
+        duration: 56.218914ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -713,7 +713,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/87948c6d-ea10-40ec-82b5-05977516bd00
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/6bb31d81-005b-4aea-adcf-add0bd121f33
         method: GET
       response:
         proto: HTTP/2.0
@@ -721,20 +721,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 586
+        content_length: 446
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:56.371001Z","description":"","environment_variables":{},"error_message":null,"id":"87948c6d-ea10-40ec-82b5-05977516bd00","name":"tf-func-elated-rubin","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncelatedrubinryziaplj","registry_namespace_id":"0e89ad85-7b5a-48f1-9080-d79156d162ee","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:05.966803Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:09:36.087385Z","custom_routes_propagation_enabled":true,"id":"6bb31d81-005b-4aea-adcf-add0bd121f33","is_default":false,"name":"TestAccFunction_PrivateNetwork","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_count":2,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","routing_enabled":true,"tags":[],"transitivity_enabled":false,"updated_at":"2026-07-03T15:09:36.087385Z"}'
         headers:
             Content-Length:
-                - "586"
+                - "446"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:07 GMT
+                - Fri, 03 Jul 2026 15:09:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -742,10 +742,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a2fa08e4-51fe-46df-98a8-878291d77ff8
+                - dc17b799-7ce5-469d-9ecf-b4aaac755e1b
         status: 200 OK
         code: 200
-        duration: 38.892222ms
+        duration: 22.523537ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -762,7 +762,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/36d3c8ee-561c-47f5-95b1-973aa85443ef
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8e8949ba-0f49-4761-ad34-e9a02d75bc55
         method: GET
       response:
         proto: HTTP/2.0
@@ -770,20 +770,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 417
+        content_length: 593
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:55.544747Z","custom_routes_propagation_enabled":true,"id":"36d3c8ee-561c-47f5-95b1-973aa85443ef","is_default":false,"name":"TestAccFunction_PrivateNetwork","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_count":2,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","routing_enabled":true,"tags":[],"updated_at":"2026-05-04T12:38:55.544747Z"}'
+        body: '{"created_at":"2026-07-03T15:09:40.800078Z","description":"","environment_variables":{},"error_message":null,"id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","name":"tf-func-admiring-haslett","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncadmiringhaslettwulbygg","registry_namespace_id":"29b67960-08ff-47ff-b909-a8a7819f1ee9","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:09:43.490527Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "417"
+                - "593"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:07 GMT
+                - Fri, 03 Jul 2026 15:09:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -791,10 +791,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 90225b3d-b795-41d9-9d33-e1d35ce21f52
+                - 0252090f-ca7e-42f1-a0ec-8ad4e40f4675
         status: 200 OK
         code: 200
-        duration: 47.999957ms
+        duration: 47.359451ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -811,7 +811,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/eeff176d-2ea9-4c03-bd41-675e65c0b176
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9c7ec006-9f9c-4337-acf3-2c7040516407
         method: GET
       response:
         proto: HTTP/2.0
@@ -819,20 +819,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1070
+        content_length: 1107
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:55.688803Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"eeff176d-2ea9-4c03-bd41-675e65c0b176","name":"test-acc-function-pn-pn01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2026-05-04T12:38:55.688803Z","id":"d6a2cf65-6a4d-48e0-88b7-e779a952842a","private_network_id":"eeff176d-2ea9-4c03-bd41-675e65c0b176","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.0.0/22","updated_at":"2026-05-04T12:38:55.688803Z","vpc_id":"36d3c8ee-561c-47f5-95b1-973aa85443ef"},{"created_at":"2026-05-04T12:38:55.688803Z","id":"f5939756-132f-44dd-8f7d-8b9c679373e8","private_network_id":"eeff176d-2ea9-4c03-bd41-675e65c0b176","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:9c9b::/64","updated_at":"2026-05-04T12:38:55.688803Z","vpc_id":"36d3c8ee-561c-47f5-95b1-973aa85443ef"}],"tags":[],"updated_at":"2026-05-04T12:38:55.688803Z","vpc_id":"36d3c8ee-561c-47f5-95b1-973aa85443ef"}'
+        body: '{"created_at":"2026-07-03T15:09:36.386569Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"9c7ec006-9f9c-4337-acf3-2c7040516407","name":"test-acc-function-pn-pn00","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2026-07-03T15:09:36.386569Z","id":"9b301033-da29-4986-b09e-a1985e20cca8","private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnet":"172.16.76.0/22","updated_at":"2026-07-03T15:09:36.386569Z","vpc_id":"6bb31d81-005b-4aea-adcf-add0bd121f33"},{"created_at":"2026-07-03T15:09:36.386569Z","id":"982a3685-d413-4a51-9c3a-e9c29efb452b","private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnet":"fd63:256c:45f7:9f34::/64","updated_at":"2026-07-03T15:09:36.386569Z","vpc_id":"6bb31d81-005b-4aea-adcf-add0bd121f33"}],"tags":[],"updated_at":"2026-07-03T15:09:36.386569Z","vpc_id":"6bb31d81-005b-4aea-adcf-add0bd121f33"}'
         headers:
             Content-Length:
-                - "1070"
+                - "1107"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:07 GMT
+                - Fri, 03 Jul 2026 15:09:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -840,10 +840,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f54618d3-3720-41a3-9697-2f8dd82ebc3d
+                - b509c9e1-f52f-4c93-a6b7-53a1bdb7dc4d
         status: 200 OK
         code: 200
-        duration: 25.403624ms
+        duration: 24.611983ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -860,7 +860,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/258f0f17-2b28-41a2-bba5-d15b6f0902f6
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c46dd6b8-6100-4f5b-9abd-e63d17bccaf0
         method: GET
       response:
         proto: HTTP/2.0
@@ -868,20 +868,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1071
+        content_length: 1107
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:55.819981Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","name":"test-acc-function-pn-pn00","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2026-05-04T12:38:55.819981Z","id":"5f3c1582-5862-4175-80ab-9ca9aa98642b","private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.16.0/22","updated_at":"2026-05-04T12:38:55.819981Z","vpc_id":"36d3c8ee-561c-47f5-95b1-973aa85443ef"},{"created_at":"2026-05-04T12:38:55.819981Z","id":"03c23551-f7c3-4677-95e2-b3c06a282251","private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:8f19::/64","updated_at":"2026-05-04T12:38:55.819981Z","vpc_id":"36d3c8ee-561c-47f5-95b1-973aa85443ef"}],"tags":[],"updated_at":"2026-05-04T12:38:55.819981Z","vpc_id":"36d3c8ee-561c-47f5-95b1-973aa85443ef"}'
+        body: '{"created_at":"2026-07-03T15:09:36.236952Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"c46dd6b8-6100-4f5b-9abd-e63d17bccaf0","name":"test-acc-function-pn-pn01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2026-07-03T15:09:36.236952Z","id":"8eb6d00f-c872-4fec-99ea-d7da2e69b216","private_network_id":"c46dd6b8-6100-4f5b-9abd-e63d17bccaf0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnet":"172.16.64.0/22","updated_at":"2026-07-03T15:09:36.236952Z","vpc_id":"6bb31d81-005b-4aea-adcf-add0bd121f33"},{"created_at":"2026-07-03T15:09:36.236952Z","id":"b05f379d-6785-4c2e-a230-7b60778339f9","private_network_id":"c46dd6b8-6100-4f5b-9abd-e63d17bccaf0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnet":"fd63:256c:45f7:ad3f::/64","updated_at":"2026-07-03T15:09:36.236952Z","vpc_id":"6bb31d81-005b-4aea-adcf-add0bd121f33"}],"tags":[],"updated_at":"2026-07-03T15:09:36.236952Z","vpc_id":"6bb31d81-005b-4aea-adcf-add0bd121f33"}'
         headers:
             Content-Length:
-                - "1071"
+                - "1107"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:07 GMT
+                - Fri, 03 Jul 2026 15:09:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -889,10 +889,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bfdc54de-9c0b-4a97-9e45-ea4310a9543e
+                - c110e657-2259-4326-979d-28c0afd040d0
         status: 200 OK
         code: 200
-        duration: 54.158423ms
+        duration: 27.529106ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -909,7 +909,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/89758c34-e02e-480b-bf6a-327e16c25282
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/ccc47e98-2042-4072-8c5c-cfd01fe9ad17
         method: GET
       response:
         proto: HTTP/2.0
@@ -917,20 +917,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 756
+        content_length: 759
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:06.756021Z","description":"","domain_name":"tffuncelatedrubinryziaplj-test-acc-function-pn-00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"89758c34-e02e-480b-bf6a-327e16c25282","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-00","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","privacy":"private","private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:06.756021Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:09:46.188577Z","description":"","domain_name":"tffuncadmiringhaslettwulbygg-test-acc-function-pn-00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"ccc47e98-2042-4072-8c5c-cfd01fe9ad17","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-00","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","privacy":"private","private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407","ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:09:46.188577Z"}'
         headers:
             Content-Length:
-                - "756"
+                - "759"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:07 GMT
+                - Fri, 03 Jul 2026 15:09:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -938,10 +938,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d1ec6466-9774-4e07-9556-8f4b725da56a
+                - e2ef54a4-e2c9-4990-b336-4f8e2689d10a
         status: 200 OK
         code: 200
-        duration: 68.001909ms
+        duration: 56.581867ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -958,7 +958,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/87948c6d-ea10-40ec-82b5-05977516bd00
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/6bb31d81-005b-4aea-adcf-add0bd121f33
         method: GET
       response:
         proto: HTTP/2.0
@@ -966,20 +966,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 586
+        content_length: 446
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:56.371001Z","description":"","environment_variables":{},"error_message":null,"id":"87948c6d-ea10-40ec-82b5-05977516bd00","name":"tf-func-elated-rubin","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncelatedrubinryziaplj","registry_namespace_id":"0e89ad85-7b5a-48f1-9080-d79156d162ee","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:05.966803Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:09:36.087385Z","custom_routes_propagation_enabled":true,"id":"6bb31d81-005b-4aea-adcf-add0bd121f33","is_default":false,"name":"TestAccFunction_PrivateNetwork","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_count":2,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","routing_enabled":true,"tags":[],"transitivity_enabled":false,"updated_at":"2026-07-03T15:09:36.087385Z"}'
         headers:
             Content-Length:
-                - "586"
+                - "446"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:08 GMT
+                - Fri, 03 Jul 2026 15:09:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -987,10 +987,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e8aeca8b-891d-4c65-be98-b4e75634f752
+                - e4a31de0-491c-4dc0-8c00-0208c847d019
         status: 200 OK
         code: 200
-        duration: 40.05005ms
+        duration: 26.135867ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1007,7 +1007,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/36d3c8ee-561c-47f5-95b1-973aa85443ef
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8e8949ba-0f49-4761-ad34-e9a02d75bc55
         method: GET
       response:
         proto: HTTP/2.0
@@ -1015,20 +1015,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 417
+        content_length: 593
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:55.544747Z","custom_routes_propagation_enabled":true,"id":"36d3c8ee-561c-47f5-95b1-973aa85443ef","is_default":false,"name":"TestAccFunction_PrivateNetwork","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_count":2,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","routing_enabled":true,"tags":[],"updated_at":"2026-05-04T12:38:55.544747Z"}'
+        body: '{"created_at":"2026-07-03T15:09:40.800078Z","description":"","environment_variables":{},"error_message":null,"id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","name":"tf-func-admiring-haslett","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncadmiringhaslettwulbygg","registry_namespace_id":"29b67960-08ff-47ff-b909-a8a7819f1ee9","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:09:43.490527Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "417"
+                - "593"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:08 GMT
+                - Fri, 03 Jul 2026 15:09:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1036,10 +1036,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 778194a5-f3dd-4987-880f-ac83d00ff0c5
+                - 8ca24af0-f324-48a7-a1f8-620412be655d
         status: 200 OK
         code: 200
-        duration: 50.761963ms
+        duration: 42.202298ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1056,7 +1056,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/258f0f17-2b28-41a2-bba5-d15b6f0902f6
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9c7ec006-9f9c-4337-acf3-2c7040516407
         method: GET
       response:
         proto: HTTP/2.0
@@ -1064,20 +1064,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1071
+        content_length: 1107
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:55.819981Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","name":"test-acc-function-pn-pn00","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2026-05-04T12:38:55.819981Z","id":"5f3c1582-5862-4175-80ab-9ca9aa98642b","private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.16.0/22","updated_at":"2026-05-04T12:38:55.819981Z","vpc_id":"36d3c8ee-561c-47f5-95b1-973aa85443ef"},{"created_at":"2026-05-04T12:38:55.819981Z","id":"03c23551-f7c3-4677-95e2-b3c06a282251","private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:8f19::/64","updated_at":"2026-05-04T12:38:55.819981Z","vpc_id":"36d3c8ee-561c-47f5-95b1-973aa85443ef"}],"tags":[],"updated_at":"2026-05-04T12:38:55.819981Z","vpc_id":"36d3c8ee-561c-47f5-95b1-973aa85443ef"}'
+        body: '{"created_at":"2026-07-03T15:09:36.386569Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"9c7ec006-9f9c-4337-acf3-2c7040516407","name":"test-acc-function-pn-pn00","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2026-07-03T15:09:36.386569Z","id":"9b301033-da29-4986-b09e-a1985e20cca8","private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnet":"172.16.76.0/22","updated_at":"2026-07-03T15:09:36.386569Z","vpc_id":"6bb31d81-005b-4aea-adcf-add0bd121f33"},{"created_at":"2026-07-03T15:09:36.386569Z","id":"982a3685-d413-4a51-9c3a-e9c29efb452b","private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnet":"fd63:256c:45f7:9f34::/64","updated_at":"2026-07-03T15:09:36.386569Z","vpc_id":"6bb31d81-005b-4aea-adcf-add0bd121f33"}],"tags":[],"updated_at":"2026-07-03T15:09:36.386569Z","vpc_id":"6bb31d81-005b-4aea-adcf-add0bd121f33"}'
         headers:
             Content-Length:
-                - "1071"
+                - "1107"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:08 GMT
+                - Fri, 03 Jul 2026 15:09:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1085,10 +1085,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1ba91edd-2df8-45dc-811d-b31d665fada3
+                - ffed8c30-c826-4965-ad0e-c8dbf9348126
         status: 200 OK
         code: 200
-        duration: 30.379075ms
+        duration: 26.673038ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1105,7 +1105,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/eeff176d-2ea9-4c03-bd41-675e65c0b176
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c46dd6b8-6100-4f5b-9abd-e63d17bccaf0
         method: GET
       response:
         proto: HTTP/2.0
@@ -1113,20 +1113,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1070
+        content_length: 1107
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:55.688803Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"eeff176d-2ea9-4c03-bd41-675e65c0b176","name":"test-acc-function-pn-pn01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2026-05-04T12:38:55.688803Z","id":"d6a2cf65-6a4d-48e0-88b7-e779a952842a","private_network_id":"eeff176d-2ea9-4c03-bd41-675e65c0b176","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.0.0/22","updated_at":"2026-05-04T12:38:55.688803Z","vpc_id":"36d3c8ee-561c-47f5-95b1-973aa85443ef"},{"created_at":"2026-05-04T12:38:55.688803Z","id":"f5939756-132f-44dd-8f7d-8b9c679373e8","private_network_id":"eeff176d-2ea9-4c03-bd41-675e65c0b176","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:9c9b::/64","updated_at":"2026-05-04T12:38:55.688803Z","vpc_id":"36d3c8ee-561c-47f5-95b1-973aa85443ef"}],"tags":[],"updated_at":"2026-05-04T12:38:55.688803Z","vpc_id":"36d3c8ee-561c-47f5-95b1-973aa85443ef"}'
+        body: '{"created_at":"2026-07-03T15:09:36.236952Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"c46dd6b8-6100-4f5b-9abd-e63d17bccaf0","name":"test-acc-function-pn-pn01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2026-07-03T15:09:36.236952Z","id":"8eb6d00f-c872-4fec-99ea-d7da2e69b216","private_network_id":"c46dd6b8-6100-4f5b-9abd-e63d17bccaf0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnet":"172.16.64.0/22","updated_at":"2026-07-03T15:09:36.236952Z","vpc_id":"6bb31d81-005b-4aea-adcf-add0bd121f33"},{"created_at":"2026-07-03T15:09:36.236952Z","id":"b05f379d-6785-4c2e-a230-7b60778339f9","private_network_id":"c46dd6b8-6100-4f5b-9abd-e63d17bccaf0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnet":"fd63:256c:45f7:ad3f::/64","updated_at":"2026-07-03T15:09:36.236952Z","vpc_id":"6bb31d81-005b-4aea-adcf-add0bd121f33"}],"tags":[],"updated_at":"2026-07-03T15:09:36.236952Z","vpc_id":"6bb31d81-005b-4aea-adcf-add0bd121f33"}'
         headers:
             Content-Length:
-                - "1070"
+                - "1107"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:08 GMT
+                - Fri, 03 Jul 2026 15:09:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1134,10 +1134,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - be05b72e-0cdc-4831-bb93-fa5c05f9fe07
+                - e3446ae2-7fad-48fd-b091-64c27504f049
         status: 200 OK
         code: 200
-        duration: 35.586312ms
+        duration: 26.661957ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1154,7 +1154,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/89758c34-e02e-480b-bf6a-327e16c25282
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/ccc47e98-2042-4072-8c5c-cfd01fe9ad17
         method: GET
       response:
         proto: HTTP/2.0
@@ -1162,20 +1162,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 756
+        content_length: 759
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:06.756021Z","description":"","domain_name":"tffuncelatedrubinryziaplj-test-acc-function-pn-00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"89758c34-e02e-480b-bf6a-327e16c25282","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-00","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","privacy":"private","private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:06.756021Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:09:46.188577Z","description":"","domain_name":"tffuncadmiringhaslettwulbygg-test-acc-function-pn-00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"ccc47e98-2042-4072-8c5c-cfd01fe9ad17","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-00","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","privacy":"private","private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407","ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:09:46.188577Z"}'
         headers:
             Content-Length:
-                - "756"
+                - "759"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:08 GMT
+                - Fri, 03 Jul 2026 15:09:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1183,10 +1183,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 807f9141-d6ac-475b-a2f4-aea9b55030d4
+                - 69563639-761e-432b-b05a-1037d0a0a3e1
         status: 200 OK
         code: 200
-        duration: 58.941683ms
+        duration: 48.198198ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1203,7 +1203,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/89758c34-e02e-480b-bf6a-327e16c25282
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/ccc47e98-2042-4072-8c5c-cfd01fe9ad17
         method: GET
       response:
         proto: HTTP/2.0
@@ -1211,20 +1211,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 756
+        content_length: 759
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:06.756021Z","description":"","domain_name":"tffuncelatedrubinryziaplj-test-acc-function-pn-00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"89758c34-e02e-480b-bf6a-327e16c25282","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-00","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","privacy":"private","private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:06.756021Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:09:46.188577Z","description":"","domain_name":"tffuncadmiringhaslettwulbygg-test-acc-function-pn-00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"ccc47e98-2042-4072-8c5c-cfd01fe9ad17","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-00","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","privacy":"private","private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407","ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:09:46.188577Z"}'
         headers:
             Content-Length:
-                - "756"
+                - "759"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:08 GMT
+                - Fri, 03 Jul 2026 15:09:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1232,10 +1232,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e95997ac-9476-45e8-901a-113d5d9e03e6
+                - ce66b2d8-2ff5-4ba1-8948-d56392b2fc16
         status: 200 OK
         code: 200
-        duration: 76.37951ms
+        duration: 47.754504ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1247,7 +1247,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"test-acc-function-pn-f02","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"go123","memory_limit":256,"handler":"Handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"v1","tags":null,"private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6"}'
+        body: '{"name":"test-acc-function-pn-f02","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"go126","memory_limit":256,"handler":"Handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"v1","tags":null,"private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407"}'
         form: {}
         headers:
             Content-Type:
@@ -1262,20 +1262,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 764
+        content_length: 767
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:08.410483366Z","description":"","domain_name":"tffuncelatedrubinryziaplj-test-acc-function-pn-f02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"30a091ba-e233-4560-a994-18f6b8b34433","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f02","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","privacy":"private","private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:08.410483366Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:09:47.434333540Z","description":"","domain_name":"tffuncadmiringhaslettwulbygg-test-acc-function-pn-f02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d245d3b3-630a-4879-aca6-5ad9244c0ee9","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f02","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","privacy":"private","private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407","ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:09:47.434333540Z"}'
         headers:
             Content-Length:
-                - "764"
+                - "767"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:08 GMT
+                - Fri, 03 Jul 2026 15:09:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1283,10 +1283,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9e59d6e7-82ee-41ba-9d15-aede33c889e7
+                - 8bc3233d-3701-4039-a7fb-520553b4c6f7
         status: 200 OK
         code: 200
-        duration: 174.763741ms
+        duration: 205.076742ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1298,7 +1298,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"test-acc-function-pn-f01","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"go123","memory_limit":256,"handler":"Handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"v1","tags":null,"private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6"}'
+        body: '{"name":"test-acc-function-pn-f01","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"go126","memory_limit":256,"handler":"Handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"v1","tags":null,"private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407"}'
         form: {}
         headers:
             Content-Type:
@@ -1313,20 +1313,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 764
+        content_length: 767
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:08.419520694Z","description":"","domain_name":"tffuncelatedrubinryziaplj-test-acc-function-pn-f01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"63c8b9ed-1de4-4789-a5f3-ba3d25380387","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f01","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","privacy":"private","private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:08.419520694Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:09:47.437406552Z","description":"","domain_name":"tffuncadmiringhaslettwulbygg-test-acc-function-pn-f01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"7053737c-21bd-441e-8e6d-1a1d16181a2e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f01","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","privacy":"private","private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407","ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:09:47.437406552Z"}'
         headers:
             Content-Length:
-                - "764"
+                - "767"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:08 GMT
+                - Fri, 03 Jul 2026 15:09:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1334,10 +1334,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 666e74c1-237b-449d-9b37-3ee8a040c554
+                - a5be92cb-926d-48c2-b25f-c8e7288231b7
         status: 200 OK
         code: 200
-        duration: 365.604019ms
+        duration: 205.957408ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1354,7 +1354,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/30a091ba-e233-4560-a994-18f6b8b34433
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7053737c-21bd-441e-8e6d-1a1d16181a2e
         method: GET
       response:
         proto: HTTP/2.0
@@ -1362,20 +1362,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 758
+        content_length: 761
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:08.410483Z","description":"","domain_name":"tffuncelatedrubinryziaplj-test-acc-function-pn-f02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"30a091ba-e233-4560-a994-18f6b8b34433","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f02","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","privacy":"private","private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:08.410483Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:09:47.437407Z","description":"","domain_name":"tffuncadmiringhaslettwulbygg-test-acc-function-pn-f01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"7053737c-21bd-441e-8e6d-1a1d16181a2e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f01","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","privacy":"private","private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407","ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:09:47.437407Z"}'
         headers:
             Content-Length:
-                - "758"
+                - "761"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:08 GMT
+                - Fri, 03 Jul 2026 15:09:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1383,10 +1383,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f9f9ee18-bb73-4d9f-9939-13db449a419d
+                - a8c7a774-41f7-4e91-9841-b170ea503ca2
         status: 200 OK
         code: 200
-        duration: 189.715231ms
+        duration: 43.120093ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1403,28 +1403,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/89758c34-e02e-480b-bf6a-327e16c25282
-        method: DELETE
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d245d3b3-630a-4879-aca6-5ad9244c0ee9
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 760
+        content_length: 761
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:06.756021Z","description":"","domain_name":"tffuncelatedrubinryziaplj-test-acc-function-pn-00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"89758c34-e02e-480b-bf6a-327e16c25282","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-00","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","privacy":"private","private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:08.405882208Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:09:47.434334Z","description":"","domain_name":"tffuncadmiringhaslettwulbygg-test-acc-function-pn-f02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d245d3b3-630a-4879-aca6-5ad9244c0ee9","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f02","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","privacy":"private","private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407","ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:09:47.434334Z"}'
         headers:
             Content-Length:
-                - "760"
+                - "761"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:08 GMT
+                - Fri, 03 Jul 2026 15:09:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1432,10 +1432,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ff66f738-3519-4993-b347-6bad57436bf6
+                - 786631f1-92ae-4594-a903-0201a34362af
         status: 200 OK
         code: 200
-        duration: 291.046255ms
+        duration: 53.648904ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1452,7 +1452,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/30a091ba-e233-4560-a994-18f6b8b34433
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7053737c-21bd-441e-8e6d-1a1d16181a2e
         method: GET
       response:
         proto: HTTP/2.0
@@ -1460,20 +1460,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 758
+        content_length: 761
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:08.410483Z","description":"","domain_name":"tffuncelatedrubinryziaplj-test-acc-function-pn-f02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"30a091ba-e233-4560-a994-18f6b8b34433","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f02","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","privacy":"private","private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:08.410483Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:09:47.437407Z","description":"","domain_name":"tffuncadmiringhaslettwulbygg-test-acc-function-pn-f01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"7053737c-21bd-441e-8e6d-1a1d16181a2e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f01","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","privacy":"private","private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407","ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:09:47.437407Z"}'
         headers:
             Content-Length:
-                - "758"
+                - "761"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:08 GMT
+                - Fri, 03 Jul 2026 15:09:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1481,10 +1481,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cb68b0c3-45c3-45e2-b969-67e7bfa922ea
+                - d50fa572-2837-4f1a-989f-134dec6b6709
         status: 200 OK
         code: 200
-        duration: 47.500657ms
+        duration: 51.38603ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1501,7 +1501,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/63c8b9ed-1de4-4789-a5f3-ba3d25380387
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d245d3b3-630a-4879-aca6-5ad9244c0ee9
         method: GET
       response:
         proto: HTTP/2.0
@@ -1509,20 +1509,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 758
+        content_length: 761
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:08.419521Z","description":"","domain_name":"tffuncelatedrubinryziaplj-test-acc-function-pn-f01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"63c8b9ed-1de4-4789-a5f3-ba3d25380387","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f01","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","privacy":"private","private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:08.419521Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:09:47.434334Z","description":"","domain_name":"tffuncadmiringhaslettwulbygg-test-acc-function-pn-f02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d245d3b3-630a-4879-aca6-5ad9244c0ee9","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f02","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","privacy":"private","private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407","ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:09:47.434334Z"}'
         headers:
             Content-Length:
-                - "758"
+                - "761"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:08 GMT
+                - Fri, 03 Jul 2026 15:09:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1530,10 +1530,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e4fe0309-72a4-4135-8910-0eeddac7f120
+                - d85e40e0-eeec-480f-9a63-1f91d97f2d85
         status: 200 OK
         code: 200
-        duration: 57.651496ms
+        duration: 54.18377ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1550,28 +1550,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/63c8b9ed-1de4-4789-a5f3-ba3d25380387
-        method: GET
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/ccc47e98-2042-4072-8c5c-cfd01fe9ad17
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 758
+        content_length: 763
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:08.419521Z","description":"","domain_name":"tffuncelatedrubinryziaplj-test-acc-function-pn-f01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"63c8b9ed-1de4-4789-a5f3-ba3d25380387","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f01","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","privacy":"private","private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:08.419521Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:09:46.188577Z","description":"","domain_name":"tffuncadmiringhaslettwulbygg-test-acc-function-pn-00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"ccc47e98-2042-4072-8c5c-cfd01fe9ad17","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-00","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","privacy":"private","private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407","ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:09:47.366166579Z"}'
         headers:
             Content-Length:
-                - "758"
+                - "763"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:08 GMT
+                - Fri, 03 Jul 2026 15:09:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1579,10 +1579,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5286b452-f57d-4e65-b8ed-10811deac75a
+                - dd0576ba-169c-45be-b35e-3beedaec04f9
         status: 200 OK
         code: 200
-        duration: 119.766208ms
+        duration: 340.569167ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1594,7 +1594,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"test-acc-function-pn-f00","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"go123","memory_limit":256,"handler":"Handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"v1","tags":null,"private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6"}'
+        body: '{"name":"test-acc-function-pn-f00","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"go126","memory_limit":256,"handler":"Handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"v1","tags":null,"private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407"}'
         form: {}
         headers:
             Content-Type:
@@ -1609,20 +1609,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 764
+        content_length: 767
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:08.775392379Z","description":"","domain_name":"tffuncelatedrubinryziaplj-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"8162ed34-7c8b-4101-a0db-d73f8de7f99f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","privacy":"private","private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:08.775392379Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:09:47.792736799Z","description":"","domain_name":"tffuncadmiringhaslettwulbygg-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"ef769143-043d-47f3-96fa-c2e8775a82e0","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","privacy":"private","private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407","ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:09:47.792736799Z"}'
         headers:
             Content-Length:
-                - "764"
+                - "767"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:08 GMT
+                - Fri, 03 Jul 2026 15:09:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1630,10 +1630,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e0e640e1-7438-466c-b560-cfd7db4bf4e7
+                - da97c69e-f1ae-445c-9026-21e49a2872d4
         status: 200 OK
         code: 200
-        duration: 162.09722ms
+        duration: 153.080335ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1650,7 +1650,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/8162ed34-7c8b-4101-a0db-d73f8de7f99f
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/ef769143-043d-47f3-96fa-c2e8775a82e0
         method: GET
       response:
         proto: HTTP/2.0
@@ -1658,20 +1658,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 758
+        content_length: 761
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:08.775392Z","description":"","domain_name":"tffuncelatedrubinryziaplj-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"8162ed34-7c8b-4101-a0db-d73f8de7f99f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","privacy":"private","private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:08.775392Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:09:47.792737Z","description":"","domain_name":"tffuncadmiringhaslettwulbygg-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"ef769143-043d-47f3-96fa-c2e8775a82e0","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","privacy":"private","private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407","ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:09:47.792737Z"}'
         headers:
             Content-Length:
-                - "758"
+                - "761"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:08 GMT
+                - Fri, 03 Jul 2026 15:09:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1679,10 +1679,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 191e6ad4-4266-4570-b40b-34b5e68c1a3e
+                - 0d4c57d4-08cc-4f80-a739-648c058b5648
         status: 200 OK
         code: 200
-        duration: 130.071557ms
+        duration: 58.182395ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1699,7 +1699,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/8162ed34-7c8b-4101-a0db-d73f8de7f99f
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/ef769143-043d-47f3-96fa-c2e8775a82e0
         method: GET
       response:
         proto: HTTP/2.0
@@ -1707,20 +1707,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 758
+        content_length: 761
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:08.775392Z","description":"","domain_name":"tffuncelatedrubinryziaplj-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"8162ed34-7c8b-4101-a0db-d73f8de7f99f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","privacy":"private","private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:08.775392Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:09:47.792737Z","description":"","domain_name":"tffuncadmiringhaslettwulbygg-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"ef769143-043d-47f3-96fa-c2e8775a82e0","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","privacy":"private","private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407","ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:09:47.792737Z"}'
         headers:
             Content-Length:
-                - "758"
+                - "761"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:08 GMT
+                - Fri, 03 Jul 2026 15:09:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1728,10 +1728,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0d65ef15-5e1a-45b8-8660-fe0c74c94572
+                - d15e3431-846e-4cec-8c16-dfc9da148b41
         status: 200 OK
         code: 200
-        duration: 51.633964ms
+        duration: 53.102656ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1748,7 +1748,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/8162ed34-7c8b-4101-a0db-d73f8de7f99f
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/ef769143-043d-47f3-96fa-c2e8775a82e0
         method: GET
       response:
         proto: HTTP/2.0
@@ -1756,20 +1756,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 758
+        content_length: 761
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:08.775392Z","description":"","domain_name":"tffuncelatedrubinryziaplj-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"8162ed34-7c8b-4101-a0db-d73f8de7f99f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","privacy":"private","private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:08.775392Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:09:47.792737Z","description":"","domain_name":"tffuncadmiringhaslettwulbygg-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"ef769143-043d-47f3-96fa-c2e8775a82e0","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","privacy":"private","private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407","ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:09:47.792737Z"}'
         headers:
             Content-Length:
-                - "758"
+                - "761"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:09 GMT
+                - Fri, 03 Jul 2026 15:09:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1777,10 +1777,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 37bc635f-7736-422a-b23c-78f687ae54a0
+                - 8563771c-eb76-44f5-a7c1-c2dcdae22445
         status: 200 OK
         code: 200
-        duration: 88.302123ms
+        duration: 44.425917ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1797,7 +1797,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/63c8b9ed-1de4-4789-a5f3-ba3d25380387
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7053737c-21bd-441e-8e6d-1a1d16181a2e
         method: GET
       response:
         proto: HTTP/2.0
@@ -1805,20 +1805,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 758
+        content_length: 761
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:08.419521Z","description":"","domain_name":"tffuncelatedrubinryziaplj-test-acc-function-pn-f01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"63c8b9ed-1de4-4789-a5f3-ba3d25380387","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f01","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","privacy":"private","private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:08.419521Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:09:47.437407Z","description":"","domain_name":"tffuncadmiringhaslettwulbygg-test-acc-function-pn-f01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"7053737c-21bd-441e-8e6d-1a1d16181a2e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f01","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","privacy":"private","private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407","ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:09:47.437407Z"}'
         headers:
             Content-Length:
-                - "758"
+                - "761"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:09 GMT
+                - Fri, 03 Jul 2026 15:09:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1826,10 +1826,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7fddf26c-cbb7-4feb-8a28-87f0bf08b254
+                - 84460795-6f4a-43f0-ab40-c80545ef8019
         status: 200 OK
         code: 200
-        duration: 69.864243ms
+        duration: 42.671279ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1846,7 +1846,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/30a091ba-e233-4560-a994-18f6b8b34433
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d245d3b3-630a-4879-aca6-5ad9244c0ee9
         method: GET
       response:
         proto: HTTP/2.0
@@ -1854,20 +1854,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 758
+        content_length: 761
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:08.410483Z","description":"","domain_name":"tffuncelatedrubinryziaplj-test-acc-function-pn-f02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"30a091ba-e233-4560-a994-18f6b8b34433","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f02","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","privacy":"private","private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:08.410483Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:09:47.434334Z","description":"","domain_name":"tffuncadmiringhaslettwulbygg-test-acc-function-pn-f02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d245d3b3-630a-4879-aca6-5ad9244c0ee9","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f02","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","privacy":"private","private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407","ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:09:47.434334Z"}'
         headers:
             Content-Length:
-                - "758"
+                - "761"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:09 GMT
+                - Fri, 03 Jul 2026 15:09:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1875,10 +1875,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ab209ba9-85b1-4cc7-93c7-0a9af312543b
+                - f1cda42e-04c2-421f-a1c3-c77a5ec72dce
         status: 200 OK
         code: 200
-        duration: 42.275337ms
+        duration: 47.265696ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1895,7 +1895,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/36d3c8ee-561c-47f5-95b1-973aa85443ef
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/6bb31d81-005b-4aea-adcf-add0bd121f33
         method: GET
       response:
         proto: HTTP/2.0
@@ -1903,20 +1903,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 417
+        content_length: 446
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:55.544747Z","custom_routes_propagation_enabled":true,"id":"36d3c8ee-561c-47f5-95b1-973aa85443ef","is_default":false,"name":"TestAccFunction_PrivateNetwork","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_count":2,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","routing_enabled":true,"tags":[],"updated_at":"2026-05-04T12:38:55.544747Z"}'
+        body: '{"created_at":"2026-07-03T15:09:36.087385Z","custom_routes_propagation_enabled":true,"id":"6bb31d81-005b-4aea-adcf-add0bd121f33","is_default":false,"name":"TestAccFunction_PrivateNetwork","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_count":2,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","routing_enabled":true,"tags":[],"transitivity_enabled":false,"updated_at":"2026-07-03T15:09:36.087385Z"}'
         headers:
             Content-Length:
-                - "417"
+                - "446"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:09 GMT
+                - Fri, 03 Jul 2026 15:09:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1924,10 +1924,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7b243b24-58c3-49aa-8385-d1418c63f17c
+                - 188ebcc6-73d6-4332-867e-cf4e1085ea0a
         status: 200 OK
         code: 200
-        duration: 23.925955ms
+        duration: 34.428936ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1944,7 +1944,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/87948c6d-ea10-40ec-82b5-05977516bd00
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8e8949ba-0f49-4761-ad34-e9a02d75bc55
         method: GET
       response:
         proto: HTTP/2.0
@@ -1952,20 +1952,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 586
+        content_length: 593
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:56.371001Z","description":"","environment_variables":{},"error_message":null,"id":"87948c6d-ea10-40ec-82b5-05977516bd00","name":"tf-func-elated-rubin","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncelatedrubinryziaplj","registry_namespace_id":"0e89ad85-7b5a-48f1-9080-d79156d162ee","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:05.966803Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:09:40.800078Z","description":"","environment_variables":{},"error_message":null,"id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","name":"tf-func-admiring-haslett","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncadmiringhaslettwulbygg","registry_namespace_id":"29b67960-08ff-47ff-b909-a8a7819f1ee9","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:09:43.490527Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "586"
+                - "593"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:09 GMT
+                - Fri, 03 Jul 2026 15:09:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1973,10 +1973,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8914066a-e100-4dec-b3d7-63c5603980cc
+                - 1f5d6766-bf48-41b0-b13e-2b4d2ac1f390
         status: 200 OK
         code: 200
-        duration: 31.494964ms
+        duration: 36.427822ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -1993,7 +1993,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/eeff176d-2ea9-4c03-bd41-675e65c0b176
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9c7ec006-9f9c-4337-acf3-2c7040516407
         method: GET
       response:
         proto: HTTP/2.0
@@ -2001,20 +2001,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1070
+        content_length: 1107
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:55.688803Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"eeff176d-2ea9-4c03-bd41-675e65c0b176","name":"test-acc-function-pn-pn01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2026-05-04T12:38:55.688803Z","id":"d6a2cf65-6a4d-48e0-88b7-e779a952842a","private_network_id":"eeff176d-2ea9-4c03-bd41-675e65c0b176","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.0.0/22","updated_at":"2026-05-04T12:38:55.688803Z","vpc_id":"36d3c8ee-561c-47f5-95b1-973aa85443ef"},{"created_at":"2026-05-04T12:38:55.688803Z","id":"f5939756-132f-44dd-8f7d-8b9c679373e8","private_network_id":"eeff176d-2ea9-4c03-bd41-675e65c0b176","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:9c9b::/64","updated_at":"2026-05-04T12:38:55.688803Z","vpc_id":"36d3c8ee-561c-47f5-95b1-973aa85443ef"}],"tags":[],"updated_at":"2026-05-04T12:38:55.688803Z","vpc_id":"36d3c8ee-561c-47f5-95b1-973aa85443ef"}'
+        body: '{"created_at":"2026-07-03T15:09:36.386569Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"9c7ec006-9f9c-4337-acf3-2c7040516407","name":"test-acc-function-pn-pn00","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2026-07-03T15:09:36.386569Z","id":"9b301033-da29-4986-b09e-a1985e20cca8","private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnet":"172.16.76.0/22","updated_at":"2026-07-03T15:09:36.386569Z","vpc_id":"6bb31d81-005b-4aea-adcf-add0bd121f33"},{"created_at":"2026-07-03T15:09:36.386569Z","id":"982a3685-d413-4a51-9c3a-e9c29efb452b","private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnet":"fd63:256c:45f7:9f34::/64","updated_at":"2026-07-03T15:09:36.386569Z","vpc_id":"6bb31d81-005b-4aea-adcf-add0bd121f33"}],"tags":[],"updated_at":"2026-07-03T15:09:36.386569Z","vpc_id":"6bb31d81-005b-4aea-adcf-add0bd121f33"}'
         headers:
             Content-Length:
-                - "1070"
+                - "1107"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:09 GMT
+                - Fri, 03 Jul 2026 15:09:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2022,10 +2022,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fbee69bd-9944-4e97-acc9-fb3ed4f62cf5
+                - e60701db-cd32-49d6-871f-8e869e05f7e4
         status: 200 OK
         code: 200
-        duration: 23.811199ms
+        duration: 30.316667ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2042,7 +2042,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/258f0f17-2b28-41a2-bba5-d15b6f0902f6
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c46dd6b8-6100-4f5b-9abd-e63d17bccaf0
         method: GET
       response:
         proto: HTTP/2.0
@@ -2050,20 +2050,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1071
+        content_length: 1107
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:55.819981Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","name":"test-acc-function-pn-pn00","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2026-05-04T12:38:55.819981Z","id":"5f3c1582-5862-4175-80ab-9ca9aa98642b","private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.16.0/22","updated_at":"2026-05-04T12:38:55.819981Z","vpc_id":"36d3c8ee-561c-47f5-95b1-973aa85443ef"},{"created_at":"2026-05-04T12:38:55.819981Z","id":"03c23551-f7c3-4677-95e2-b3c06a282251","private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:8f19::/64","updated_at":"2026-05-04T12:38:55.819981Z","vpc_id":"36d3c8ee-561c-47f5-95b1-973aa85443ef"}],"tags":[],"updated_at":"2026-05-04T12:38:55.819981Z","vpc_id":"36d3c8ee-561c-47f5-95b1-973aa85443ef"}'
+        body: '{"created_at":"2026-07-03T15:09:36.236952Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"c46dd6b8-6100-4f5b-9abd-e63d17bccaf0","name":"test-acc-function-pn-pn01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2026-07-03T15:09:36.236952Z","id":"8eb6d00f-c872-4fec-99ea-d7da2e69b216","private_network_id":"c46dd6b8-6100-4f5b-9abd-e63d17bccaf0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnet":"172.16.64.0/22","updated_at":"2026-07-03T15:09:36.236952Z","vpc_id":"6bb31d81-005b-4aea-adcf-add0bd121f33"},{"created_at":"2026-07-03T15:09:36.236952Z","id":"b05f379d-6785-4c2e-a230-7b60778339f9","private_network_id":"c46dd6b8-6100-4f5b-9abd-e63d17bccaf0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnet":"fd63:256c:45f7:ad3f::/64","updated_at":"2026-07-03T15:09:36.236952Z","vpc_id":"6bb31d81-005b-4aea-adcf-add0bd121f33"}],"tags":[],"updated_at":"2026-07-03T15:09:36.236952Z","vpc_id":"6bb31d81-005b-4aea-adcf-add0bd121f33"}'
         headers:
             Content-Length:
-                - "1071"
+                - "1107"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:09 GMT
+                - Fri, 03 Jul 2026 15:09:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2071,10 +2071,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a3705d3f-dda7-4ce4-9726-a1b1f17f6120
+                - 6c05be04-57a1-458e-b01e-622bd171685a
         status: 200 OK
         code: 200
-        duration: 49.295004ms
+        duration: 34.544113ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -2091,7 +2091,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/30a091ba-e233-4560-a994-18f6b8b34433
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7053737c-21bd-441e-8e6d-1a1d16181a2e
         method: GET
       response:
         proto: HTTP/2.0
@@ -2099,20 +2099,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 758
+        content_length: 761
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:08.410483Z","description":"","domain_name":"tffuncelatedrubinryziaplj-test-acc-function-pn-f02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"30a091ba-e233-4560-a994-18f6b8b34433","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f02","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","privacy":"private","private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:08.410483Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:09:47.437407Z","description":"","domain_name":"tffuncadmiringhaslettwulbygg-test-acc-function-pn-f01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"7053737c-21bd-441e-8e6d-1a1d16181a2e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f01","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","privacy":"private","private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407","ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:09:47.437407Z"}'
         headers:
             Content-Length:
-                - "758"
+                - "761"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:09 GMT
+                - Fri, 03 Jul 2026 15:09:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2120,10 +2120,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cc803c70-13b3-43dd-9350-f62cd7d8d413
+                - ce8f455f-9933-4b95-9a04-60460a08c659
         status: 200 OK
         code: 200
-        duration: 55.032178ms
+        duration: 45.971132ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -2140,7 +2140,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/63c8b9ed-1de4-4789-a5f3-ba3d25380387
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/ef769143-043d-47f3-96fa-c2e8775a82e0
         method: GET
       response:
         proto: HTTP/2.0
@@ -2148,20 +2148,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 758
+        content_length: 761
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:08.419521Z","description":"","domain_name":"tffuncelatedrubinryziaplj-test-acc-function-pn-f01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"63c8b9ed-1de4-4789-a5f3-ba3d25380387","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f01","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","privacy":"private","private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:08.419521Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:09:47.792737Z","description":"","domain_name":"tffuncadmiringhaslettwulbygg-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"ef769143-043d-47f3-96fa-c2e8775a82e0","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","privacy":"private","private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407","ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:09:47.792737Z"}'
         headers:
             Content-Length:
-                - "758"
+                - "761"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:09 GMT
+                - Fri, 03 Jul 2026 15:09:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2169,10 +2169,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4e9d1e89-a520-4efc-a087-9aa3c35c02ed
+                - 458cb1cc-2f50-4f0c-b2dd-ed8c8a8eb7c3
         status: 200 OK
         code: 200
-        duration: 61.90044ms
+        duration: 45.961223ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -2189,7 +2189,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/8162ed34-7c8b-4101-a0db-d73f8de7f99f
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d245d3b3-630a-4879-aca6-5ad9244c0ee9
         method: GET
       response:
         proto: HTTP/2.0
@@ -2197,20 +2197,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 758
+        content_length: 761
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:08.775392Z","description":"","domain_name":"tffuncelatedrubinryziaplj-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"8162ed34-7c8b-4101-a0db-d73f8de7f99f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","privacy":"private","private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:08.775392Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:09:47.434334Z","description":"","domain_name":"tffuncadmiringhaslettwulbygg-test-acc-function-pn-f02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d245d3b3-630a-4879-aca6-5ad9244c0ee9","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f02","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","privacy":"private","private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407","ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:09:47.434334Z"}'
         headers:
             Content-Length:
-                - "758"
+                - "761"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:09 GMT
+                - Fri, 03 Jul 2026 15:09:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2218,10 +2218,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d0fcb1ed-738f-47fc-9d17-5f20f2e9252a
+                - 6b3a8688-b8d1-4193-a462-031ccac836b8
         status: 200 OK
         code: 200
-        duration: 62.003234ms
+        duration: 59.88221ms
     - id: 45
       request:
         proto: HTTP/1.1
@@ -2238,7 +2238,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/87948c6d-ea10-40ec-82b5-05977516bd00
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/6bb31d81-005b-4aea-adcf-add0bd121f33
         method: GET
       response:
         proto: HTTP/2.0
@@ -2246,20 +2246,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 586
+        content_length: 446
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:56.371001Z","description":"","environment_variables":{},"error_message":null,"id":"87948c6d-ea10-40ec-82b5-05977516bd00","name":"tf-func-elated-rubin","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncelatedrubinryziaplj","registry_namespace_id":"0e89ad85-7b5a-48f1-9080-d79156d162ee","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:05.966803Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:09:36.087385Z","custom_routes_propagation_enabled":true,"id":"6bb31d81-005b-4aea-adcf-add0bd121f33","is_default":false,"name":"TestAccFunction_PrivateNetwork","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_count":2,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","routing_enabled":true,"tags":[],"transitivity_enabled":false,"updated_at":"2026-07-03T15:09:36.087385Z"}'
         headers:
             Content-Length:
-                - "586"
+                - "446"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:09 GMT
+                - Fri, 03 Jul 2026 15:09:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2267,10 +2267,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a7045e3d-5730-4dac-b3d3-fd97aad54803
+                - 87067b1b-bc43-42d4-80d9-ce3c47fa0674
         status: 200 OK
         code: 200
-        duration: 36.963664ms
+        duration: 31.337344ms
     - id: 46
       request:
         proto: HTTP/1.1
@@ -2287,7 +2287,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/36d3c8ee-561c-47f5-95b1-973aa85443ef
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8e8949ba-0f49-4761-ad34-e9a02d75bc55
         method: GET
       response:
         proto: HTTP/2.0
@@ -2295,20 +2295,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 417
+        content_length: 593
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:55.544747Z","custom_routes_propagation_enabled":true,"id":"36d3c8ee-561c-47f5-95b1-973aa85443ef","is_default":false,"name":"TestAccFunction_PrivateNetwork","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_count":2,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","routing_enabled":true,"tags":[],"updated_at":"2026-05-04T12:38:55.544747Z"}'
+        body: '{"created_at":"2026-07-03T15:09:40.800078Z","description":"","environment_variables":{},"error_message":null,"id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","name":"tf-func-admiring-haslett","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncadmiringhaslettwulbygg","registry_namespace_id":"29b67960-08ff-47ff-b909-a8a7819f1ee9","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:09:43.490527Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "417"
+                - "593"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:09 GMT
+                - Fri, 03 Jul 2026 15:09:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2316,10 +2316,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 02533ca1-7c2b-4d57-9bc9-287ed94cc5cd
+                - 54326990-040d-445e-8fe6-37ccd34cc713
         status: 200 OK
         code: 200
-        duration: 51.055466ms
+        duration: 35.642337ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -2336,7 +2336,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/8162ed34-7c8b-4101-a0db-d73f8de7f99f
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9c7ec006-9f9c-4337-acf3-2c7040516407
         method: GET
       response:
         proto: HTTP/2.0
@@ -2344,20 +2344,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 758
+        content_length: 1107
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:08.775392Z","description":"","domain_name":"tffuncelatedrubinryziaplj-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"8162ed34-7c8b-4101-a0db-d73f8de7f99f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","privacy":"private","private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:08.775392Z"}'
+        body: '{"created_at":"2026-07-03T15:09:36.386569Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"9c7ec006-9f9c-4337-acf3-2c7040516407","name":"test-acc-function-pn-pn00","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2026-07-03T15:09:36.386569Z","id":"9b301033-da29-4986-b09e-a1985e20cca8","private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnet":"172.16.76.0/22","updated_at":"2026-07-03T15:09:36.386569Z","vpc_id":"6bb31d81-005b-4aea-adcf-add0bd121f33"},{"created_at":"2026-07-03T15:09:36.386569Z","id":"982a3685-d413-4a51-9c3a-e9c29efb452b","private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnet":"fd63:256c:45f7:9f34::/64","updated_at":"2026-07-03T15:09:36.386569Z","vpc_id":"6bb31d81-005b-4aea-adcf-add0bd121f33"}],"tags":[],"updated_at":"2026-07-03T15:09:36.386569Z","vpc_id":"6bb31d81-005b-4aea-adcf-add0bd121f33"}'
         headers:
             Content-Length:
-                - "758"
+                - "1107"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:09 GMT
+                - Fri, 03 Jul 2026 15:09:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2365,10 +2365,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cb1b904e-4d12-4eb2-8785-141f08cc06e3
+                - ff61b7b0-94c7-4d3d-91c1-093c3be0fb9a
         status: 200 OK
         code: 200
-        duration: 38.980228ms
+        duration: 32.374644ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -2385,7 +2385,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/258f0f17-2b28-41a2-bba5-d15b6f0902f6
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c46dd6b8-6100-4f5b-9abd-e63d17bccaf0
         method: GET
       response:
         proto: HTTP/2.0
@@ -2393,20 +2393,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1071
+        content_length: 1107
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:55.819981Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","name":"test-acc-function-pn-pn00","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2026-05-04T12:38:55.819981Z","id":"5f3c1582-5862-4175-80ab-9ca9aa98642b","private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.16.0/22","updated_at":"2026-05-04T12:38:55.819981Z","vpc_id":"36d3c8ee-561c-47f5-95b1-973aa85443ef"},{"created_at":"2026-05-04T12:38:55.819981Z","id":"03c23551-f7c3-4677-95e2-b3c06a282251","private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:8f19::/64","updated_at":"2026-05-04T12:38:55.819981Z","vpc_id":"36d3c8ee-561c-47f5-95b1-973aa85443ef"}],"tags":[],"updated_at":"2026-05-04T12:38:55.819981Z","vpc_id":"36d3c8ee-561c-47f5-95b1-973aa85443ef"}'
+        body: '{"created_at":"2026-07-03T15:09:36.236952Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"c46dd6b8-6100-4f5b-9abd-e63d17bccaf0","name":"test-acc-function-pn-pn01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2026-07-03T15:09:36.236952Z","id":"8eb6d00f-c872-4fec-99ea-d7da2e69b216","private_network_id":"c46dd6b8-6100-4f5b-9abd-e63d17bccaf0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnet":"172.16.64.0/22","updated_at":"2026-07-03T15:09:36.236952Z","vpc_id":"6bb31d81-005b-4aea-adcf-add0bd121f33"},{"created_at":"2026-07-03T15:09:36.236952Z","id":"b05f379d-6785-4c2e-a230-7b60778339f9","private_network_id":"c46dd6b8-6100-4f5b-9abd-e63d17bccaf0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnet":"fd63:256c:45f7:ad3f::/64","updated_at":"2026-07-03T15:09:36.236952Z","vpc_id":"6bb31d81-005b-4aea-adcf-add0bd121f33"}],"tags":[],"updated_at":"2026-07-03T15:09:36.236952Z","vpc_id":"6bb31d81-005b-4aea-adcf-add0bd121f33"}'
         headers:
             Content-Length:
-                - "1071"
+                - "1107"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:09 GMT
+                - Fri, 03 Jul 2026 15:09:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2414,10 +2414,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e8fd7df0-b84c-4d57-85d7-0ba5d92b83d3
+                - 15c4ef01-15b2-4e00-b62e-63e8b88d85cf
         status: 200 OK
         code: 200
-        duration: 29.530219ms
+        duration: 32.651535ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -2434,7 +2434,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/eeff176d-2ea9-4c03-bd41-675e65c0b176
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/ef769143-043d-47f3-96fa-c2e8775a82e0
         method: GET
       response:
         proto: HTTP/2.0
@@ -2442,20 +2442,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1070
+        content_length: 761
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:55.688803Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"eeff176d-2ea9-4c03-bd41-675e65c0b176","name":"test-acc-function-pn-pn01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2026-05-04T12:38:55.688803Z","id":"d6a2cf65-6a4d-48e0-88b7-e779a952842a","private_network_id":"eeff176d-2ea9-4c03-bd41-675e65c0b176","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.0.0/22","updated_at":"2026-05-04T12:38:55.688803Z","vpc_id":"36d3c8ee-561c-47f5-95b1-973aa85443ef"},{"created_at":"2026-05-04T12:38:55.688803Z","id":"f5939756-132f-44dd-8f7d-8b9c679373e8","private_network_id":"eeff176d-2ea9-4c03-bd41-675e65c0b176","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:9c9b::/64","updated_at":"2026-05-04T12:38:55.688803Z","vpc_id":"36d3c8ee-561c-47f5-95b1-973aa85443ef"}],"tags":[],"updated_at":"2026-05-04T12:38:55.688803Z","vpc_id":"36d3c8ee-561c-47f5-95b1-973aa85443ef"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:09:47.792737Z","description":"","domain_name":"tffuncadmiringhaslettwulbygg-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"ef769143-043d-47f3-96fa-c2e8775a82e0","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","privacy":"private","private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407","ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:09:47.792737Z"}'
         headers:
             Content-Length:
-                - "1070"
+                - "761"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:09 GMT
+                - Fri, 03 Jul 2026 15:09:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2463,10 +2463,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a971cf5e-d7fb-4a56-a334-c22d83c0132d
+                - 63b8599c-9e28-4f7c-a891-1a0ba2d1a113
         status: 200 OK
         code: 200
-        duration: 46.830247ms
+        duration: 49.987442ms
     - id: 50
       request:
         proto: HTTP/1.1
@@ -2483,7 +2483,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/30a091ba-e233-4560-a994-18f6b8b34433
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7053737c-21bd-441e-8e6d-1a1d16181a2e
         method: GET
       response:
         proto: HTTP/2.0
@@ -2491,20 +2491,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 758
+        content_length: 761
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:08.410483Z","description":"","domain_name":"tffuncelatedrubinryziaplj-test-acc-function-pn-f02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"30a091ba-e233-4560-a994-18f6b8b34433","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f02","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","privacy":"private","private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:08.410483Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:09:47.437407Z","description":"","domain_name":"tffuncadmiringhaslettwulbygg-test-acc-function-pn-f01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"7053737c-21bd-441e-8e6d-1a1d16181a2e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f01","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","privacy":"private","private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407","ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:09:47.437407Z"}'
         headers:
             Content-Length:
-                - "758"
+                - "761"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:09 GMT
+                - Fri, 03 Jul 2026 15:09:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2512,10 +2512,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2ceedd53-b1d9-4773-a58c-680c48cb29ad
+                - fbe669ae-06c6-47fa-a146-2a34ca45e38d
         status: 200 OK
         code: 200
-        duration: 39.599232ms
+        duration: 44.02302ms
     - id: 51
       request:
         proto: HTTP/1.1
@@ -2532,7 +2532,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/63c8b9ed-1de4-4789-a5f3-ba3d25380387
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d245d3b3-630a-4879-aca6-5ad9244c0ee9
         method: GET
       response:
         proto: HTTP/2.0
@@ -2540,20 +2540,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 758
+        content_length: 761
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:08.419521Z","description":"","domain_name":"tffuncelatedrubinryziaplj-test-acc-function-pn-f01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"63c8b9ed-1de4-4789-a5f3-ba3d25380387","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f01","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","privacy":"private","private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:08.419521Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:09:47.434334Z","description":"","domain_name":"tffuncadmiringhaslettwulbygg-test-acc-function-pn-f02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d245d3b3-630a-4879-aca6-5ad9244c0ee9","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f02","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","privacy":"private","private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407","ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:09:47.434334Z"}'
         headers:
             Content-Length:
-                - "758"
+                - "761"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:09 GMT
+                - Fri, 03 Jul 2026 15:09:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2561,10 +2561,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2afcc379-2730-432a-b148-a088e41f5712
+                - b9dd7486-1070-4f0e-a09d-b99b6928844c
         status: 200 OK
         code: 200
-        duration: 47.37442ms
+        duration: 48.500256ms
     - id: 52
       request:
         proto: HTTP/1.1
@@ -2581,7 +2581,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/8162ed34-7c8b-4101-a0db-d73f8de7f99f
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/ef769143-043d-47f3-96fa-c2e8775a82e0
         method: GET
       response:
         proto: HTTP/2.0
@@ -2589,20 +2589,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 758
+        content_length: 761
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:08.775392Z","description":"","domain_name":"tffuncelatedrubinryziaplj-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"8162ed34-7c8b-4101-a0db-d73f8de7f99f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","privacy":"private","private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:08.775392Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:09:47.792737Z","description":"","domain_name":"tffuncadmiringhaslettwulbygg-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"ef769143-043d-47f3-96fa-c2e8775a82e0","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","privacy":"private","private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407","ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:09:47.792737Z"}'
         headers:
             Content-Length:
-                - "758"
+                - "761"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:10 GMT
+                - Fri, 03 Jul 2026 15:09:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2610,11 +2610,109 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2ec12966-4c8d-4508-ba95-e619d039faf5
+                - 9fe3ec2c-5e84-4213-93b5-e50616eb6477
         status: 200 OK
         code: 200
-        duration: 57.376208ms
+        duration: 39.493987ms
     - id: 53
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d245d3b3-630a-4879-aca6-5ad9244c0ee9
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 761
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:09:47.434334Z","description":"","domain_name":"tffuncadmiringhaslettwulbygg-test-acc-function-pn-f02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d245d3b3-630a-4879-aca6-5ad9244c0ee9","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f02","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","privacy":"private","private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407","ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:09:47.434334Z"}'
+        headers:
+            Content-Length:
+                - "761"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:09:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 884f9669-45f6-48df-a510-beffa9a58674
+        status: 200 OK
+        code: 200
+        duration: 47.712264ms
+    - id: 54
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7053737c-21bd-441e-8e6d-1a1d16181a2e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 761
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:09:47.437407Z","description":"","domain_name":"tffuncadmiringhaslettwulbygg-test-acc-function-pn-f01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"7053737c-21bd-441e-8e6d-1a1d16181a2e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f01","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","privacy":"private","private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407","ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:09:47.437407Z"}'
+        headers:
+            Content-Length:
+                - "761"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:09:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0fdd4025-1c54-4399-9dc2-2bc781e1b26e
+        status: 200 OK
+        code: 200
+        duration: 102.205636ms
+    - id: 55
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2632,7 +2730,7 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/8162ed34-7c8b-4101-a0db-d73f8de7f99f
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/ef769143-043d-47f3-96fa-c2e8775a82e0
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -2640,20 +2738,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 727
+        content_length: 730
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:08.775392Z","description":"","domain_name":"tffuncelatedrubinryziaplj-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"8162ed34-7c8b-4101-a0db-d73f8de7f99f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:10.190325901Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:09:47.792737Z","description":"","domain_name":"tffuncadmiringhaslettwulbygg-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"ef769143-043d-47f3-96fa-c2e8775a82e0","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:09:49.140853674Z"}'
         headers:
             Content-Length:
-                - "727"
+                - "730"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:10 GMT
+                - Fri, 03 Jul 2026 15:09:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2661,108 +2759,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 291acc8d-090b-426f-a937-2fe52590f3ba
+                - bd05ed25-aaa0-4485-bb3e-70a051804b9c
         status: 200 OK
         code: 200
-        duration: 70.46244ms
-    - id: 54
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/63c8b9ed-1de4-4789-a5f3-ba3d25380387
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 758
-        uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:08.419521Z","description":"","domain_name":"tffuncelatedrubinryziaplj-test-acc-function-pn-f01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"63c8b9ed-1de4-4789-a5f3-ba3d25380387","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f01","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","privacy":"private","private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:08.419521Z"}'
-        headers:
-            Content-Length:
-                - "758"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 04 May 2026 12:39:10 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 98ceef11-43ab-4bf5-b120-3fbaeb082523
-        status: 200 OK
-        code: 200
-        duration: 305.457152ms
-    - id: 55
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/30a091ba-e233-4560-a994-18f6b8b34433
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 758
-        uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:08.410483Z","description":"","domain_name":"tffuncelatedrubinryziaplj-test-acc-function-pn-f02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"30a091ba-e233-4560-a994-18f6b8b34433","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f02","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","privacy":"private","private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:08.410483Z"}'
-        headers:
-            Content-Length:
-                - "758"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 04 May 2026 12:39:10 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 9ace0c40-f11a-4be2-a178-7ebd5d664c9b
-        status: 200 OK
-        code: 200
-        duration: 445.109647ms
+        duration: 111.008082ms
     - id: 56
       request:
         proto: HTTP/1.1
@@ -2774,14 +2774,14 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"runtime":"unknown_runtime","privacy":"unknown_privacy","secret_environment_variables":null,"http_option":"unknown_http_option","sandbox":"unknown_sandbox","private_network_id":"eeff176d-2ea9-4c03-bd41-675e65c0b176"}'
+        body: '{"runtime":"unknown_runtime","privacy":"unknown_privacy","secret_environment_variables":null,"http_option":"unknown_http_option","sandbox":"unknown_sandbox","private_network_id":"c46dd6b8-6100-4f5b-9abd-e63d17bccaf0"}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/63c8b9ed-1de4-4789-a5f3-ba3d25380387
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7053737c-21bd-441e-8e6d-1a1d16181a2e
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -2789,20 +2789,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 761
+        content_length: 764
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:08.419521Z","description":"","domain_name":"tffuncelatedrubinryziaplj-test-acc-function-pn-f01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"63c8b9ed-1de4-4789-a5f3-ba3d25380387","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f01","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","privacy":"private","private_network_id":"eeff176d-2ea9-4c03-bd41-675e65c0b176","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:10.520756794Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:09:47.437407Z","description":"","domain_name":"tffuncadmiringhaslettwulbygg-test-acc-function-pn-f01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"7053737c-21bd-441e-8e6d-1a1d16181a2e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f01","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","privacy":"private","private_network_id":"c46dd6b8-6100-4f5b-9abd-e63d17bccaf0","ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:09:49.212823563Z"}'
         headers:
             Content-Length:
-                - "761"
+                - "764"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:10 GMT
+                - Fri, 03 Jul 2026 15:09:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2810,10 +2810,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8b6fa6fa-9163-4f39-9d97-a31ed203f3e6
+                - 38a594f6-6abf-4e6f-8a3a-bc833476bb36
         status: 200 OK
         code: 200
-        duration: 156.129455ms
+        duration: 112.855475ms
     - id: 57
       request:
         proto: HTTP/1.1
@@ -2830,7 +2830,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/30a091ba-e233-4560-a994-18f6b8b34433
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d245d3b3-630a-4879-aca6-5ad9244c0ee9
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2838,20 +2838,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 762
+        content_length: 765
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:08.410483Z","description":"","domain_name":"tffuncelatedrubinryziaplj-test-acc-function-pn-f02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"30a091ba-e233-4560-a994-18f6b8b34433","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f02","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","privacy":"private","private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:10.562790657Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:09:47.434334Z","description":"","domain_name":"tffuncadmiringhaslettwulbygg-test-acc-function-pn-f02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"d245d3b3-630a-4879-aca6-5ad9244c0ee9","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f02","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","privacy":"private","private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407","ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:09:49.102188664Z"}'
         headers:
             Content-Length:
-                - "762"
+                - "765"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:10 GMT
+                - Fri, 03 Jul 2026 15:09:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2859,10 +2859,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6c1f59eb-3ba6-45d5-b2b5-2830614735fc
+                - 3aaa3317-834a-4272-b469-85fcfbc3bb8b
         status: 200 OK
         code: 200
-        duration: 134.528234ms
+        duration: 257.42933ms
     - id: 58
       request:
         proto: HTTP/1.1
@@ -2874,7 +2874,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"test-acc-function-pn-02","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"go123","memory_limit":256,"handler":"Handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"v1","tags":null,"private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6"}'
+        body: '{"name":"test-acc-function-pn-02","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"go126","memory_limit":256,"handler":"Handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"v1","tags":null,"private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407"}'
         form: {}
         headers:
             Content-Type:
@@ -2889,20 +2889,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 762
+        content_length: 765
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:10.795815228Z","description":"","domain_name":"tffuncelatedrubinryziaplj-test-acc-function-pn-02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"46ec5364-0d87-4f83-b412-1c775ddb9d9f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-02","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","privacy":"private","private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:10.795815228Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:09:49.472074858Z","description":"","domain_name":"tffuncadmiringhaslettwulbygg-test-acc-function-pn-02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"e95af029-ca96-4028-80cb-308094fe9b35","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-02","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","privacy":"private","private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407","ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:09:49.472074858Z"}'
         headers:
             Content-Length:
-                - "762"
+                - "765"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:10 GMT
+                - Fri, 03 Jul 2026 15:09:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2910,10 +2910,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2b007ee7-b0c4-48b0-98f6-488e881791bb
+                - 0dfd33a2-3f08-47c6-87f1-85252748f713
         status: 200 OK
         code: 200
-        duration: 153.303838ms
+        duration: 162.800757ms
     - id: 59
       request:
         proto: HTTP/1.1
@@ -2930,7 +2930,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/46ec5364-0d87-4f83-b412-1c775ddb9d9f
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e95af029-ca96-4028-80cb-308094fe9b35
         method: GET
       response:
         proto: HTTP/2.0
@@ -2938,20 +2938,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 756
+        content_length: 759
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:10.795815Z","description":"","domain_name":"tffuncelatedrubinryziaplj-test-acc-function-pn-02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"46ec5364-0d87-4f83-b412-1c775ddb9d9f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-02","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","privacy":"private","private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:10.795815Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:09:49.472075Z","description":"","domain_name":"tffuncadmiringhaslettwulbygg-test-acc-function-pn-02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"e95af029-ca96-4028-80cb-308094fe9b35","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-02","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","privacy":"private","private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407","ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:09:49.472075Z"}'
         headers:
             Content-Length:
-                - "756"
+                - "759"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:10 GMT
+                - Fri, 03 Jul 2026 15:09:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2959,10 +2959,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7561c702-c007-40ba-af75-f978b304233f
+                - 1eca4564-3dcb-4441-bbe0-81c560105e3c
         status: 200 OK
         code: 200
-        duration: 51.106042ms
+        duration: 50.22085ms
     - id: 60
       request:
         proto: HTTP/1.1
@@ -2979,7 +2979,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/46ec5364-0d87-4f83-b412-1c775ddb9d9f
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e95af029-ca96-4028-80cb-308094fe9b35
         method: GET
       response:
         proto: HTTP/2.0
@@ -2987,20 +2987,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 756
+        content_length: 759
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:10.795815Z","description":"","domain_name":"tffuncelatedrubinryziaplj-test-acc-function-pn-02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"46ec5364-0d87-4f83-b412-1c775ddb9d9f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-02","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","privacy":"private","private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:10.795815Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:09:49.472075Z","description":"","domain_name":"tffuncadmiringhaslettwulbygg-test-acc-function-pn-02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"e95af029-ca96-4028-80cb-308094fe9b35","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-02","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","privacy":"private","private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407","ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:09:49.472075Z"}'
         headers:
             Content-Length:
-                - "756"
+                - "759"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:10 GMT
+                - Fri, 03 Jul 2026 15:09:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3008,10 +3008,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 637f0f5e-22c7-457b-a13c-73a1fc50bfe6
+                - a613ac74-7826-4443-b090-eb0f14df59db
         status: 200 OK
         code: 200
-        duration: 39.86327ms
+        duration: 56.039498ms
     - id: 61
       request:
         proto: HTTP/1.1
@@ -3028,7 +3028,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/8162ed34-7c8b-4101-a0db-d73f8de7f99f
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/ef769143-043d-47f3-96fa-c2e8775a82e0
         method: GET
       response:
         proto: HTTP/2.0
@@ -3036,20 +3036,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 724
+        content_length: 727
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:08.775392Z","description":"","domain_name":"tffuncelatedrubinryziaplj-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"8162ed34-7c8b-4101-a0db-d73f8de7f99f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:10.190326Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:09:47.792737Z","description":"","domain_name":"tffuncadmiringhaslettwulbygg-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"ef769143-043d-47f3-96fa-c2e8775a82e0","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:09:49.140854Z"}'
         headers:
             Content-Length:
-                - "724"
+                - "727"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:11 GMT
+                - Fri, 03 Jul 2026 15:09:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3057,10 +3057,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8d48b851-4372-44a8-b72a-71630ba263fe
+                - d236c410-b50c-4734-aa0d-4da139db488e
         status: 200 OK
         code: 200
-        duration: 48.860928ms
+        duration: 49.273199ms
     - id: 62
       request:
         proto: HTTP/1.1
@@ -3077,7 +3077,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/8162ed34-7c8b-4101-a0db-d73f8de7f99f
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/ef769143-043d-47f3-96fa-c2e8775a82e0
         method: GET
       response:
         proto: HTTP/2.0
@@ -3085,20 +3085,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 734
+        content_length: 737
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:08.775392Z","description":"","domain_name":"tffuncelatedrubinryziaplj-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"Handle","http_option":"enabled","id":"8162ed34-7c8b-4101-a0db-d73f8de7f99f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:11.273879Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:09:47.792737Z","description":"","domain_name":"tffuncadmiringhaslettwulbygg-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"Handle","http_option":"enabled","id":"ef769143-043d-47f3-96fa-c2e8775a82e0","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:09:54.811420Z"}'
         headers:
             Content-Length:
-                - "734"
+                - "737"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:16 GMT
+                - Fri, 03 Jul 2026 15:09:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3106,10 +3106,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e457d048-8369-4a69-896c-e0f32ab20215
+                - bc4ce079-cd33-4482-b766-30cee9325b16
         status: 200 OK
         code: 200
-        duration: 50.490024ms
+        duration: 36.986283ms
     - id: 63
       request:
         proto: HTTP/1.1
@@ -3126,7 +3126,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/63c8b9ed-1de4-4789-a5f3-ba3d25380387
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7053737c-21bd-441e-8e6d-1a1d16181a2e
         method: GET
       response:
         proto: HTTP/2.0
@@ -3134,20 +3134,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 768
+        content_length: 771
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:08.419521Z","description":"","domain_name":"tffuncelatedrubinryziaplj-test-acc-function-pn-f01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"Handle","http_option":"enabled","id":"63c8b9ed-1de4-4789-a5f3-ba3d25380387","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f01","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","privacy":"private","private_network_id":"eeff176d-2ea9-4c03-bd41-675e65c0b176","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:11.967872Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:09:47.437407Z","description":"","domain_name":"tffuncadmiringhaslettwulbygg-test-acc-function-pn-f01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"Handle","http_option":"enabled","id":"7053737c-21bd-441e-8e6d-1a1d16181a2e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f01","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","privacy":"private","private_network_id":"c46dd6b8-6100-4f5b-9abd-e63d17bccaf0","ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:09:55.177869Z"}'
         headers:
             Content-Length:
-                - "768"
+                - "771"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:16 GMT
+                - Fri, 03 Jul 2026 15:09:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3155,10 +3155,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2dbf9d87-6055-4fc5-b3e2-d33d483d0899
+                - 989b56ed-f995-4255-b6e5-563042eecdf9
         status: 200 OK
         code: 200
-        duration: 377.479692ms
+        duration: 51.096396ms
     - id: 64
       request:
         proto: HTTP/1.1
@@ -3175,7 +3175,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/8162ed34-7c8b-4101-a0db-d73f8de7f99f
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/ef769143-043d-47f3-96fa-c2e8775a82e0
         method: GET
       response:
         proto: HTTP/2.0
@@ -3183,20 +3183,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 734
+        content_length: 737
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:08.775392Z","description":"","domain_name":"tffuncelatedrubinryziaplj-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"Handle","http_option":"enabled","id":"8162ed34-7c8b-4101-a0db-d73f8de7f99f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:11.273879Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:09:47.792737Z","description":"","domain_name":"tffuncadmiringhaslettwulbygg-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"Handle","http_option":"enabled","id":"ef769143-043d-47f3-96fa-c2e8775a82e0","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:09:54.811420Z"}'
         headers:
             Content-Length:
-                - "734"
+                - "737"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:17 GMT
+                - Fri, 03 Jul 2026 15:09:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3204,10 +3204,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b145bfe9-29c1-4b0e-8f1e-d8099c127752
+                - 3ab51181-bc8b-47e1-8aec-89e3269d29a9
         status: 200 OK
         code: 200
-        duration: 53.815862ms
+        duration: 33.635084ms
     - id: 65
       request:
         proto: HTTP/1.1
@@ -3224,7 +3224,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/63c8b9ed-1de4-4789-a5f3-ba3d25380387
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7053737c-21bd-441e-8e6d-1a1d16181a2e
         method: GET
       response:
         proto: HTTP/2.0
@@ -3232,20 +3232,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 768
+        content_length: 771
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:08.419521Z","description":"","domain_name":"tffuncelatedrubinryziaplj-test-acc-function-pn-f01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"Handle","http_option":"enabled","id":"63c8b9ed-1de4-4789-a5f3-ba3d25380387","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f01","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","privacy":"private","private_network_id":"eeff176d-2ea9-4c03-bd41-675e65c0b176","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:11.967872Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:09:47.437407Z","description":"","domain_name":"tffuncadmiringhaslettwulbygg-test-acc-function-pn-f01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"Handle","http_option":"enabled","id":"7053737c-21bd-441e-8e6d-1a1d16181a2e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f01","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","privacy":"private","private_network_id":"c46dd6b8-6100-4f5b-9abd-e63d17bccaf0","ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:09:55.177869Z"}'
         headers:
             Content-Length:
-                - "768"
+                - "771"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:17 GMT
+                - Fri, 03 Jul 2026 15:09:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3253,10 +3253,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e4121461-ce02-475e-9580-6dbb66148940
+                - b2db8f12-41a5-4632-b911-99fa9629110f
         status: 200 OK
         code: 200
-        duration: 41.532372ms
+        duration: 51.365623ms
     - id: 66
       request:
         proto: HTTP/1.1
@@ -3273,7 +3273,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/46ec5364-0d87-4f83-b412-1c775ddb9d9f
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e95af029-ca96-4028-80cb-308094fe9b35
         method: GET
       response:
         proto: HTTP/2.0
@@ -3281,20 +3281,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 756
+        content_length: 759
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:10.795815Z","description":"","domain_name":"tffuncelatedrubinryziaplj-test-acc-function-pn-02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"46ec5364-0d87-4f83-b412-1c775ddb9d9f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-02","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","privacy":"private","private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:10.795815Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:09:49.472075Z","description":"","domain_name":"tffuncadmiringhaslettwulbygg-test-acc-function-pn-02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"e95af029-ca96-4028-80cb-308094fe9b35","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-02","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","privacy":"private","private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407","ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:09:49.472075Z"}'
         headers:
             Content-Length:
-                - "756"
+                - "759"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:17 GMT
+                - Fri, 03 Jul 2026 15:09:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3302,10 +3302,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7fb78541-7cc5-4de3-89f9-cd74d0833388
+                - 9ddcd4ad-434e-499a-8f4b-b86518ac3993
         status: 200 OK
         code: 200
-        duration: 38.910629ms
+        duration: 35.354687ms
     - id: 67
       request:
         proto: HTTP/1.1
@@ -3322,7 +3322,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/36d3c8ee-561c-47f5-95b1-973aa85443ef
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/6bb31d81-005b-4aea-adcf-add0bd121f33
         method: GET
       response:
         proto: HTTP/2.0
@@ -3330,20 +3330,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 417
+        content_length: 446
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:55.544747Z","custom_routes_propagation_enabled":true,"id":"36d3c8ee-561c-47f5-95b1-973aa85443ef","is_default":false,"name":"TestAccFunction_PrivateNetwork","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_count":2,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","routing_enabled":true,"tags":[],"updated_at":"2026-05-04T12:38:55.544747Z"}'
+        body: '{"created_at":"2026-07-03T15:09:36.087385Z","custom_routes_propagation_enabled":true,"id":"6bb31d81-005b-4aea-adcf-add0bd121f33","is_default":false,"name":"TestAccFunction_PrivateNetwork","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_count":2,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","routing_enabled":true,"tags":[],"transitivity_enabled":false,"updated_at":"2026-07-03T15:09:36.087385Z"}'
         headers:
             Content-Length:
-                - "417"
+                - "446"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:17 GMT
+                - Fri, 03 Jul 2026 15:09:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3351,10 +3351,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7794fa0f-0f71-4bd1-8c5c-6747b38f0974
+                - 88c6fedc-382b-4b74-a91e-bd2ba8e962e3
         status: 200 OK
         code: 200
-        duration: 28.843438ms
+        duration: 31.657537ms
     - id: 68
       request:
         proto: HTTP/1.1
@@ -3371,7 +3371,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/87948c6d-ea10-40ec-82b5-05977516bd00
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8e8949ba-0f49-4761-ad34-e9a02d75bc55
         method: GET
       response:
         proto: HTTP/2.0
@@ -3379,20 +3379,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 586
+        content_length: 593
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:56.371001Z","description":"","environment_variables":{},"error_message":null,"id":"87948c6d-ea10-40ec-82b5-05977516bd00","name":"tf-func-elated-rubin","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncelatedrubinryziaplj","registry_namespace_id":"0e89ad85-7b5a-48f1-9080-d79156d162ee","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:05.966803Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:09:40.800078Z","description":"","environment_variables":{},"error_message":null,"id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","name":"tf-func-admiring-haslett","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncadmiringhaslettwulbygg","registry_namespace_id":"29b67960-08ff-47ff-b909-a8a7819f1ee9","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:09:43.490527Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "586"
+                - "593"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:17 GMT
+                - Fri, 03 Jul 2026 15:09:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3400,10 +3400,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a1149515-82b6-4f28-802f-1239c7c2fa44
+                - 7a7676f5-9d6b-4c43-9e3d-55b4dacd01cd
         status: 200 OK
         code: 200
-        duration: 40.568999ms
+        duration: 41.743295ms
     - id: 69
       request:
         proto: HTTP/1.1
@@ -3420,7 +3420,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/eeff176d-2ea9-4c03-bd41-675e65c0b176
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c46dd6b8-6100-4f5b-9abd-e63d17bccaf0
         method: GET
       response:
         proto: HTTP/2.0
@@ -3428,20 +3428,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1070
+        content_length: 1107
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:55.688803Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"eeff176d-2ea9-4c03-bd41-675e65c0b176","name":"test-acc-function-pn-pn01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2026-05-04T12:38:55.688803Z","id":"d6a2cf65-6a4d-48e0-88b7-e779a952842a","private_network_id":"eeff176d-2ea9-4c03-bd41-675e65c0b176","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.0.0/22","updated_at":"2026-05-04T12:38:55.688803Z","vpc_id":"36d3c8ee-561c-47f5-95b1-973aa85443ef"},{"created_at":"2026-05-04T12:38:55.688803Z","id":"f5939756-132f-44dd-8f7d-8b9c679373e8","private_network_id":"eeff176d-2ea9-4c03-bd41-675e65c0b176","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:9c9b::/64","updated_at":"2026-05-04T12:38:55.688803Z","vpc_id":"36d3c8ee-561c-47f5-95b1-973aa85443ef"}],"tags":[],"updated_at":"2026-05-04T12:38:55.688803Z","vpc_id":"36d3c8ee-561c-47f5-95b1-973aa85443ef"}'
+        body: '{"created_at":"2026-07-03T15:09:36.236952Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"c46dd6b8-6100-4f5b-9abd-e63d17bccaf0","name":"test-acc-function-pn-pn01","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2026-07-03T15:09:36.236952Z","id":"8eb6d00f-c872-4fec-99ea-d7da2e69b216","private_network_id":"c46dd6b8-6100-4f5b-9abd-e63d17bccaf0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnet":"172.16.64.0/22","updated_at":"2026-07-03T15:09:36.236952Z","vpc_id":"6bb31d81-005b-4aea-adcf-add0bd121f33"},{"created_at":"2026-07-03T15:09:36.236952Z","id":"b05f379d-6785-4c2e-a230-7b60778339f9","private_network_id":"c46dd6b8-6100-4f5b-9abd-e63d17bccaf0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnet":"fd63:256c:45f7:ad3f::/64","updated_at":"2026-07-03T15:09:36.236952Z","vpc_id":"6bb31d81-005b-4aea-adcf-add0bd121f33"}],"tags":[],"updated_at":"2026-07-03T15:09:36.236952Z","vpc_id":"6bb31d81-005b-4aea-adcf-add0bd121f33"}'
         headers:
             Content-Length:
-                - "1070"
+                - "1107"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:17 GMT
+                - Fri, 03 Jul 2026 15:09:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3449,10 +3449,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1666496e-4e37-4f0c-96e5-ebc8fc30c79a
+                - d89d32a2-ed18-42e5-924f-e9afc4951f95
         status: 200 OK
         code: 200
-        duration: 24.006687ms
+        duration: 26.595061ms
     - id: 70
       request:
         proto: HTTP/1.1
@@ -3469,7 +3469,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/258f0f17-2b28-41a2-bba5-d15b6f0902f6
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9c7ec006-9f9c-4337-acf3-2c7040516407
         method: GET
       response:
         proto: HTTP/2.0
@@ -3477,20 +3477,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1071
+        content_length: 1107
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:55.819981Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","name":"test-acc-function-pn-pn00","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2026-05-04T12:38:55.819981Z","id":"5f3c1582-5862-4175-80ab-9ca9aa98642b","private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"172.16.16.0/22","updated_at":"2026-05-04T12:38:55.819981Z","vpc_id":"36d3c8ee-561c-47f5-95b1-973aa85443ef"},{"created_at":"2026-05-04T12:38:55.819981Z","id":"03c23551-f7c3-4677-95e2-b3c06a282251","private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"fd63:256c:45f7:8f19::/64","updated_at":"2026-05-04T12:38:55.819981Z","vpc_id":"36d3c8ee-561c-47f5-95b1-973aa85443ef"}],"tags":[],"updated_at":"2026-05-04T12:38:55.819981Z","vpc_id":"36d3c8ee-561c-47f5-95b1-973aa85443ef"}'
+        body: '{"created_at":"2026-07-03T15:09:36.386569Z","default_route_propagation_enabled":false,"dhcp_enabled":true,"id":"9c7ec006-9f9c-4337-acf3-2c7040516407","name":"test-acc-function-pn-pn00","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2026-07-03T15:09:36.386569Z","id":"9b301033-da29-4986-b09e-a1985e20cca8","private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnet":"172.16.76.0/22","updated_at":"2026-07-03T15:09:36.386569Z","vpc_id":"6bb31d81-005b-4aea-adcf-add0bd121f33"},{"created_at":"2026-07-03T15:09:36.386569Z","id":"982a3685-d413-4a51-9c3a-e9c29efb452b","private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnet":"fd63:256c:45f7:9f34::/64","updated_at":"2026-07-03T15:09:36.386569Z","vpc_id":"6bb31d81-005b-4aea-adcf-add0bd121f33"}],"tags":[],"updated_at":"2026-07-03T15:09:36.386569Z","vpc_id":"6bb31d81-005b-4aea-adcf-add0bd121f33"}'
         headers:
             Content-Length:
-                - "1071"
+                - "1107"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:17 GMT
+                - Fri, 03 Jul 2026 15:09:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3498,10 +3498,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 20a782ff-86cd-496b-bc15-2750c420771c
+                - 098dbdf6-49f6-4d8e-9b18-d0d8fc5f00f4
         status: 200 OK
         code: 200
-        duration: 23.978725ms
+        duration: 26.73294ms
     - id: 71
       request:
         proto: HTTP/1.1
@@ -3518,7 +3518,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/8162ed34-7c8b-4101-a0db-d73f8de7f99f
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/ef769143-043d-47f3-96fa-c2e8775a82e0
         method: GET
       response:
         proto: HTTP/2.0
@@ -3526,20 +3526,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 734
+        content_length: 737
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:08.775392Z","description":"","domain_name":"tffuncelatedrubinryziaplj-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"Handle","http_option":"enabled","id":"8162ed34-7c8b-4101-a0db-d73f8de7f99f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:11.273879Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:09:47.792737Z","description":"","domain_name":"tffuncadmiringhaslettwulbygg-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"Handle","http_option":"enabled","id":"ef769143-043d-47f3-96fa-c2e8775a82e0","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:09:54.811420Z"}'
         headers:
             Content-Length:
-                - "734"
+                - "737"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:17 GMT
+                - Fri, 03 Jul 2026 15:09:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3547,10 +3547,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6ca68e0e-6e4b-4dfc-9409-736a5a065b76
+                - 5a68eed5-7ae3-421d-9277-2fa8b0dd62ff
         status: 200 OK
         code: 200
-        duration: 39.31506ms
+        duration: 49.258982ms
     - id: 72
       request:
         proto: HTTP/1.1
@@ -3567,7 +3567,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/63c8b9ed-1de4-4789-a5f3-ba3d25380387
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7053737c-21bd-441e-8e6d-1a1d16181a2e
         method: GET
       response:
         proto: HTTP/2.0
@@ -3575,20 +3575,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 768
+        content_length: 771
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:08.419521Z","description":"","domain_name":"tffuncelatedrubinryziaplj-test-acc-function-pn-f01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"Handle","http_option":"enabled","id":"63c8b9ed-1de4-4789-a5f3-ba3d25380387","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f01","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","privacy":"private","private_network_id":"eeff176d-2ea9-4c03-bd41-675e65c0b176","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:11.967872Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:09:47.437407Z","description":"","domain_name":"tffuncadmiringhaslettwulbygg-test-acc-function-pn-f01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"Handle","http_option":"enabled","id":"7053737c-21bd-441e-8e6d-1a1d16181a2e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f01","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","privacy":"private","private_network_id":"c46dd6b8-6100-4f5b-9abd-e63d17bccaf0","ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:09:55.177869Z"}'
         headers:
             Content-Length:
-                - "768"
+                - "771"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:17 GMT
+                - Fri, 03 Jul 2026 15:09:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3596,10 +3596,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bacfb3c2-dd4f-46b3-b8dd-eb93d0863bd8
+                - c3da6605-eec3-4ace-a4ab-2871ba61fcbb
         status: 200 OK
         code: 200
-        duration: 56.22769ms
+        duration: 33.535897ms
     - id: 73
       request:
         proto: HTTP/1.1
@@ -3616,7 +3616,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/46ec5364-0d87-4f83-b412-1c775ddb9d9f
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e95af029-ca96-4028-80cb-308094fe9b35
         method: GET
       response:
         proto: HTTP/2.0
@@ -3624,20 +3624,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 756
+        content_length: 759
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:10.795815Z","description":"","domain_name":"tffuncelatedrubinryziaplj-test-acc-function-pn-02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"46ec5364-0d87-4f83-b412-1c775ddb9d9f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-02","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","privacy":"private","private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:10.795815Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:09:49.472075Z","description":"","domain_name":"tffuncadmiringhaslettwulbygg-test-acc-function-pn-02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"e95af029-ca96-4028-80cb-308094fe9b35","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-02","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","privacy":"private","private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407","ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:09:49.472075Z"}'
         headers:
             Content-Length:
-                - "756"
+                - "759"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:17 GMT
+                - Fri, 03 Jul 2026 15:09:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3645,10 +3645,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 18a9a50f-de82-409a-a7da-bce5be0fc657
+                - 29bba053-9afa-4583-83bf-d0e97f0198b8
         status: 200 OK
         code: 200
-        duration: 56.135287ms
+        duration: 48.750276ms
     - id: 74
       request:
         proto: HTTP/1.1
@@ -3665,7 +3665,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/63c8b9ed-1de4-4789-a5f3-ba3d25380387
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7053737c-21bd-441e-8e6d-1a1d16181a2e
         method: GET
       response:
         proto: HTTP/2.0
@@ -3673,20 +3673,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 768
+        content_length: 771
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:08.419521Z","description":"","domain_name":"tffuncelatedrubinryziaplj-test-acc-function-pn-f01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"Handle","http_option":"enabled","id":"63c8b9ed-1de4-4789-a5f3-ba3d25380387","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f01","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","privacy":"private","private_network_id":"eeff176d-2ea9-4c03-bd41-675e65c0b176","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:11.967872Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:09:47.437407Z","description":"","domain_name":"tffuncadmiringhaslettwulbygg-test-acc-function-pn-f01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"Handle","http_option":"enabled","id":"7053737c-21bd-441e-8e6d-1a1d16181a2e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f01","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","privacy":"private","private_network_id":"c46dd6b8-6100-4f5b-9abd-e63d17bccaf0","ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:09:55.177869Z"}'
         headers:
             Content-Length:
-                - "768"
+                - "771"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:17 GMT
+                - Fri, 03 Jul 2026 15:09:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3694,10 +3694,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e720a686-b0a3-4ff2-a492-24bed52456fb
+                - 538eb27d-bc0b-420b-9626-553626252cd8
         status: 200 OK
         code: 200
-        duration: 41.040066ms
+        duration: 43.893207ms
     - id: 75
       request:
         proto: HTTP/1.1
@@ -3714,7 +3714,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/8162ed34-7c8b-4101-a0db-d73f8de7f99f
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e95af029-ca96-4028-80cb-308094fe9b35
         method: GET
       response:
         proto: HTTP/2.0
@@ -3722,20 +3722,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 734
+        content_length: 759
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:08.775392Z","description":"","domain_name":"tffuncelatedrubinryziaplj-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"Handle","http_option":"enabled","id":"8162ed34-7c8b-4101-a0db-d73f8de7f99f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:11.273879Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:09:49.472075Z","description":"","domain_name":"tffuncadmiringhaslettwulbygg-test-acc-function-pn-02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"e95af029-ca96-4028-80cb-308094fe9b35","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-02","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","privacy":"private","private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407","ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:09:49.472075Z"}'
         headers:
             Content-Length:
-                - "734"
+                - "759"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:17 GMT
+                - Fri, 03 Jul 2026 15:09:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3743,10 +3743,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2c44a720-2618-4eec-bc00-3f84c900d551
+                - 539eefa3-5f80-4d2f-b743-bba523a2b1c3
         status: 200 OK
         code: 200
-        duration: 42.164962ms
+        duration: 47.802585ms
     - id: 76
       request:
         proto: HTTP/1.1
@@ -3763,7 +3763,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/46ec5364-0d87-4f83-b412-1c775ddb9d9f
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/ef769143-043d-47f3-96fa-c2e8775a82e0
         method: GET
       response:
         proto: HTTP/2.0
@@ -3771,20 +3771,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 756
+        content_length: 737
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:10.795815Z","description":"","domain_name":"tffuncelatedrubinryziaplj-test-acc-function-pn-02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"46ec5364-0d87-4f83-b412-1c775ddb9d9f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-02","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","privacy":"private","private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:10.795815Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:09:47.792737Z","description":"","domain_name":"tffuncadmiringhaslettwulbygg-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"Handle","http_option":"enabled","id":"ef769143-043d-47f3-96fa-c2e8775a82e0","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:09:54.811420Z"}'
         headers:
             Content-Length:
-                - "756"
+                - "737"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:17 GMT
+                - Fri, 03 Jul 2026 15:09:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3792,10 +3792,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0340e7ea-96f7-4994-84b3-1c34ccf39d2e
+                - 6c210a0d-5f04-4e9e-a858-434c95334bf9
         status: 200 OK
         code: 200
-        duration: 70.23795ms
+        duration: 56.291753ms
     - id: 77
       request:
         proto: HTTP/1.1
@@ -3812,7 +3812,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/8162ed34-7c8b-4101-a0db-d73f8de7f99f
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e95af029-ca96-4028-80cb-308094fe9b35
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -3820,20 +3820,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 728
+        content_length: 763
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:08.775392Z","description":"","domain_name":"tffuncelatedrubinryziaplj-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"8162ed34-7c8b-4101-a0db-d73f8de7f99f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:17.839719797Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:09:49.472075Z","description":"","domain_name":"tffuncadmiringhaslettwulbygg-test-acc-function-pn-02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"e95af029-ca96-4028-80cb-308094fe9b35","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-02","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","privacy":"private","private_network_id":"9c7ec006-9f9c-4337-acf3-2c7040516407","ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:09:56.233831071Z"}'
         headers:
             Content-Length:
-                - "728"
+                - "763"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:17 GMT
+                - Fri, 03 Jul 2026 15:09:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3841,10 +3841,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f9f5d704-010b-4256-928f-4ed0e26ac6c3
+                - ccaa9f79-8308-4e26-8801-4c66a6c08d84
         status: 200 OK
         code: 200
-        duration: 186.813433ms
+        duration: 298.941114ms
     - id: 78
       request:
         proto: HTTP/1.1
@@ -3861,7 +3861,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/63c8b9ed-1de4-4789-a5f3-ba3d25380387
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/ef769143-043d-47f3-96fa-c2e8775a82e0
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -3869,20 +3869,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 762
+        content_length: 731
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:08.419521Z","description":"","domain_name":"tffuncelatedrubinryziaplj-test-acc-function-pn-f01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"63c8b9ed-1de4-4789-a5f3-ba3d25380387","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f01","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","privacy":"private","private_network_id":"eeff176d-2ea9-4c03-bd41-675e65c0b176","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:17.837805673Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:09:47.792737Z","description":"","domain_name":"tffuncadmiringhaslettwulbygg-test-acc-function-pn-f00.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"ef769143-043d-47f3-96fa-c2e8775a82e0","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f00","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:09:56.248304355Z"}'
         headers:
             Content-Length:
-                - "762"
+                - "731"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:17 GMT
+                - Fri, 03 Jul 2026 15:09:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3890,10 +3890,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 251f5edc-df0d-4827-ab59-dbc931784e28
+                - 6646fe55-f8e6-47ac-bfe2-a577b6f906b2
         status: 200 OK
         code: 200
-        duration: 190.060462ms
+        duration: 352.963069ms
     - id: 79
       request:
         proto: HTTP/1.1
@@ -3910,7 +3910,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/46ec5364-0d87-4f83-b412-1c775ddb9d9f
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7053737c-21bd-441e-8e6d-1a1d16181a2e
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -3918,20 +3918,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 760
+        content_length: 765
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:10.795815Z","description":"","domain_name":"tffuncelatedrubinryziaplj-test-acc-function-pn-02.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"46ec5364-0d87-4f83-b412-1c775ddb9d9f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-02","namespace_id":"87948c6d-ea10-40ec-82b5-05977516bd00","privacy":"private","private_network_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","ready_at":null,"region":"fr-par","runtime":"go123","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:17.923212495Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:09:47.437407Z","description":"","domain_name":"tffuncadmiringhaslettwulbygg-test-acc-function-pn-f01.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"7053737c-21bd-441e-8e6d-1a1d16181a2e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-acc-function-pn-f01","namespace_id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","privacy":"private","private_network_id":"c46dd6b8-6100-4f5b-9abd-e63d17bccaf0","ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:09:56.247022869Z"}'
         headers:
             Content-Length:
-                - "760"
+                - "765"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:18 GMT
+                - Fri, 03 Jul 2026 15:09:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3939,10 +3939,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4ed29413-3fa8-4cde-89c0-4752305f22aa
+                - 382c1c04-33a1-4bc1-a34d-3ceab105918b
         status: 200 OK
         code: 200
-        duration: 218.95649ms
+        duration: 377.841984ms
     - id: 80
       request:
         proto: HTTP/1.1
@@ -3959,7 +3959,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/87948c6d-ea10-40ec-82b5-05977516bd00
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8e8949ba-0f49-4761-ad34-e9a02d75bc55
         method: GET
       response:
         proto: HTTP/2.0
@@ -3967,20 +3967,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 586
+        content_length: 593
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:56.371001Z","description":"","environment_variables":{},"error_message":null,"id":"87948c6d-ea10-40ec-82b5-05977516bd00","name":"tf-func-elated-rubin","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncelatedrubinryziaplj","registry_namespace_id":"0e89ad85-7b5a-48f1-9080-d79156d162ee","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:05.966803Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:09:40.800078Z","description":"","environment_variables":{},"error_message":null,"id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","name":"tf-func-admiring-haslett","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncadmiringhaslettwulbygg","registry_namespace_id":"29b67960-08ff-47ff-b909-a8a7819f1ee9","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:09:43.490527Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "586"
+                - "593"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:18 GMT
+                - Fri, 03 Jul 2026 15:09:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3988,10 +3988,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dfef5298-94e7-43d0-965b-d15b54c11cce
+                - 2d7186d3-5c0f-432b-b2d4-0ad7eb1e224b
         status: 200 OK
         code: 200
-        duration: 32.848985ms
+        duration: 42.950044ms
     - id: 81
       request:
         proto: HTTP/1.1
@@ -4008,7 +4008,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/87948c6d-ea10-40ec-82b5-05977516bd00
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8e8949ba-0f49-4761-ad34-e9a02d75bc55
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -4016,20 +4016,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 592
+        content_length: 599
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:56.371001Z","description":"","environment_variables":{},"error_message":null,"id":"87948c6d-ea10-40ec-82b5-05977516bd00","name":"tf-func-elated-rubin","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncelatedrubinryziaplj","registry_namespace_id":"0e89ad85-7b5a-48f1-9080-d79156d162ee","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-05-04T12:39:18.110114926Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:09:40.800078Z","description":"","environment_variables":{},"error_message":null,"id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","name":"tf-func-admiring-haslett","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncadmiringhaslettwulbygg","registry_namespace_id":"29b67960-08ff-47ff-b909-a8a7819f1ee9","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-07-03T15:09:56.645254703Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "592"
+                - "599"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:18 GMT
+                - Fri, 03 Jul 2026 15:09:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4037,10 +4037,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 24894f17-9806-40a4-9968-3b16b35dc0b3
+                - a8a8b935-a932-45ab-8c52-3034b684ed98
         status: 200 OK
         code: 200
-        duration: 508.1657ms
+        duration: 425.7142ms
     - id: 82
       request:
         proto: HTTP/1.1
@@ -4057,7 +4057,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/87948c6d-ea10-40ec-82b5-05977516bd00
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8e8949ba-0f49-4761-ad34-e9a02d75bc55
         method: GET
       response:
         proto: HTTP/2.0
@@ -4065,20 +4065,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 589
+        content_length: 596
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:56.371001Z","description":"","environment_variables":{},"error_message":null,"id":"87948c6d-ea10-40ec-82b5-05977516bd00","name":"tf-func-elated-rubin","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncelatedrubinryziaplj","registry_namespace_id":"0e89ad85-7b5a-48f1-9080-d79156d162ee","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-05-04T12:39:18.110115Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:09:40.800078Z","description":"","environment_variables":{},"error_message":null,"id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","name":"tf-func-admiring-haslett","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncadmiringhaslettwulbygg","registry_namespace_id":"29b67960-08ff-47ff-b909-a8a7819f1ee9","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-07-03T15:09:56.645255Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "589"
+                - "596"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:18 GMT
+                - Fri, 03 Jul 2026 15:09:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4086,10 +4086,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 07463008-5d0e-4b32-9bda-0917ca6402f4
+                - 2368e172-ac1b-48e5-8862-d0dc483a83b8
         status: 200 OK
         code: 200
-        duration: 36.175474ms
+        duration: 35.227557ms
     - id: 83
       request:
         proto: HTTP/1.1
@@ -4106,7 +4106,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/eeff176d-2ea9-4c03-bd41-675e65c0b176
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c46dd6b8-6100-4f5b-9abd-e63d17bccaf0
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -4123,9 +4123,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:19 GMT
+                - Fri, 03 Jul 2026 15:09:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4133,10 +4133,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e33d6331-61e9-4c6a-9b33-1a04180258ba
+                - e9cdd6c6-c6ee-415a-81bb-c37dcf81141f
         status: 204 No Content
         code: 204
-        duration: 1.830560586s
+        duration: 1.744556277s
     - id: 84
       request:
         proto: HTTP/1.1
@@ -4153,7 +4153,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/258f0f17-2b28-41a2-bba5-d15b6f0902f6
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9c7ec006-9f9c-4337-acf3-2c7040516407
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -4170,9 +4170,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:20 GMT
+                - Fri, 03 Jul 2026 15:09:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4180,10 +4180,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4a569e3a-aba8-4565-95ca-6d60ab508a2f
+                - 06ccdeb1-b996-496a-9dba-1213e5f48e87
         status: 204 No Content
         code: 204
-        duration: 2.09035717s
+        duration: 1.870850573s
     - id: 85
       request:
         proto: HTTP/1.1
@@ -4200,7 +4200,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/36d3c8ee-561c-47f5-95b1-973aa85443ef
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/6bb31d81-005b-4aea-adcf-add0bd121f33
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -4217,9 +4217,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:20 GMT
+                - Fri, 03 Jul 2026 15:09:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4227,10 +4227,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 504ff9ac-9c01-46a0-ba20-4ad580f415fb
+                - 67b7e584-a7fd-4549-99ba-8f39373013bc
         status: 204 No Content
         code: 204
-        duration: 483.77171ms
+        duration: 413.305717ms
     - id: 86
       request:
         proto: HTTP/1.1
@@ -4247,7 +4247,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/87948c6d-ea10-40ec-82b5-05977516bd00
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8e8949ba-0f49-4761-ad34-e9a02d75bc55
         method: GET
       response:
         proto: HTTP/2.0
@@ -4255,20 +4255,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 589
+        content_length: 596
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:56.371001Z","description":"","environment_variables":{},"error_message":null,"id":"87948c6d-ea10-40ec-82b5-05977516bd00","name":"tf-func-elated-rubin","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncelatedrubinryziaplj","registry_namespace_id":"0e89ad85-7b5a-48f1-9080-d79156d162ee","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-05-04T12:39:18.110115Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:09:40.800078Z","description":"","environment_variables":{},"error_message":null,"id":"8e8949ba-0f49-4761-ad34-e9a02d75bc55","name":"tf-func-admiring-haslett","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncadmiringhaslettwulbygg","registry_namespace_id":"29b67960-08ff-47ff-b909-a8a7819f1ee9","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-07-03T15:09:56.645255Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "589"
+                - "596"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:23 GMT
+                - Fri, 03 Jul 2026 15:10:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4276,10 +4276,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3dba3b54-5d17-4ba1-9326-cd37407400c7
+                - f98e86f4-f2c4-4eb1-a748-5dd769dbda9e
         status: 200 OK
         code: 200
-        duration: 34.878625ms
+        duration: 51.397583ms
     - id: 87
       request:
         proto: HTTP/1.1
@@ -4296,7 +4296,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/87948c6d-ea10-40ec-82b5-05977516bd00
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8e8949ba-0f49-4761-ad34-e9a02d75bc55
         method: GET
       response:
         proto: HTTP/2.0
@@ -4315,9 +4315,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:49 GMT
+                - Fri, 03 Jul 2026 15:10:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4325,10 +4325,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2fd1e40f-80b2-4da9-96e6-7af53fef9563
+                - a2f291a8-780a-4177-a405-93236214c253
         status: 404 Not Found
         code: 404
-        duration: 249.277652ms
+        duration: 24.78002ms
     - id: 88
       request:
         proto: HTTP/1.1
@@ -4345,7 +4345,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/87948c6d-ea10-40ec-82b5-05977516bd00
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/8e8949ba-0f49-4761-ad34-e9a02d75bc55
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -4364,9 +4364,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:49 GMT
+                - Fri, 03 Jul 2026 15:10:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4374,10 +4374,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8f410a67-70e7-4794-a5d3-3482600a0645
+                - ce6cae16-2d1b-4fea-8e58-6a90ddd6351d
         status: 404 Not Found
         code: 404
-        duration: 34.452038ms
+        duration: 20.979577ms
     - id: 89
       request:
         proto: HTTP/1.1
@@ -4394,7 +4394,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/8162ed34-7c8b-4101-a0db-d73f8de7f99f
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/e95af029-ca96-4028-80cb-308094fe9b35
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -4413,9 +4413,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:49 GMT
+                - Fri, 03 Jul 2026 15:10:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4423,10 +4423,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 94274793-5c0c-4eab-878f-b707e8737418
+                - 8e00b385-cb57-421f-ad92-bee60ca92480
         status: 404 Not Found
         code: 404
-        duration: 22.625144ms
+        duration: 28.869398ms
     - id: 90
       request:
         proto: HTTP/1.1
@@ -4443,7 +4443,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/63c8b9ed-1de4-4789-a5f3-ba3d25380387
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/ef769143-043d-47f3-96fa-c2e8775a82e0
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -4462,9 +4462,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:49 GMT
+                - Fri, 03 Jul 2026 15:10:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4472,10 +4472,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 051f13e7-090a-4d67-916c-72ed3254af4e
+                - 8c4682fb-de73-42bf-aa78-507c7226928c
         status: 404 Not Found
         code: 404
-        duration: 21.978106ms
+        duration: 29.082438ms
     - id: 91
       request:
         proto: HTTP/1.1
@@ -4492,7 +4492,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/46ec5364-0d87-4f83-b412-1c775ddb9d9f
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7053737c-21bd-441e-8e6d-1a1d16181a2e
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -4511,9 +4511,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:49 GMT
+                - Fri, 03 Jul 2026 15:10:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4521,10 +4521,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a7ffcf3d-8893-455b-bc12-e9d1de76911c
+                - 060c11fe-13c8-47f5-ad36-1acfec4484cd
         status: 404 Not Found
         code: 404
-        duration: 23.634152ms
+        duration: 34.521522ms
     - id: 92
       request:
         proto: HTTP/1.1
@@ -4541,7 +4541,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/258f0f17-2b28-41a2-bba5-d15b6f0902f6
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c46dd6b8-6100-4f5b-9abd-e63d17bccaf0
         method: GET
       response:
         proto: HTTP/2.0
@@ -4551,7 +4551,7 @@ interactions:
         trailer: {}
         content_length: 136
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"private_network","resource_id":"258f0f17-2b28-41a2-bba5-d15b6f0902f6","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"private_network","resource_id":"c46dd6b8-6100-4f5b-9abd-e63d17bccaf0","type":"not_found"}'
         headers:
             Content-Length:
                 - "136"
@@ -4560,9 +4560,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:49 GMT
+                - Fri, 03 Jul 2026 15:10:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4570,10 +4570,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d7d8cd00-1b6b-4710-8af7-3b7e53bc05a2
+                - dca75aee-8aa3-4f88-af11-7d7c12f7d3e9
         status: 404 Not Found
         code: 404
-        duration: 22.124581ms
+        duration: 28.840444ms
     - id: 93
       request:
         proto: HTTP/1.1
@@ -4590,7 +4590,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/eeff176d-2ea9-4c03-bd41-675e65c0b176
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9c7ec006-9f9c-4337-acf3-2c7040516407
         method: GET
       response:
         proto: HTTP/2.0
@@ -4600,7 +4600,7 @@ interactions:
         trailer: {}
         content_length: 136
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"private_network","resource_id":"eeff176d-2ea9-4c03-bd41-675e65c0b176","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"private_network","resource_id":"9c7ec006-9f9c-4337-acf3-2c7040516407","type":"not_found"}'
         headers:
             Content-Length:
                 - "136"
@@ -4609,9 +4609,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:49 GMT
+                - Fri, 03 Jul 2026 15:10:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4619,7 +4619,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dba8519f-a1aa-4e8a-ad4d-9dcaf4d233e5
+                - ababd7a2-3abe-4746-9545-c778aacee590
         status: 404 Not Found
         code: 404
-        duration: 17.532831ms
+        duration: 29.235806ms

--- a/internal/services/function/testdata/function-sandbox.cassette.yaml
+++ b/internal/services/function/testdata/function-sandbox.cassette.yaml
@@ -6,13 +6,13 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 157
+        content_length: 158
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-func-silly-faraday","environment_variables":{},"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","secret_environment_variables":[],"tags":null}'
+        body: '{"name":"tf-func-strange-rhodes","environment_variables":{},"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","secret_environment_variables":[],"tags":null}'
         form: {}
         headers:
             Content-Type:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 507
+        content_length: 508
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.508598757Z","description":"","environment_variables":{},"error_message":null,"id":"483075a5-b5b5-46d7-97ad-b0b8acede406","name":"tf-func-silly-faraday","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-05-04T12:38:57.508598757Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.389268698Z","description":"","environment_variables":{},"error_message":null,"id":"fb29f060-4f87-4a2c-869f-182a59be9b0d","name":"tf-func-strange-rhodes","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-07-03T15:01:47.389268698Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "507"
+                - "508"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:38:57 GMT
+                - Fri, 03 Jul 2026 15:01:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 05acf2fb-0693-45a0-a857-5c7ac68a6729
+                - 1203d398-2777-4995-859c-617d883473bf
         status: 200 OK
         code: 200
-        duration: 1.601416703s
+        duration: 7.892692929s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -68,7 +68,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/483075a5-b5b5-46d7-97ad-b0b8acede406
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fb29f060-4f87-4a2c-869f-182a59be9b0d
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 501
+        content_length: 502
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.508599Z","description":"","environment_variables":{},"error_message":null,"id":"483075a5-b5b5-46d7-97ad-b0b8acede406","name":"tf-func-silly-faraday","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-05-04T12:38:57.508599Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.389269Z","description":"","environment_variables":{},"error_message":null,"id":"fb29f060-4f87-4a2c-869f-182a59be9b0d","name":"tf-func-strange-rhodes","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-07-03T15:01:47.389269Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "501"
+                - "502"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:38:57 GMT
+                - Fri, 03 Jul 2026 15:01:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 678cd7b6-dc4e-4e15-b556-4c74f776f91d
+                - f1b580b3-213a-49d0-9283-fbe4ca409b07
         status: 200 OK
         code: 200
-        duration: 60.230603ms
+        duration: 38.915638ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -117,7 +117,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/483075a5-b5b5-46d7-97ad-b0b8acede406
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fb29f060-4f87-4a2c-869f-182a59be9b0d
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,20 +125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 588
+        content_length: 590
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.508599Z","description":"","environment_variables":{},"error_message":null,"id":"483075a5-b5b5-46d7-97ad-b0b8acede406","name":"tf-func-silly-faraday","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncsillyfaraday29mnywsu","registry_namespace_id":"382f1cf5-abef-4e8b-a116-5962a1660926","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:28.406596Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.389269Z","description":"","environment_variables":{},"error_message":null,"id":"fb29f060-4f87-4a2c-869f-182a59be9b0d","name":"tf-func-strange-rhodes","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncstrangerhodesiyrs6exx","registry_namespace_id":"a38f4353-de04-4b5a-a26e-ef3377e261e9","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:02.007965Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "588"
+                - "590"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:32 GMT
+                - Fri, 03 Jul 2026 15:02:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8b591300-f133-4d39-b504-8aaee23343b4
+                - 99672d86-dd0e-451a-96c1-34e30c12b129
         status: 200 OK
         code: 200
-        duration: 34.385809ms
+        duration: 42.350116ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -166,7 +166,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/483075a5-b5b5-46d7-97ad-b0b8acede406
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fb29f060-4f87-4a2c-869f-182a59be9b0d
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,20 +174,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 588
+        content_length: 590
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.508599Z","description":"","environment_variables":{},"error_message":null,"id":"483075a5-b5b5-46d7-97ad-b0b8acede406","name":"tf-func-silly-faraday","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncsillyfaraday29mnywsu","registry_namespace_id":"382f1cf5-abef-4e8b-a116-5962a1660926","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:28.406596Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.389269Z","description":"","environment_variables":{},"error_message":null,"id":"fb29f060-4f87-4a2c-869f-182a59be9b0d","name":"tf-func-strange-rhodes","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncstrangerhodesiyrs6exx","registry_namespace_id":"a38f4353-de04-4b5a-a26e-ef3377e261e9","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:02.007965Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "588"
+                - "590"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:32 GMT
+                - Fri, 03 Jul 2026 15:02:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,10 +195,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b0483823-fed3-4410-803b-334ca91b911a
+                - 11565fcd-6f3b-4455-9ce7-2a18cef81ef6
         status: 200 OK
         code: 200
-        duration: 31.660391ms
+        duration: 33.548304ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -210,7 +210,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"foobar","namespace_id":"483075a5-b5b5-46d7-97ad-b0b8acede406","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node22","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox","tags":null}'
+        body: '{"name":"foobar","namespace_id":"fb29f060-4f87-4a2c-869f-182a59be9b0d","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node26","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox","tags":null}'
         form: {}
         headers:
             Content-Type:
@@ -225,20 +225,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 704
+        content_length: 705
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:32.967685395Z","description":"","domain_name":"tffuncsillyfaraday29mnywsu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"7240f67a-8e9f-46be-a656-78e304ece11d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"483075a5-b5b5-46d7-97ad-b0b8acede406","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:32.967685395Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:02.686320245Z","description":"","domain_name":"tffuncstrangerhodesiyrs6exx-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"d1ef9ce7-fe34-45ea-9ce8-d64e60c18a3a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"fb29f060-4f87-4a2c-869f-182a59be9b0d","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:02.686320245Z"}'
         headers:
             Content-Length:
-                - "704"
+                - "705"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:33 GMT
+                - Fri, 03 Jul 2026 15:02:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -246,10 +246,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 85c97e28-70d2-4f50-8907-e9bc3e328f66
+                - 736fe75b-ab32-4e87-8ecd-cb6dc0845291
         status: 200 OK
         code: 200
-        duration: 128.031551ms
+        duration: 106.158249ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -266,7 +266,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7240f67a-8e9f-46be-a656-78e304ece11d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1ef9ce7-fe34-45ea-9ce8-d64e60c18a3a
         method: GET
       response:
         proto: HTTP/2.0
@@ -274,20 +274,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 698
+        content_length: 699
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:32.967685Z","description":"","domain_name":"tffuncsillyfaraday29mnywsu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"7240f67a-8e9f-46be-a656-78e304ece11d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"483075a5-b5b5-46d7-97ad-b0b8acede406","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:32.967685Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:02.686320Z","description":"","domain_name":"tffuncstrangerhodesiyrs6exx-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"d1ef9ce7-fe34-45ea-9ce8-d64e60c18a3a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"fb29f060-4f87-4a2c-869f-182a59be9b0d","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:02.686320Z"}'
         headers:
             Content-Length:
-                - "698"
+                - "699"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:33 GMT
+                - Fri, 03 Jul 2026 15:02:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -295,10 +295,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - baddb158-c4c1-4b35-8039-11d1220536a7
+                - 999ddf93-69f0-4dd9-94e9-d16a1e5b4a33
         status: 200 OK
         code: 200
-        duration: 48.61366ms
+        duration: 52.998603ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -315,7 +315,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7240f67a-8e9f-46be-a656-78e304ece11d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1ef9ce7-fe34-45ea-9ce8-d64e60c18a3a
         method: GET
       response:
         proto: HTTP/2.0
@@ -323,20 +323,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 698
+        content_length: 699
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:32.967685Z","description":"","domain_name":"tffuncsillyfaraday29mnywsu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"7240f67a-8e9f-46be-a656-78e304ece11d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"483075a5-b5b5-46d7-97ad-b0b8acede406","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:32.967685Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:02.686320Z","description":"","domain_name":"tffuncstrangerhodesiyrs6exx-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"d1ef9ce7-fe34-45ea-9ce8-d64e60c18a3a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"fb29f060-4f87-4a2c-869f-182a59be9b0d","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:02.686320Z"}'
         headers:
             Content-Length:
-                - "698"
+                - "699"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:33 GMT
+                - Fri, 03 Jul 2026 15:02:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -344,10 +344,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 770bd9a6-d301-4983-a76a-de88a0316b41
+                - 8f73e861-3757-45b0-a01f-0f77380e517c
         status: 200 OK
         code: 200
-        duration: 42.365935ms
+        duration: 45.392399ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -364,7 +364,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7240f67a-8e9f-46be-a656-78e304ece11d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1ef9ce7-fe34-45ea-9ce8-d64e60c18a3a
         method: GET
       response:
         proto: HTTP/2.0
@@ -372,20 +372,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 698
+        content_length: 699
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:32.967685Z","description":"","domain_name":"tffuncsillyfaraday29mnywsu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"7240f67a-8e9f-46be-a656-78e304ece11d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"483075a5-b5b5-46d7-97ad-b0b8acede406","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:32.967685Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:02.686320Z","description":"","domain_name":"tffuncstrangerhodesiyrs6exx-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"d1ef9ce7-fe34-45ea-9ce8-d64e60c18a3a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"fb29f060-4f87-4a2c-869f-182a59be9b0d","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:02.686320Z"}'
         headers:
             Content-Length:
-                - "698"
+                - "699"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:33 GMT
+                - Fri, 03 Jul 2026 15:02:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -393,10 +393,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7bf932dd-ef25-469a-b6a2-36c1986ccd89
+                - cdf2631c-45f7-4ddd-a5bd-141d66e9ec97
         status: 200 OK
         code: 200
-        duration: 45.39237ms
+        duration: 56.645772ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -413,7 +413,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/483075a5-b5b5-46d7-97ad-b0b8acede406
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fb29f060-4f87-4a2c-869f-182a59be9b0d
         method: GET
       response:
         proto: HTTP/2.0
@@ -421,20 +421,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 588
+        content_length: 590
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.508599Z","description":"","environment_variables":{},"error_message":null,"id":"483075a5-b5b5-46d7-97ad-b0b8acede406","name":"tf-func-silly-faraday","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncsillyfaraday29mnywsu","registry_namespace_id":"382f1cf5-abef-4e8b-a116-5962a1660926","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:28.406596Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.389269Z","description":"","environment_variables":{},"error_message":null,"id":"fb29f060-4f87-4a2c-869f-182a59be9b0d","name":"tf-func-strange-rhodes","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncstrangerhodesiyrs6exx","registry_namespace_id":"a38f4353-de04-4b5a-a26e-ef3377e261e9","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:02.007965Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "588"
+                - "590"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:33 GMT
+                - Fri, 03 Jul 2026 15:02:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -442,10 +442,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fcb07f20-8451-4aae-965b-86d70cc9cf25
+                - d0792441-680c-433b-93bb-b2f92298effb
         status: 200 OK
         code: 200
-        duration: 35.669094ms
+        duration: 34.013599ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -462,7 +462,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7240f67a-8e9f-46be-a656-78e304ece11d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1ef9ce7-fe34-45ea-9ce8-d64e60c18a3a
         method: GET
       response:
         proto: HTTP/2.0
@@ -470,20 +470,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 698
+        content_length: 699
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:32.967685Z","description":"","domain_name":"tffuncsillyfaraday29mnywsu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"7240f67a-8e9f-46be-a656-78e304ece11d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"483075a5-b5b5-46d7-97ad-b0b8acede406","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:32.967685Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:02.686320Z","description":"","domain_name":"tffuncstrangerhodesiyrs6exx-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"d1ef9ce7-fe34-45ea-9ce8-d64e60c18a3a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"fb29f060-4f87-4a2c-869f-182a59be9b0d","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:02.686320Z"}'
         headers:
             Content-Length:
-                - "698"
+                - "699"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:33 GMT
+                - Fri, 03 Jul 2026 15:02:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -491,10 +491,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b5959a95-7e64-44ba-a6c5-8c07d9af6d16
+                - 1e0815a8-dffd-46b4-bf88-146d5f1c2215
         status: 200 OK
         code: 200
-        duration: 48.069657ms
+        duration: 42.908236ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -511,7 +511,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/483075a5-b5b5-46d7-97ad-b0b8acede406
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fb29f060-4f87-4a2c-869f-182a59be9b0d
         method: GET
       response:
         proto: HTTP/2.0
@@ -519,20 +519,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 588
+        content_length: 590
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.508599Z","description":"","environment_variables":{},"error_message":null,"id":"483075a5-b5b5-46d7-97ad-b0b8acede406","name":"tf-func-silly-faraday","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncsillyfaraday29mnywsu","registry_namespace_id":"382f1cf5-abef-4e8b-a116-5962a1660926","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:28.406596Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.389269Z","description":"","environment_variables":{},"error_message":null,"id":"fb29f060-4f87-4a2c-869f-182a59be9b0d","name":"tf-func-strange-rhodes","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncstrangerhodesiyrs6exx","registry_namespace_id":"a38f4353-de04-4b5a-a26e-ef3377e261e9","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:02.007965Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "588"
+                - "590"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:33 GMT
+                - Fri, 03 Jul 2026 15:02:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -540,10 +540,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5dbe485e-6dad-4e23-9544-49c6518acbdd
+                - 3a3ecf27-8b89-4784-ab14-93f49f956a5c
         status: 200 OK
         code: 200
-        duration: 31.511361ms
+        duration: 28.710055ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -560,7 +560,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7240f67a-8e9f-46be-a656-78e304ece11d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1ef9ce7-fe34-45ea-9ce8-d64e60c18a3a
         method: GET
       response:
         proto: HTTP/2.0
@@ -568,20 +568,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 698
+        content_length: 699
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:32.967685Z","description":"","domain_name":"tffuncsillyfaraday29mnywsu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"7240f67a-8e9f-46be-a656-78e304ece11d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"483075a5-b5b5-46d7-97ad-b0b8acede406","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:32.967685Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:02.686320Z","description":"","domain_name":"tffuncstrangerhodesiyrs6exx-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"d1ef9ce7-fe34-45ea-9ce8-d64e60c18a3a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"fb29f060-4f87-4a2c-869f-182a59be9b0d","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:02.686320Z"}'
         headers:
             Content-Length:
-                - "698"
+                - "699"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:33 GMT
+                - Fri, 03 Jul 2026 15:02:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -589,10 +589,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5992981f-d95e-4531-9589-4dfd71201fa1
+                - 021fd8c9-3e14-42ca-9ab7-e433b575a28e
         status: 200 OK
         code: 200
-        duration: 48.667232ms
+        duration: 42.443101ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -609,7 +609,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7240f67a-8e9f-46be-a656-78e304ece11d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1ef9ce7-fe34-45ea-9ce8-d64e60c18a3a
         method: GET
       response:
         proto: HTTP/2.0
@@ -617,20 +617,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 698
+        content_length: 699
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:32.967685Z","description":"","domain_name":"tffuncsillyfaraday29mnywsu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"7240f67a-8e9f-46be-a656-78e304ece11d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"483075a5-b5b5-46d7-97ad-b0b8acede406","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:32.967685Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:02.686320Z","description":"","domain_name":"tffuncstrangerhodesiyrs6exx-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"d1ef9ce7-fe34-45ea-9ce8-d64e60c18a3a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"fb29f060-4f87-4a2c-869f-182a59be9b0d","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:02.686320Z"}'
         headers:
             Content-Length:
-                - "698"
+                - "699"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:33 GMT
+                - Fri, 03 Jul 2026 15:02:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -638,10 +638,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 53a4963a-68fc-46e3-a332-2adb87cec874
+                - ded459ef-bd00-4bc8-96e0-5c71a304806f
         status: 200 OK
         code: 200
-        duration: 37.545926ms
+        duration: 82.276185ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -658,7 +658,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/483075a5-b5b5-46d7-97ad-b0b8acede406
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fb29f060-4f87-4a2c-869f-182a59be9b0d
         method: GET
       response:
         proto: HTTP/2.0
@@ -666,20 +666,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 588
+        content_length: 590
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.508599Z","description":"","environment_variables":{},"error_message":null,"id":"483075a5-b5b5-46d7-97ad-b0b8acede406","name":"tf-func-silly-faraday","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncsillyfaraday29mnywsu","registry_namespace_id":"382f1cf5-abef-4e8b-a116-5962a1660926","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:28.406596Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.389269Z","description":"","environment_variables":{},"error_message":null,"id":"fb29f060-4f87-4a2c-869f-182a59be9b0d","name":"tf-func-strange-rhodes","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncstrangerhodesiyrs6exx","registry_namespace_id":"a38f4353-de04-4b5a-a26e-ef3377e261e9","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:02.007965Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "588"
+                - "590"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:34 GMT
+                - Fri, 03 Jul 2026 15:02:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -687,10 +687,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7ef9a3ec-81cd-4199-991d-3f35a71b60d0
+                - e97629f4-335b-4186-8f99-95be754727c6
         status: 200 OK
         code: 200
-        duration: 33.57793ms
+        duration: 35.344462ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -707,7 +707,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7240f67a-8e9f-46be-a656-78e304ece11d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1ef9ce7-fe34-45ea-9ce8-d64e60c18a3a
         method: GET
       response:
         proto: HTTP/2.0
@@ -715,20 +715,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 698
+        content_length: 699
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:32.967685Z","description":"","domain_name":"tffuncsillyfaraday29mnywsu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"7240f67a-8e9f-46be-a656-78e304ece11d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"483075a5-b5b5-46d7-97ad-b0b8acede406","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:32.967685Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:02.686320Z","description":"","domain_name":"tffuncstrangerhodesiyrs6exx-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"d1ef9ce7-fe34-45ea-9ce8-d64e60c18a3a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"fb29f060-4f87-4a2c-869f-182a59be9b0d","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:02.686320Z"}'
         headers:
             Content-Length:
-                - "698"
+                - "699"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:34 GMT
+                - Fri, 03 Jul 2026 15:02:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -736,10 +736,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5311f05a-bb21-454a-9a7a-fde7bb9b70ab
+                - f696ba7a-968a-4c33-9027-898f262c22fe
         status: 200 OK
         code: 200
-        duration: 45.118244ms
+        duration: 41.260247ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -756,7 +756,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/483075a5-b5b5-46d7-97ad-b0b8acede406
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fb29f060-4f87-4a2c-869f-182a59be9b0d
         method: GET
       response:
         proto: HTTP/2.0
@@ -764,20 +764,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 588
+        content_length: 590
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.508599Z","description":"","environment_variables":{},"error_message":null,"id":"483075a5-b5b5-46d7-97ad-b0b8acede406","name":"tf-func-silly-faraday","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncsillyfaraday29mnywsu","registry_namespace_id":"382f1cf5-abef-4e8b-a116-5962a1660926","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:28.406596Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.389269Z","description":"","environment_variables":{},"error_message":null,"id":"fb29f060-4f87-4a2c-869f-182a59be9b0d","name":"tf-func-strange-rhodes","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncstrangerhodesiyrs6exx","registry_namespace_id":"a38f4353-de04-4b5a-a26e-ef3377e261e9","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:02.007965Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "588"
+                - "590"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:34 GMT
+                - Fri, 03 Jul 2026 15:02:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -785,10 +785,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8a39944b-efc6-4f48-bc5c-8950676e8bed
+                - 357cee55-8ea6-4f5d-96db-8d87af1a6fec
         status: 200 OK
         code: 200
-        duration: 36.580419ms
+        duration: 38.477424ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -805,7 +805,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7240f67a-8e9f-46be-a656-78e304ece11d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1ef9ce7-fe34-45ea-9ce8-d64e60c18a3a
         method: GET
       response:
         proto: HTTP/2.0
@@ -813,20 +813,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 698
+        content_length: 699
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:32.967685Z","description":"","domain_name":"tffuncsillyfaraday29mnywsu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"7240f67a-8e9f-46be-a656-78e304ece11d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"483075a5-b5b5-46d7-97ad-b0b8acede406","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:32.967685Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:02.686320Z","description":"","domain_name":"tffuncstrangerhodesiyrs6exx-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"d1ef9ce7-fe34-45ea-9ce8-d64e60c18a3a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"fb29f060-4f87-4a2c-869f-182a59be9b0d","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:02.686320Z"}'
         headers:
             Content-Length:
-                - "698"
+                - "699"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:34 GMT
+                - Fri, 03 Jul 2026 15:02:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -834,10 +834,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b3a40e4d-7e4d-413a-8e21-da9c0316f7c2
+                - 66f22504-e4bf-45c7-884f-f71e2f90a5ea
         status: 200 OK
         code: 200
-        duration: 42.863842ms
+        duration: 40.912733ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -854,7 +854,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7240f67a-8e9f-46be-a656-78e304ece11d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1ef9ce7-fe34-45ea-9ce8-d64e60c18a3a
         method: GET
       response:
         proto: HTTP/2.0
@@ -862,20 +862,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 698
+        content_length: 699
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:32.967685Z","description":"","domain_name":"tffuncsillyfaraday29mnywsu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"7240f67a-8e9f-46be-a656-78e304ece11d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"483075a5-b5b5-46d7-97ad-b0b8acede406","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:32.967685Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:02.686320Z","description":"","domain_name":"tffuncstrangerhodesiyrs6exx-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"d1ef9ce7-fe34-45ea-9ce8-d64e60c18a3a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"fb29f060-4f87-4a2c-869f-182a59be9b0d","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:02.686320Z"}'
         headers:
             Content-Length:
-                - "698"
+                - "699"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:34 GMT
+                - Fri, 03 Jul 2026 15:02:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -883,10 +883,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a1b9244c-bb19-4542-93e8-d3aa682d7668
+                - f39419fa-9b0f-4789-8dc9-1fb586a770ae
         status: 200 OK
         code: 200
-        duration: 34.379739ms
+        duration: 210.093899ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -905,7 +905,7 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7240f67a-8e9f-46be-a656-78e304ece11d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1ef9ce7-fe34-45ea-9ce8-d64e60c18a3a
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -913,20 +913,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 701
+        content_length: 702
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:32.967685Z","description":"","domain_name":"tffuncsillyfaraday29mnywsu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"7240f67a-8e9f-46be-a656-78e304ece11d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"483075a5-b5b5-46d7-97ad-b0b8acede406","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:34.623874163Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:02.686320Z","description":"","domain_name":"tffuncstrangerhodesiyrs6exx-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"d1ef9ce7-fe34-45ea-9ce8-d64e60c18a3a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"fb29f060-4f87-4a2c-869f-182a59be9b0d","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:04.711541958Z"}'
         headers:
             Content-Length:
-                - "701"
+                - "702"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:34 GMT
+                - Fri, 03 Jul 2026 15:02:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -934,10 +934,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ecd7304b-b0b6-48f6-acba-0821dd030b20
+                - 322546cf-7671-4aeb-a2a5-7bec75eaea72
         status: 200 OK
         code: 200
-        duration: 66.313193ms
+        duration: 145.56481ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -954,7 +954,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7240f67a-8e9f-46be-a656-78e304ece11d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1ef9ce7-fe34-45ea-9ce8-d64e60c18a3a
         method: GET
       response:
         proto: HTTP/2.0
@@ -962,20 +962,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 708
+        content_length: 699
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:32.967685Z","description":"","domain_name":"tffuncsillyfaraday29mnywsu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"7240f67a-8e9f-46be-a656-78e304ece11d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"483075a5-b5b5-46d7-97ad-b0b8acede406","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:35.436874Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:02.686320Z","description":"","domain_name":"tffuncstrangerhodesiyrs6exx-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"d1ef9ce7-fe34-45ea-9ce8-d64e60c18a3a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"fb29f060-4f87-4a2c-869f-182a59be9b0d","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:04.711542Z"}'
         headers:
             Content-Length:
-                - "708"
+                - "699"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:35 GMT
+                - Fri, 03 Jul 2026 15:02:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -983,10 +983,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d950e13a-7717-432b-ad5a-77d4d1e10d6a
+                - 532ef20e-16d3-496a-8a06-8b582bca78f5
         status: 200 OK
         code: 200
-        duration: 47.070026ms
+        duration: 46.60021ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1003,7 +1003,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7240f67a-8e9f-46be-a656-78e304ece11d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1ef9ce7-fe34-45ea-9ce8-d64e60c18a3a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1011,20 +1011,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 708
+        content_length: 709
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:32.967685Z","description":"","domain_name":"tffuncsillyfaraday29mnywsu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"7240f67a-8e9f-46be-a656-78e304ece11d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"483075a5-b5b5-46d7-97ad-b0b8acede406","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:35.436874Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:02.686320Z","description":"","domain_name":"tffuncstrangerhodesiyrs6exx-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"d1ef9ce7-fe34-45ea-9ce8-d64e60c18a3a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"fb29f060-4f87-4a2c-869f-182a59be9b0d","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:10.360071Z"}'
         headers:
             Content-Length:
-                - "708"
+                - "709"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:35 GMT
+                - Fri, 03 Jul 2026 15:02:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1032,10 +1032,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c6daeffd-90ad-4b8b-808b-a793625a9132
+                - 09f1e6a5-b650-49b3-b1da-adc67ee99dab
         status: 200 OK
         code: 200
-        duration: 30.040323ms
+        duration: 49.507367ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1052,7 +1052,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/483075a5-b5b5-46d7-97ad-b0b8acede406
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1ef9ce7-fe34-45ea-9ce8-d64e60c18a3a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1060,20 +1060,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 588
+        content_length: 709
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.508599Z","description":"","environment_variables":{},"error_message":null,"id":"483075a5-b5b5-46d7-97ad-b0b8acede406","name":"tf-func-silly-faraday","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncsillyfaraday29mnywsu","registry_namespace_id":"382f1cf5-abef-4e8b-a116-5962a1660926","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:28.406596Z","vpc_integration_activated":false}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:02.686320Z","description":"","domain_name":"tffuncstrangerhodesiyrs6exx-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"d1ef9ce7-fe34-45ea-9ce8-d64e60c18a3a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"fb29f060-4f87-4a2c-869f-182a59be9b0d","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:10.360071Z"}'
         headers:
             Content-Length:
-                - "588"
+                - "709"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:36 GMT
+                - Fri, 03 Jul 2026 15:02:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1081,10 +1081,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 964ab530-d4b0-4457-9bdb-b2ae787386ea
+                - ab0445da-ef89-4beb-9637-43043bdf220e
         status: 200 OK
         code: 200
-        duration: 61.973369ms
+        duration: 47.293133ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1101,7 +1101,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7240f67a-8e9f-46be-a656-78e304ece11d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fb29f060-4f87-4a2c-869f-182a59be9b0d
         method: GET
       response:
         proto: HTTP/2.0
@@ -1109,20 +1109,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 708
+        content_length: 590
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:32.967685Z","description":"","domain_name":"tffuncsillyfaraday29mnywsu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"7240f67a-8e9f-46be-a656-78e304ece11d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"483075a5-b5b5-46d7-97ad-b0b8acede406","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:35.436874Z"}'
+        body: '{"created_at":"2026-07-03T15:01:47.389269Z","description":"","environment_variables":{},"error_message":null,"id":"fb29f060-4f87-4a2c-869f-182a59be9b0d","name":"tf-func-strange-rhodes","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncstrangerhodesiyrs6exx","registry_namespace_id":"a38f4353-de04-4b5a-a26e-ef3377e261e9","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:02.007965Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "708"
+                - "590"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:36 GMT
+                - Fri, 03 Jul 2026 15:02:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1130,10 +1130,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d6688e51-8bcc-4f8a-a598-b4b807dd9057
+                - eff4c7f3-8ea4-4ab8-b23c-6467c6fba00c
         status: 200 OK
         code: 200
-        duration: 76.297541ms
+        duration: 94.0884ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1150,7 +1150,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/483075a5-b5b5-46d7-97ad-b0b8acede406
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1ef9ce7-fe34-45ea-9ce8-d64e60c18a3a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1158,20 +1158,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 588
+        content_length: 709
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.508599Z","description":"","environment_variables":{},"error_message":null,"id":"483075a5-b5b5-46d7-97ad-b0b8acede406","name":"tf-func-silly-faraday","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncsillyfaraday29mnywsu","registry_namespace_id":"382f1cf5-abef-4e8b-a116-5962a1660926","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:28.406596Z","vpc_integration_activated":false}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:02.686320Z","description":"","domain_name":"tffuncstrangerhodesiyrs6exx-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"d1ef9ce7-fe34-45ea-9ce8-d64e60c18a3a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"fb29f060-4f87-4a2c-869f-182a59be9b0d","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:10.360071Z"}'
         headers:
             Content-Length:
-                - "588"
+                - "709"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:36 GMT
+                - Fri, 03 Jul 2026 15:02:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1179,10 +1179,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9fe183bf-e9ec-4778-a52b-d716e1e8ea6b
+                - 8eced39b-0b5d-4f16-a7ca-92753a732f78
         status: 200 OK
         code: 200
-        duration: 84.113688ms
+        duration: 65.254422ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1199,7 +1199,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7240f67a-8e9f-46be-a656-78e304ece11d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fb29f060-4f87-4a2c-869f-182a59be9b0d
         method: GET
       response:
         proto: HTTP/2.0
@@ -1207,20 +1207,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 708
+        content_length: 590
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:32.967685Z","description":"","domain_name":"tffuncsillyfaraday29mnywsu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"7240f67a-8e9f-46be-a656-78e304ece11d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"483075a5-b5b5-46d7-97ad-b0b8acede406","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:35.436874Z"}'
+        body: '{"created_at":"2026-07-03T15:01:47.389269Z","description":"","environment_variables":{},"error_message":null,"id":"fb29f060-4f87-4a2c-869f-182a59be9b0d","name":"tf-func-strange-rhodes","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncstrangerhodesiyrs6exx","registry_namespace_id":"a38f4353-de04-4b5a-a26e-ef3377e261e9","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:02.007965Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "708"
+                - "590"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:36 GMT
+                - Fri, 03 Jul 2026 15:02:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1228,10 +1228,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 63e9a67a-ce27-474b-a3dd-76954b6e5b27
+                - 215bba30-c7e1-4e93-9574-d7fd72239a3e
         status: 200 OK
         code: 200
-        duration: 99.927874ms
+        duration: 30.379924ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1248,7 +1248,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7240f67a-8e9f-46be-a656-78e304ece11d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1ef9ce7-fe34-45ea-9ce8-d64e60c18a3a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1256,20 +1256,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 708
+        content_length: 709
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:32.967685Z","description":"","domain_name":"tffuncsillyfaraday29mnywsu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"7240f67a-8e9f-46be-a656-78e304ece11d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"483075a5-b5b5-46d7-97ad-b0b8acede406","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:35.436874Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:02.686320Z","description":"","domain_name":"tffuncstrangerhodesiyrs6exx-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"d1ef9ce7-fe34-45ea-9ce8-d64e60c18a3a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"fb29f060-4f87-4a2c-869f-182a59be9b0d","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:10.360071Z"}'
         headers:
             Content-Length:
-                - "708"
+                - "709"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:36 GMT
+                - Fri, 03 Jul 2026 15:02:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1277,11 +1277,60 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 74606388-bf09-45be-981f-4f6cb6294944
+                - d81eb9e9-ee41-403e-b115-c87f0ce62f16
         status: 200 OK
         code: 200
-        duration: 64.603167ms
+        duration: 46.862303ms
     - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1ef9ce7-fe34-45ea-9ce8-d64e60c18a3a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 709
+        uncompressed: false
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:02.686320Z","description":"","domain_name":"tffuncstrangerhodesiyrs6exx-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"d1ef9ce7-fe34-45ea-9ce8-d64e60c18a3a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"fb29f060-4f87-4a2c-869f-182a59be9b0d","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v1","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:10.360071Z"}'
+        headers:
+            Content-Length:
+                - "709"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:02:11 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3c6fec7e-fd7e-45f0-8616-a5f290375028
+        status: 200 OK
+        code: 200
+        duration: 35.360853ms
+    - id: 27
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1299,7 +1348,7 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7240f67a-8e9f-46be-a656-78e304ece11d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1ef9ce7-fe34-45ea-9ce8-d64e60c18a3a
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -1307,20 +1356,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 701
+        content_length: 702
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:32.967685Z","description":"","domain_name":"tffuncsillyfaraday29mnywsu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"7240f67a-8e9f-46be-a656-78e304ece11d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"483075a5-b5b5-46d7-97ad-b0b8acede406","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:36.738174629Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:02.686320Z","description":"","domain_name":"tffuncstrangerhodesiyrs6exx-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"d1ef9ce7-fe34-45ea-9ce8-d64e60c18a3a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"fb29f060-4f87-4a2c-869f-182a59be9b0d","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:11.867852183Z"}'
         headers:
             Content-Length:
-                - "701"
+                - "702"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:36 GMT
+                - Fri, 03 Jul 2026 15:02:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1328,59 +1377,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4f57dc4d-ed25-4571-a926-a918ad4bb813
+                - c519ed6f-dd84-44b9-976a-6b33c42cc552
         status: 200 OK
         code: 200
-        duration: 72.324676ms
-    - id: 27
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7240f67a-8e9f-46be-a656-78e304ece11d
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 698
-        uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:32.967685Z","description":"","domain_name":"tffuncsillyfaraday29mnywsu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"7240f67a-8e9f-46be-a656-78e304ece11d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"483075a5-b5b5-46d7-97ad-b0b8acede406","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:36.738175Z"}'
-        headers:
-            Content-Length:
-                - "698"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 04 May 2026 12:39:37 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 0efdd3f7-30aa-4884-abeb-27b4eb2a0d70
-        status: 200 OK
-        code: 200
-        duration: 194.092365ms
+        duration: 60.085231ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1397,7 +1397,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7240f67a-8e9f-46be-a656-78e304ece11d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1ef9ce7-fe34-45ea-9ce8-d64e60c18a3a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1405,20 +1405,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 708
+        content_length: 699
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:32.967685Z","description":"","domain_name":"tffuncsillyfaraday29mnywsu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"7240f67a-8e9f-46be-a656-78e304ece11d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"483075a5-b5b5-46d7-97ad-b0b8acede406","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:42.476654Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:02.686320Z","description":"","domain_name":"tffuncstrangerhodesiyrs6exx-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"d1ef9ce7-fe34-45ea-9ce8-d64e60c18a3a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"fb29f060-4f87-4a2c-869f-182a59be9b0d","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"pending","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:11.867852Z"}'
         headers:
             Content-Length:
-                - "708"
+                - "699"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:43 GMT
+                - Fri, 03 Jul 2026 15:02:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1426,10 +1426,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c50770dc-d572-4b53-872d-9301dc4e6ba9
+                - b60e26ab-0310-4f91-b786-6f1e91469419
         status: 200 OK
         code: 200
-        duration: 180.520285ms
+        duration: 40.017039ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1446,7 +1446,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7240f67a-8e9f-46be-a656-78e304ece11d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1ef9ce7-fe34-45ea-9ce8-d64e60c18a3a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1454,20 +1454,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 708
+        content_length: 709
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:32.967685Z","description":"","domain_name":"tffuncsillyfaraday29mnywsu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"7240f67a-8e9f-46be-a656-78e304ece11d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"483075a5-b5b5-46d7-97ad-b0b8acede406","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:42.476654Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:02.686320Z","description":"","domain_name":"tffuncstrangerhodesiyrs6exx-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"d1ef9ce7-fe34-45ea-9ce8-d64e60c18a3a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"fb29f060-4f87-4a2c-869f-182a59be9b0d","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:17.411240Z"}'
         headers:
             Content-Length:
-                - "708"
+                - "709"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:43 GMT
+                - Fri, 03 Jul 2026 15:02:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1475,10 +1475,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3bfb6a6f-ec62-4eb7-bcd3-8ae23e1a2af6
+                - bfaf4d07-816d-4b4c-8331-981284a3835b
         status: 200 OK
         code: 200
-        duration: 115.631348ms
+        duration: 44.563029ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1495,7 +1495,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/483075a5-b5b5-46d7-97ad-b0b8acede406
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1ef9ce7-fe34-45ea-9ce8-d64e60c18a3a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1503,20 +1503,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 588
+        content_length: 709
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.508599Z","description":"","environment_variables":{},"error_message":null,"id":"483075a5-b5b5-46d7-97ad-b0b8acede406","name":"tf-func-silly-faraday","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncsillyfaraday29mnywsu","registry_namespace_id":"382f1cf5-abef-4e8b-a116-5962a1660926","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:28.406596Z","vpc_integration_activated":false}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:02.686320Z","description":"","domain_name":"tffuncstrangerhodesiyrs6exx-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"d1ef9ce7-fe34-45ea-9ce8-d64e60c18a3a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"fb29f060-4f87-4a2c-869f-182a59be9b0d","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:17.411240Z"}'
         headers:
             Content-Length:
-                - "588"
+                - "709"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:43 GMT
+                - Fri, 03 Jul 2026 15:02:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1524,10 +1524,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 31780469-729a-4132-9481-4056b8508282
+                - 6bc9145c-2a41-480d-b2ae-3dcab31ac28d
         status: 200 OK
         code: 200
-        duration: 66.299873ms
+        duration: 33.78592ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1544,7 +1544,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7240f67a-8e9f-46be-a656-78e304ece11d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fb29f060-4f87-4a2c-869f-182a59be9b0d
         method: GET
       response:
         proto: HTTP/2.0
@@ -1552,20 +1552,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 708
+        content_length: 590
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:32.967685Z","description":"","domain_name":"tffuncsillyfaraday29mnywsu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"7240f67a-8e9f-46be-a656-78e304ece11d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"483075a5-b5b5-46d7-97ad-b0b8acede406","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:42.476654Z"}'
+        body: '{"created_at":"2026-07-03T15:01:47.389269Z","description":"","environment_variables":{},"error_message":null,"id":"fb29f060-4f87-4a2c-869f-182a59be9b0d","name":"tf-func-strange-rhodes","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncstrangerhodesiyrs6exx","registry_namespace_id":"a38f4353-de04-4b5a-a26e-ef3377e261e9","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:02.007965Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "708"
+                - "590"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:43 GMT
+                - Fri, 03 Jul 2026 15:02:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1573,10 +1573,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 30cad4bf-7852-454c-b573-4fb43bd71994
+                - 39352c34-862c-4676-986d-e7270c4cf075
         status: 200 OK
         code: 200
-        duration: 38.253309ms
+        duration: 35.494925ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1593,7 +1593,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7240f67a-8e9f-46be-a656-78e304ece11d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1ef9ce7-fe34-45ea-9ce8-d64e60c18a3a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1601,20 +1601,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 708
+        content_length: 709
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:32.967685Z","description":"","domain_name":"tffuncsillyfaraday29mnywsu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"7240f67a-8e9f-46be-a656-78e304ece11d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"483075a5-b5b5-46d7-97ad-b0b8acede406","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:42.476654Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:02.686320Z","description":"","domain_name":"tffuncstrangerhodesiyrs6exx-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"d1ef9ce7-fe34-45ea-9ce8-d64e60c18a3a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"fb29f060-4f87-4a2c-869f-182a59be9b0d","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:17.411240Z"}'
         headers:
             Content-Length:
-                - "708"
+                - "709"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:43 GMT
+                - Fri, 03 Jul 2026 15:02:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1622,10 +1622,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 60cb0c1e-98e4-4b9f-8661-cf5b9658bcd6
+                - 37607cb4-4a86-409d-acfb-d013f66424d9
         status: 200 OK
         code: 200
-        duration: 59.242974ms
+        duration: 46.335912ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1642,28 +1642,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7240f67a-8e9f-46be-a656-78e304ece11d
-        method: DELETE
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1ef9ce7-fe34-45ea-9ce8-d64e60c18a3a
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 702
+        content_length: 709
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:32.967685Z","description":"","domain_name":"tffuncsillyfaraday29mnywsu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"7240f67a-8e9f-46be-a656-78e304ece11d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"483075a5-b5b5-46d7-97ad-b0b8acede406","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:43.938664812Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:02.686320Z","description":"","domain_name":"tffuncstrangerhodesiyrs6exx-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":"internal error","handler":"handler.handle","http_option":"enabled","id":"d1ef9ce7-fe34-45ea-9ce8-d64e60c18a3a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"fb29f060-4f87-4a2c-869f-182a59be9b0d","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"error","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:17.411240Z"}'
         headers:
             Content-Length:
-                - "702"
+                - "709"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:44 GMT
+                - Fri, 03 Jul 2026 15:02:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1671,10 +1671,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b26d7a26-3bf2-4312-b7a6-74403d4893f6
+                - a2ef94f9-1972-4940-9187-4e889b77bd10
         status: 200 OK
         code: 200
-        duration: 148.377875ms
+        duration: 36.292294ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1691,28 +1691,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/483075a5-b5b5-46d7-97ad-b0b8acede406
-        method: GET
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1ef9ce7-fe34-45ea-9ce8-d64e60c18a3a
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 588
+        content_length: 703
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.508599Z","description":"","environment_variables":{},"error_message":null,"id":"483075a5-b5b5-46d7-97ad-b0b8acede406","name":"tf-func-silly-faraday","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncsillyfaraday29mnywsu","registry_namespace_id":"382f1cf5-abef-4e8b-a116-5962a1660926","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:28.406596Z","vpc_integration_activated":false}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:02.686320Z","description":"","domain_name":"tffuncstrangerhodesiyrs6exx-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"d1ef9ce7-fe34-45ea-9ce8-d64e60c18a3a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"fb29f060-4f87-4a2c-869f-182a59be9b0d","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:18.752719661Z"}'
         headers:
             Content-Length:
-                - "588"
+                - "703"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:44 GMT
+                - Fri, 03 Jul 2026 15:02:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1720,10 +1720,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 53687f2d-2555-4e0c-a1b2-f81b62227b00
+                - 898ab975-a383-4d86-a17e-53ab6aa16c3c
         status: 200 OK
         code: 200
-        duration: 43.012945ms
+        duration: 234.430097ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1740,28 +1740,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/483075a5-b5b5-46d7-97ad-b0b8acede406
-        method: DELETE
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fb29f060-4f87-4a2c-869f-182a59be9b0d
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 594
+        content_length: 590
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.508599Z","description":"","environment_variables":{},"error_message":null,"id":"483075a5-b5b5-46d7-97ad-b0b8acede406","name":"tf-func-silly-faraday","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncsillyfaraday29mnywsu","registry_namespace_id":"382f1cf5-abef-4e8b-a116-5962a1660926","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-05-04T12:39:44.132892290Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.389269Z","description":"","environment_variables":{},"error_message":null,"id":"fb29f060-4f87-4a2c-869f-182a59be9b0d","name":"tf-func-strange-rhodes","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncstrangerhodesiyrs6exx","registry_namespace_id":"a38f4353-de04-4b5a-a26e-ef3377e261e9","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:02.007965Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "594"
+                - "590"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:44 GMT
+                - Fri, 03 Jul 2026 15:02:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1769,10 +1769,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 824098a5-9f37-4535-a040-f35d487742e2
+                - fa31aad7-8776-4712-a769-632b2aacc99d
         status: 200 OK
         code: 200
-        duration: 266.094307ms
+        duration: 29.414308ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1789,28 +1789,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/483075a5-b5b5-46d7-97ad-b0b8acede406
-        method: GET
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fb29f060-4f87-4a2c-869f-182a59be9b0d
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 591
+        content_length: 596
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.508599Z","description":"","environment_variables":{},"error_message":null,"id":"483075a5-b5b5-46d7-97ad-b0b8acede406","name":"tf-func-silly-faraday","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncsillyfaraday29mnywsu","registry_namespace_id":"382f1cf5-abef-4e8b-a116-5962a1660926","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-05-04T12:39:44.132892Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.389269Z","description":"","environment_variables":{},"error_message":null,"id":"fb29f060-4f87-4a2c-869f-182a59be9b0d","name":"tf-func-strange-rhodes","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncstrangerhodesiyrs6exx","registry_namespace_id":"a38f4353-de04-4b5a-a26e-ef3377e261e9","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-07-03T15:02:19.011301884Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "591"
+                - "596"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:44 GMT
+                - Fri, 03 Jul 2026 15:02:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1818,10 +1818,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b82a942c-ec11-452b-bf2f-6e4b0dfe2bd7
+                - 5d236473-59ba-48af-9ffa-158549532f61
         status: 200 OK
         code: 200
-        duration: 31.080944ms
+        duration: 406.258942ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1838,7 +1838,56 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/483075a5-b5b5-46d7-97ad-b0b8acede406
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fb29f060-4f87-4a2c-869f-182a59be9b0d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 593
+        uncompressed: false
+        body: '{"created_at":"2026-07-03T15:01:47.389269Z","description":"","environment_variables":{},"error_message":null,"id":"fb29f060-4f87-4a2c-869f-182a59be9b0d","name":"tf-func-strange-rhodes","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncstrangerhodesiyrs6exx","registry_namespace_id":"a38f4353-de04-4b5a-a26e-ef3377e261e9","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-07-03T15:02:19.011302Z","vpc_integration_activated":false}'
+        headers:
+            Content-Length:
+                - "593"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:02:19 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 8113d34f-18ae-45f6-a0ad-76df8fe61b71
+        status: 200 OK
+        code: 200
+        duration: 38.166929ms
+    - id: 38
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/fb29f060-4f87-4a2c-869f-182a59be9b0d
         method: GET
       response:
         proto: HTTP/2.0
@@ -1857,9 +1906,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:40:15 GMT
+                - Fri, 03 Jul 2026 15:02:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1867,11 +1916,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 53aae341-c16c-4187-a92c-604ef9ddf8c3
+                - 3140ffaa-9d4f-4891-a082-ae45771de946
         status: 404 Not Found
         code: 404
-        duration: 39.68993ms
-    - id: 38
+        duration: 20.246246ms
+    - id: 39
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1887,7 +1936,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/7240f67a-8e9f-46be-a656-78e304ece11d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/d1ef9ce7-fe34-45ea-9ce8-d64e60c18a3a
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1906,9 +1955,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:40:15 GMT
+                - Fri, 03 Jul 2026 15:02:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1916,7 +1965,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e1a0b259-7a76-48c4-a7b3-eb0eacbe838a
+                - a472bc43-58e5-4244-8612-f579785b2313
         status: 404 Not Found
         code: 404
-        duration: 27.357833ms
+        duration: 22.072461ms

--- a/internal/services/function/testdata/function-timeout.cassette.yaml
+++ b/internal/services/function/testdata/function-timeout.cassette.yaml
@@ -6,13 +6,13 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 161
+        content_length: 159
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-func-infallible-yonath","environment_variables":{},"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","secret_environment_variables":[],"tags":null}'
+        body: '{"name":"tf-func-laughing-hoover","environment_variables":{},"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","secret_environment_variables":[],"tags":null}'
         form: {}
         headers:
             Content-Type:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 511
+        content_length: 509
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:39:26.226315313Z","description":"","environment_variables":{},"error_message":null,"id":"4bac3ff0-1cf0-4396-b775-07a1906fb0e3","name":"tf-func-infallible-yonath","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-05-04T12:39:26.226315313Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.230311795Z","description":"","environment_variables":{},"error_message":null,"id":"b7a9baad-b5bd-440f-a40b-109215f02b24","name":"tf-func-laughing-hoover","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-07-03T15:01:47.230311795Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "511"
+                - "509"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:26 GMT
+                - Fri, 03 Jul 2026 15:01:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 29a016d4-b68e-4605-bf3d-4c69a07a0562
+                - ffa88a96-c68e-4112-ad82-4185a49831b3
         status: 200 OK
         code: 200
-        duration: 463.826783ms
+        duration: 7.737838248s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -68,7 +68,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/4bac3ff0-1cf0-4396-b775-07a1906fb0e3
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b7a9baad-b5bd-440f-a40b-109215f02b24
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 505
+        content_length: 503
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:39:26.226315Z","description":"","environment_variables":{},"error_message":null,"id":"4bac3ff0-1cf0-4396-b775-07a1906fb0e3","name":"tf-func-infallible-yonath","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-05-04T12:39:26.226315Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.230312Z","description":"","environment_variables":{},"error_message":null,"id":"b7a9baad-b5bd-440f-a40b-109215f02b24","name":"tf-func-laughing-hoover","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-07-03T15:01:47.230312Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "505"
+                - "503"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:26 GMT
+                - Fri, 03 Jul 2026 15:01:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4de0002c-0786-4505-bbc5-c29d80c072da
+                - cdfd718a-0a00-41b0-a927-b1779b286a68
         status: 200 OK
         code: 200
-        duration: 32.248586ms
+        duration: 39.687469ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -117,7 +117,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/4bac3ff0-1cf0-4396-b775-07a1906fb0e3
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b7a9baad-b5bd-440f-a40b-109215f02b24
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,20 +125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 594
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:39:26.226315Z","description":"","environment_variables":{},"error_message":null,"id":"4bac3ff0-1cf0-4396-b775-07a1906fb0e3","name":"tf-func-infallible-yonath","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncinfallibleyonacg96umyu","registry_namespace_id":"b98774cc-5f2d-4559-9c42-f3e47e74a9c7","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:30.238575Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.230312Z","description":"","environment_variables":{},"error_message":null,"id":"b7a9baad-b5bd-440f-a40b-109215f02b24","name":"tf-func-laughing-hoover","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunclaughinghooverf3tor5xw","registry_namespace_id":"3ef090fb-8c49-4a8d-a8bb-eca8ac729a3a","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:02.064323Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "594"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:31 GMT
+                - Fri, 03 Jul 2026 15:02:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 62b0e018-cace-49c5-9bfa-5d5582f784f5
+                - efe87ecb-0bd9-4031-af76-be52c3a996bf
         status: 200 OK
         code: 200
-        duration: 31.449625ms
+        duration: 33.146658ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -166,7 +166,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/4bac3ff0-1cf0-4396-b775-07a1906fb0e3
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b7a9baad-b5bd-440f-a40b-109215f02b24
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,20 +174,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 594
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:39:26.226315Z","description":"","environment_variables":{},"error_message":null,"id":"4bac3ff0-1cf0-4396-b775-07a1906fb0e3","name":"tf-func-infallible-yonath","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncinfallibleyonacg96umyu","registry_namespace_id":"b98774cc-5f2d-4559-9c42-f3e47e74a9c7","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:30.238575Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.230312Z","description":"","environment_variables":{},"error_message":null,"id":"b7a9baad-b5bd-440f-a40b-109215f02b24","name":"tf-func-laughing-hoover","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunclaughinghooverf3tor5xw","registry_namespace_id":"3ef090fb-8c49-4a8d-a8bb-eca8ac729a3a","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:02.064323Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "594"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:31 GMT
+                - Fri, 03 Jul 2026 15:02:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,10 +195,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 72a44aec-c083-4916-897d-c4eb87c2d37f
+                - 68818fda-7364-40f8-af41-d679aac93236
         status: 200 OK
         code: 200
-        duration: 28.23184ms
+        duration: 29.378942ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -210,7 +210,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"foobar","namespace_id":"4bac3ff0-1cf0-4396-b775-07a1906fb0e3","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node22","memory_limit":256,"timeout":"10.000000000s","handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox","tags":null}'
+        body: '{"name":"foobar","namespace_id":"b7a9baad-b5bd-440f-a40b-109215f02b24","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node26","memory_limit":256,"timeout":"10.000000000s","handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox","tags":null}'
         form: {}
         headers:
             Content-Type:
@@ -227,7 +227,7 @@ interactions:
         trailer: {}
         content_length: 705
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:31.833938670Z","description":"","domain_name":"tffuncinfallibleyonacg96umyu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"f2cdc163-3c81-4ccc-9c33-339c1aee5c5c","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"4bac3ff0-1cf0-4396-b775-07a1906fb0e3","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"10s","updated_at":"2026-05-04T12:39:31.833938670Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:02.523611522Z","description":"","domain_name":"tffunclaughinghooverf3tor5xw-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"4d98c325-8431-498c-ac8e-3cc980551af7","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"b7a9baad-b5bd-440f-a40b-109215f02b24","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"10s","updated_at":"2026-07-03T15:02:02.523611522Z"}'
         headers:
             Content-Length:
                 - "705"
@@ -236,9 +236,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:31 GMT
+                - Fri, 03 Jul 2026 15:02:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -246,10 +246,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0ab3cf9a-3309-49dc-aaf6-4138cc38db50
+                - 923b1a95-417d-4630-b7e7-a7bc999634e0
         status: 200 OK
         code: 200
-        duration: 425.030092ms
+        duration: 99.238705ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -266,7 +266,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/f2cdc163-3c81-4ccc-9c33-339c1aee5c5c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4d98c325-8431-498c-ac8e-3cc980551af7
         method: GET
       response:
         proto: HTTP/2.0
@@ -276,7 +276,7 @@ interactions:
         trailer: {}
         content_length: 699
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:31.833939Z","description":"","domain_name":"tffuncinfallibleyonacg96umyu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"f2cdc163-3c81-4ccc-9c33-339c1aee5c5c","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"4bac3ff0-1cf0-4396-b775-07a1906fb0e3","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"10s","updated_at":"2026-05-04T12:39:31.833939Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:02.523612Z","description":"","domain_name":"tffunclaughinghooverf3tor5xw-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"4d98c325-8431-498c-ac8e-3cc980551af7","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"b7a9baad-b5bd-440f-a40b-109215f02b24","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"10s","updated_at":"2026-07-03T15:02:02.523612Z"}'
         headers:
             Content-Length:
                 - "699"
@@ -285,9 +285,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:31 GMT
+                - Fri, 03 Jul 2026 15:02:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -295,10 +295,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - da5e522f-e46e-4c0a-b187-ff67eca58fb7
+                - 1da21646-b5a2-4ec3-a67a-90a39e65cbfc
         status: 200 OK
         code: 200
-        duration: 43.988678ms
+        duration: 36.521996ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -315,7 +315,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/f2cdc163-3c81-4ccc-9c33-339c1aee5c5c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4d98c325-8431-498c-ac8e-3cc980551af7
         method: GET
       response:
         proto: HTTP/2.0
@@ -325,7 +325,7 @@ interactions:
         trailer: {}
         content_length: 699
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:31.833939Z","description":"","domain_name":"tffuncinfallibleyonacg96umyu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"f2cdc163-3c81-4ccc-9c33-339c1aee5c5c","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"4bac3ff0-1cf0-4396-b775-07a1906fb0e3","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"10s","updated_at":"2026-05-04T12:39:31.833939Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:02.523612Z","description":"","domain_name":"tffunclaughinghooverf3tor5xw-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"4d98c325-8431-498c-ac8e-3cc980551af7","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"b7a9baad-b5bd-440f-a40b-109215f02b24","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"10s","updated_at":"2026-07-03T15:02:02.523612Z"}'
         headers:
             Content-Length:
                 - "699"
@@ -334,9 +334,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:31 GMT
+                - Fri, 03 Jul 2026 15:02:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -344,10 +344,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2cfb3929-02cf-4cfa-a79b-d93cf7309edd
+                - 19014b02-e81a-4cd8-9d09-7051168b09b6
         status: 200 OK
         code: 200
-        duration: 41.698398ms
+        duration: 38.477283ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -364,7 +364,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/f2cdc163-3c81-4ccc-9c33-339c1aee5c5c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4d98c325-8431-498c-ac8e-3cc980551af7
         method: GET
       response:
         proto: HTTP/2.0
@@ -374,7 +374,7 @@ interactions:
         trailer: {}
         content_length: 699
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:31.833939Z","description":"","domain_name":"tffuncinfallibleyonacg96umyu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"f2cdc163-3c81-4ccc-9c33-339c1aee5c5c","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"4bac3ff0-1cf0-4396-b775-07a1906fb0e3","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"10s","updated_at":"2026-05-04T12:39:31.833939Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:02.523612Z","description":"","domain_name":"tffunclaughinghooverf3tor5xw-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"4d98c325-8431-498c-ac8e-3cc980551af7","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"b7a9baad-b5bd-440f-a40b-109215f02b24","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"10s","updated_at":"2026-07-03T15:02:02.523612Z"}'
         headers:
             Content-Length:
                 - "699"
@@ -383,9 +383,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:32 GMT
+                - Fri, 03 Jul 2026 15:02:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -393,10 +393,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9a37046c-87fa-4007-bd07-a9f625ee9111
+                - 099606a0-5a44-40a5-949d-666bac7a07ad
         status: 200 OK
         code: 200
-        duration: 77.788845ms
+        duration: 43.929367ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -413,7 +413,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/4bac3ff0-1cf0-4396-b775-07a1906fb0e3
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b7a9baad-b5bd-440f-a40b-109215f02b24
         method: GET
       response:
         proto: HTTP/2.0
@@ -421,20 +421,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 594
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:39:26.226315Z","description":"","environment_variables":{},"error_message":null,"id":"4bac3ff0-1cf0-4396-b775-07a1906fb0e3","name":"tf-func-infallible-yonath","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncinfallibleyonacg96umyu","registry_namespace_id":"b98774cc-5f2d-4559-9c42-f3e47e74a9c7","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:30.238575Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.230312Z","description":"","environment_variables":{},"error_message":null,"id":"b7a9baad-b5bd-440f-a40b-109215f02b24","name":"tf-func-laughing-hoover","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunclaughinghooverf3tor5xw","registry_namespace_id":"3ef090fb-8c49-4a8d-a8bb-eca8ac729a3a","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:02.064323Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "594"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:32 GMT
+                - Fri, 03 Jul 2026 15:02:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -442,10 +442,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9d9c5d23-f649-43c4-9346-06772511caaa
+                - b414dc7c-8d54-4adf-9c83-5b1de166079a
         status: 200 OK
         code: 200
-        duration: 33.675533ms
+        duration: 140.892222ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -462,7 +462,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/f2cdc163-3c81-4ccc-9c33-339c1aee5c5c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4d98c325-8431-498c-ac8e-3cc980551af7
         method: GET
       response:
         proto: HTTP/2.0
@@ -472,7 +472,7 @@ interactions:
         trailer: {}
         content_length: 699
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:31.833939Z","description":"","domain_name":"tffuncinfallibleyonacg96umyu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"f2cdc163-3c81-4ccc-9c33-339c1aee5c5c","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"4bac3ff0-1cf0-4396-b775-07a1906fb0e3","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"10s","updated_at":"2026-05-04T12:39:31.833939Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:02.523612Z","description":"","domain_name":"tffunclaughinghooverf3tor5xw-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"4d98c325-8431-498c-ac8e-3cc980551af7","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"b7a9baad-b5bd-440f-a40b-109215f02b24","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"10s","updated_at":"2026-07-03T15:02:02.523612Z"}'
         headers:
             Content-Length:
                 - "699"
@@ -481,9 +481,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:32 GMT
+                - Fri, 03 Jul 2026 15:02:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -491,10 +491,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 474e2bd3-645c-4860-9720-f8906214c7b8
+                - 84b56fbe-a719-412f-a05c-820e25d677a9
         status: 200 OK
         code: 200
-        duration: 149.160526ms
+        duration: 34.225837ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -511,7 +511,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/f2cdc163-3c81-4ccc-9c33-339c1aee5c5c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4d98c325-8431-498c-ac8e-3cc980551af7
         method: GET
       response:
         proto: HTTP/2.0
@@ -521,7 +521,7 @@ interactions:
         trailer: {}
         content_length: 699
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:31.833939Z","description":"","domain_name":"tffuncinfallibleyonacg96umyu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"f2cdc163-3c81-4ccc-9c33-339c1aee5c5c","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"4bac3ff0-1cf0-4396-b775-07a1906fb0e3","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"10s","updated_at":"2026-05-04T12:39:31.833939Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:02.523612Z","description":"","domain_name":"tffunclaughinghooverf3tor5xw-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"4d98c325-8431-498c-ac8e-3cc980551af7","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"b7a9baad-b5bd-440f-a40b-109215f02b24","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"10s","updated_at":"2026-07-03T15:02:02.523612Z"}'
         headers:
             Content-Length:
                 - "699"
@@ -530,9 +530,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:32 GMT
+                - Fri, 03 Jul 2026 15:02:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -540,10 +540,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b8a27624-d27d-41cf-aeff-ee088daf8e49
+                - c6e68a97-32cb-46f6-917a-d182d992b557
         status: 200 OK
         code: 200
-        duration: 44.798211ms
+        duration: 39.491481ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -560,7 +560,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/f2cdc163-3c81-4ccc-9c33-339c1aee5c5c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4d98c325-8431-498c-ac8e-3cc980551af7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -570,7 +570,7 @@ interactions:
         trailer: {}
         content_length: 703
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:31.833939Z","description":"","domain_name":"tffuncinfallibleyonacg96umyu-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"f2cdc163-3c81-4ccc-9c33-339c1aee5c5c","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"4bac3ff0-1cf0-4396-b775-07a1906fb0e3","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"10s","updated_at":"2026-05-04T12:39:32.778519409Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:02.523612Z","description":"","domain_name":"tffunclaughinghooverf3tor5xw-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"4d98c325-8431-498c-ac8e-3cc980551af7","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"b7a9baad-b5bd-440f-a40b-109215f02b24","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"10s","updated_at":"2026-07-03T15:02:03.688801068Z"}'
         headers:
             Content-Length:
                 - "703"
@@ -579,9 +579,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:32 GMT
+                - Fri, 03 Jul 2026 15:02:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -589,10 +589,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2b0fcaa8-5fa7-4059-b232-3eb04ef52261
+                - 44937b7c-e934-4927-8c47-71453b2e10cf
         status: 200 OK
         code: 200
-        duration: 149.734376ms
+        duration: 501.223137ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -609,7 +609,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/4bac3ff0-1cf0-4396-b775-07a1906fb0e3
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b7a9baad-b5bd-440f-a40b-109215f02b24
         method: GET
       response:
         proto: HTTP/2.0
@@ -617,20 +617,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 594
+        content_length: 592
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:39:26.226315Z","description":"","environment_variables":{},"error_message":null,"id":"4bac3ff0-1cf0-4396-b775-07a1906fb0e3","name":"tf-func-infallible-yonath","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncinfallibleyonacg96umyu","registry_namespace_id":"b98774cc-5f2d-4559-9c42-f3e47e74a9c7","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:30.238575Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.230312Z","description":"","environment_variables":{},"error_message":null,"id":"b7a9baad-b5bd-440f-a40b-109215f02b24","name":"tf-func-laughing-hoover","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunclaughinghooverf3tor5xw","registry_namespace_id":"3ef090fb-8c49-4a8d-a8bb-eca8ac729a3a","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:02.064323Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "594"
+                - "592"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:32 GMT
+                - Fri, 03 Jul 2026 15:02:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -638,10 +638,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2e450ec2-bd28-4bcd-8b4d-6bdeaf4b2962
+                - 857d1d5f-f880-4a0c-99e0-a8c935c8dcf6
         status: 200 OK
         code: 200
-        duration: 86.766247ms
+        duration: 33.20065ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -658,7 +658,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/4bac3ff0-1cf0-4396-b775-07a1906fb0e3
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b7a9baad-b5bd-440f-a40b-109215f02b24
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -666,20 +666,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 600
+        content_length: 598
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:39:26.226315Z","description":"","environment_variables":{},"error_message":null,"id":"4bac3ff0-1cf0-4396-b775-07a1906fb0e3","name":"tf-func-infallible-yonath","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncinfallibleyonacg96umyu","registry_namespace_id":"b98774cc-5f2d-4559-9c42-f3e47e74a9c7","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-05-04T12:39:33.006648311Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.230312Z","description":"","environment_variables":{},"error_message":null,"id":"b7a9baad-b5bd-440f-a40b-109215f02b24","name":"tf-func-laughing-hoover","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunclaughinghooverf3tor5xw","registry_namespace_id":"3ef090fb-8c49-4a8d-a8bb-eca8ac729a3a","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-07-03T15:02:04.114357111Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "600"
+                - "598"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:33 GMT
+                - Fri, 03 Jul 2026 15:02:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -687,10 +687,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 743703c0-0e24-4863-a4a0-2146e87f2aa8
+                - f19bc07b-845d-4376-89fe-5eb3eb367ea0
         status: 200 OK
         code: 200
-        duration: 245.666791ms
+        duration: 1.426279497s
     - id: 14
       request:
         proto: HTTP/1.1
@@ -707,7 +707,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/4bac3ff0-1cf0-4396-b775-07a1906fb0e3
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b7a9baad-b5bd-440f-a40b-109215f02b24
         method: GET
       response:
         proto: HTTP/2.0
@@ -715,20 +715,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 597
+        content_length: 595
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:39:26.226315Z","description":"","environment_variables":{},"error_message":null,"id":"4bac3ff0-1cf0-4396-b775-07a1906fb0e3","name":"tf-func-infallible-yonath","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffuncinfallibleyonacg96umyu","registry_namespace_id":"b98774cc-5f2d-4559-9c42-f3e47e74a9c7","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-05-04T12:39:33.006648Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.230312Z","description":"","environment_variables":{},"error_message":null,"id":"b7a9baad-b5bd-440f-a40b-109215f02b24","name":"tf-func-laughing-hoover","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunclaughinghooverf3tor5xw","registry_namespace_id":"3ef090fb-8c49-4a8d-a8bb-eca8ac729a3a","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-07-03T15:02:04.114357Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "597"
+                - "595"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:33 GMT
+                - Fri, 03 Jul 2026 15:02:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -736,10 +736,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b653ff8a-734e-489d-9ab1-e62213507235
+                - c625f67e-bd18-43e5-90f2-1371f376dab2
         status: 200 OK
         code: 200
-        duration: 32.798624ms
+        duration: 103.231635ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -756,7 +756,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/4bac3ff0-1cf0-4396-b775-07a1906fb0e3
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/b7a9baad-b5bd-440f-a40b-109215f02b24
         method: GET
       response:
         proto: HTTP/2.0
@@ -775,9 +775,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:38 GMT
+                - Fri, 03 Jul 2026 15:02:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -785,10 +785,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9b2aa4d5-f684-49d5-aa1a-daabc4dda4b4
+                - e3f2e087-baf3-4bac-84b0-c146127cd763
         status: 404 Not Found
         code: 404
-        duration: 168.460748ms
+        duration: 28.954765ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -805,7 +805,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/f2cdc163-3c81-4ccc-9c33-339c1aee5c5c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4d98c325-8431-498c-ac8e-3cc980551af7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -824,9 +824,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:38 GMT
+                - Fri, 03 Jul 2026 15:02:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -834,7 +834,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dc552b62-e6f0-4273-8d7a-1afe4c0b9b52
+                - 40eaea5b-6ecd-4cf7-9f44-f9c156b19b53
         status: 404 Not Found
         code: 404
-        duration: 21.815458ms
+        duration: 25.587141ms

--- a/internal/services/function/testdata/function-token-basic.cassette.yaml
+++ b/internal/services/function/testdata/function-token-basic.cassette.yaml
@@ -29,7 +29,7 @@ interactions:
         trailer: {}
         content_length: 508
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.817323977Z","description":"","environment_variables":{},"error_message":null,"id":"a5121c57-55c6-40cf-80b7-bf81d5a7ee8d","name":"test-function-token-ns","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-05-04T12:38:57.817323977Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.384243699Z","description":"","environment_variables":{},"error_message":null,"id":"1e93890a-7879-4077-8a6f-c7320bdeec79","name":"test-function-token-ns","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-07-03T15:01:47.384243699Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "508"
@@ -38,9 +38,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:38:57 GMT
+                - Fri, 03 Jul 2026 15:01:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d081f28d-b13d-47f2-807d-a2a88cd5d90e
+                - dc00f190-d1e2-445b-b9ec-98d31a49f6c0
         status: 200 OK
         code: 200
-        duration: 1.827777052s
+        duration: 7.925657193s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -68,7 +68,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a5121c57-55c6-40cf-80b7-bf81d5a7ee8d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/1e93890a-7879-4077-8a6f-c7320bdeec79
         method: GET
       response:
         proto: HTTP/2.0
@@ -78,7 +78,7 @@ interactions:
         trailer: {}
         content_length: 502
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.817324Z","description":"","environment_variables":{},"error_message":null,"id":"a5121c57-55c6-40cf-80b7-bf81d5a7ee8d","name":"test-function-token-ns","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-05-04T12:38:57.817324Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.384244Z","description":"","environment_variables":{},"error_message":null,"id":"1e93890a-7879-4077-8a6f-c7320bdeec79","name":"test-function-token-ns","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-07-03T15:01:47.384244Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "502"
@@ -87,9 +87,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:38:57 GMT
+                - Fri, 03 Jul 2026 15:01:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7386bece-0f53-410f-afa9-c6a238bbbfda
+                - 4c152ea9-db72-40f0-9747-e529ed715365
         status: 200 OK
         code: 200
-        duration: 47.176424ms
+        duration: 35.837929ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -117,7 +117,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a5121c57-55c6-40cf-80b7-bf81d5a7ee8d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/1e93890a-7879-4077-8a6f-c7320bdeec79
         method: GET
       response:
         proto: HTTP/2.0
@@ -127,7 +127,7 @@ interactions:
         trailer: {}
         content_length: 590
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.817324Z","description":"","environment_variables":{},"error_message":null,"id":"a5121c57-55c6-40cf-80b7-bf81d5a7ee8d","name":"test-function-token-ns","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontokenns8iwtyjld","registry_namespace_id":"96e1f22e-19ee-4364-b336-ec468ad3e02c","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:14.852084Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.384244Z","description":"","environment_variables":{},"error_message":null,"id":"1e93890a-7879-4077-8a6f-c7320bdeec79","name":"test-function-token-ns","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontokenns1jkwoysc","registry_namespace_id":"6ed0ddd9-9636-4398-8b84-13a7c5b7705d","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:01:58.868721Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "590"
@@ -136,9 +136,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:18 GMT
+                - Fri, 03 Jul 2026 15:02:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e7e507e4-369a-4412-ac6d-dab180f51855
+                - 075949e6-6265-4f47-8026-6e3c177c292c
         status: 200 OK
         code: 200
-        duration: 34.322036ms
+        duration: 29.07993ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -166,7 +166,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a5121c57-55c6-40cf-80b7-bf81d5a7ee8d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/1e93890a-7879-4077-8a6f-c7320bdeec79
         method: GET
       response:
         proto: HTTP/2.0
@@ -176,7 +176,7 @@ interactions:
         trailer: {}
         content_length: 590
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.817324Z","description":"","environment_variables":{},"error_message":null,"id":"a5121c57-55c6-40cf-80b7-bf81d5a7ee8d","name":"test-function-token-ns","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontokenns8iwtyjld","registry_namespace_id":"96e1f22e-19ee-4364-b336-ec468ad3e02c","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:14.852084Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.384244Z","description":"","environment_variables":{},"error_message":null,"id":"1e93890a-7879-4077-8a6f-c7320bdeec79","name":"test-function-token-ns","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontokenns1jkwoysc","registry_namespace_id":"6ed0ddd9-9636-4398-8b84-13a7c5b7705d","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:01:58.868721Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "590"
@@ -185,9 +185,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:18 GMT
+                - Fri, 03 Jul 2026 15:02:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,62 +195,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a7f2b22f-6a4e-4024-82c2-df55712bee7a
+                - e035f5be-6c11-4d73-b434-4df1636ab8c5
         status: 200 OK
         code: 200
-        duration: 32.791446ms
+        duration: 35.993252ms
     - id: 4
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 96
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"namespace_id":"a5121c57-55c6-40cf-80b7-bf81d5a7ee8d","expires_at":"2026-05-05T14:37:48+02:00"}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2050
-        uncompressed: false
-        body: '{"description":"","expires_at":"2026-05-05T12:37:48Z","id":"06b8e342-d97b-494a-b864-247b22da9c8a","namespace_id":"a5121c57-55c6-40cf-80b7-bf81d5a7ee8d","public_key":"-----BEGIN RSA PUBLIC KEY-----\nMIICCgKCAgEAvREYsKv4dVhi0jdyFEVmyKv9O4ARS+ak5MC3O4qWK7Ltpw1BtqZA\ngi9XmWLGB+p3yUj7DikYvJUPIut62WzXu3mrZIO7lVxZo6P/M6iaFqbnGe+x2/P1\nmUwc8Z/ztd4aW4LqeVD2doh0dDKAJ/JnL2eR9lNN6kJmyC8n38uzbTPIiqtw2hSe\nd9mMG1INuFXNfsSHEwzfAtp2fvpxKwjz4jnoTuJaMYb17PdKocjy2w+R/U5JmJQK\nVxG2e7WxNSPq5pGWEPsdbBzq9f+7ik7K268ZgutKsuAwAdvnxkj0C77IkzxvhD1c\n3kY7t570g58y4DaGXnuAv9A/5XKL3FFI+zVcSzZSwhJUn7Vqz/s8frcmccKdNtlA\nT372qgLlhiqHf+65TP+UpccOy4MG1dQzcg1sSYXGWyFbb++kyle14K/ktjkyJawa\nIueyJmab0iJyiSdXwnTQ5mGiDdHYfh2dzscBcGiNKs7kDjX1n2UK7R59O4sCWdxH\nRI2J2Rg+FaArp14VKoq4IfYvTIguVvDW9E3010p2hLM5i/l8f5fXafutQeRTZo2c\nqG110Ik57XH9+Axk2Omku5UWOlx3/vTBR+QdszSa4mf1IWZKEtvDsACyCIN+YZBd\nYsOqlyRm/uvtcOewslIC9W5lEapyKiQIXr+seDmgOS3o/+YR15megL0CAwEAAQ==\n-----END RSA PUBLIC KEY-----\n","status":"creating","token":"xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxxxxxx"}'
-        headers:
-            Content-Length:
-                - "2050"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 04 May 2026 12:39:18 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 6061ac78-d9ff-474a-812e-3ad3b60efd8b
-        status: 200 OK
-        code: 200
-        duration: 275.155237ms
-    - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -261,7 +210,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-func-elated-cohen","namespace_id":"a5121c57-55c6-40cf-80b7-bf81d5a7ee8d","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node22","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox","tags":null}'
+        body: '{"name":"tf-func-cool-jackson","namespace_id":"1e93890a-7879-4077-8a6f-c7320bdeec79","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node26","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox","tags":null}'
         form: {}
         headers:
             Content-Type:
@@ -278,7 +227,7 @@ interactions:
         trailer: {}
         content_length: 733
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:18.149403115Z","description":"","domain_name":"testfunctiontokenns8iwtyjld-tf-func-elated-cohen.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"ab388442-943b-4408-bb36-713c84e9d3b8","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-elated-cohen","namespace_id":"a5121c57-55c6-40cf-80b7-bf81d5a7ee8d","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:18.149403115Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:02.653859709Z","description":"","domain_name":"testfunctiontokenns1jkwoysc-tf-func-cool-jackson.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"b723d47a-37e6-452f-9544-062439b88c8e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-cool-jackson","namespace_id":"1e93890a-7879-4077-8a6f-c7320bdeec79","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:02.653859709Z"}'
         headers:
             Content-Length:
                 - "733"
@@ -287,9 +236,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:18 GMT
+                - Fri, 03 Jul 2026 15:02:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -297,11 +246,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 11579aca-c106-4d9f-bcf8-d5223e038336
+                - c7001bfb-c747-4ea8-afbb-bdec5a436164
         status: 200 OK
         code: 200
-        duration: 273.922488ms
-    - id: 6
+        duration: 96.458447ms
+    - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -317,7 +266,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/06b8e342-d97b-494a-b864-247b22da9c8a
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/b723d47a-37e6-452f-9544-062439b88c8e
         method: GET
       response:
         proto: HTTP/2.0
@@ -325,20 +274,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 207
+        content_length: 727
         uncompressed: false
-        body: '{"description":"","expires_at":"2026-05-05T12:37:48Z","id":"06b8e342-d97b-494a-b864-247b22da9c8a","namespace_id":"a5121c57-55c6-40cf-80b7-bf81d5a7ee8d","public_key":"","status":"creating","token":"xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxxxxxx"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:02.653860Z","description":"","domain_name":"testfunctiontokenns1jkwoysc-tf-func-cool-jackson.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"b723d47a-37e6-452f-9544-062439b88c8e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-cool-jackson","namespace_id":"1e93890a-7879-4077-8a6f-c7320bdeec79","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:02.653860Z"}'
         headers:
             Content-Length:
-                - "207"
+                - "727"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:18 GMT
+                - Fri, 03 Jul 2026 15:02:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -346,10 +295,61 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2c6fa940-7f43-4b38-b091-fff6f94edc8c
+                - 283de4bd-62ee-4e59-a472-8eac7128be27
         status: 200 OK
         code: 200
-        duration: 38.989387ms
+        duration: 120.38755ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 96
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"namespace_id":"1e93890a-7879-4077-8a6f-c7320bdeec79","expires_at":"2026-07-04T17:01:38+02:00"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2050
+        uncompressed: false
+        body: '{"description":"","expires_at":"2026-07-04T15:01:38Z","id":"8ec34b77-2c58-43fa-b93e-f3fceeecc6ab","namespace_id":"1e93890a-7879-4077-8a6f-c7320bdeec79","public_key":"-----BEGIN RSA PUBLIC KEY-----\nMIICCgKCAgEAttUpB6CPFtNcqXRrcpl5jAuwBXOxl6IZbuaKjF4zA3XfQcuI0A5d\nBLVtYp+ruGTKn2YSrqbjhtSA/14icArWvEpPoaWLFMRsfm9fIIZVypV3Fb6zvUUx\n6g0Izi9RmHDuAcnLAWYIyc9j1ri6sLo1Kg1xneolsIS7Mdz7GNnbTC4WZgJaXVq6\nl14fBuosAULI0kVPAwqIpII5WJl2NpfBNTArNQCUtCKfhyM9LogkSviazic9e9Ry\nDBvi5X11nbDlRPRfk1mk7UuxOxaMHvF0i+2mcJ6PdxIECj+QpaX5wMcFrX4bzszI\nptPYUFOjRtoVhWDP2hQFdJM7202Xii6dM7fpL989vhHLyu4o01dw/59nCskP7yME\n5opqJZY7CrwhgS2nxbAfgUBBaHMe0BGmPzNJGwzjMp9AyVb6WrS6HVmS9YJ3DXjM\nFWAiHrfQ/k6zt7BvOw/U3AEXTRK2RBknGHSY1gqHo7pX3nC0uQnsOiLU56G2DGkq\nhKuAfuzt0pGJyLcNxwDnm+/ZBUj0l+UuCvaI/ee/F4MsXJjIgaZNtIBV6ri+pft5\nDW8d88TvrtQc/51VU+o8YBwyXu7wQqWN+uzPELTHLS+ouFbuCY6a91fuWotK/6Ql\nGAyZOzeX48g87qaAbur/9AJNMtr1oLjNF0MBJ80/edNY1QMpextJWoECAwEAAQ==\n-----END RSA PUBLIC KEY-----\n","status":"creating","token":"xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxxxxxx"}'
+        headers:
+            Content-Length:
+                - "2050"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:02:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3e8bfa58-e79c-4dd1-b66e-0795e2f9f3eb
+        status: 200 OK
+        code: 200
+        duration: 227.648963ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -366,7 +366,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/ab388442-943b-4408-bb36-713c84e9d3b8
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/8ec34b77-2c58-43fa-b93e-f3fceeecc6ab
         method: GET
       response:
         proto: HTTP/2.0
@@ -374,20 +374,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 727
+        content_length: 207
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:18.149403Z","description":"","domain_name":"testfunctiontokenns8iwtyjld-tf-func-elated-cohen.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"ab388442-943b-4408-bb36-713c84e9d3b8","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-elated-cohen","namespace_id":"a5121c57-55c6-40cf-80b7-bf81d5a7ee8d","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:18.149403Z"}'
+        body: '{"description":"","expires_at":"2026-07-04T15:01:38Z","id":"8ec34b77-2c58-43fa-b93e-f3fceeecc6ab","namespace_id":"1e93890a-7879-4077-8a6f-c7320bdeec79","public_key":"","status":"creating","token":"xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxxxxxx"}'
         headers:
             Content-Length:
-                - "727"
+                - "207"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:18 GMT
+                - Fri, 03 Jul 2026 15:02:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -395,10 +395,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3fd8ae64-e0f3-46df-869b-b9abdf2071d7
+                - 38607aae-7a0a-4abb-a99d-4cce908179c8
         status: 200 OK
         code: 200
-        duration: 92.973618ms
+        duration: 28.392827ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -415,7 +415,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/ab388442-943b-4408-bb36-713c84e9d3b8
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/b723d47a-37e6-452f-9544-062439b88c8e
         method: GET
       response:
         proto: HTTP/2.0
@@ -425,7 +425,7 @@ interactions:
         trailer: {}
         content_length: 727
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:18.149403Z","description":"","domain_name":"testfunctiontokenns8iwtyjld-tf-func-elated-cohen.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"ab388442-943b-4408-bb36-713c84e9d3b8","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-elated-cohen","namespace_id":"a5121c57-55c6-40cf-80b7-bf81d5a7ee8d","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:18.149403Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:02.653860Z","description":"","domain_name":"testfunctiontokenns1jkwoysc-tf-func-cool-jackson.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"b723d47a-37e6-452f-9544-062439b88c8e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-cool-jackson","namespace_id":"1e93890a-7879-4077-8a6f-c7320bdeec79","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:02.653860Z"}'
         headers:
             Content-Length:
                 - "727"
@@ -434,9 +434,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:18 GMT
+                - Fri, 03 Jul 2026 15:02:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -444,10 +444,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ee1c4a0c-60fe-4e7c-bdc4-8d49227c52f6
+                - e1e691cc-bf29-4589-a0b4-2780340abaf0
         status: 200 OK
         code: 200
-        duration: 66.32008ms
+        duration: 42.18131ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -459,7 +459,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"function_id":"ab388442-943b-4408-bb36-713c84e9d3b8"}'
+        body: '{"function_id":"b723d47a-37e6-452f-9544-062439b88c8e"}'
         form: {}
         headers:
             Content-Type:
@@ -476,7 +476,7 @@ interactions:
         trailer: {}
         content_length: 2008
         uncompressed: false
-        body: '{"description":"","expires_at":null,"function_id":"ab388442-943b-4408-bb36-713c84e9d3b8","id":"88bcedf8-aa2b-4c84-abe0-c7933148d381","public_key":"-----BEGIN RSA PUBLIC KEY-----\nMIICCgKCAgEAvREYsKv4dVhi0jdyFEVmyKv9O4ARS+ak5MC3O4qWK7Ltpw1BtqZA\ngi9XmWLGB+p3yUj7DikYvJUPIut62WzXu3mrZIO7lVxZo6P/M6iaFqbnGe+x2/P1\nmUwc8Z/ztd4aW4LqeVD2doh0dDKAJ/JnL2eR9lNN6kJmyC8n38uzbTPIiqtw2hSe\nd9mMG1INuFXNfsSHEwzfAtp2fvpxKwjz4jnoTuJaMYb17PdKocjy2w+R/U5JmJQK\nVxG2e7WxNSPq5pGWEPsdbBzq9f+7ik7K268ZgutKsuAwAdvnxkj0C77IkzxvhD1c\n3kY7t570g58y4DaGXnuAv9A/5XKL3FFI+zVcSzZSwhJUn7Vqz/s8frcmccKdNtlA\nT372qgLlhiqHf+65TP+UpccOy4MG1dQzcg1sSYXGWyFbb++kyle14K/ktjkyJawa\nIueyJmab0iJyiSdXwnTQ5mGiDdHYfh2dzscBcGiNKs7kDjX1n2UK7R59O4sCWdxH\nRI2J2Rg+FaArp14VKoq4IfYvTIguVvDW9E3010p2hLM5i/l8f5fXafutQeRTZo2c\nqG110Ik57XH9+Axk2Omku5UWOlx3/vTBR+QdszSa4mf1IWZKEtvDsACyCIN+YZBd\nYsOqlyRm/uvtcOewslIC9W5lEapyKiQIXr+seDmgOS3o/+YR15megL0CAwEAAQ==\n-----END RSA PUBLIC KEY-----\n","status":"creating","token":"xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxxxxxx"}'
+        body: '{"description":"","expires_at":null,"function_id":"b723d47a-37e6-452f-9544-062439b88c8e","id":"92538d72-c932-4e0c-8896-fb9cad5240db","public_key":"-----BEGIN RSA PUBLIC KEY-----\nMIICCgKCAgEAttUpB6CPFtNcqXRrcpl5jAuwBXOxl6IZbuaKjF4zA3XfQcuI0A5d\nBLVtYp+ruGTKn2YSrqbjhtSA/14icArWvEpPoaWLFMRsfm9fIIZVypV3Fb6zvUUx\n6g0Izi9RmHDuAcnLAWYIyc9j1ri6sLo1Kg1xneolsIS7Mdz7GNnbTC4WZgJaXVq6\nl14fBuosAULI0kVPAwqIpII5WJl2NpfBNTArNQCUtCKfhyM9LogkSviazic9e9Ry\nDBvi5X11nbDlRPRfk1mk7UuxOxaMHvF0i+2mcJ6PdxIECj+QpaX5wMcFrX4bzszI\nptPYUFOjRtoVhWDP2hQFdJM7202Xii6dM7fpL989vhHLyu4o01dw/59nCskP7yME\n5opqJZY7CrwhgS2nxbAfgUBBaHMe0BGmPzNJGwzjMp9AyVb6WrS6HVmS9YJ3DXjM\nFWAiHrfQ/k6zt7BvOw/U3AEXTRK2RBknGHSY1gqHo7pX3nC0uQnsOiLU56G2DGkq\nhKuAfuzt0pGJyLcNxwDnm+/ZBUj0l+UuCvaI/ee/F4MsXJjIgaZNtIBV6ri+pft5\nDW8d88TvrtQc/51VU+o8YBwyXu7wQqWN+uzPELTHLS+ouFbuCY6a91fuWotK/6Ql\nGAyZOzeX48g87qaAbur/9AJNMtr1oLjNF0MBJ80/edNY1QMpextJWoECAwEAAQ==\n-----END RSA PUBLIC KEY-----\n","status":"creating","token":"xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxxxxxx"}'
         headers:
             Content-Length:
                 - "2008"
@@ -485,9 +485,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:18 GMT
+                - Fri, 03 Jul 2026 15:02:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -495,10 +495,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 18134581-6584-4a53-8cce-46d0078fd8b0
+                - a8766ba9-d463-4c2b-89de-6ae29fcbff39
         status: 200 OK
         code: 200
-        duration: 158.578371ms
+        duration: 269.800858ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -515,7 +515,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/88bcedf8-aa2b-4c84-abe0-c7933148d381
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/92538d72-c932-4e0c-8896-fb9cad5240db
         method: GET
       response:
         proto: HTTP/2.0
@@ -525,7 +525,7 @@ interactions:
         trailer: {}
         content_length: 188
         uncompressed: false
-        body: '{"description":"","expires_at":null,"function_id":"ab388442-943b-4408-bb36-713c84e9d3b8","id":"88bcedf8-aa2b-4c84-abe0-c7933148d381","public_key":"","status":"creating","token":"xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxxxxxx"}'
+        body: '{"description":"","expires_at":null,"function_id":"b723d47a-37e6-452f-9544-062439b88c8e","id":"92538d72-c932-4e0c-8896-fb9cad5240db","public_key":"","status":"creating","token":"xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxxxxxx"}'
         headers:
             Content-Length:
                 - "188"
@@ -534,9 +534,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:18 GMT
+                - Fri, 03 Jul 2026 15:02:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -544,10 +544,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a6e409ed-4a09-46ec-8220-5d0ba3d83e1e
+                - bbcd1038-dea4-4e9f-8b46-4a47430e5d2b
         status: 200 OK
         code: 200
-        duration: 45.525515ms
+        duration: 71.355506ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -564,7 +564,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/06b8e342-d97b-494a-b864-247b22da9c8a
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/8ec34b77-2c58-43fa-b93e-f3fceeecc6ab
         method: GET
       response:
         proto: HTTP/2.0
@@ -574,7 +574,7 @@ interactions:
         trailer: {}
         content_length: 204
         uncompressed: false
-        body: '{"description":"","expires_at":"2026-05-05T12:37:48Z","id":"06b8e342-d97b-494a-b864-247b22da9c8a","namespace_id":"a5121c57-55c6-40cf-80b7-bf81d5a7ee8d","public_key":"","status":"ready","token":"xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxxxxxx"}'
+        body: '{"description":"","expires_at":"2026-07-04T15:01:38Z","id":"8ec34b77-2c58-43fa-b93e-f3fceeecc6ab","namespace_id":"1e93890a-7879-4077-8a6f-c7320bdeec79","public_key":"","status":"ready","token":"xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxxxxxx"}'
         headers:
             Content-Length:
                 - "204"
@@ -583,9 +583,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:18 GMT
+                - Fri, 03 Jul 2026 15:02:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -593,10 +593,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c45adc95-bdc6-442e-b58c-df0872e7fea3
+                - 7bd15f29-0f17-4728-b1fb-2bcf15fa92e0
         status: 200 OK
         code: 200
-        duration: 31.967486ms
+        duration: 35.004071ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -613,7 +613,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/88bcedf8-aa2b-4c84-abe0-c7933148d381
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/92538d72-c932-4e0c-8896-fb9cad5240db
         method: GET
       response:
         proto: HTTP/2.0
@@ -621,20 +621,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 185
+        content_length: 188
         uncompressed: false
-        body: '{"description":"","expires_at":null,"function_id":"ab388442-943b-4408-bb36-713c84e9d3b8","id":"88bcedf8-aa2b-4c84-abe0-c7933148d381","public_key":"","status":"ready","token":"xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxxxxxx"}'
+        body: '{"description":"","expires_at":null,"function_id":"b723d47a-37e6-452f-9544-062439b88c8e","id":"92538d72-c932-4e0c-8896-fb9cad5240db","public_key":"","status":"creating","token":"xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxxxxxx"}'
         headers:
             Content-Length:
-                - "185"
+                - "188"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:18 GMT
+                - Fri, 03 Jul 2026 15:02:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -642,10 +642,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7fe15b26-f765-4abf-95e9-ddea1d230f3c
+                - 0b761df6-16e3-4c6a-9e0a-488caf63aa89
         status: 200 OK
         code: 200
-        duration: 68.848407ms
+        duration: 50.765985ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -662,7 +662,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a5121c57-55c6-40cf-80b7-bf81d5a7ee8d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/1e93890a-7879-4077-8a6f-c7320bdeec79
         method: GET
       response:
         proto: HTTP/2.0
@@ -672,7 +672,7 @@ interactions:
         trailer: {}
         content_length: 590
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.817324Z","description":"","environment_variables":{},"error_message":null,"id":"a5121c57-55c6-40cf-80b7-bf81d5a7ee8d","name":"test-function-token-ns","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontokenns8iwtyjld","registry_namespace_id":"96e1f22e-19ee-4364-b336-ec468ad3e02c","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:14.852084Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.384244Z","description":"","environment_variables":{},"error_message":null,"id":"1e93890a-7879-4077-8a6f-c7320bdeec79","name":"test-function-token-ns","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontokenns1jkwoysc","registry_namespace_id":"6ed0ddd9-9636-4398-8b84-13a7c5b7705d","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:01:58.868721Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "590"
@@ -681,9 +681,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:19 GMT
+                - Fri, 03 Jul 2026 15:02:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -691,10 +691,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c597e9d6-0c97-4eac-8f92-e04d157b5fba
+                - 0aad5711-0609-49d0-ac6d-be4eed0c3d55
         status: 200 OK
         code: 200
-        duration: 41.885246ms
+        duration: 255.738671ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -711,7 +711,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/06b8e342-d97b-494a-b864-247b22da9c8a
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/8ec34b77-2c58-43fa-b93e-f3fceeecc6ab
         method: GET
       response:
         proto: HTTP/2.0
@@ -721,7 +721,7 @@ interactions:
         trailer: {}
         content_length: 204
         uncompressed: false
-        body: '{"description":"","expires_at":"2026-05-05T12:37:48Z","id":"06b8e342-d97b-494a-b864-247b22da9c8a","namespace_id":"a5121c57-55c6-40cf-80b7-bf81d5a7ee8d","public_key":"","status":"ready","token":"xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxxxxxx"}'
+        body: '{"description":"","expires_at":"2026-07-04T15:01:38Z","id":"8ec34b77-2c58-43fa-b93e-f3fceeecc6ab","namespace_id":"1e93890a-7879-4077-8a6f-c7320bdeec79","public_key":"","status":"ready","token":"xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxxxxxx"}'
         headers:
             Content-Length:
                 - "204"
@@ -730,9 +730,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:19 GMT
+                - Fri, 03 Jul 2026 15:02:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -740,10 +740,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e4288848-139f-454b-9db5-0ad7e1146290
+                - a88c6d55-f86d-425d-9721-49faeab857a3
         status: 200 OK
         code: 200
-        duration: 66.847933ms
+        duration: 39.297205ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -760,7 +760,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/ab388442-943b-4408-bb36-713c84e9d3b8
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/b723d47a-37e6-452f-9544-062439b88c8e
         method: GET
       response:
         proto: HTTP/2.0
@@ -770,7 +770,7 @@ interactions:
         trailer: {}
         content_length: 727
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:18.149403Z","description":"","domain_name":"testfunctiontokenns8iwtyjld-tf-func-elated-cohen.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"ab388442-943b-4408-bb36-713c84e9d3b8","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-elated-cohen","namespace_id":"a5121c57-55c6-40cf-80b7-bf81d5a7ee8d","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:18.149403Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:02.653860Z","description":"","domain_name":"testfunctiontokenns1jkwoysc-tf-func-cool-jackson.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"b723d47a-37e6-452f-9544-062439b88c8e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-cool-jackson","namespace_id":"1e93890a-7879-4077-8a6f-c7320bdeec79","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:02.653860Z"}'
         headers:
             Content-Length:
                 - "727"
@@ -779,9 +779,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:19 GMT
+                - Fri, 03 Jul 2026 15:02:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -789,10 +789,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3766bfe7-0e9d-421a-a935-457dea39ef9b
+                - 7545de6e-36e4-4d24-8fbe-589e490b17ca
         status: 200 OK
         code: 200
-        duration: 66.181609ms
+        duration: 117.990952ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -809,7 +809,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/88bcedf8-aa2b-4c84-abe0-c7933148d381
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/92538d72-c932-4e0c-8896-fb9cad5240db
         method: GET
       response:
         proto: HTTP/2.0
@@ -819,7 +819,7 @@ interactions:
         trailer: {}
         content_length: 185
         uncompressed: false
-        body: '{"description":"","expires_at":null,"function_id":"ab388442-943b-4408-bb36-713c84e9d3b8","id":"88bcedf8-aa2b-4c84-abe0-c7933148d381","public_key":"","status":"ready","token":"xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxxxxxx"}'
+        body: '{"description":"","expires_at":null,"function_id":"b723d47a-37e6-452f-9544-062439b88c8e","id":"92538d72-c932-4e0c-8896-fb9cad5240db","public_key":"","status":"ready","token":"xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxxxxxx"}'
         headers:
             Content-Length:
                 - "185"
@@ -828,9 +828,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:19 GMT
+                - Fri, 03 Jul 2026 15:02:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -838,10 +838,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - eb6f087f-ccd5-41ba-8563-79de42038989
+                - 36a4ef8d-70fc-4a5b-8cc4-69e3fdfa9765
         status: 200 OK
         code: 200
-        duration: 49.01492ms
+        duration: 52.234576ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -858,7 +858,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/88bcedf8-aa2b-4c84-abe0-c7933148d381
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/8ec34b77-2c58-43fa-b93e-f3fceeecc6ab
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -866,20 +866,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 180
+        content_length: 199
         uncompressed: false
-        body: '{"description":"","expires_at":null,"function_id":"ab388442-943b-4408-bb36-713c84e9d3b8","id":"88bcedf8-aa2b-4c84-abe0-c7933148d381","public_key":"","status":"deleting","token":"xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxxxxxx"}'
+        body: '{"description":"","expires_at":"2026-07-04T15:01:38Z","id":"8ec34b77-2c58-43fa-b93e-f3fceeecc6ab","namespace_id":"1e93890a-7879-4077-8a6f-c7320bdeec79","public_key":"","status":"deleting","token":"xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxxxxxx"}'
         headers:
             Content-Length:
-                - "180"
+                - "199"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:19 GMT
+                - Fri, 03 Jul 2026 15:02:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -887,10 +887,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9a9e2e18-00bb-46f5-a7e3-67a88b9dd58d
+                - 25c537e8-9b07-42a1-9e12-3e0521d0562c
         status: 200 OK
         code: 200
-        duration: 56.169231ms
+        duration: 61.15862ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -907,7 +907,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/06b8e342-d97b-494a-b864-247b22da9c8a
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/92538d72-c932-4e0c-8896-fb9cad5240db
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -915,20 +915,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 199
+        content_length: 180
         uncompressed: false
-        body: '{"description":"","expires_at":"2026-05-05T12:37:48Z","id":"06b8e342-d97b-494a-b864-247b22da9c8a","namespace_id":"a5121c57-55c6-40cf-80b7-bf81d5a7ee8d","public_key":"","status":"deleting","token":"xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxxxxxx"}'
+        body: '{"description":"","expires_at":null,"function_id":"b723d47a-37e6-452f-9544-062439b88c8e","id":"92538d72-c932-4e0c-8896-fb9cad5240db","public_key":"","status":"deleting","token":"xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxxxxxx"}'
         headers:
             Content-Length:
-                - "199"
+                - "180"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:19 GMT
+                - Fri, 03 Jul 2026 15:02:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -936,10 +936,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ccd071fc-df2d-4875-ac1d-c54b69072e38
+                - f61df408-da0a-4ac2-b544-ed0d1c75417e
         status: 200 OK
         code: 200
-        duration: 242.446458ms
+        duration: 221.895363ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -956,7 +956,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/ab388442-943b-4408-bb36-713c84e9d3b8
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/b723d47a-37e6-452f-9544-062439b88c8e
         method: GET
       response:
         proto: HTTP/2.0
@@ -966,7 +966,7 @@ interactions:
         trailer: {}
         content_length: 727
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:18.149403Z","description":"","domain_name":"testfunctiontokenns8iwtyjld-tf-func-elated-cohen.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"ab388442-943b-4408-bb36-713c84e9d3b8","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-elated-cohen","namespace_id":"a5121c57-55c6-40cf-80b7-bf81d5a7ee8d","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:18.149403Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:02.653860Z","description":"","domain_name":"testfunctiontokenns1jkwoysc-tf-func-cool-jackson.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"b723d47a-37e6-452f-9544-062439b88c8e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-cool-jackson","namespace_id":"1e93890a-7879-4077-8a6f-c7320bdeec79","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:02.653860Z"}'
         headers:
             Content-Length:
                 - "727"
@@ -975,9 +975,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:19 GMT
+                - Fri, 03 Jul 2026 15:02:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -985,10 +985,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3423ca6f-8eb6-4977-824f-20bd620ad5d3
+                - 853c9d48-0d1e-4183-8160-1c2091e510d4
         status: 200 OK
         code: 200
-        duration: 259.122663ms
+        duration: 45.274126ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1005,7 +1005,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/ab388442-943b-4408-bb36-713c84e9d3b8
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/b723d47a-37e6-452f-9544-062439b88c8e
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1015,7 +1015,7 @@ interactions:
         trailer: {}
         content_length: 731
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:18.149403Z","description":"","domain_name":"testfunctiontokenns8iwtyjld-tf-func-elated-cohen.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"ab388442-943b-4408-bb36-713c84e9d3b8","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-elated-cohen","namespace_id":"a5121c57-55c6-40cf-80b7-bf81d5a7ee8d","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:20.063845279Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:02.653860Z","description":"","domain_name":"testfunctiontokenns1jkwoysc-tf-func-cool-jackson.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"b723d47a-37e6-452f-9544-062439b88c8e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-cool-jackson","namespace_id":"1e93890a-7879-4077-8a6f-c7320bdeec79","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:04.605473646Z"}'
         headers:
             Content-Length:
                 - "731"
@@ -1024,9 +1024,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:20 GMT
+                - Fri, 03 Jul 2026 15:02:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1034,10 +1034,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a71565e2-b8c4-42c8-acff-8d2255e1cc3c
+                - 46e6d166-74af-42e2-81c2-3fb1e92c8242
         status: 200 OK
         code: 200
-        duration: 572.756022ms
+        duration: 383.216204ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1054,7 +1054,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a5121c57-55c6-40cf-80b7-bf81d5a7ee8d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/1e93890a-7879-4077-8a6f-c7320bdeec79
         method: GET
       response:
         proto: HTTP/2.0
@@ -1064,7 +1064,7 @@ interactions:
         trailer: {}
         content_length: 590
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.817324Z","description":"","environment_variables":{},"error_message":null,"id":"a5121c57-55c6-40cf-80b7-bf81d5a7ee8d","name":"test-function-token-ns","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontokenns8iwtyjld","registry_namespace_id":"96e1f22e-19ee-4364-b336-ec468ad3e02c","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:14.852084Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.384244Z","description":"","environment_variables":{},"error_message":null,"id":"1e93890a-7879-4077-8a6f-c7320bdeec79","name":"test-function-token-ns","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontokenns1jkwoysc","registry_namespace_id":"6ed0ddd9-9636-4398-8b84-13a7c5b7705d","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:01:58.868721Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "590"
@@ -1073,9 +1073,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:20 GMT
+                - Fri, 03 Jul 2026 15:02:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1083,10 +1083,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c07deb38-7356-424f-bda4-d7d45933a340
+                - 5791b060-245d-4661-8942-9005fc65e7ca
         status: 200 OK
         code: 200
-        duration: 39.093854ms
+        duration: 35.229004ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1103,7 +1103,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a5121c57-55c6-40cf-80b7-bf81d5a7ee8d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/1e93890a-7879-4077-8a6f-c7320bdeec79
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1113,7 +1113,7 @@ interactions:
         trailer: {}
         content_length: 596
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.817324Z","description":"","environment_variables":{},"error_message":null,"id":"a5121c57-55c6-40cf-80b7-bf81d5a7ee8d","name":"test-function-token-ns","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontokenns8iwtyjld","registry_namespace_id":"96e1f22e-19ee-4364-b336-ec468ad3e02c","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-05-04T12:39:20.514746164Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.384244Z","description":"","environment_variables":{},"error_message":null,"id":"1e93890a-7879-4077-8a6f-c7320bdeec79","name":"test-function-token-ns","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontokenns1jkwoysc","registry_namespace_id":"6ed0ddd9-9636-4398-8b84-13a7c5b7705d","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-07-03T15:02:05.011831607Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "596"
@@ -1122,9 +1122,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:20 GMT
+                - Fri, 03 Jul 2026 15:02:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1132,10 +1132,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8510b9c1-3bd4-48b8-b856-02e0c4424169
+                - 2842601d-1603-478d-9614-a960ac0187cd
         status: 200 OK
         code: 200
-        duration: 340.832873ms
+        duration: 1.006612872s
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1152,7 +1152,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a5121c57-55c6-40cf-80b7-bf81d5a7ee8d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/1e93890a-7879-4077-8a6f-c7320bdeec79
         method: GET
       response:
         proto: HTTP/2.0
@@ -1162,7 +1162,7 @@ interactions:
         trailer: {}
         content_length: 593
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.817324Z","description":"","environment_variables":{},"error_message":null,"id":"a5121c57-55c6-40cf-80b7-bf81d5a7ee8d","name":"test-function-token-ns","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontokenns8iwtyjld","registry_namespace_id":"96e1f22e-19ee-4364-b336-ec468ad3e02c","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-05-04T12:39:20.514746Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.384244Z","description":"","environment_variables":{},"error_message":null,"id":"1e93890a-7879-4077-8a6f-c7320bdeec79","name":"test-function-token-ns","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontokenns1jkwoysc","registry_namespace_id":"6ed0ddd9-9636-4398-8b84-13a7c5b7705d","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-07-03T15:02:05.011832Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "593"
@@ -1171,9 +1171,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:20 GMT
+                - Fri, 03 Jul 2026 15:02:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1181,10 +1181,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e054db30-3305-4ed5-885c-ee5ba6c71a81
+                - 5814bbe6-59f7-48a5-be93-865a37d25d33
         status: 200 OK
         code: 200
-        duration: 45.221243ms
+        duration: 35.72654ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1201,7 +1201,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/a5121c57-55c6-40cf-80b7-bf81d5a7ee8d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/1e93890a-7879-4077-8a6f-c7320bdeec79
         method: GET
       response:
         proto: HTTP/2.0
@@ -1220,9 +1220,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:51 GMT
+                - Fri, 03 Jul 2026 15:02:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1230,10 +1230,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 15cc7638-90c9-4182-b0b9-8aa6bb0c8593
+                - 0584a5b9-3e64-473e-b425-766735795537
         status: 404 Not Found
         code: 404
-        duration: 26.988905ms
+        duration: 29.120607ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1250,7 +1250,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/88bcedf8-aa2b-4c84-abe0-c7933148d381
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/92538d72-c932-4e0c-8896-fb9cad5240db
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1269,9 +1269,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:51 GMT
+                - Fri, 03 Jul 2026 15:02:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1279,10 +1279,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3cbed52f-0733-4bf2-9e15-f58822652b94
+                - 727a068e-dea9-4196-bef8-81b8c1f5e2ac
         status: 404 Not Found
         code: 404
-        duration: 123.819842ms
+        duration: 21.512709ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1299,7 +1299,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/06b8e342-d97b-494a-b864-247b22da9c8a
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/8ec34b77-2c58-43fa-b93e-f3fceeecc6ab
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1318,9 +1318,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:51 GMT
+                - Fri, 03 Jul 2026 15:02:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1328,7 +1328,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4fd1845b-81b5-46dc-a868-7e3f9b54078d
+                - 538c825a-0eb6-4c42-bba1-c1e51080c77a
         status: 404 Not Found
         code: 404
-        duration: 25.976479ms
+        duration: 27.109283ms

--- a/internal/services/function/testdata/function-token-basic.cassette.yaml
+++ b/internal/services/function/testdata/function-token-basic.cassette.yaml
@@ -29,7 +29,7 @@ interactions:
         trailer: {}
         content_length: 508
         uncompressed: false
-        body: '{"created_at":"2026-07-03T15:01:47.384243699Z","description":"","environment_variables":{},"error_message":null,"id":"1e93890a-7879-4077-8a6f-c7320bdeec79","name":"test-function-token-ns","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-07-03T15:01:47.384243699Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T16:49:40.756198811Z","description":"","environment_variables":{},"error_message":null,"id":"5d8b0883-a64a-4635-a520-b3d430673382","name":"test-function-token-ns","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-07-03T16:49:40.756198811Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "508"
@@ -38,9 +38,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:01:47 GMT
+                - Fri, 03 Jul 2026 16:49:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dc00f190-d1e2-445b-b9ec-98d31a49f6c0
+                - 008773a9-bf65-4faa-8829-9c02b57ee883
         status: 200 OK
         code: 200
-        duration: 7.925657193s
+        duration: 948.076494ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -68,7 +68,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/1e93890a-7879-4077-8a6f-c7320bdeec79
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5d8b0883-a64a-4635-a520-b3d430673382
         method: GET
       response:
         proto: HTTP/2.0
@@ -78,7 +78,7 @@ interactions:
         trailer: {}
         content_length: 502
         uncompressed: false
-        body: '{"created_at":"2026-07-03T15:01:47.384244Z","description":"","environment_variables":{},"error_message":null,"id":"1e93890a-7879-4077-8a6f-c7320bdeec79","name":"test-function-token-ns","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-07-03T15:01:47.384244Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T16:49:40.756199Z","description":"","environment_variables":{},"error_message":null,"id":"5d8b0883-a64a-4635-a520-b3d430673382","name":"test-function-token-ns","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-07-03T16:49:40.756199Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "502"
@@ -87,9 +87,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:01:47 GMT
+                - Fri, 03 Jul 2026 16:49:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4c152ea9-db72-40f0-9747-e529ed715365
+                - 18d9390b-4ad3-4d20-91b9-415b2093ada9
         status: 200 OK
         code: 200
-        duration: 35.837929ms
+        duration: 51.041908ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -117,7 +117,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/1e93890a-7879-4077-8a6f-c7320bdeec79
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5d8b0883-a64a-4635-a520-b3d430673382
         method: GET
       response:
         proto: HTTP/2.0
@@ -127,7 +127,7 @@ interactions:
         trailer: {}
         content_length: 590
         uncompressed: false
-        body: '{"created_at":"2026-07-03T15:01:47.384244Z","description":"","environment_variables":{},"error_message":null,"id":"1e93890a-7879-4077-8a6f-c7320bdeec79","name":"test-function-token-ns","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontokenns1jkwoysc","registry_namespace_id":"6ed0ddd9-9636-4398-8b84-13a7c5b7705d","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:01:58.868721Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T16:49:40.756199Z","description":"","environment_variables":{},"error_message":null,"id":"5d8b0883-a64a-4635-a520-b3d430673382","name":"test-function-token-ns","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontokennsy4jqt2ty","registry_namespace_id":"43f85f09-9aef-4864-aafa-d96cd9aa0149","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T16:49:41.781728Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "590"
@@ -136,9 +136,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:02:02 GMT
+                - Fri, 03 Jul 2026 16:49:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 075949e6-6265-4f47-8026-6e3c177c292c
+                - 965a0910-f3c8-45c7-981c-2871466230e2
         status: 200 OK
         code: 200
-        duration: 29.07993ms
+        duration: 56.094811ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -166,7 +166,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/1e93890a-7879-4077-8a6f-c7320bdeec79
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5d8b0883-a64a-4635-a520-b3d430673382
         method: GET
       response:
         proto: HTTP/2.0
@@ -176,7 +176,7 @@ interactions:
         trailer: {}
         content_length: 590
         uncompressed: false
-        body: '{"created_at":"2026-07-03T15:01:47.384244Z","description":"","environment_variables":{},"error_message":null,"id":"1e93890a-7879-4077-8a6f-c7320bdeec79","name":"test-function-token-ns","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontokenns1jkwoysc","registry_namespace_id":"6ed0ddd9-9636-4398-8b84-13a7c5b7705d","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:01:58.868721Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T16:49:40.756199Z","description":"","environment_variables":{},"error_message":null,"id":"5d8b0883-a64a-4635-a520-b3d430673382","name":"test-function-token-ns","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontokennsy4jqt2ty","registry_namespace_id":"43f85f09-9aef-4864-aafa-d96cd9aa0149","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T16:49:41.781728Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "590"
@@ -185,9 +185,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:02:02 GMT
+                - Fri, 03 Jul 2026 16:49:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,22 +195,22 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e035f5be-6c11-4d73-b434-4df1636ab8c5
+                - 5c962ad0-1942-4862-a0cc-0a8d6a0a1ef1
         status: 200 OK
         code: 200
-        duration: 35.993252ms
+        duration: 58.138155ms
     - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 324
+        content_length: 322
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-func-cool-jackson","namespace_id":"1e93890a-7879-4077-8a6f-c7320bdeec79","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node26","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox","tags":null}'
+        body: '{"name":"tf-func-great-saha","namespace_id":"5d8b0883-a64a-4635-a520-b3d430673382","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node26","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox","tags":null}'
         form: {}
         headers:
             Content-Type:
@@ -225,20 +225,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 733
+        content_length: 729
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:02.653859709Z","description":"","domain_name":"testfunctiontokenns1jkwoysc-tf-func-cool-jackson.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"b723d47a-37e6-452f-9544-062439b88c8e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-cool-jackson","namespace_id":"1e93890a-7879-4077-8a6f-c7320bdeec79","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:02.653859709Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T16:49:46.074987469Z","description":"","domain_name":"testfunctiontokennsy4jqt2ty-tf-func-great-saha.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"95aa6808-bb3b-43d8-8a00-628d9a458d4a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-great-saha","namespace_id":"5d8b0883-a64a-4635-a520-b3d430673382","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T16:49:46.074987469Z"}'
         headers:
             Content-Length:
-                - "733"
+                - "729"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:02:02 GMT
+                - Fri, 03 Jul 2026 16:49:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -246,10 +246,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c7001bfb-c747-4ea8-afbb-bdec5a436164
+                - 5644810b-d65e-42d8-abe2-f712d4b4ab7a
         status: 200 OK
         code: 200
-        duration: 96.458447ms
+        duration: 134.590894ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -266,7 +266,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/b723d47a-37e6-452f-9544-062439b88c8e
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/95aa6808-bb3b-43d8-8a00-628d9a458d4a
         method: GET
       response:
         proto: HTTP/2.0
@@ -274,20 +274,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 727
+        content_length: 723
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:02.653860Z","description":"","domain_name":"testfunctiontokenns1jkwoysc-tf-func-cool-jackson.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"b723d47a-37e6-452f-9544-062439b88c8e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-cool-jackson","namespace_id":"1e93890a-7879-4077-8a6f-c7320bdeec79","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:02.653860Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T16:49:46.074987Z","description":"","domain_name":"testfunctiontokennsy4jqt2ty-tf-func-great-saha.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"95aa6808-bb3b-43d8-8a00-628d9a458d4a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-great-saha","namespace_id":"5d8b0883-a64a-4635-a520-b3d430673382","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T16:49:46.074987Z"}'
         headers:
             Content-Length:
-                - "727"
+                - "723"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:02:02 GMT
+                - Fri, 03 Jul 2026 16:49:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -295,10 +295,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 283de4bd-62ee-4e59-a472-8eac7128be27
+                - be52c9ed-97a3-429d-83ae-adfcdd20ca46
         status: 200 OK
         code: 200
-        duration: 120.38755ms
+        duration: 61.210022ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -310,7 +310,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"namespace_id":"1e93890a-7879-4077-8a6f-c7320bdeec79","expires_at":"2026-07-04T17:01:38+02:00"}'
+        body: '{"namespace_id":"5d8b0883-a64a-4635-a520-b3d430673382","expires_at":"2026-07-04T18:49:39+02:00"}'
         form: {}
         headers:
             Content-Type:
@@ -327,7 +327,7 @@ interactions:
         trailer: {}
         content_length: 2050
         uncompressed: false
-        body: '{"description":"","expires_at":"2026-07-04T15:01:38Z","id":"8ec34b77-2c58-43fa-b93e-f3fceeecc6ab","namespace_id":"1e93890a-7879-4077-8a6f-c7320bdeec79","public_key":"-----BEGIN RSA PUBLIC KEY-----\nMIICCgKCAgEAttUpB6CPFtNcqXRrcpl5jAuwBXOxl6IZbuaKjF4zA3XfQcuI0A5d\nBLVtYp+ruGTKn2YSrqbjhtSA/14icArWvEpPoaWLFMRsfm9fIIZVypV3Fb6zvUUx\n6g0Izi9RmHDuAcnLAWYIyc9j1ri6sLo1Kg1xneolsIS7Mdz7GNnbTC4WZgJaXVq6\nl14fBuosAULI0kVPAwqIpII5WJl2NpfBNTArNQCUtCKfhyM9LogkSviazic9e9Ry\nDBvi5X11nbDlRPRfk1mk7UuxOxaMHvF0i+2mcJ6PdxIECj+QpaX5wMcFrX4bzszI\nptPYUFOjRtoVhWDP2hQFdJM7202Xii6dM7fpL989vhHLyu4o01dw/59nCskP7yME\n5opqJZY7CrwhgS2nxbAfgUBBaHMe0BGmPzNJGwzjMp9AyVb6WrS6HVmS9YJ3DXjM\nFWAiHrfQ/k6zt7BvOw/U3AEXTRK2RBknGHSY1gqHo7pX3nC0uQnsOiLU56G2DGkq\nhKuAfuzt0pGJyLcNxwDnm+/ZBUj0l+UuCvaI/ee/F4MsXJjIgaZNtIBV6ri+pft5\nDW8d88TvrtQc/51VU+o8YBwyXu7wQqWN+uzPELTHLS+ouFbuCY6a91fuWotK/6Ql\nGAyZOzeX48g87qaAbur/9AJNMtr1oLjNF0MBJ80/edNY1QMpextJWoECAwEAAQ==\n-----END RSA PUBLIC KEY-----\n","status":"creating","token":"xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxxxxxx"}'
+        body: '{"description":"","expires_at":"2026-07-04T16:49:39Z","id":"99cfbf5d-4c36-47ea-98ff-5fd3df667cd6","namespace_id":"5d8b0883-a64a-4635-a520-b3d430673382","public_key":"-----BEGIN RSA PUBLIC KEY-----\nMIICCgKCAgEAuymZ/b34rGHJpoJyMnDd8oDcfaiy7eJRncrA72PXbB5RfAyIm/T6\nF7skuyMYK9heGspNeeHlTJHOSkogsUd8oPnaf2+hebPXkwVdK06n6PUdRyYP1ozV\nYUh29311nUdRE4NWkB1dlq1wiwtVB63vk7JqYvSLheDb/4gE0oGBKHV8moQA3n8d\nVgaF28aYyUJ9vOjQ0prsTZVGweH4B26GYze2vcDKeWtvc0+hB8A2rZhMLMIiPzFx\nrwUfHLVxune9TNyZt3NYgpjHNzHAoDH5saffSrOXEyuJJZp1Z/QBVKtmlVGVnqUJ\nZn7ajqyCDS7E4gVOj7b36dzAV93mGluJIAR1sq4ymsIWtpRwt0FZnlml+kBAhVbe\nnfJUAdW6R+p8zd+fSJbtVnnmzybAOYAavM6sOAxzs8qcJ9r7pqaYdvZ2Lcawxe5r\nhnPa1TNRXTzlZZoKU8RhO3j7wH34VYcN1bXabPoaorFX8FIxtieSXz6uVATp3XCv\nVk4tScyI84abeG71XXuyS2VTqdUlTAD4cYXUb1E0SLRWNB+pFuReMIl4I26tQ7I2\nxsWLHU9Qh89HwhS68vczv+EcJNC4b86DAEM171lO1TYE6HJt47tPQEoRB7qDmZQC\nlDDddLF30Fi6btqjaNF2f0HKiscjHCEmZohyC1SxAqYD5b7MS1lBcIkCAwEAAQ==\n-----END RSA PUBLIC KEY-----\n","status":"creating","token":"xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxxxxxx"}'
         headers:
             Content-Length:
                 - "2050"
@@ -336,9 +336,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:02:02 GMT
+                - Fri, 03 Jul 2026 16:49:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -346,10 +346,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3e8bfa58-e79c-4dd1-b66e-0795e2f9f3eb
+                - 9ea0c0dc-e35a-471e-a54b-b83d4aebfc2a
         status: 200 OK
         code: 200
-        duration: 227.648963ms
+        duration: 217.288229ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -366,7 +366,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/8ec34b77-2c58-43fa-b93e-f3fceeecc6ab
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/95aa6808-bb3b-43d8-8a00-628d9a458d4a
         method: GET
       response:
         proto: HTTP/2.0
@@ -374,20 +374,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 207
+        content_length: 723
         uncompressed: false
-        body: '{"description":"","expires_at":"2026-07-04T15:01:38Z","id":"8ec34b77-2c58-43fa-b93e-f3fceeecc6ab","namespace_id":"1e93890a-7879-4077-8a6f-c7320bdeec79","public_key":"","status":"creating","token":"xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxxxxxx"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T16:49:46.074987Z","description":"","domain_name":"testfunctiontokennsy4jqt2ty-tf-func-great-saha.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"95aa6808-bb3b-43d8-8a00-628d9a458d4a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-great-saha","namespace_id":"5d8b0883-a64a-4635-a520-b3d430673382","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T16:49:46.074987Z"}'
         headers:
             Content-Length:
-                - "207"
+                - "723"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:02:02 GMT
+                - Fri, 03 Jul 2026 16:49:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -395,10 +395,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 38607aae-7a0a-4abb-a99d-4cce908179c8
+                - 48399490-a04a-4386-a210-2685ed5de281
         status: 200 OK
         code: 200
-        duration: 28.392827ms
+        duration: 45.634998ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -415,7 +415,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/b723d47a-37e6-452f-9544-062439b88c8e
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/99cfbf5d-4c36-47ea-98ff-5fd3df667cd6
         method: GET
       response:
         proto: HTTP/2.0
@@ -423,20 +423,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 727
+        content_length: 207
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:02.653860Z","description":"","domain_name":"testfunctiontokenns1jkwoysc-tf-func-cool-jackson.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"b723d47a-37e6-452f-9544-062439b88c8e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-cool-jackson","namespace_id":"1e93890a-7879-4077-8a6f-c7320bdeec79","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:02.653860Z"}'
+        body: '{"description":"","expires_at":"2026-07-04T16:49:39Z","id":"99cfbf5d-4c36-47ea-98ff-5fd3df667cd6","namespace_id":"5d8b0883-a64a-4635-a520-b3d430673382","public_key":"","status":"creating","token":"xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxxxxxx"}'
         headers:
             Content-Length:
-                - "727"
+                - "207"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:02:02 GMT
+                - Fri, 03 Jul 2026 16:49:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -444,10 +444,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e1e691cc-bf29-4589-a0b4-2780340abaf0
+                - dbe6bf22-3e64-4035-9830-5edfe9477cd4
         status: 200 OK
         code: 200
-        duration: 42.18131ms
+        duration: 40.24966ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -459,7 +459,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"function_id":"b723d47a-37e6-452f-9544-062439b88c8e"}'
+        body: '{"function_id":"95aa6808-bb3b-43d8-8a00-628d9a458d4a"}'
         form: {}
         headers:
             Content-Type:
@@ -476,7 +476,7 @@ interactions:
         trailer: {}
         content_length: 2008
         uncompressed: false
-        body: '{"description":"","expires_at":null,"function_id":"b723d47a-37e6-452f-9544-062439b88c8e","id":"92538d72-c932-4e0c-8896-fb9cad5240db","public_key":"-----BEGIN RSA PUBLIC KEY-----\nMIICCgKCAgEAttUpB6CPFtNcqXRrcpl5jAuwBXOxl6IZbuaKjF4zA3XfQcuI0A5d\nBLVtYp+ruGTKn2YSrqbjhtSA/14icArWvEpPoaWLFMRsfm9fIIZVypV3Fb6zvUUx\n6g0Izi9RmHDuAcnLAWYIyc9j1ri6sLo1Kg1xneolsIS7Mdz7GNnbTC4WZgJaXVq6\nl14fBuosAULI0kVPAwqIpII5WJl2NpfBNTArNQCUtCKfhyM9LogkSviazic9e9Ry\nDBvi5X11nbDlRPRfk1mk7UuxOxaMHvF0i+2mcJ6PdxIECj+QpaX5wMcFrX4bzszI\nptPYUFOjRtoVhWDP2hQFdJM7202Xii6dM7fpL989vhHLyu4o01dw/59nCskP7yME\n5opqJZY7CrwhgS2nxbAfgUBBaHMe0BGmPzNJGwzjMp9AyVb6WrS6HVmS9YJ3DXjM\nFWAiHrfQ/k6zt7BvOw/U3AEXTRK2RBknGHSY1gqHo7pX3nC0uQnsOiLU56G2DGkq\nhKuAfuzt0pGJyLcNxwDnm+/ZBUj0l+UuCvaI/ee/F4MsXJjIgaZNtIBV6ri+pft5\nDW8d88TvrtQc/51VU+o8YBwyXu7wQqWN+uzPELTHLS+ouFbuCY6a91fuWotK/6Ql\nGAyZOzeX48g87qaAbur/9AJNMtr1oLjNF0MBJ80/edNY1QMpextJWoECAwEAAQ==\n-----END RSA PUBLIC KEY-----\n","status":"creating","token":"xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxxxxxx"}'
+        body: '{"description":"","expires_at":null,"function_id":"95aa6808-bb3b-43d8-8a00-628d9a458d4a","id":"a2728291-11b4-4596-af7a-181c5a3309d5","public_key":"-----BEGIN RSA PUBLIC KEY-----\nMIICCgKCAgEAuymZ/b34rGHJpoJyMnDd8oDcfaiy7eJRncrA72PXbB5RfAyIm/T6\nF7skuyMYK9heGspNeeHlTJHOSkogsUd8oPnaf2+hebPXkwVdK06n6PUdRyYP1ozV\nYUh29311nUdRE4NWkB1dlq1wiwtVB63vk7JqYvSLheDb/4gE0oGBKHV8moQA3n8d\nVgaF28aYyUJ9vOjQ0prsTZVGweH4B26GYze2vcDKeWtvc0+hB8A2rZhMLMIiPzFx\nrwUfHLVxune9TNyZt3NYgpjHNzHAoDH5saffSrOXEyuJJZp1Z/QBVKtmlVGVnqUJ\nZn7ajqyCDS7E4gVOj7b36dzAV93mGluJIAR1sq4ymsIWtpRwt0FZnlml+kBAhVbe\nnfJUAdW6R+p8zd+fSJbtVnnmzybAOYAavM6sOAxzs8qcJ9r7pqaYdvZ2Lcawxe5r\nhnPa1TNRXTzlZZoKU8RhO3j7wH34VYcN1bXabPoaorFX8FIxtieSXz6uVATp3XCv\nVk4tScyI84abeG71XXuyS2VTqdUlTAD4cYXUb1E0SLRWNB+pFuReMIl4I26tQ7I2\nxsWLHU9Qh89HwhS68vczv+EcJNC4b86DAEM171lO1TYE6HJt47tPQEoRB7qDmZQC\nlDDddLF30Fi6btqjaNF2f0HKiscjHCEmZohyC1SxAqYD5b7MS1lBcIkCAwEAAQ==\n-----END RSA PUBLIC KEY-----\n","status":"creating","token":"xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxxxxxx"}'
         headers:
             Content-Length:
                 - "2008"
@@ -485,9 +485,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:02:03 GMT
+                - Fri, 03 Jul 2026 16:49:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -495,10 +495,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a8766ba9-d463-4c2b-89de-6ae29fcbff39
+                - 18403c62-e33c-4ab6-9893-d56c3a21a26c
         status: 200 OK
         code: 200
-        duration: 269.800858ms
+        duration: 187.281633ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -515,7 +515,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/92538d72-c932-4e0c-8896-fb9cad5240db
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/a2728291-11b4-4596-af7a-181c5a3309d5
         method: GET
       response:
         proto: HTTP/2.0
@@ -525,7 +525,7 @@ interactions:
         trailer: {}
         content_length: 188
         uncompressed: false
-        body: '{"description":"","expires_at":null,"function_id":"b723d47a-37e6-452f-9544-062439b88c8e","id":"92538d72-c932-4e0c-8896-fb9cad5240db","public_key":"","status":"creating","token":"xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxxxxxx"}'
+        body: '{"description":"","expires_at":null,"function_id":"95aa6808-bb3b-43d8-8a00-628d9a458d4a","id":"a2728291-11b4-4596-af7a-181c5a3309d5","public_key":"","status":"creating","token":"xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxxxxxx"}'
         headers:
             Content-Length:
                 - "188"
@@ -534,9 +534,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:02:03 GMT
+                - Fri, 03 Jul 2026 16:49:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -544,10 +544,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bbcd1038-dea4-4e9f-8b46-4a47430e5d2b
+                - 9604da18-4d89-4f8d-8176-7a580d62e4d9
         status: 200 OK
         code: 200
-        duration: 71.355506ms
+        duration: 60.873349ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -564,7 +564,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/8ec34b77-2c58-43fa-b93e-f3fceeecc6ab
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/99cfbf5d-4c36-47ea-98ff-5fd3df667cd6
         method: GET
       response:
         proto: HTTP/2.0
@@ -574,7 +574,7 @@ interactions:
         trailer: {}
         content_length: 204
         uncompressed: false
-        body: '{"description":"","expires_at":"2026-07-04T15:01:38Z","id":"8ec34b77-2c58-43fa-b93e-f3fceeecc6ab","namespace_id":"1e93890a-7879-4077-8a6f-c7320bdeec79","public_key":"","status":"ready","token":"xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxxxxxx"}'
+        body: '{"description":"","expires_at":"2026-07-04T16:49:39Z","id":"99cfbf5d-4c36-47ea-98ff-5fd3df667cd6","namespace_id":"5d8b0883-a64a-4635-a520-b3d430673382","public_key":"","status":"ready","token":"xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxxxxxx"}'
         headers:
             Content-Length:
                 - "204"
@@ -583,9 +583,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:02:03 GMT
+                - Fri, 03 Jul 2026 16:49:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -593,10 +593,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7bd15f29-0f17-4728-b1fb-2bcf15fa92e0
+                - cab5527f-f943-46ba-8d97-3d049513d1e3
         status: 200 OK
         code: 200
-        duration: 35.004071ms
+        duration: 59.377565ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -613,7 +613,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/92538d72-c932-4e0c-8896-fb9cad5240db
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/a2728291-11b4-4596-af7a-181c5a3309d5
         method: GET
       response:
         proto: HTTP/2.0
@@ -621,20 +621,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 188
+        content_length: 185
         uncompressed: false
-        body: '{"description":"","expires_at":null,"function_id":"b723d47a-37e6-452f-9544-062439b88c8e","id":"92538d72-c932-4e0c-8896-fb9cad5240db","public_key":"","status":"creating","token":"xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxxxxxx"}'
+        body: '{"description":"","expires_at":null,"function_id":"95aa6808-bb3b-43d8-8a00-628d9a458d4a","id":"a2728291-11b4-4596-af7a-181c5a3309d5","public_key":"","status":"ready","token":"xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxxxxxx"}'
         headers:
             Content-Length:
-                - "188"
+                - "185"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:02:03 GMT
+                - Fri, 03 Jul 2026 16:49:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -642,10 +642,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0b761df6-16e3-4c6a-9e0a-488caf63aa89
+                - cf329c25-28e8-4117-8728-3fc4dde5c64a
         status: 200 OK
         code: 200
-        duration: 50.765985ms
+        duration: 60.789491ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -662,7 +662,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/1e93890a-7879-4077-8a6f-c7320bdeec79
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5d8b0883-a64a-4635-a520-b3d430673382
         method: GET
       response:
         proto: HTTP/2.0
@@ -672,7 +672,7 @@ interactions:
         trailer: {}
         content_length: 590
         uncompressed: false
-        body: '{"created_at":"2026-07-03T15:01:47.384244Z","description":"","environment_variables":{},"error_message":null,"id":"1e93890a-7879-4077-8a6f-c7320bdeec79","name":"test-function-token-ns","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontokenns1jkwoysc","registry_namespace_id":"6ed0ddd9-9636-4398-8b84-13a7c5b7705d","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:01:58.868721Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T16:49:40.756199Z","description":"","environment_variables":{},"error_message":null,"id":"5d8b0883-a64a-4635-a520-b3d430673382","name":"test-function-token-ns","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontokennsy4jqt2ty","registry_namespace_id":"43f85f09-9aef-4864-aafa-d96cd9aa0149","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T16:49:41.781728Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "590"
@@ -681,9 +681,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:02:03 GMT
+                - Fri, 03 Jul 2026 16:49:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -691,10 +691,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0aad5711-0609-49d0-ac6d-be4eed0c3d55
+                - 0c971cfc-8f36-4216-9c52-9ebc81f95edd
         status: 200 OK
         code: 200
-        duration: 255.738671ms
+        duration: 40.583208ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -711,7 +711,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/8ec34b77-2c58-43fa-b93e-f3fceeecc6ab
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/95aa6808-bb3b-43d8-8a00-628d9a458d4a
         method: GET
       response:
         proto: HTTP/2.0
@@ -719,20 +719,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 204
+        content_length: 723
         uncompressed: false
-        body: '{"description":"","expires_at":"2026-07-04T15:01:38Z","id":"8ec34b77-2c58-43fa-b93e-f3fceeecc6ab","namespace_id":"1e93890a-7879-4077-8a6f-c7320bdeec79","public_key":"","status":"ready","token":"xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxxxxxx"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T16:49:46.074987Z","description":"","domain_name":"testfunctiontokennsy4jqt2ty-tf-func-great-saha.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"95aa6808-bb3b-43d8-8a00-628d9a458d4a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-great-saha","namespace_id":"5d8b0883-a64a-4635-a520-b3d430673382","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T16:49:46.074987Z"}'
         headers:
             Content-Length:
-                - "204"
+                - "723"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:02:03 GMT
+                - Fri, 03 Jul 2026 16:49:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -740,10 +740,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a88c6d55-f86d-425d-9721-49faeab857a3
+                - ff447211-613c-4b89-808e-ce8f390bb657
         status: 200 OK
         code: 200
-        duration: 39.297205ms
+        duration: 50.606168ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -760,7 +760,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/b723d47a-37e6-452f-9544-062439b88c8e
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/99cfbf5d-4c36-47ea-98ff-5fd3df667cd6
         method: GET
       response:
         proto: HTTP/2.0
@@ -768,20 +768,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 727
+        content_length: 204
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:02.653860Z","description":"","domain_name":"testfunctiontokenns1jkwoysc-tf-func-cool-jackson.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"b723d47a-37e6-452f-9544-062439b88c8e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-cool-jackson","namespace_id":"1e93890a-7879-4077-8a6f-c7320bdeec79","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:02.653860Z"}'
+        body: '{"description":"","expires_at":"2026-07-04T16:49:39Z","id":"99cfbf5d-4c36-47ea-98ff-5fd3df667cd6","namespace_id":"5d8b0883-a64a-4635-a520-b3d430673382","public_key":"","status":"ready","token":"xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxxxxxx"}'
         headers:
             Content-Length:
-                - "727"
+                - "204"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:02:04 GMT
+                - Fri, 03 Jul 2026 16:49:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -789,10 +789,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7545de6e-36e4-4d24-8fbe-589e490b17ca
+                - 7a1d0c64-32a0-46e6-8617-3f95b35dd68d
         status: 200 OK
         code: 200
-        duration: 117.990952ms
+        duration: 51.036247ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -809,7 +809,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/92538d72-c932-4e0c-8896-fb9cad5240db
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/a2728291-11b4-4596-af7a-181c5a3309d5
         method: GET
       response:
         proto: HTTP/2.0
@@ -819,7 +819,7 @@ interactions:
         trailer: {}
         content_length: 185
         uncompressed: false
-        body: '{"description":"","expires_at":null,"function_id":"b723d47a-37e6-452f-9544-062439b88c8e","id":"92538d72-c932-4e0c-8896-fb9cad5240db","public_key":"","status":"ready","token":"xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxxxxxx"}'
+        body: '{"description":"","expires_at":null,"function_id":"95aa6808-bb3b-43d8-8a00-628d9a458d4a","id":"a2728291-11b4-4596-af7a-181c5a3309d5","public_key":"","status":"ready","token":"xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxxxxxx"}'
         headers:
             Content-Length:
                 - "185"
@@ -828,9 +828,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:02:04 GMT
+                - Fri, 03 Jul 2026 16:49:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -838,10 +838,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 36a4ef8d-70fc-4a5b-8cc4-69e3fdfa9765
+                - ea0a5e7b-e73a-4cb9-9200-8635ad91445a
         status: 200 OK
         code: 200
-        duration: 52.234576ms
+        duration: 54.182845ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -858,7 +858,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/8ec34b77-2c58-43fa-b93e-f3fceeecc6ab
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/99cfbf5d-4c36-47ea-98ff-5fd3df667cd6
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -868,7 +868,7 @@ interactions:
         trailer: {}
         content_length: 199
         uncompressed: false
-        body: '{"description":"","expires_at":"2026-07-04T15:01:38Z","id":"8ec34b77-2c58-43fa-b93e-f3fceeecc6ab","namespace_id":"1e93890a-7879-4077-8a6f-c7320bdeec79","public_key":"","status":"deleting","token":"xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxxxxxx"}'
+        body: '{"description":"","expires_at":"2026-07-04T16:49:39Z","id":"99cfbf5d-4c36-47ea-98ff-5fd3df667cd6","namespace_id":"5d8b0883-a64a-4635-a520-b3d430673382","public_key":"","status":"deleting","token":"xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxxxxxx"}'
         headers:
             Content-Length:
                 - "199"
@@ -877,9 +877,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:02:04 GMT
+                - Fri, 03 Jul 2026 16:49:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -887,10 +887,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 25c537e8-9b07-42a1-9e12-3e0521d0562c
+                - ddc0b8fb-e9de-460c-9220-92a2104705e4
         status: 200 OK
         code: 200
-        duration: 61.15862ms
+        duration: 56.945251ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -907,7 +907,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/92538d72-c932-4e0c-8896-fb9cad5240db
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/a2728291-11b4-4596-af7a-181c5a3309d5
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -917,7 +917,7 @@ interactions:
         trailer: {}
         content_length: 180
         uncompressed: false
-        body: '{"description":"","expires_at":null,"function_id":"b723d47a-37e6-452f-9544-062439b88c8e","id":"92538d72-c932-4e0c-8896-fb9cad5240db","public_key":"","status":"deleting","token":"xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxxxxxx"}'
+        body: '{"description":"","expires_at":null,"function_id":"95aa6808-bb3b-43d8-8a00-628d9a458d4a","id":"a2728291-11b4-4596-af7a-181c5a3309d5","public_key":"","status":"deleting","token":"xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxxxxxx"}'
         headers:
             Content-Length:
                 - "180"
@@ -926,9 +926,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:02:04 GMT
+                - Fri, 03 Jul 2026 16:49:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -936,10 +936,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f61df408-da0a-4ac2-b544-ed0d1c75417e
+                - e4122ac3-2473-422c-96ee-2d6e535b3c78
         status: 200 OK
         code: 200
-        duration: 221.895363ms
+        duration: 67.191842ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -956,7 +956,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/b723d47a-37e6-452f-9544-062439b88c8e
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/95aa6808-bb3b-43d8-8a00-628d9a458d4a
         method: GET
       response:
         proto: HTTP/2.0
@@ -964,20 +964,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 727
+        content_length: 723
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:02.653860Z","description":"","domain_name":"testfunctiontokenns1jkwoysc-tf-func-cool-jackson.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"b723d47a-37e6-452f-9544-062439b88c8e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-cool-jackson","namespace_id":"1e93890a-7879-4077-8a6f-c7320bdeec79","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:02.653860Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T16:49:46.074987Z","description":"","domain_name":"testfunctiontokennsy4jqt2ty-tf-func-great-saha.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"95aa6808-bb3b-43d8-8a00-628d9a458d4a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-great-saha","namespace_id":"5d8b0883-a64a-4635-a520-b3d430673382","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T16:49:46.074987Z"}'
         headers:
             Content-Length:
-                - "727"
+                - "723"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:02:04 GMT
+                - Fri, 03 Jul 2026 16:49:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -985,10 +985,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 853c9d48-0d1e-4183-8160-1c2091e510d4
+                - 45b4a251-e634-41bc-8a9b-94ffa520bdaa
         status: 200 OK
         code: 200
-        duration: 45.274126ms
+        duration: 66.914901ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1005,7 +1005,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/b723d47a-37e6-452f-9544-062439b88c8e
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/95aa6808-bb3b-43d8-8a00-628d9a458d4a
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1013,20 +1013,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 731
+        content_length: 727
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:02.653860Z","description":"","domain_name":"testfunctiontokenns1jkwoysc-tf-func-cool-jackson.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"b723d47a-37e6-452f-9544-062439b88c8e","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-cool-jackson","namespace_id":"1e93890a-7879-4077-8a6f-c7320bdeec79","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:04.605473646Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T16:49:46.074987Z","description":"","domain_name":"testfunctiontokennsy4jqt2ty-tf-func-great-saha.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"95aa6808-bb3b-43d8-8a00-628d9a458d4a","max_scale":20,"memory_limit":256,"min_scale":0,"name":"tf-func-great-saha","namespace_id":"5d8b0883-a64a-4635-a520-b3d430673382","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2026-07-03T16:49:47.531680104Z"}'
         headers:
             Content-Length:
-                - "731"
+                - "727"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:02:04 GMT
+                - Fri, 03 Jul 2026 16:49:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1034,10 +1034,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 46e6d166-74af-42e2-81c2-3fb1e92c8242
+                - be4be92c-3c7d-47d0-95ec-ce234cd316c6
         status: 200 OK
         code: 200
-        duration: 383.216204ms
+        duration: 177.249846ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1054,7 +1054,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/1e93890a-7879-4077-8a6f-c7320bdeec79
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5d8b0883-a64a-4635-a520-b3d430673382
         method: GET
       response:
         proto: HTTP/2.0
@@ -1064,7 +1064,7 @@ interactions:
         trailer: {}
         content_length: 590
         uncompressed: false
-        body: '{"created_at":"2026-07-03T15:01:47.384244Z","description":"","environment_variables":{},"error_message":null,"id":"1e93890a-7879-4077-8a6f-c7320bdeec79","name":"test-function-token-ns","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontokenns1jkwoysc","registry_namespace_id":"6ed0ddd9-9636-4398-8b84-13a7c5b7705d","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:01:58.868721Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T16:49:40.756199Z","description":"","environment_variables":{},"error_message":null,"id":"5d8b0883-a64a-4635-a520-b3d430673382","name":"test-function-token-ns","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontokennsy4jqt2ty","registry_namespace_id":"43f85f09-9aef-4864-aafa-d96cd9aa0149","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T16:49:41.781728Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "590"
@@ -1073,9 +1073,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:02:04 GMT
+                - Fri, 03 Jul 2026 16:49:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1083,10 +1083,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5791b060-245d-4661-8942-9005fc65e7ca
+                - 225f9a30-1dbb-4dec-af16-8b5687cc7e69
         status: 200 OK
         code: 200
-        duration: 35.229004ms
+        duration: 37.706507ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1103,7 +1103,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/1e93890a-7879-4077-8a6f-c7320bdeec79
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5d8b0883-a64a-4635-a520-b3d430673382
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1113,7 +1113,7 @@ interactions:
         trailer: {}
         content_length: 596
         uncompressed: false
-        body: '{"created_at":"2026-07-03T15:01:47.384244Z","description":"","environment_variables":{},"error_message":null,"id":"1e93890a-7879-4077-8a6f-c7320bdeec79","name":"test-function-token-ns","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontokenns1jkwoysc","registry_namespace_id":"6ed0ddd9-9636-4398-8b84-13a7c5b7705d","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-07-03T15:02:05.011831607Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T16:49:40.756199Z","description":"","environment_variables":{},"error_message":null,"id":"5d8b0883-a64a-4635-a520-b3d430673382","name":"test-function-token-ns","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontokennsy4jqt2ty","registry_namespace_id":"43f85f09-9aef-4864-aafa-d96cd9aa0149","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-07-03T16:49:47.725378230Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "596"
@@ -1122,9 +1122,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:02:05 GMT
+                - Fri, 03 Jul 2026 16:49:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1132,10 +1132,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2842601d-1603-478d-9614-a960ac0187cd
+                - 7c6df6a6-9350-4aa7-864d-1a088befbc54
         status: 200 OK
         code: 200
-        duration: 1.006612872s
+        duration: 240.261046ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1152,7 +1152,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/1e93890a-7879-4077-8a6f-c7320bdeec79
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5d8b0883-a64a-4635-a520-b3d430673382
         method: GET
       response:
         proto: HTTP/2.0
@@ -1162,7 +1162,7 @@ interactions:
         trailer: {}
         content_length: 593
         uncompressed: false
-        body: '{"created_at":"2026-07-03T15:01:47.384244Z","description":"","environment_variables":{},"error_message":null,"id":"1e93890a-7879-4077-8a6f-c7320bdeec79","name":"test-function-token-ns","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontokenns1jkwoysc","registry_namespace_id":"6ed0ddd9-9636-4398-8b84-13a7c5b7705d","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-07-03T15:02:05.011832Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T16:49:40.756199Z","description":"","environment_variables":{},"error_message":null,"id":"5d8b0883-a64a-4635-a520-b3d430673382","name":"test-function-token-ns","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontokennsy4jqt2ty","registry_namespace_id":"43f85f09-9aef-4864-aafa-d96cd9aa0149","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-07-03T16:49:47.725378Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "593"
@@ -1171,9 +1171,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:02:06 GMT
+                - Fri, 03 Jul 2026 16:49:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1181,10 +1181,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5814bbe6-59f7-48a5-be93-865a37d25d33
+                - 562b4c9c-b43a-49c0-98a6-d4a695ed4a50
         status: 200 OK
         code: 200
-        duration: 35.72654ms
+        duration: 37.63343ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1201,7 +1201,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/1e93890a-7879-4077-8a6f-c7320bdeec79
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/5d8b0883-a64a-4635-a520-b3d430673382
         method: GET
       response:
         proto: HTTP/2.0
@@ -1220,9 +1220,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:02:11 GMT
+                - Fri, 03 Jul 2026 16:49:52 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1230,10 +1230,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0584a5b9-3e64-473e-b425-766735795537
+                - e41cae65-e8ee-48f3-a132-76b0948e854a
         status: 404 Not Found
         code: 404
-        duration: 29.120607ms
+        duration: 23.938403ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1250,7 +1250,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/92538d72-c932-4e0c-8896-fb9cad5240db
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/a2728291-11b4-4596-af7a-181c5a3309d5
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1269,9 +1269,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:02:11 GMT
+                - Fri, 03 Jul 2026 16:49:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1279,10 +1279,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 727a068e-dea9-4196-bef8-81b8c1f5e2ac
+                - 228be1a4-ae69-4606-934b-922b55099431
         status: 404 Not Found
         code: 404
-        duration: 21.512709ms
+        duration: 24.088715ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1299,7 +1299,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/8ec34b77-2c58-43fa-b93e-f3fceeecc6ab
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/tokens/99cfbf5d-4c36-47ea-98ff-5fd3df667cd6
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1318,9 +1318,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:02:11 GMT
+                - Fri, 03 Jul 2026 16:49:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1328,7 +1328,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 538c825a-0eb6-4c42-bba1-c1e51080c77a
+                - 7a2d45a6-2d6b-4dd9-8bb6-c5656c725bf1
         status: 404 Not Found
         code: 404
-        duration: 27.109283ms
+        duration: 19.974237ms

--- a/internal/services/function/testdata/function-trigger-nats.cassette.yaml
+++ b/internal/services/function/testdata/function-trigger-nats.cassette.yaml
@@ -6,13 +6,13 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 100
+        content_length: 94
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-nats-account-beautiful-brahmagupta","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552"}'
+        body: '{"name":"tf-nats-account-crazy-mendeleev","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552"}'
         form: {}
         headers:
             Content-Type:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 328
+        content_length: 322
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:56.064561012Z","endpoint":"nats://nats.mnq.fr-par.scaleway.com:4222","id":"AD2GESGP5R57DBT2GYL6LPUBY742EMHZSCY23OWYHMTIIGBWDW42PINF","name":"tf-nats-account-beautiful-brahmagupta","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","updated_at":"2026-05-04T12:38:56.064561012Z"}'
+        body: '{"created_at":"2026-07-03T15:01:39.604727690Z","endpoint":"nats://nats.mnq.fr-par.scaleway.com:4222","id":"ABQEEPYDTKS65L6P3CFVO56UDTNXOVAA7YP76ZBRYQSSGYT5NVF2D6RS","name":"tf-nats-account-crazy-mendeleev","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","updated_at":"2026-07-03T15:01:39.604727690Z"}'
         headers:
             Content-Length:
-                - "328"
+                - "322"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:38:56 GMT
+                - Fri, 03 Jul 2026 15:01:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d8cf7b5d-acb3-4305-b731-1d59eee71bfe
+                - 3e41f17f-a4c8-47b4-8e34-b80f8392fd26
         status: 200 OK
         code: 200
-        duration: 148.608941ms
+        duration: 177.453261ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -68,7 +68,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/nats-accounts/AD2GESGP5R57DBT2GYL6LPUBY742EMHZSCY23OWYHMTIIGBWDW42PINF
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/nats-accounts/ABQEEPYDTKS65L6P3CFVO56UDTNXOVAA7YP76ZBRYQSSGYT5NVF2D6RS
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 322
+        content_length: 316
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:56.064561Z","endpoint":"nats://nats.mnq.fr-par.scaleway.com:4222","id":"AD2GESGP5R57DBT2GYL6LPUBY742EMHZSCY23OWYHMTIIGBWDW42PINF","name":"tf-nats-account-beautiful-brahmagupta","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","updated_at":"2026-05-04T12:38:56.064561Z"}'
+        body: '{"created_at":"2026-07-03T15:01:39.604727Z","endpoint":"nats://nats.mnq.fr-par.scaleway.com:4222","id":"ABQEEPYDTKS65L6P3CFVO56UDTNXOVAA7YP76ZBRYQSSGYT5NVF2D6RS","name":"tf-nats-account-crazy-mendeleev","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","updated_at":"2026-07-03T15:01:39.604727Z"}'
         headers:
             Content-Length:
-                - "322"
+                - "316"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:38:56 GMT
+                - Fri, 03 Jul 2026 15:01:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bfdc976f-49ae-441b-a5df-4e4da5c32c26
+                - 7532384b-c35e-4c97-acda-e8f934ad623f
         status: 200 OK
         code: 200
-        duration: 39.390286ms
+        duration: 35.709808ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -117,7 +117,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/nats-accounts/AD2GESGP5R57DBT2GYL6LPUBY742EMHZSCY23OWYHMTIIGBWDW42PINF
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/nats-accounts/ABQEEPYDTKS65L6P3CFVO56UDTNXOVAA7YP76ZBRYQSSGYT5NVF2D6RS
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,20 +125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 322
+        content_length: 316
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:56.064561Z","endpoint":"nats://nats.mnq.fr-par.scaleway.com:4222","id":"AD2GESGP5R57DBT2GYL6LPUBY742EMHZSCY23OWYHMTIIGBWDW42PINF","name":"tf-nats-account-beautiful-brahmagupta","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","updated_at":"2026-05-04T12:38:56.064561Z"}'
+        body: '{"created_at":"2026-07-03T15:01:39.604727Z","endpoint":"nats://nats.mnq.fr-par.scaleway.com:4222","id":"ABQEEPYDTKS65L6P3CFVO56UDTNXOVAA7YP76ZBRYQSSGYT5NVF2D6RS","name":"tf-nats-account-crazy-mendeleev","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","updated_at":"2026-07-03T15:01:39.604727Z"}'
         headers:
             Content-Length:
-                - "322"
+                - "316"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:38:56 GMT
+                - Fri, 03 Jul 2026 15:01:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 915e1427-b6cd-45be-8ce2-6b684af3116a
+                - 9f0840d1-a1ff-47c2-816a-e93d090ef315
         status: 200 OK
         code: 200
-        duration: 35.648015ms
+        duration: 45.147918ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -178,7 +178,7 @@ interactions:
         trailer: {}
         content_length: 511
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.940378538Z","description":"","environment_variables":{},"error_message":null,"id":"1b3ceea8-7c68-47f9-9853-3d9f5814489c","name":"test-function-trigger-sqs","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-05-04T12:38:57.940378538Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.230051634Z","description":"","environment_variables":{},"error_message":null,"id":"d4f5b4cd-2011-4226-9199-89079ebc193b","name":"test-function-trigger-sqs","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-07-03T15:01:47.230051634Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "511"
@@ -187,9 +187,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:38:57 GMT
+                - Fri, 03 Jul 2026 15:01:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -197,10 +197,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4378e502-520a-462b-b003-cb8b147e431e
+                - 6033d840-c427-47f2-af32-461dc8060f46
         status: 200 OK
         code: 200
-        duration: 1.965674933s
+        duration: 7.728749635s
     - id: 4
       request:
         proto: HTTP/1.1
@@ -217,7 +217,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/1b3ceea8-7c68-47f9-9853-3d9f5814489c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d4f5b4cd-2011-4226-9199-89079ebc193b
         method: GET
       response:
         proto: HTTP/2.0
@@ -227,7 +227,7 @@ interactions:
         trailer: {}
         content_length: 505
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.940379Z","description":"","environment_variables":{},"error_message":null,"id":"1b3ceea8-7c68-47f9-9853-3d9f5814489c","name":"test-function-trigger-sqs","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-05-04T12:38:57.940379Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.230052Z","description":"","environment_variables":{},"error_message":null,"id":"d4f5b4cd-2011-4226-9199-89079ebc193b","name":"test-function-trigger-sqs","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-07-03T15:01:47.230052Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "505"
@@ -236,9 +236,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:38:57 GMT
+                - Fri, 03 Jul 2026 15:01:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -246,10 +246,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b7dc9307-8614-4764-b78e-bc53727f16be
+                - 8436792f-906a-4f6b-b04a-36cca68dd4e5
         status: 200 OK
         code: 200
-        duration: 46.189447ms
+        duration: 39.552165ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -266,7 +266,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/1b3ceea8-7c68-47f9-9853-3d9f5814489c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d4f5b4cd-2011-4226-9199-89079ebc193b
         method: GET
       response:
         proto: HTTP/2.0
@@ -276,7 +276,7 @@ interactions:
         trailer: {}
         content_length: 594
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.940379Z","description":"","environment_variables":{},"error_message":null,"id":"1b3ceea8-7c68-47f9-9853-3d9f5814489c","name":"test-function-trigger-sqs","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersrq66lue9","registry_namespace_id":"79f718fe-0a58-4697-b455-ae5548c12f83","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:15.971702Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.230052Z","description":"","environment_variables":{},"error_message":null,"id":"d4f5b4cd-2011-4226-9199-89079ebc193b","name":"test-function-trigger-sqs","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersunjgo9mv","registry_namespace_id":"b70d05e0-5f73-4ab7-bd1f-46408891e312","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:05.505956Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "594"
@@ -285,9 +285,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:18 GMT
+                - Fri, 03 Jul 2026 15:02:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -295,10 +295,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b5052154-99c3-4734-b113-d7e983a57208
+                - a0c26f97-5bf1-48ad-a837-9664f7cddd10
         status: 200 OK
         code: 200
-        duration: 38.664656ms
+        duration: 33.566828ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -315,7 +315,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/1b3ceea8-7c68-47f9-9853-3d9f5814489c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d4f5b4cd-2011-4226-9199-89079ebc193b
         method: GET
       response:
         proto: HTTP/2.0
@@ -325,7 +325,7 @@ interactions:
         trailer: {}
         content_length: 594
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.940379Z","description":"","environment_variables":{},"error_message":null,"id":"1b3ceea8-7c68-47f9-9853-3d9f5814489c","name":"test-function-trigger-sqs","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersrq66lue9","registry_namespace_id":"79f718fe-0a58-4697-b455-ae5548c12f83","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:15.971702Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.230052Z","description":"","environment_variables":{},"error_message":null,"id":"d4f5b4cd-2011-4226-9199-89079ebc193b","name":"test-function-trigger-sqs","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersunjgo9mv","registry_namespace_id":"b70d05e0-5f73-4ab7-bd1f-46408891e312","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:05.505956Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "594"
@@ -334,9 +334,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:18 GMT
+                - Fri, 03 Jul 2026 15:02:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -344,10 +344,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0abd0750-523f-47d3-a085-40e59202ebe9
+                - 951c7111-b745-47d3-ba48-762b64acddf6
         status: 200 OK
         code: 200
-        duration: 185.197664ms
+        duration: 43.728709ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -359,7 +359,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"test-function-trigger-sqs","namespace_id":"1b3ceea8-7c68-47f9-9853-3d9f5814489c","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node22","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox","tags":null}'
+        body: '{"name":"test-function-trigger-sqs","namespace_id":"d4f5b4cd-2011-4226-9199-89079ebc193b","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node26","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox","tags":null}'
         form: {}
         headers:
             Content-Type:
@@ -376,7 +376,7 @@ interactions:
         trailer: {}
         content_length: 744
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:18.429407524Z","description":"","domain_name":"testfunctiontriggersrq66lue9-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"b64eb93a-1615-4586-8525-4a9521b4a709","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"1b3ceea8-7c68-47f9-9853-3d9f5814489c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:18.429407524Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:07.609930715Z","description":"","domain_name":"testfunctiontriggersunjgo9mv-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"5d120bd2-3d7a-423e-ba36-aee6cdb419d8","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"d4f5b4cd-2011-4226-9199-89079ebc193b","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:07.609930715Z"}'
         headers:
             Content-Length:
                 - "744"
@@ -385,9 +385,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:18 GMT
+                - Fri, 03 Jul 2026 15:02:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -395,10 +395,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3cfe5304-e254-4f41-ac52-d965950ed9e9
+                - 3ab3610d-72de-42dd-bc6d-2b04a3812f4c
         status: 200 OK
         code: 200
-        duration: 110.164351ms
+        duration: 177.219171ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -415,7 +415,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/b64eb93a-1615-4586-8525-4a9521b4a709
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/5d120bd2-3d7a-423e-ba36-aee6cdb419d8
         method: GET
       response:
         proto: HTTP/2.0
@@ -425,7 +425,7 @@ interactions:
         trailer: {}
         content_length: 738
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:18.429408Z","description":"","domain_name":"testfunctiontriggersrq66lue9-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"b64eb93a-1615-4586-8525-4a9521b4a709","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"1b3ceea8-7c68-47f9-9853-3d9f5814489c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:18.429408Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:07.609931Z","description":"","domain_name":"testfunctiontriggersunjgo9mv-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"5d120bd2-3d7a-423e-ba36-aee6cdb419d8","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"d4f5b4cd-2011-4226-9199-89079ebc193b","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:07.609931Z"}'
         headers:
             Content-Length:
                 - "738"
@@ -434,9 +434,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:18 GMT
+                - Fri, 03 Jul 2026 15:02:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -444,10 +444,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 14601dc6-00c6-45cb-baa6-37280536a70b
+                - a72ea984-aae9-4583-8db1-30a4709b6e3b
         status: 200 OK
         code: 200
-        duration: 37.692397ms
+        duration: 48.476529ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -464,7 +464,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/b64eb93a-1615-4586-8525-4a9521b4a709
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/5d120bd2-3d7a-423e-ba36-aee6cdb419d8
         method: GET
       response:
         proto: HTTP/2.0
@@ -474,7 +474,7 @@ interactions:
         trailer: {}
         content_length: 738
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:18.429408Z","description":"","domain_name":"testfunctiontriggersrq66lue9-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"b64eb93a-1615-4586-8525-4a9521b4a709","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"1b3ceea8-7c68-47f9-9853-3d9f5814489c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:18.429408Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:07.609931Z","description":"","domain_name":"testfunctiontriggersunjgo9mv-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"5d120bd2-3d7a-423e-ba36-aee6cdb419d8","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"d4f5b4cd-2011-4226-9199-89079ebc193b","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:07.609931Z"}'
         headers:
             Content-Length:
                 - "738"
@@ -483,9 +483,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:18 GMT
+                - Fri, 03 Jul 2026 15:02:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -493,10 +493,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 38d51496-d0ab-4d60-bdfe-de26e05ad2af
+                - 3eb8aa5d-b602-4a57-9556-751c1fd6c086
         status: 200 OK
         code: 200
-        duration: 40.919519ms
+        duration: 34.629787ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -508,7 +508,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"test-function-trigger-nats","function_id":"b64eb93a-1615-4586-8525-4a9521b4a709","scw_nats_config":{"subject":"TestSubject","mnq_nats_account_id":"AD2GESGP5R57DBT2GYL6LPUBY742EMHZSCY23OWYHMTIIGBWDW42PINF","mnq_project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","mnq_region":"fr-par"}}'
+        body: '{"name":"test-function-trigger-nats","function_id":"5d120bd2-3d7a-423e-ba36-aee6cdb419d8","scw_nats_config":{"subject":"TestSubject","mnq_nats_account_id":"ABQEEPYDTKS65L6P3CFVO56UDTNXOVAA7YP76ZBRYQSSGYT5NVF2D6RS","mnq_project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","mnq_region":"fr-par"}}'
         form: {}
         headers:
             Content-Type:
@@ -525,7 +525,7 @@ interactions:
         trailer: {}
         content_length: 444
         uncompressed: false
-        body: '{"description":"","error_message":null,"function_id":"b64eb93a-1615-4586-8525-4a9521b4a709","id":"c5fe156e-c9f5-4efe-b5bc-d575520bcdea","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":null,"mnq_nats_account_id":"AD2GESGP5R57DBT2GYL6LPUBY742EMHZSCY23OWYHMTIIGBWDW42PINF","mnq_project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","mnq_region":"fr-par","subject":"TestSubject"},"status":"creating"}'
+        body: '{"description":"","error_message":null,"function_id":"5d120bd2-3d7a-423e-ba36-aee6cdb419d8","id":"077c1456-9278-46ec-be79-79973857e287","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":null,"mnq_nats_account_id":"ABQEEPYDTKS65L6P3CFVO56UDTNXOVAA7YP76ZBRYQSSGYT5NVF2D6RS","mnq_project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","mnq_region":"fr-par","subject":"TestSubject"},"status":"creating"}'
         headers:
             Content-Length:
                 - "444"
@@ -534,9 +534,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:18 GMT
+                - Fri, 03 Jul 2026 15:02:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -544,10 +544,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 17ae31cf-c685-44d8-8b22-829f691d8818
+                - e4076d0d-25c3-4fd9-aaaf-ece304155a9f
         status: 200 OK
         code: 200
-        duration: 181.632487ms
+        duration: 227.739544ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -564,7 +564,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/c5fe156e-c9f5-4efe-b5bc-d575520bcdea
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/077c1456-9278-46ec-be79-79973857e287
         method: GET
       response:
         proto: HTTP/2.0
@@ -574,7 +574,7 @@ interactions:
         trailer: {}
         content_length: 444
         uncompressed: false
-        body: '{"description":"","error_message":null,"function_id":"b64eb93a-1615-4586-8525-4a9521b4a709","id":"c5fe156e-c9f5-4efe-b5bc-d575520bcdea","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":null,"mnq_nats_account_id":"AD2GESGP5R57DBT2GYL6LPUBY742EMHZSCY23OWYHMTIIGBWDW42PINF","mnq_project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","mnq_region":"fr-par","subject":"TestSubject"},"status":"creating"}'
+        body: '{"description":"","error_message":null,"function_id":"5d120bd2-3d7a-423e-ba36-aee6cdb419d8","id":"077c1456-9278-46ec-be79-79973857e287","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":null,"mnq_nats_account_id":"ABQEEPYDTKS65L6P3CFVO56UDTNXOVAA7YP76ZBRYQSSGYT5NVF2D6RS","mnq_project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","mnq_region":"fr-par","subject":"TestSubject"},"status":"creating"}'
         headers:
             Content-Length:
                 - "444"
@@ -583,9 +583,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:18 GMT
+                - Fri, 03 Jul 2026 15:02:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -593,10 +593,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d9df6e59-bddb-414d-9cb7-f40cb424a02f
+                - 5a7dd011-970b-4fdb-b412-f4ca49a274bb
         status: 200 OK
         code: 200
-        duration: 63.040199ms
+        duration: 126.739246ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -613,7 +613,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/c5fe156e-c9f5-4efe-b5bc-d575520bcdea
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/077c1456-9278-46ec-be79-79973857e287
         method: GET
       response:
         proto: HTTP/2.0
@@ -623,7 +623,7 @@ interactions:
         trailer: {}
         content_length: 475
         uncompressed: false
-        body: '{"description":"","error_message":null,"function_id":"b64eb93a-1615-4586-8525-4a9521b4a709","id":"c5fe156e-c9f5-4efe-b5bc-d575520bcdea","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"022ecb50-9fb0-4a3f-a0fc-cb5ef052d0f2","mnq_nats_account_id":"AD2GESGP5R57DBT2GYL6LPUBY742EMHZSCY23OWYHMTIIGBWDW42PINF","mnq_project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
+        body: '{"description":"","error_message":null,"function_id":"5d120bd2-3d7a-423e-ba36-aee6cdb419d8","id":"077c1456-9278-46ec-be79-79973857e287","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"64ed6def-562f-41ae-a9fd-fb696b94bcfc","mnq_nats_account_id":"ABQEEPYDTKS65L6P3CFVO56UDTNXOVAA7YP76ZBRYQSSGYT5NVF2D6RS","mnq_project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
         headers:
             Content-Length:
                 - "475"
@@ -632,9 +632,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:33 GMT
+                - Fri, 03 Jul 2026 15:02:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -642,10 +642,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5f229f3d-5ffa-4164-8934-2c151d413073
+                - ae664e0f-fdae-48dd-8c43-065fdf44e263
         status: 200 OK
         code: 200
-        duration: 57.018856ms
+        duration: 60.462691ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -662,7 +662,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/c5fe156e-c9f5-4efe-b5bc-d575520bcdea
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/077c1456-9278-46ec-be79-79973857e287
         method: GET
       response:
         proto: HTTP/2.0
@@ -672,7 +672,7 @@ interactions:
         trailer: {}
         content_length: 475
         uncompressed: false
-        body: '{"description":"","error_message":null,"function_id":"b64eb93a-1615-4586-8525-4a9521b4a709","id":"c5fe156e-c9f5-4efe-b5bc-d575520bcdea","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"022ecb50-9fb0-4a3f-a0fc-cb5ef052d0f2","mnq_nats_account_id":"AD2GESGP5R57DBT2GYL6LPUBY742EMHZSCY23OWYHMTIIGBWDW42PINF","mnq_project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
+        body: '{"description":"","error_message":null,"function_id":"5d120bd2-3d7a-423e-ba36-aee6cdb419d8","id":"077c1456-9278-46ec-be79-79973857e287","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"64ed6def-562f-41ae-a9fd-fb696b94bcfc","mnq_nats_account_id":"ABQEEPYDTKS65L6P3CFVO56UDTNXOVAA7YP76ZBRYQSSGYT5NVF2D6RS","mnq_project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
         headers:
             Content-Length:
                 - "475"
@@ -681,9 +681,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:34 GMT
+                - Fri, 03 Jul 2026 15:02:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -691,10 +691,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 92092ecd-eccf-496b-bbeb-77df457b3b1d
+                - 5114bcfe-ce53-4a77-90f0-995eb78dfc3e
         status: 200 OK
         code: 200
-        duration: 56.160701ms
+        duration: 67.692688ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -711,7 +711,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/c5fe156e-c9f5-4efe-b5bc-d575520bcdea
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/077c1456-9278-46ec-be79-79973857e287
         method: GET
       response:
         proto: HTTP/2.0
@@ -721,7 +721,7 @@ interactions:
         trailer: {}
         content_length: 475
         uncompressed: false
-        body: '{"description":"","error_message":null,"function_id":"b64eb93a-1615-4586-8525-4a9521b4a709","id":"c5fe156e-c9f5-4efe-b5bc-d575520bcdea","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"022ecb50-9fb0-4a3f-a0fc-cb5ef052d0f2","mnq_nats_account_id":"AD2GESGP5R57DBT2GYL6LPUBY742EMHZSCY23OWYHMTIIGBWDW42PINF","mnq_project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
+        body: '{"description":"","error_message":null,"function_id":"5d120bd2-3d7a-423e-ba36-aee6cdb419d8","id":"077c1456-9278-46ec-be79-79973857e287","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"64ed6def-562f-41ae-a9fd-fb696b94bcfc","mnq_nats_account_id":"ABQEEPYDTKS65L6P3CFVO56UDTNXOVAA7YP76ZBRYQSSGYT5NVF2D6RS","mnq_project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
         headers:
             Content-Length:
                 - "475"
@@ -730,9 +730,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:34 GMT
+                - Fri, 03 Jul 2026 15:02:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -740,10 +740,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 27e388ac-ce05-4eb5-801b-5efcdc3b3ce6
+                - 83dd45d2-d78c-4ba4-be0a-38ef25f8b605
         status: 200 OK
         code: 200
-        duration: 53.995157ms
+        duration: 59.566125ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -760,7 +760,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/c5fe156e-c9f5-4efe-b5bc-d575520bcdea
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/077c1456-9278-46ec-be79-79973857e287
         method: GET
       response:
         proto: HTTP/2.0
@@ -770,7 +770,7 @@ interactions:
         trailer: {}
         content_length: 475
         uncompressed: false
-        body: '{"description":"","error_message":null,"function_id":"b64eb93a-1615-4586-8525-4a9521b4a709","id":"c5fe156e-c9f5-4efe-b5bc-d575520bcdea","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"022ecb50-9fb0-4a3f-a0fc-cb5ef052d0f2","mnq_nats_account_id":"AD2GESGP5R57DBT2GYL6LPUBY742EMHZSCY23OWYHMTIIGBWDW42PINF","mnq_project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
+        body: '{"description":"","error_message":null,"function_id":"5d120bd2-3d7a-423e-ba36-aee6cdb419d8","id":"077c1456-9278-46ec-be79-79973857e287","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"64ed6def-562f-41ae-a9fd-fb696b94bcfc","mnq_nats_account_id":"ABQEEPYDTKS65L6P3CFVO56UDTNXOVAA7YP76ZBRYQSSGYT5NVF2D6RS","mnq_project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
         headers:
             Content-Length:
                 - "475"
@@ -779,9 +779,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:34 GMT
+                - Fri, 03 Jul 2026 15:02:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -789,10 +789,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ea40b7c4-f4a0-4943-ab1b-fa1eef8578dd
+                - 7d2ae877-4a78-413f-9734-88439764dca5
         status: 200 OK
         code: 200
-        duration: 55.579357ms
+        duration: 37.198418ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -809,7 +809,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/1b3ceea8-7c68-47f9-9853-3d9f5814489c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d4f5b4cd-2011-4226-9199-89079ebc193b
         method: GET
       response:
         proto: HTTP/2.0
@@ -819,7 +819,7 @@ interactions:
         trailer: {}
         content_length: 594
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.940379Z","description":"","environment_variables":{},"error_message":null,"id":"1b3ceea8-7c68-47f9-9853-3d9f5814489c","name":"test-function-trigger-sqs","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersrq66lue9","registry_namespace_id":"79f718fe-0a58-4697-b455-ae5548c12f83","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:15.971702Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.230052Z","description":"","environment_variables":{},"error_message":null,"id":"d4f5b4cd-2011-4226-9199-89079ebc193b","name":"test-function-trigger-sqs","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersunjgo9mv","registry_namespace_id":"b70d05e0-5f73-4ab7-bd1f-46408891e312","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:05.505956Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "594"
@@ -828,9 +828,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:34 GMT
+                - Fri, 03 Jul 2026 15:02:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -838,10 +838,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9371d596-183d-4699-987b-73e2dc3758cc
+                - 26bd2d8e-9e5e-4934-b9f5-7b74db114755
         status: 200 OK
         code: 200
-        duration: 40.052252ms
+        duration: 31.946301ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -858,7 +858,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/nats-accounts/AD2GESGP5R57DBT2GYL6LPUBY742EMHZSCY23OWYHMTIIGBWDW42PINF
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/nats-accounts/ABQEEPYDTKS65L6P3CFVO56UDTNXOVAA7YP76ZBRYQSSGYT5NVF2D6RS
         method: GET
       response:
         proto: HTTP/2.0
@@ -866,20 +866,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 322
+        content_length: 316
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:56.064561Z","endpoint":"nats://nats.mnq.fr-par.scaleway.com:4222","id":"AD2GESGP5R57DBT2GYL6LPUBY742EMHZSCY23OWYHMTIIGBWDW42PINF","name":"tf-nats-account-beautiful-brahmagupta","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","updated_at":"2026-05-04T12:38:56.064561Z"}'
+        body: '{"created_at":"2026-07-03T15:01:39.604727Z","endpoint":"nats://nats.mnq.fr-par.scaleway.com:4222","id":"ABQEEPYDTKS65L6P3CFVO56UDTNXOVAA7YP76ZBRYQSSGYT5NVF2D6RS","name":"tf-nats-account-crazy-mendeleev","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","updated_at":"2026-07-03T15:01:39.604727Z"}'
         headers:
             Content-Length:
-                - "322"
+                - "316"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:34 GMT
+                - Fri, 03 Jul 2026 15:02:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -887,10 +887,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9a0feebb-113b-4028-a8a4-1e456c63d62d
+                - dbb1a39a-41e6-4e5a-9c99-77cdbcd48b8c
         status: 200 OK
         code: 200
-        duration: 41.814137ms
+        duration: 31.954015ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -907,7 +907,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/b64eb93a-1615-4586-8525-4a9521b4a709
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/5d120bd2-3d7a-423e-ba36-aee6cdb419d8
         method: GET
       response:
         proto: HTTP/2.0
@@ -917,7 +917,7 @@ interactions:
         trailer: {}
         content_length: 738
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:18.429408Z","description":"","domain_name":"testfunctiontriggersrq66lue9-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"b64eb93a-1615-4586-8525-4a9521b4a709","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"1b3ceea8-7c68-47f9-9853-3d9f5814489c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:18.429408Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:07.609931Z","description":"","domain_name":"testfunctiontriggersunjgo9mv-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"5d120bd2-3d7a-423e-ba36-aee6cdb419d8","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"d4f5b4cd-2011-4226-9199-89079ebc193b","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:07.609931Z"}'
         headers:
             Content-Length:
                 - "738"
@@ -926,9 +926,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:34 GMT
+                - Fri, 03 Jul 2026 15:02:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -936,10 +936,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c465ee73-efab-44ce-9d55-711972c23f50
+                - 93cde376-e602-4646-a8aa-c98affe1e473
         status: 200 OK
         code: 200
-        duration: 41.883667ms
+        duration: 33.670033ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -956,7 +956,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/c5fe156e-c9f5-4efe-b5bc-d575520bcdea
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/077c1456-9278-46ec-be79-79973857e287
         method: GET
       response:
         proto: HTTP/2.0
@@ -966,7 +966,7 @@ interactions:
         trailer: {}
         content_length: 475
         uncompressed: false
-        body: '{"description":"","error_message":null,"function_id":"b64eb93a-1615-4586-8525-4a9521b4a709","id":"c5fe156e-c9f5-4efe-b5bc-d575520bcdea","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"022ecb50-9fb0-4a3f-a0fc-cb5ef052d0f2","mnq_nats_account_id":"AD2GESGP5R57DBT2GYL6LPUBY742EMHZSCY23OWYHMTIIGBWDW42PINF","mnq_project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
+        body: '{"description":"","error_message":null,"function_id":"5d120bd2-3d7a-423e-ba36-aee6cdb419d8","id":"077c1456-9278-46ec-be79-79973857e287","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"64ed6def-562f-41ae-a9fd-fb696b94bcfc","mnq_nats_account_id":"ABQEEPYDTKS65L6P3CFVO56UDTNXOVAA7YP76ZBRYQSSGYT5NVF2D6RS","mnq_project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
         headers:
             Content-Length:
                 - "475"
@@ -975,9 +975,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:34 GMT
+                - Fri, 03 Jul 2026 15:02:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -985,10 +985,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d70fe6bb-eeba-41b0-9d14-745ebef5e815
+                - 75b66a04-e983-4950-98dd-43ec09a1042c
         status: 200 OK
         code: 200
-        duration: 41.678873ms
+        duration: 56.243466ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1005,7 +1005,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/1b3ceea8-7c68-47f9-9853-3d9f5814489c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d4f5b4cd-2011-4226-9199-89079ebc193b
         method: GET
       response:
         proto: HTTP/2.0
@@ -1015,7 +1015,7 @@ interactions:
         trailer: {}
         content_length: 594
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.940379Z","description":"","environment_variables":{},"error_message":null,"id":"1b3ceea8-7c68-47f9-9853-3d9f5814489c","name":"test-function-trigger-sqs","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersrq66lue9","registry_namespace_id":"79f718fe-0a58-4697-b455-ae5548c12f83","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:15.971702Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.230052Z","description":"","environment_variables":{},"error_message":null,"id":"d4f5b4cd-2011-4226-9199-89079ebc193b","name":"test-function-trigger-sqs","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersunjgo9mv","registry_namespace_id":"b70d05e0-5f73-4ab7-bd1f-46408891e312","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:05.505956Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "594"
@@ -1024,9 +1024,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:34 GMT
+                - Fri, 03 Jul 2026 15:02:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1034,10 +1034,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 238c4728-796c-45e6-82af-39cc2a6ce9ae
+                - 56c269df-1694-4d31-afbe-2e9b6d3fd1f8
         status: 200 OK
         code: 200
-        duration: 44.974583ms
+        duration: 27.227076ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1054,7 +1054,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/nats-accounts/AD2GESGP5R57DBT2GYL6LPUBY742EMHZSCY23OWYHMTIIGBWDW42PINF
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/nats-accounts/ABQEEPYDTKS65L6P3CFVO56UDTNXOVAA7YP76ZBRYQSSGYT5NVF2D6RS
         method: GET
       response:
         proto: HTTP/2.0
@@ -1062,20 +1062,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 322
+        content_length: 316
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:56.064561Z","endpoint":"nats://nats.mnq.fr-par.scaleway.com:4222","id":"AD2GESGP5R57DBT2GYL6LPUBY742EMHZSCY23OWYHMTIIGBWDW42PINF","name":"tf-nats-account-beautiful-brahmagupta","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","updated_at":"2026-05-04T12:38:56.064561Z"}'
+        body: '{"created_at":"2026-07-03T15:01:39.604727Z","endpoint":"nats://nats.mnq.fr-par.scaleway.com:4222","id":"ABQEEPYDTKS65L6P3CFVO56UDTNXOVAA7YP76ZBRYQSSGYT5NVF2D6RS","name":"tf-nats-account-crazy-mendeleev","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","updated_at":"2026-07-03T15:01:39.604727Z"}'
         headers:
             Content-Length:
-                - "322"
+                - "316"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:34 GMT
+                - Fri, 03 Jul 2026 15:02:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1083,10 +1083,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 35bff4b6-bdb0-4e24-b79c-cb8bf09bab6c
+                - cef72e10-4302-42fc-ad79-8e024cc239e6
         status: 200 OK
         code: 200
-        duration: 45.890917ms
+        duration: 44.647638ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1103,7 +1103,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/b64eb93a-1615-4586-8525-4a9521b4a709
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/5d120bd2-3d7a-423e-ba36-aee6cdb419d8
         method: GET
       response:
         proto: HTTP/2.0
@@ -1113,7 +1113,7 @@ interactions:
         trailer: {}
         content_length: 738
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:18.429408Z","description":"","domain_name":"testfunctiontriggersrq66lue9-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"b64eb93a-1615-4586-8525-4a9521b4a709","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"1b3ceea8-7c68-47f9-9853-3d9f5814489c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:18.429408Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:07.609931Z","description":"","domain_name":"testfunctiontriggersunjgo9mv-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"5d120bd2-3d7a-423e-ba36-aee6cdb419d8","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"d4f5b4cd-2011-4226-9199-89079ebc193b","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:07.609931Z"}'
         headers:
             Content-Length:
                 - "738"
@@ -1122,9 +1122,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:34 GMT
+                - Fri, 03 Jul 2026 15:02:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1132,10 +1132,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 22da147c-ead8-4180-8cec-7dc12748aa3b
+                - bc0aa682-1979-44af-a77a-30522a281ef5
         status: 200 OK
         code: 200
-        duration: 37.579599ms
+        duration: 33.693858ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1152,7 +1152,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/c5fe156e-c9f5-4efe-b5bc-d575520bcdea
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/077c1456-9278-46ec-be79-79973857e287
         method: GET
       response:
         proto: HTTP/2.0
@@ -1162,7 +1162,7 @@ interactions:
         trailer: {}
         content_length: 475
         uncompressed: false
-        body: '{"description":"","error_message":null,"function_id":"b64eb93a-1615-4586-8525-4a9521b4a709","id":"c5fe156e-c9f5-4efe-b5bc-d575520bcdea","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"022ecb50-9fb0-4a3f-a0fc-cb5ef052d0f2","mnq_nats_account_id":"AD2GESGP5R57DBT2GYL6LPUBY742EMHZSCY23OWYHMTIIGBWDW42PINF","mnq_project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
+        body: '{"description":"","error_message":null,"function_id":"5d120bd2-3d7a-423e-ba36-aee6cdb419d8","id":"077c1456-9278-46ec-be79-79973857e287","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"64ed6def-562f-41ae-a9fd-fb696b94bcfc","mnq_nats_account_id":"ABQEEPYDTKS65L6P3CFVO56UDTNXOVAA7YP76ZBRYQSSGYT5NVF2D6RS","mnq_project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
         headers:
             Content-Length:
                 - "475"
@@ -1171,9 +1171,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:34 GMT
+                - Fri, 03 Jul 2026 15:02:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1181,10 +1181,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d35138aa-2305-4575-a96f-216ab6a4113e
+                - 17961c58-223e-4762-b7b0-1f34ed66ddec
         status: 200 OK
         code: 200
-        duration: 78.386782ms
+        duration: 55.040383ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1201,7 +1201,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/c5fe156e-c9f5-4efe-b5bc-d575520bcdea
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/077c1456-9278-46ec-be79-79973857e287
         method: GET
       response:
         proto: HTTP/2.0
@@ -1211,7 +1211,7 @@ interactions:
         trailer: {}
         content_length: 475
         uncompressed: false
-        body: '{"description":"","error_message":null,"function_id":"b64eb93a-1615-4586-8525-4a9521b4a709","id":"c5fe156e-c9f5-4efe-b5bc-d575520bcdea","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"022ecb50-9fb0-4a3f-a0fc-cb5ef052d0f2","mnq_nats_account_id":"AD2GESGP5R57DBT2GYL6LPUBY742EMHZSCY23OWYHMTIIGBWDW42PINF","mnq_project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
+        body: '{"description":"","error_message":null,"function_id":"5d120bd2-3d7a-423e-ba36-aee6cdb419d8","id":"077c1456-9278-46ec-be79-79973857e287","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"64ed6def-562f-41ae-a9fd-fb696b94bcfc","mnq_nats_account_id":"ABQEEPYDTKS65L6P3CFVO56UDTNXOVAA7YP76ZBRYQSSGYT5NVF2D6RS","mnq_project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","mnq_region":"fr-par","subject":"TestSubject"},"status":"ready"}'
         headers:
             Content-Length:
                 - "475"
@@ -1220,9 +1220,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:35 GMT
+                - Fri, 03 Jul 2026 15:02:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1230,10 +1230,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8f13f8cc-902d-4e2f-b088-9271c6c09262
+                - 73637e9f-cb9b-47c1-9a9c-dcde5e53ed67
         status: 200 OK
         code: 200
-        duration: 49.893659ms
+        duration: 54.936107ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1250,7 +1250,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/c5fe156e-c9f5-4efe-b5bc-d575520bcdea
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/077c1456-9278-46ec-be79-79973857e287
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1260,7 +1260,7 @@ interactions:
         trailer: {}
         content_length: 478
         uncompressed: false
-        body: '{"description":"","error_message":null,"function_id":"b64eb93a-1615-4586-8525-4a9521b4a709","id":"c5fe156e-c9f5-4efe-b5bc-d575520bcdea","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"022ecb50-9fb0-4a3f-a0fc-cb5ef052d0f2","mnq_nats_account_id":"AD2GESGP5R57DBT2GYL6LPUBY742EMHZSCY23OWYHMTIIGBWDW42PINF","mnq_project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","mnq_region":"fr-par","subject":"TestSubject"},"status":"deleting"}'
+        body: '{"description":"","error_message":null,"function_id":"5d120bd2-3d7a-423e-ba36-aee6cdb419d8","id":"077c1456-9278-46ec-be79-79973857e287","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"64ed6def-562f-41ae-a9fd-fb696b94bcfc","mnq_nats_account_id":"ABQEEPYDTKS65L6P3CFVO56UDTNXOVAA7YP76ZBRYQSSGYT5NVF2D6RS","mnq_project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","mnq_region":"fr-par","subject":"TestSubject"},"status":"deleting"}'
         headers:
             Content-Length:
                 - "478"
@@ -1269,9 +1269,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:35 GMT
+                - Fri, 03 Jul 2026 15:02:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1279,10 +1279,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1a59c3ea-77c0-4443-8870-c999ea62190d
+                - 7d0c90f1-ea44-4a28-90a2-a630e98a9422
         status: 200 OK
         code: 200
-        duration: 102.369037ms
+        duration: 81.852458ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1299,7 +1299,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/c5fe156e-c9f5-4efe-b5bc-d575520bcdea
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/077c1456-9278-46ec-be79-79973857e287
         method: GET
       response:
         proto: HTTP/2.0
@@ -1309,7 +1309,7 @@ interactions:
         trailer: {}
         content_length: 478
         uncompressed: false
-        body: '{"description":"","error_message":null,"function_id":"b64eb93a-1615-4586-8525-4a9521b4a709","id":"c5fe156e-c9f5-4efe-b5bc-d575520bcdea","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"022ecb50-9fb0-4a3f-a0fc-cb5ef052d0f2","mnq_nats_account_id":"AD2GESGP5R57DBT2GYL6LPUBY742EMHZSCY23OWYHMTIIGBWDW42PINF","mnq_project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","mnq_region":"fr-par","subject":"TestSubject"},"status":"deleting"}'
+        body: '{"description":"","error_message":null,"function_id":"5d120bd2-3d7a-423e-ba36-aee6cdb419d8","id":"077c1456-9278-46ec-be79-79973857e287","input_type":"scw_nats","name":"test-function-trigger-nats","scw_nats_config":{"mnq_credential_id":"64ed6def-562f-41ae-a9fd-fb696b94bcfc","mnq_nats_account_id":"ABQEEPYDTKS65L6P3CFVO56UDTNXOVAA7YP76ZBRYQSSGYT5NVF2D6RS","mnq_project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","mnq_region":"fr-par","subject":"TestSubject"},"status":"deleting"}'
         headers:
             Content-Length:
                 - "478"
@@ -1318,9 +1318,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:35 GMT
+                - Fri, 03 Jul 2026 15:02:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1328,10 +1328,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 594fefd0-241c-4c99-a020-527ecd9d678c
+                - 51c568f4-a839-44b1-9317-611a22dbc689
         status: 200 OK
         code: 200
-        duration: 37.19685ms
+        duration: 52.042104ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1348,7 +1348,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/c5fe156e-c9f5-4efe-b5bc-d575520bcdea
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/077c1456-9278-46ec-be79-79973857e287
         method: GET
       response:
         proto: HTTP/2.0
@@ -1367,9 +1367,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:50 GMT
+                - Fri, 03 Jul 2026 15:02:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1377,10 +1377,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 46694501-921d-4965-984b-f072360ccc4f
+                - 4ba92abd-62cd-4a2c-8350-7cb213e081d0
         status: 404 Not Found
         code: 404
-        duration: 27.807225ms
+        duration: 25.672091ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1397,7 +1397,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/b64eb93a-1615-4586-8525-4a9521b4a709
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/5d120bd2-3d7a-423e-ba36-aee6cdb419d8
         method: GET
       response:
         proto: HTTP/2.0
@@ -1407,7 +1407,7 @@ interactions:
         trailer: {}
         content_length: 738
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:18.429408Z","description":"","domain_name":"testfunctiontriggersrq66lue9-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"b64eb93a-1615-4586-8525-4a9521b4a709","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"1b3ceea8-7c68-47f9-9853-3d9f5814489c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:18.429408Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:07.609931Z","description":"","domain_name":"testfunctiontriggersunjgo9mv-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"5d120bd2-3d7a-423e-ba36-aee6cdb419d8","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"d4f5b4cd-2011-4226-9199-89079ebc193b","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:07.609931Z"}'
         headers:
             Content-Length:
                 - "738"
@@ -1416,9 +1416,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:50 GMT
+                - Fri, 03 Jul 2026 15:02:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1426,10 +1426,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1abc779f-124a-4756-9416-5dd59d5aba5e
+                - 3c6bf2bb-58b3-488b-9583-c249705994a2
         status: 200 OK
         code: 200
-        duration: 50.565258ms
+        duration: 56.728147ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1446,7 +1446,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/nats-accounts/AD2GESGP5R57DBT2GYL6LPUBY742EMHZSCY23OWYHMTIIGBWDW42PINF
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/nats-accounts/ABQEEPYDTKS65L6P3CFVO56UDTNXOVAA7YP76ZBRYQSSGYT5NVF2D6RS
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1463,9 +1463,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:50 GMT
+                - Fri, 03 Jul 2026 15:02:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1473,10 +1473,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bdfa5dbf-1192-48ca-ad18-a73f05802a91
+                - 7ece2419-af4f-41b3-973b-4aaf9a3984b8
         status: 204 No Content
         code: 204
-        duration: 142.670492ms
+        duration: 177.447232ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1493,7 +1493,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/b64eb93a-1615-4586-8525-4a9521b4a709
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/5d120bd2-3d7a-423e-ba36-aee6cdb419d8
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1503,7 +1503,7 @@ interactions:
         trailer: {}
         content_length: 742
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:18.429408Z","description":"","domain_name":"testfunctiontriggersrq66lue9-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"b64eb93a-1615-4586-8525-4a9521b4a709","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"1b3ceea8-7c68-47f9-9853-3d9f5814489c","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:50.765582643Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:07.609931Z","description":"","domain_name":"testfunctiontriggersunjgo9mv-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"5d120bd2-3d7a-423e-ba36-aee6cdb419d8","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"d4f5b4cd-2011-4226-9199-89079ebc193b","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:45.136290572Z"}'
         headers:
             Content-Length:
                 - "742"
@@ -1512,9 +1512,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:50 GMT
+                - Fri, 03 Jul 2026 15:02:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1522,10 +1522,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fbac9560-dce1-4552-9f21-79c493b1e343
+                - 0f616bb4-1e19-4dda-a97c-177dc4a3c884
         status: 200 OK
         code: 200
-        duration: 144.977913ms
+        duration: 217.225191ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1542,7 +1542,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/1b3ceea8-7c68-47f9-9853-3d9f5814489c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d4f5b4cd-2011-4226-9199-89079ebc193b
         method: GET
       response:
         proto: HTTP/2.0
@@ -1552,7 +1552,7 @@ interactions:
         trailer: {}
         content_length: 594
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.940379Z","description":"","environment_variables":{},"error_message":null,"id":"1b3ceea8-7c68-47f9-9853-3d9f5814489c","name":"test-function-trigger-sqs","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersrq66lue9","registry_namespace_id":"79f718fe-0a58-4697-b455-ae5548c12f83","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:15.971702Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.230052Z","description":"","environment_variables":{},"error_message":null,"id":"d4f5b4cd-2011-4226-9199-89079ebc193b","name":"test-function-trigger-sqs","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersunjgo9mv","registry_namespace_id":"b70d05e0-5f73-4ab7-bd1f-46408891e312","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:05.505956Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "594"
@@ -1561,9 +1561,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:50 GMT
+                - Fri, 03 Jul 2026 15:02:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1571,10 +1571,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d09a787a-7e86-41b7-b497-5a0e85d09a7f
+                - cc74d50c-904e-4733-b6f4-9c8c11b05983
         status: 200 OK
         code: 200
-        duration: 108.343369ms
+        duration: 34.122003ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1591,7 +1591,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/1b3ceea8-7c68-47f9-9853-3d9f5814489c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d4f5b4cd-2011-4226-9199-89079ebc193b
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1601,7 +1601,7 @@ interactions:
         trailer: {}
         content_length: 600
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.940379Z","description":"","environment_variables":{},"error_message":null,"id":"1b3ceea8-7c68-47f9-9853-3d9f5814489c","name":"test-function-trigger-sqs","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersrq66lue9","registry_namespace_id":"79f718fe-0a58-4697-b455-ae5548c12f83","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-05-04T12:39:51.014277024Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.230052Z","description":"","environment_variables":{},"error_message":null,"id":"d4f5b4cd-2011-4226-9199-89079ebc193b","name":"test-function-trigger-sqs","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersunjgo9mv","registry_namespace_id":"b70d05e0-5f73-4ab7-bd1f-46408891e312","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-07-03T15:02:45.393849326Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "600"
@@ -1610,9 +1610,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:51 GMT
+                - Fri, 03 Jul 2026 15:02:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1620,10 +1620,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - de6bef9b-2cd0-4c39-9343-7e33ce788b0f
+                - 6dfa81b6-ab33-40cf-a7d5-1698c71bcb4e
         status: 200 OK
         code: 200
-        duration: 398.822433ms
+        duration: 442.49923ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1640,7 +1640,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/1b3ceea8-7c68-47f9-9853-3d9f5814489c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d4f5b4cd-2011-4226-9199-89079ebc193b
         method: GET
       response:
         proto: HTTP/2.0
@@ -1650,7 +1650,7 @@ interactions:
         trailer: {}
         content_length: 597
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.940379Z","description":"","environment_variables":{},"error_message":null,"id":"1b3ceea8-7c68-47f9-9853-3d9f5814489c","name":"test-function-trigger-sqs","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersrq66lue9","registry_namespace_id":"79f718fe-0a58-4697-b455-ae5548c12f83","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-05-04T12:39:51.014277Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:01:47.230052Z","description":"","environment_variables":{},"error_message":null,"id":"d4f5b4cd-2011-4226-9199-89079ebc193b","name":"test-function-trigger-sqs","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersunjgo9mv","registry_namespace_id":"b70d05e0-5f73-4ab7-bd1f-46408891e312","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-07-03T15:02:45.393849Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "597"
@@ -1659,9 +1659,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:51 GMT
+                - Fri, 03 Jul 2026 15:02:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1669,10 +1669,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4d14fa3a-dda2-4ce2-bc0c-b22aeb05b6a4
+                - 99c11f70-cb3e-415a-b736-275866f93b79
         status: 200 OK
         code: 200
-        duration: 29.417926ms
+        duration: 31.537892ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1689,7 +1689,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/1b3ceea8-7c68-47f9-9853-3d9f5814489c
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d4f5b4cd-2011-4226-9199-89079ebc193b
         method: GET
       response:
         proto: HTTP/2.0
@@ -1708,9 +1708,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:56 GMT
+                - Fri, 03 Jul 2026 15:02:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1718,10 +1718,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a635d266-d07f-4ffa-9d0b-514265c6c69f
+                - 5a08a8f0-cfb8-4889-9fcd-67fec304df78
         status: 404 Not Found
         code: 404
-        duration: 40.020377ms
+        duration: 24.737443ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1738,7 +1738,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/c5fe156e-c9f5-4efe-b5bc-d575520bcdea
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/077c1456-9278-46ec-be79-79973857e287
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1748,7 +1748,7 @@ interactions:
         trailer: {}
         content_length: 105
         uncompressed: false
-        body: '{"message":"trigger does not exist: could not find trigger with id c5fe156e-c9f5-4efe-b5bc-d575520bcdea"}'
+        body: '{"message":"trigger does not exist: could not find trigger with id 077c1456-9278-46ec-be79-79973857e287"}'
         headers:
             Content-Length:
                 - "105"
@@ -1757,9 +1757,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:56 GMT
+                - Fri, 03 Jul 2026 15:02:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1767,7 +1767,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 63a2a736-2f0d-4d5b-bf89-fe313225d105
+                - 581b21db-e8d0-47f4-910f-66bb12428f8e
         status: 404 Not Found
         code: 404
-        duration: 42.210949ms
+        duration: 25.123098ms

--- a/internal/services/function/testdata/function-trigger-sqs.cassette.yaml
+++ b/internal/services/function/testdata/function-trigger-sqs.cassette.yaml
@@ -12,7 +12,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf_tests_function_trigger_sqs","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","description":""}'
+        body: '{"name":"tf_tests_function_trigger_sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","description":""}'
         form: {}
         headers:
             Content-Type:
@@ -29,7 +29,7 @@ interactions:
         trailer: {}
         content_length: 265
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:56.114381Z","description":"","id":"8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8","name":"tf_tests_function_trigger_sqs","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","qualification":null,"updated_at":"2026-05-04T12:38:56.114381Z"}'
+        body: '{"created_at":"2026-07-03T15:10:15.545529Z","description":"","id":"9fc11550-d58f-45a2-96f9-99efd4e86520","name":"tf_tests_function_trigger_sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","qualification":null,"updated_at":"2026-07-03T15:10:15.545529Z"}'
         headers:
             Content-Length:
                 - "265"
@@ -38,9 +38,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:38:56 GMT
+                - Fri, 03 Jul 2026 15:10:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f98a8f5a-b14c-48cc-bcb0-07c77bc7f85d
+                - 06d94114-889e-4d0c-a84b-becc36ee27cf
         status: 200 OK
         code: 200
-        duration: 244.133622ms
+        duration: 756.507511ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -68,7 +68,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/account/v3/projects/8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8
+        url: https://api.scaleway.com/account/v3/projects/9fc11550-d58f-45a2-96f9-99efd4e86520
         method: GET
       response:
         proto: HTTP/2.0
@@ -78,7 +78,7 @@ interactions:
         trailer: {}
         content_length: 310
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:56.114381Z","description":"","id":"8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8","name":"tf_tests_function_trigger_sqs","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2026-05-04T12:38:56.114381Z"}'
+        body: '{"created_at":"2026-07-03T15:10:15.545529Z","description":"","id":"9fc11550-d58f-45a2-96f9-99efd4e86520","name":"tf_tests_function_trigger_sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2026-07-03T15:10:15.545529Z"}'
         headers:
             Content-Length:
                 - "310"
@@ -87,9 +87,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:38:56 GMT
+                - Fri, 03 Jul 2026 15:10:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1ae71e54-e290-4c0f-ab1a-46ce846a08f6
+                - 6c7b1e1a-615c-44da-a4d5-9a64dc48db96
         status: 200 OK
         code: 200
-        duration: 68.914681ms
+        duration: 268.488971ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -112,7 +112,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"project_id":"8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8"}'
+        body: '{"project_id":"9fc11550-d58f-45a2-96f9-99efd4e86520"}'
         form: {}
         headers:
             Content-Type:
@@ -129,7 +129,7 @@ interactions:
         trailer: {}
         content_length: 239
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:56.385930589Z","project_id":"8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"enabled","updated_at":"2026-05-04T12:38:56.385930589Z"}'
+        body: '{"created_at":"2026-07-03T15:10:16.389044259Z","project_id":"9fc11550-d58f-45a2-96f9-99efd4e86520","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"enabled","updated_at":"2026-07-03T15:10:16.389044259Z"}'
         headers:
             Content-Length:
                 - "239"
@@ -138,9 +138,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:38:56 GMT
+                - Fri, 03 Jul 2026 15:10:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -148,10 +148,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2eff8a28-05b2-4e76-aac9-fa7c5d8079dc
+                - 0099ac04-9a16-4645-9b6b-983eca875bb3
         status: 200 OK
         code: 200
-        duration: 102.046532ms
+        duration: 207.836439ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -168,7 +168,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-info?project_id=8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-info?project_id=9fc11550-d58f-45a2-96f9-99efd4e86520
         method: GET
       response:
         proto: HTTP/2.0
@@ -178,7 +178,7 @@ interactions:
         trailer: {}
         content_length: 233
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:56.385930Z","project_id":"8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"enabled","updated_at":"2026-05-04T12:38:56.385930Z"}'
+        body: '{"created_at":"2026-07-03T15:10:16.389044Z","project_id":"9fc11550-d58f-45a2-96f9-99efd4e86520","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"enabled","updated_at":"2026-07-03T15:10:16.389044Z"}'
         headers:
             Content-Length:
                 - "233"
@@ -187,9 +187,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:38:56 GMT
+                - Fri, 03 Jul 2026 15:10:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -197,22 +197,22 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1bce973e-7f21-4a5a-8f67-84812d118e21
+                - 40fcda57-c1ec-4439-8cd0-7d716603a892
         status: 200 OK
         code: 200
-        duration: 35.713508ms
+        duration: 128.652324ms
     - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 171
+        content_length: 165
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"project_id":"8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8","name":"tf-sqs-credentials-friendly-ishizaka","permissions":{"can_publish":true,"can_receive":true,"can_manage":true}}'
+        body: '{"project_id":"9fc11550-d58f-45a2-96f9-99efd4e86520","name":"tf-sqs-credentials-brave-ellis","permissions":{"can_publish":true,"can_receive":true,"can_manage":true}}'
         form: {}
         headers:
             Content-Type:
@@ -227,20 +227,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 502
+        content_length: 496
         uncompressed: false
-        body: '{"access_key":"UmZVg8b3FArGhHzfF1Le","created_at":"2026-05-04T12:38:56.533300218Z","id":"326dff10-8afb-423e-9717-32e932ce4564","name":"tf-sqs-credentials-friendly-ishizaka","permissions":{"can_manage":true,"can_publish":true,"can_receive":true},"project_id":"8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8","region":"fr-par","secret_checksum":"4c5b0023f0b4b1a3d909580a465910c1989eca53","secret_key":"00000000-0000-0000-0000-000000000000","updated_at":"2026-05-04T12:38:56.533300218Z"}'
+        body: '{"access_key":"f3iOgyMgseJxnRnND0P8","created_at":"2026-07-03T15:10:16.863784828Z","id":"e5a29adf-df41-439d-8f65-3a6f402ae04a","name":"tf-sqs-credentials-brave-ellis","permissions":{"can_manage":true,"can_publish":true,"can_receive":true},"project_id":"9fc11550-d58f-45a2-96f9-99efd4e86520","region":"fr-par","secret_checksum":"14bcc6dac53fc75822d52c660628b073625d02a3","secret_key":"00000000-0000-0000-0000-000000000000","updated_at":"2026-07-03T15:10:16.863784828Z"}'
         headers:
             Content-Length:
-                - "502"
+                - "496"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:38:56 GMT
+                - Fri, 03 Jul 2026 15:10:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -248,10 +248,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7e23e2b0-d95f-4739-ad06-044020a8b27a
+                - 0b98375d-ab0f-405e-8c68-fdaf3493db33
         status: 200 OK
         code: 200
-        duration: 58.488005ms
+        duration: 263.842257ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -268,7 +268,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-credentials/326dff10-8afb-423e-9717-32e932ce4564
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-credentials/e5a29adf-df41-439d-8f65-3a6f402ae04a
         method: GET
       response:
         proto: HTTP/2.0
@@ -276,20 +276,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 432
+        content_length: 426
         uncompressed: false
-        body: '{"access_key":"UmZVg8b3FArGhHzfF1Le","created_at":"2026-05-04T12:38:56.533300Z","id":"326dff10-8afb-423e-9717-32e932ce4564","name":"tf-sqs-credentials-friendly-ishizaka","permissions":{"can_manage":true,"can_publish":true,"can_receive":true},"project_id":"8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8","region":"fr-par","secret_checksum":"4c5b0023f0b4b1a3d909580a465910c1989eca53","secret_key":"00000000-0000-0000-0000-000000000000","updated_at":"2026-05-04T12:38:56.533300Z"}'
+        body: '{"access_key":"f3iOgyMgseJxnRnND0P8","created_at":"2026-07-03T15:10:16.863784Z","id":"e5a29adf-df41-439d-8f65-3a6f402ae04a","name":"tf-sqs-credentials-brave-ellis","permissions":{"can_manage":true,"can_publish":true,"can_receive":true},"project_id":"9fc11550-d58f-45a2-96f9-99efd4e86520","region":"fr-par","secret_checksum":"14bcc6dac53fc75822d52c660628b073625d02a3","secret_key":"00000000-0000-0000-0000-000000000000","updated_at":"2026-07-03T15:10:16.863784Z"}'
         headers:
             Content-Length:
-                - "432"
+                - "426"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:38:56 GMT
+                - Fri, 03 Jul 2026 15:10:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -297,10 +297,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dae3cb9a-a968-446f-b53f-0ef7c54f2754
+                - c42c4fe9-5cec-4259-8c7e-e2c30be0be32
         status: 200 OK
         code: 200
-        duration: 43.379611ms
+        duration: 133.077271ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -317,7 +317,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-info?project_id=8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-info?project_id=9fc11550-d58f-45a2-96f9-99efd4e86520
         method: GET
       response:
         proto: HTTP/2.0
@@ -327,7 +327,7 @@ interactions:
         trailer: {}
         content_length: 233
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:56.385930Z","project_id":"8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"enabled","updated_at":"2026-05-04T12:38:56.385930Z"}'
+        body: '{"created_at":"2026-07-03T15:10:16.389044Z","project_id":"9fc11550-d58f-45a2-96f9-99efd4e86520","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"enabled","updated_at":"2026-07-03T15:10:16.389044Z"}'
         headers:
             Content-Length:
                 - "233"
@@ -336,9 +336,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:38:56 GMT
+                - Fri, 03 Jul 2026 15:10:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -346,10 +346,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7291c1a6-287f-406e-bb74-20330d707bef
+                - 3061de0a-5afb-404c-a920-408b6358dfbf
         status: 200 OK
         code: 200
-        duration: 43.665658ms
+        duration: 159.965784ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -361,19 +361,19 @@ interactions:
         host: sqs.mnq.fr-par.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"Attributes":{"MessageRetentionPeriod":"345600","VisibilityTimeout":"30","MaximumMessageSize":"262144"},"QueueName":"TestQueue"}'
+        body: '{"Attributes":{"VisibilityTimeout":"30","MaximumMessageSize":"262144","MessageRetentionPeriod":"345600"},"QueueName":"TestQueue"}'
         form: {}
         headers:
             Amz-Sdk-Invocation-Id:
-                - 80d7322b-5dff-481b-92c7-278e10bda99a
+                - bb9c5f54-1d92-4f6b-8cad-38aa6fa2a06b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
                 - application/x-amz-json-1.0
             User-Agent:
-                - aws-sdk-go-v2/1.41.5 ua/2.1 os/linux lang/go#1.26.0 md/GOOS#linux md/GOARCH#amd64 api/sqs#1.42.24 m/E,e
+                - aws-sdk-go-v2/1.42.1 ua/2.1 os/linux lang/go#1.26.0 md/GOOS#linux md/GOARCH#amd64 api/sqs#1.44.2 m/E,e
             X-Amz-Date:
-                - 20260504T123856Z
+                - 20260703T151017Z
             X-Amz-Target:
                 - AmazonSQS.CreateQueue
             X-Amzn-Query-Mode:
@@ -388,19 +388,19 @@ interactions:
         trailer: {}
         content_length: 106
         uncompressed: false
-        body: '{"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8/TestQueue"}'
+        body: '{"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-9fc11550-d58f-45a2-96f9-99efd4e86520/TestQueue"}'
         headers:
             Content-Length:
                 - "106"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 04 May 2026 12:38:56 GMT
+                - Fri, 03 Jul 2026 15:10:17 GMT
             X-Amzn-Requestid:
-                - txe1c8070c-758c-4d67-bc0d-49419d501deb
+                - tx97dbe381-8a09-4bde-bc33-6d69a918606c
         status: 200 OK
         code: 200
-        duration: 320.913019ms
+        duration: 222.223204ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -416,15 +416,15 @@ interactions:
         form: {}
         headers:
             Amz-Sdk-Invocation-Id:
-                - 8d58d67a-b940-472c-bdf5-5d415f8261ae
+                - b136b905-af9e-4697-8e55-996312b9bb24
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
                 - application/x-amz-json-1.0
             User-Agent:
-                - aws-sdk-go-v2/1.41.5 ua/2.1 os/linux lang/go#1.26.0 md/GOOS#linux md/GOARCH#amd64 api/sqs#1.42.24 m/E,e
+                - aws-sdk-go-v2/1.42.1 ua/2.1 os/linux lang/go#1.26.0 md/GOOS#linux md/GOARCH#amd64 api/sqs#1.44.2 m/E,e
             X-Amz-Date:
-                - 20260504T123856Z
+                - 20260703T151017Z
             X-Amz-Target:
                 - AmazonSQS.GetQueueUrl
             X-Amzn-Query-Mode:
@@ -439,19 +439,19 @@ interactions:
         trailer: {}
         content_length: 106
         uncompressed: false
-        body: '{"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8/TestQueue"}'
+        body: '{"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-9fc11550-d58f-45a2-96f9-99efd4e86520/TestQueue"}'
         headers:
             Content-Length:
                 - "106"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 04 May 2026 12:38:56 GMT
+                - Fri, 03 Jul 2026 15:10:17 GMT
             X-Amzn-Requestid:
-                - txd82c17a3-c66f-4147-9f49-114337ad2a26
+                - txc4ffde05-fd4d-47aa-a4c6-21c6831d804f
         status: 200 OK
         code: 200
-        duration: 25.359399ms
+        duration: 28.819153ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -463,19 +463,19 @@ interactions:
         host: sqs.mnq.fr-par.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"AttributeNames":["MaximumMessageSize","MessageRetentionPeriod","FifoQueue","ContentBasedDeduplication","ReceiveMessageWaitTimeSeconds","VisibilityTimeout","RedrivePolicy","QueueArn"],"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8/TestQueue"}'
+        body: '{"AttributeNames":["MaximumMessageSize","MessageRetentionPeriod","FifoQueue","ContentBasedDeduplication","ReceiveMessageWaitTimeSeconds","VisibilityTimeout","RedrivePolicy","QueueArn"],"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-9fc11550-d58f-45a2-96f9-99efd4e86520/TestQueue"}'
         form: {}
         headers:
             Amz-Sdk-Invocation-Id:
-                - ff233dc4-6190-4780-9b3b-8d71f8119e11
+                - 9f747127-7ec0-4721-bc9d-cd7ed0ec0b5d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
                 - application/x-amz-json-1.0
             User-Agent:
-                - aws-sdk-go-v2/1.41.5 ua/2.1 os/linux lang/go#1.26.0 md/GOOS#linux md/GOARCH#amd64 api/sqs#1.42.24 m/E,e
+                - aws-sdk-go-v2/1.42.1 ua/2.1 os/linux lang/go#1.26.0 md/GOOS#linux md/GOARCH#amd64 api/sqs#1.44.2 m/E,e
             X-Amz-Date:
-                - 20260504T123857Z
+                - 20260703T151017Z
             X-Amz-Target:
                 - AmazonSQS.GetQueueAttributes
             X-Amzn-Query-Mode:
@@ -490,19 +490,19 @@ interactions:
         trailer: {}
         content_length: 229
         uncompressed: false
-        body: '{"Attributes":{"MaximumMessageSize":"262144","MessageRetentionPeriod":"345600","QueueArn":"arn:scw:sqs:fr-par:project-8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8:TestQueue","ReceiveMessageWaitTimeSeconds":"0","VisibilityTimeout":"30"}}'
+        body: '{"Attributes":{"MaximumMessageSize":"262144","MessageRetentionPeriod":"345600","QueueArn":"arn:scw:sqs:fr-par:project-9fc11550-d58f-45a2-96f9-99efd4e86520:TestQueue","ReceiveMessageWaitTimeSeconds":"0","VisibilityTimeout":"30"}}'
         headers:
             Content-Length:
                 - "229"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 04 May 2026 12:38:57 GMT
+                - Fri, 03 Jul 2026 15:10:17 GMT
             X-Amzn-Requestid:
-                - txc5d8d3e1-2b64-418b-b601-3c80c1fe893f
+                - tx2dfe9544-e2d4-46d0-b59a-d8153fca3add
         status: 200 OK
         code: 200
-        duration: 24.120188ms
+        duration: 24.994333ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -514,7 +514,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"test-function-trigger-sqs","environment_variables":{},"project_id":"8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8","secret_environment_variables":[],"tags":null}'
+        body: '{"name":"test-function-trigger-sqs","environment_variables":{},"project_id":"9fc11550-d58f-45a2-96f9-99efd4e86520","secret_environment_variables":[],"tags":null}'
         form: {}
         headers:
             Content-Type:
@@ -531,7 +531,7 @@ interactions:
         trailer: {}
         content_length: 511
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.961631081Z","description":"","environment_variables":{},"error_message":null,"id":"c9093822-0b88-46fb-a16e-5af99da04a23","name":"test-function-trigger-sqs","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-05-04T12:38:57.961631081Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:10:18.273194567Z","description":"","environment_variables":{},"error_message":null,"id":"47c8f9d2-3565-4e7f-ba42-55aca2ddf6a9","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"9fc11550-d58f-45a2-96f9-99efd4e86520","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-07-03T15:10:18.273194567Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "511"
@@ -540,9 +540,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:38:57 GMT
+                - Fri, 03 Jul 2026 15:10:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -550,10 +550,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f8d5bae4-9ece-4676-9051-1acd0a56e23e
+                - f4414c07-31ad-4eab-b55b-96bcea860167
         status: 200 OK
         code: 200
-        duration: 1.645021392s
+        duration: 2.026601456s
     - id: 11
       request:
         proto: HTTP/1.1
@@ -570,7 +570,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/c9093822-0b88-46fb-a16e-5af99da04a23
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/47c8f9d2-3565-4e7f-ba42-55aca2ddf6a9
         method: GET
       response:
         proto: HTTP/2.0
@@ -580,7 +580,7 @@ interactions:
         trailer: {}
         content_length: 505
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.961631Z","description":"","environment_variables":{},"error_message":null,"id":"c9093822-0b88-46fb-a16e-5af99da04a23","name":"test-function-trigger-sqs","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-05-04T12:38:57.961631Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:10:18.273195Z","description":"","environment_variables":{},"error_message":null,"id":"47c8f9d2-3565-4e7f-ba42-55aca2ddf6a9","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"9fc11550-d58f-45a2-96f9-99efd4e86520","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-07-03T15:10:18.273195Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "505"
@@ -589,9 +589,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:38:58 GMT
+                - Fri, 03 Jul 2026 15:10:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -599,10 +599,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c10fa33d-d2d9-4bec-bf61-d72fca35ee50
+                - a51ff63d-2616-4c7a-927a-8e437eb19611
         status: 200 OK
         code: 200
-        duration: 33.847878ms
+        duration: 139.059457ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -619,7 +619,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/c9093822-0b88-46fb-a16e-5af99da04a23
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/47c8f9d2-3565-4e7f-ba42-55aca2ddf6a9
         method: GET
       response:
         proto: HTTP/2.0
@@ -629,7 +629,7 @@ interactions:
         trailer: {}
         content_length: 594
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.961631Z","description":"","environment_variables":{},"error_message":null,"id":"c9093822-0b88-46fb-a16e-5af99da04a23","name":"test-function-trigger-sqs","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersim5bvl17","registry_namespace_id":"f4198993-f952-479f-8310-bb8e64f493a4","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:23.753190Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:10:18.273195Z","description":"","environment_variables":{},"error_message":null,"id":"47c8f9d2-3565-4e7f-ba42-55aca2ddf6a9","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"9fc11550-d58f-45a2-96f9-99efd4e86520","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggerskqbuanql","registry_namespace_id":"38d230bc-4612-4eda-8b6b-89d61fe55812","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:10:22.102688Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "594"
@@ -638,9 +638,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:28 GMT
+                - Fri, 03 Jul 2026 15:10:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -648,10 +648,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 377173aa-9e4d-4fef-b85c-13c1931e6197
+                - 887b9adb-7b3f-4736-8555-215f2bde9c33
         status: 200 OK
         code: 200
-        duration: 49.496921ms
+        duration: 143.376954ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -668,7 +668,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/c9093822-0b88-46fb-a16e-5af99da04a23
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/47c8f9d2-3565-4e7f-ba42-55aca2ddf6a9
         method: GET
       response:
         proto: HTTP/2.0
@@ -678,7 +678,7 @@ interactions:
         trailer: {}
         content_length: 594
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.961631Z","description":"","environment_variables":{},"error_message":null,"id":"c9093822-0b88-46fb-a16e-5af99da04a23","name":"test-function-trigger-sqs","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersim5bvl17","registry_namespace_id":"f4198993-f952-479f-8310-bb8e64f493a4","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:23.753190Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:10:18.273195Z","description":"","environment_variables":{},"error_message":null,"id":"47c8f9d2-3565-4e7f-ba42-55aca2ddf6a9","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"9fc11550-d58f-45a2-96f9-99efd4e86520","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggerskqbuanql","registry_namespace_id":"38d230bc-4612-4eda-8b6b-89d61fe55812","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:10:22.102688Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "594"
@@ -687,9 +687,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:28 GMT
+                - Fri, 03 Jul 2026 15:10:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -697,10 +697,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b32a0520-ab18-472f-aa78-bab361be1ff4
+                - 37280479-a36f-428f-bb1c-9e443a1b2bdb
         status: 200 OK
         code: 200
-        duration: 44.099696ms
+        duration: 139.251849ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -712,7 +712,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"test-function-trigger-sqs","namespace_id":"c9093822-0b88-46fb-a16e-5af99da04a23","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node22","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox","tags":null}'
+        body: '{"name":"test-function-trigger-sqs","namespace_id":"47c8f9d2-3565-4e7f-ba42-55aca2ddf6a9","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"node26","memory_limit":256,"handler":"handler.handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox","tags":null}'
         form: {}
         headers:
             Content-Type:
@@ -729,7 +729,7 @@ interactions:
         trailer: {}
         content_length: 744
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:28.589594937Z","description":"","domain_name":"testfunctiontriggersim5bvl17-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"8b507596-7733-484b-82c5-91fecccd814d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"c9093822-0b88-46fb-a16e-5af99da04a23","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:28.589594937Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:10:24.369153748Z","description":"","domain_name":"testfunctiontriggerskqbuanql-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"56012fe3-d7c9-4b22-a421-e88c3725f15f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"47c8f9d2-3565-4e7f-ba42-55aca2ddf6a9","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:10:24.369153748Z"}'
         headers:
             Content-Length:
                 - "744"
@@ -738,9 +738,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:28 GMT
+                - Fri, 03 Jul 2026 15:10:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -748,10 +748,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 476712ee-02d0-47d2-b8c8-f5569fa22ad7
+                - 7557c935-e6c6-46ad-b328-4a8549fbad51
         status: 200 OK
         code: 200
-        duration: 141.916923ms
+        duration: 679.99268ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -768,7 +768,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/8b507596-7733-484b-82c5-91fecccd814d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/56012fe3-d7c9-4b22-a421-e88c3725f15f
         method: GET
       response:
         proto: HTTP/2.0
@@ -778,7 +778,7 @@ interactions:
         trailer: {}
         content_length: 738
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:28.589595Z","description":"","domain_name":"testfunctiontriggersim5bvl17-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"8b507596-7733-484b-82c5-91fecccd814d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"c9093822-0b88-46fb-a16e-5af99da04a23","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:28.589595Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:10:24.369154Z","description":"","domain_name":"testfunctiontriggerskqbuanql-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"56012fe3-d7c9-4b22-a421-e88c3725f15f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"47c8f9d2-3565-4e7f-ba42-55aca2ddf6a9","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:10:24.369154Z"}'
         headers:
             Content-Length:
                 - "738"
@@ -787,9 +787,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:28 GMT
+                - Fri, 03 Jul 2026 15:10:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -797,10 +797,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f58bd648-08e6-4ab7-b303-52285d169871
+                - 5846aeb9-8dc0-4cee-8ce5-9a3a2a9ac442
         status: 200 OK
         code: 200
-        duration: 48.611926ms
+        duration: 164.637118ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -817,7 +817,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/8b507596-7733-484b-82c5-91fecccd814d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/56012fe3-d7c9-4b22-a421-e88c3725f15f
         method: GET
       response:
         proto: HTTP/2.0
@@ -827,7 +827,7 @@ interactions:
         trailer: {}
         content_length: 738
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:28.589595Z","description":"","domain_name":"testfunctiontriggersim5bvl17-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"8b507596-7733-484b-82c5-91fecccd814d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"c9093822-0b88-46fb-a16e-5af99da04a23","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:28.589595Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:10:24.369154Z","description":"","domain_name":"testfunctiontriggerskqbuanql-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"56012fe3-d7c9-4b22-a421-e88c3725f15f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"47c8f9d2-3565-4e7f-ba42-55aca2ddf6a9","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:10:24.369154Z"}'
         headers:
             Content-Length:
                 - "738"
@@ -836,9 +836,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:28 GMT
+                - Fri, 03 Jul 2026 15:10:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -846,10 +846,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f7fb4e8d-933d-418b-b3b8-3ceabc80fe29
+                - acba29c3-9738-4fe0-8e87-6d6cfef48dd5
         status: 200 OK
         code: 200
-        duration: 48.589413ms
+        duration: 110.147921ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -861,7 +861,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"test-function-trigger-sqs","function_id":"8b507596-7733-484b-82c5-91fecccd814d","scw_sqs_config":{"queue":"TestQueue","mnq_project_id":"8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8","mnq_region":"fr-par"}}'
+        body: '{"name":"test-function-trigger-sqs","function_id":"56012fe3-d7c9-4b22-a421-e88c3725f15f","scw_sqs_config":{"queue":"TestQueue","mnq_project_id":"9fc11550-d58f-45a2-96f9-99efd4e86520","mnq_region":"fr-par"}}'
         form: {}
         headers:
             Content-Type:
@@ -878,7 +878,7 @@ interactions:
         trailer: {}
         content_length: 356
         uncompressed: false
-        body: '{"description":"","error_message":null,"function_id":"8b507596-7733-484b-82c5-91fecccd814d","id":"af5909c0-8109-46d7-bcb1-dfc7d75d6444","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":null,"mnq_project_id":"8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8","mnq_region":"fr-par","queue":"TestQueue"},"status":"creating"}'
+        body: '{"description":"","error_message":null,"function_id":"56012fe3-d7c9-4b22-a421-e88c3725f15f","id":"e37815fb-e326-47ad-9b30-e2a50ac6be7f","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":null,"mnq_project_id":"9fc11550-d58f-45a2-96f9-99efd4e86520","mnq_region":"fr-par","queue":"TestQueue"},"status":"creating"}'
         headers:
             Content-Length:
                 - "356"
@@ -887,9 +887,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:28 GMT
+                - Fri, 03 Jul 2026 15:10:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -897,10 +897,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ef368cbf-feb8-45e0-bf02-a4d97f428d5e
+                - 09182a11-6258-41f1-819b-0dd80dd24a8c
         status: 200 OK
         code: 200
-        duration: 167.361809ms
+        duration: 438.745836ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -917,7 +917,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/af5909c0-8109-46d7-bcb1-dfc7d75d6444
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/e37815fb-e326-47ad-9b30-e2a50ac6be7f
         method: GET
       response:
         proto: HTTP/2.0
@@ -927,7 +927,7 @@ interactions:
         trailer: {}
         content_length: 356
         uncompressed: false
-        body: '{"description":"","error_message":null,"function_id":"8b507596-7733-484b-82c5-91fecccd814d","id":"af5909c0-8109-46d7-bcb1-dfc7d75d6444","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":null,"mnq_project_id":"8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8","mnq_region":"fr-par","queue":"TestQueue"},"status":"creating"}'
+        body: '{"description":"","error_message":null,"function_id":"56012fe3-d7c9-4b22-a421-e88c3725f15f","id":"e37815fb-e326-47ad-9b30-e2a50ac6be7f","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":null,"mnq_project_id":"9fc11550-d58f-45a2-96f9-99efd4e86520","mnq_region":"fr-par","queue":"TestQueue"},"status":"creating"}'
         headers:
             Content-Length:
                 - "356"
@@ -936,9 +936,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:28 GMT
+                - Fri, 03 Jul 2026 15:10:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -946,10 +946,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 57b311ca-fac5-454b-82db-67d4e3ce3ad3
+                - 60adf95b-c7f6-47f0-a2ea-2042345288ba
         status: 200 OK
         code: 200
-        duration: 67.138394ms
+        duration: 155.644345ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -966,7 +966,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/af5909c0-8109-46d7-bcb1-dfc7d75d6444
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/e37815fb-e326-47ad-9b30-e2a50ac6be7f
         method: GET
       response:
         proto: HTTP/2.0
@@ -976,7 +976,7 @@ interactions:
         trailer: {}
         content_length: 387
         uncompressed: false
-        body: '{"description":"","error_message":null,"function_id":"8b507596-7733-484b-82c5-91fecccd814d","id":"af5909c0-8109-46d7-bcb1-dfc7d75d6444","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"b7639a20-3201-49d9-b875-c9704d3b009a","mnq_project_id":"8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
+        body: '{"description":"","error_message":null,"function_id":"56012fe3-d7c9-4b22-a421-e88c3725f15f","id":"e37815fb-e326-47ad-9b30-e2a50ac6be7f","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"308c7bd6-99c9-4920-b446-991b77a61425","mnq_project_id":"9fc11550-d58f-45a2-96f9-99efd4e86520","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
         headers:
             Content-Length:
                 - "387"
@@ -985,9 +985,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:49 GMT
+                - Fri, 03 Jul 2026 15:10:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -995,10 +995,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1d0124cc-e35b-4398-a87c-c930e76a3324
+                - edaa3a11-6f16-44d7-a5b8-9646f861d246
         status: 200 OK
         code: 200
-        duration: 58.480662ms
+        duration: 155.926328ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1015,7 +1015,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/af5909c0-8109-46d7-bcb1-dfc7d75d6444
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/e37815fb-e326-47ad-9b30-e2a50ac6be7f
         method: GET
       response:
         proto: HTTP/2.0
@@ -1025,7 +1025,7 @@ interactions:
         trailer: {}
         content_length: 387
         uncompressed: false
-        body: '{"description":"","error_message":null,"function_id":"8b507596-7733-484b-82c5-91fecccd814d","id":"af5909c0-8109-46d7-bcb1-dfc7d75d6444","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"b7639a20-3201-49d9-b875-c9704d3b009a","mnq_project_id":"8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
+        body: '{"description":"","error_message":null,"function_id":"56012fe3-d7c9-4b22-a421-e88c3725f15f","id":"e37815fb-e326-47ad-9b30-e2a50ac6be7f","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"308c7bd6-99c9-4920-b446-991b77a61425","mnq_project_id":"9fc11550-d58f-45a2-96f9-99efd4e86520","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
         headers:
             Content-Length:
                 - "387"
@@ -1034,9 +1034,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:49 GMT
+                - Fri, 03 Jul 2026 15:10:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1044,10 +1044,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f2d1113e-c122-4579-8594-ea4c82058670
+                - 68ce3bc5-36a3-462e-b1d3-606c56a4e2a4
         status: 200 OK
         code: 200
-        duration: 38.171597ms
+        duration: 162.819175ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1064,7 +1064,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/af5909c0-8109-46d7-bcb1-dfc7d75d6444
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/e37815fb-e326-47ad-9b30-e2a50ac6be7f
         method: GET
       response:
         proto: HTTP/2.0
@@ -1074,7 +1074,7 @@ interactions:
         trailer: {}
         content_length: 387
         uncompressed: false
-        body: '{"description":"","error_message":null,"function_id":"8b507596-7733-484b-82c5-91fecccd814d","id":"af5909c0-8109-46d7-bcb1-dfc7d75d6444","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"b7639a20-3201-49d9-b875-c9704d3b009a","mnq_project_id":"8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
+        body: '{"description":"","error_message":null,"function_id":"56012fe3-d7c9-4b22-a421-e88c3725f15f","id":"e37815fb-e326-47ad-9b30-e2a50ac6be7f","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"308c7bd6-99c9-4920-b446-991b77a61425","mnq_project_id":"9fc11550-d58f-45a2-96f9-99efd4e86520","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
         headers:
             Content-Length:
                 - "387"
@@ -1083,9 +1083,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:49 GMT
+                - Fri, 03 Jul 2026 15:10:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1093,10 +1093,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - aa3aab14-3770-4b3a-b7b0-13f83a8b184a
+                - f668d72e-cac1-4971-a226-0e328db80cb4
         status: 200 OK
         code: 200
-        duration: 44.411498ms
+        duration: 150.789372ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1113,7 +1113,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/af5909c0-8109-46d7-bcb1-dfc7d75d6444
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/e37815fb-e326-47ad-9b30-e2a50ac6be7f
         method: GET
       response:
         proto: HTTP/2.0
@@ -1123,7 +1123,7 @@ interactions:
         trailer: {}
         content_length: 387
         uncompressed: false
-        body: '{"description":"","error_message":null,"function_id":"8b507596-7733-484b-82c5-91fecccd814d","id":"af5909c0-8109-46d7-bcb1-dfc7d75d6444","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"b7639a20-3201-49d9-b875-c9704d3b009a","mnq_project_id":"8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
+        body: '{"description":"","error_message":null,"function_id":"56012fe3-d7c9-4b22-a421-e88c3725f15f","id":"e37815fb-e326-47ad-9b30-e2a50ac6be7f","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"308c7bd6-99c9-4920-b446-991b77a61425","mnq_project_id":"9fc11550-d58f-45a2-96f9-99efd4e86520","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
         headers:
             Content-Length:
                 - "387"
@@ -1132,9 +1132,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:49 GMT
+                - Fri, 03 Jul 2026 15:10:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1142,10 +1142,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2c6dd201-5058-4a04-84f2-b335a5bdf15c
+                - 4f5c8a3f-7f5f-4fb4-8786-dd89860e8c76
         status: 200 OK
         code: 200
-        duration: 41.545956ms
+        duration: 155.742494ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1162,7 +1162,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/account/v3/projects/8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8
+        url: https://api.scaleway.com/account/v3/projects/9fc11550-d58f-45a2-96f9-99efd4e86520
         method: GET
       response:
         proto: HTTP/2.0
@@ -1172,7 +1172,7 @@ interactions:
         trailer: {}
         content_length: 310
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:56.114381Z","description":"","id":"8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8","name":"tf_tests_function_trigger_sqs","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2026-05-04T12:38:56.114381Z"}'
+        body: '{"created_at":"2026-07-03T15:10:15.545529Z","description":"","id":"9fc11550-d58f-45a2-96f9-99efd4e86520","name":"tf_tests_function_trigger_sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2026-07-03T15:10:15.545529Z"}'
         headers:
             Content-Length:
                 - "310"
@@ -1181,9 +1181,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:49 GMT
+                - Fri, 03 Jul 2026 15:10:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1191,10 +1191,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1b37426c-792b-4f77-b3c6-5c6fabd505dc
+                - cc5b96c9-24ef-4fb8-84fe-c563c6c5c2b4
         status: 200 OK
         code: 200
-        duration: 43.783878ms
+        duration: 289.309751ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1211,7 +1211,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/c9093822-0b88-46fb-a16e-5af99da04a23
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/47c8f9d2-3565-4e7f-ba42-55aca2ddf6a9
         method: GET
       response:
         proto: HTTP/2.0
@@ -1221,7 +1221,7 @@ interactions:
         trailer: {}
         content_length: 594
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.961631Z","description":"","environment_variables":{},"error_message":null,"id":"c9093822-0b88-46fb-a16e-5af99da04a23","name":"test-function-trigger-sqs","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersim5bvl17","registry_namespace_id":"f4198993-f952-479f-8310-bb8e64f493a4","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:23.753190Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:10:18.273195Z","description":"","environment_variables":{},"error_message":null,"id":"47c8f9d2-3565-4e7f-ba42-55aca2ddf6a9","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"9fc11550-d58f-45a2-96f9-99efd4e86520","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggerskqbuanql","registry_namespace_id":"38d230bc-4612-4eda-8b6b-89d61fe55812","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:10:22.102688Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "594"
@@ -1230,9 +1230,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:49 GMT
+                - Fri, 03 Jul 2026 15:10:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1240,10 +1240,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d92005f7-b702-417c-a845-cf0c7924cc83
+                - 6ae504ac-1055-4ea4-b3cc-42936bd49110
         status: 200 OK
         code: 200
-        duration: 32.302353ms
+        duration: 121.603119ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1260,7 +1260,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-info?project_id=8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-info?project_id=9fc11550-d58f-45a2-96f9-99efd4e86520
         method: GET
       response:
         proto: HTTP/2.0
@@ -1270,7 +1270,7 @@ interactions:
         trailer: {}
         content_length: 233
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:56.385930Z","project_id":"8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"enabled","updated_at":"2026-05-04T12:38:56.385930Z"}'
+        body: '{"created_at":"2026-07-03T15:10:16.389044Z","project_id":"9fc11550-d58f-45a2-96f9-99efd4e86520","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"enabled","updated_at":"2026-07-03T15:10:16.389044Z"}'
         headers:
             Content-Length:
                 - "233"
@@ -1279,9 +1279,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:49 GMT
+                - Fri, 03 Jul 2026 15:10:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1289,10 +1289,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 40305d6b-2f1f-4a34-bc38-4614aa1e4d57
+                - aaebae1c-d17e-4009-b9c6-304b8ebcbd5b
         status: 200 OK
         code: 200
-        duration: 41.460276ms
+        duration: 124.286562ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1309,7 +1309,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/8b507596-7733-484b-82c5-91fecccd814d
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-credentials/e5a29adf-df41-439d-8f65-3a6f402ae04a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1317,20 +1317,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 738
+        content_length: 426
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:28.589595Z","description":"","domain_name":"testfunctiontriggersim5bvl17-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"8b507596-7733-484b-82c5-91fecccd814d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"c9093822-0b88-46fb-a16e-5af99da04a23","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:28.589595Z"}'
+        body: '{"access_key":"f3iOgyMgseJxnRnND0P8","created_at":"2026-07-03T15:10:16.863784Z","id":"e5a29adf-df41-439d-8f65-3a6f402ae04a","name":"tf-sqs-credentials-brave-ellis","permissions":{"can_manage":true,"can_publish":true,"can_receive":true},"project_id":"9fc11550-d58f-45a2-96f9-99efd4e86520","region":"fr-par","secret_checksum":"14bcc6dac53fc75822d52c660628b073625d02a3","secret_key":"00000000-0000-0000-0000-000000000000","updated_at":"2026-07-03T15:10:16.863784Z"}'
         headers:
             Content-Length:
-                - "738"
+                - "426"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:49 GMT
+                - Fri, 03 Jul 2026 15:10:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1338,10 +1338,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 54cef241-3953-43d4-aa7d-0d81263dbeee
+                - 0b734f6d-7f8b-4829-82d7-ea00ba2da554
         status: 200 OK
         code: 200
-        duration: 39.205722ms
+        duration: 123.628967ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1358,7 +1358,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-credentials/326dff10-8afb-423e-9717-32e932ce4564
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/56012fe3-d7c9-4b22-a421-e88c3725f15f
         method: GET
       response:
         proto: HTTP/2.0
@@ -1366,20 +1366,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 432
+        content_length: 738
         uncompressed: false
-        body: '{"access_key":"UmZVg8b3FArGhHzfF1Le","created_at":"2026-05-04T12:38:56.533300Z","id":"326dff10-8afb-423e-9717-32e932ce4564","name":"tf-sqs-credentials-friendly-ishizaka","permissions":{"can_manage":true,"can_publish":true,"can_receive":true},"project_id":"8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8","region":"fr-par","secret_checksum":"4c5b0023f0b4b1a3d909580a465910c1989eca53","secret_key":"00000000-0000-0000-0000-000000000000","updated_at":"2026-05-04T12:38:56.533300Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:10:24.369154Z","description":"","domain_name":"testfunctiontriggerskqbuanql-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"56012fe3-d7c9-4b22-a421-e88c3725f15f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"47c8f9d2-3565-4e7f-ba42-55aca2ddf6a9","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:10:24.369154Z"}'
         headers:
             Content-Length:
-                - "432"
+                - "738"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:49 GMT
+                - Fri, 03 Jul 2026 15:10:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1387,10 +1387,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 37b5bd48-b75d-41c7-b0b3-232c452daff6
+                - d518aa61-a7d8-4855-ba9c-8658383c4686
         status: 200 OK
         code: 200
-        duration: 50.871755ms
+        duration: 132.946332ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1406,15 +1406,15 @@ interactions:
         form: {}
         headers:
             Amz-Sdk-Invocation-Id:
-                - da1f625b-9f78-4e7e-9c40-32e5b9c6552b
+                - 8641e6ec-d811-48ea-bf26-1dff2ff50f08
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
                 - application/x-amz-json-1.0
             User-Agent:
-                - aws-sdk-go-v2/1.41.5 ua/2.1 os/linux lang/go#1.26.0 md/GOOS#linux md/GOARCH#amd64 api/sqs#1.42.24 m/E,e
+                - aws-sdk-go-v2/1.42.1 ua/2.1 os/linux lang/go#1.26.0 md/GOOS#linux md/GOARCH#amd64 api/sqs#1.44.2 m/E,e
             X-Amz-Date:
-                - 20260504T123949Z
+                - 20260703T151047Z
             X-Amz-Target:
                 - AmazonSQS.GetQueueUrl
             X-Amzn-Query-Mode:
@@ -1429,19 +1429,19 @@ interactions:
         trailer: {}
         content_length: 106
         uncompressed: false
-        body: '{"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8/TestQueue"}'
+        body: '{"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-9fc11550-d58f-45a2-96f9-99efd4e86520/TestQueue"}'
         headers:
             Content-Length:
                 - "106"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 04 May 2026 12:39:49 GMT
+                - Fri, 03 Jul 2026 15:10:47 GMT
             X-Amzn-Requestid:
-                - tx9d154106-e327-44ea-94ed-9355317ef4dc
+                - tx0cf07962-4640-4369-93d9-6475937d636a
         status: 200 OK
         code: 200
-        duration: 26.25293ms
+        duration: 38.367322ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1458,7 +1458,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/af5909c0-8109-46d7-bcb1-dfc7d75d6444
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/e37815fb-e326-47ad-9b30-e2a50ac6be7f
         method: GET
       response:
         proto: HTTP/2.0
@@ -1468,7 +1468,7 @@ interactions:
         trailer: {}
         content_length: 387
         uncompressed: false
-        body: '{"description":"","error_message":null,"function_id":"8b507596-7733-484b-82c5-91fecccd814d","id":"af5909c0-8109-46d7-bcb1-dfc7d75d6444","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"b7639a20-3201-49d9-b875-c9704d3b009a","mnq_project_id":"8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
+        body: '{"description":"","error_message":null,"function_id":"56012fe3-d7c9-4b22-a421-e88c3725f15f","id":"e37815fb-e326-47ad-9b30-e2a50ac6be7f","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"308c7bd6-99c9-4920-b446-991b77a61425","mnq_project_id":"9fc11550-d58f-45a2-96f9-99efd4e86520","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
         headers:
             Content-Length:
                 - "387"
@@ -1477,9 +1477,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:49 GMT
+                - Fri, 03 Jul 2026 15:10:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1487,10 +1487,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ef891dc6-d746-4224-8bb2-f674ee6c0e2c
+                - 00e1f2e7-516d-4a01-a0a8-cb8656a62333
         status: 200 OK
         code: 200
-        duration: 39.799751ms
+        duration: 56.369142ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1502,19 +1502,19 @@ interactions:
         host: sqs.mnq.fr-par.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"AttributeNames":["MessageRetentionPeriod","FifoQueue","ContentBasedDeduplication","ReceiveMessageWaitTimeSeconds","VisibilityTimeout","RedrivePolicy","QueueArn","MaximumMessageSize"],"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8/TestQueue"}'
+        body: '{"AttributeNames":["MessageRetentionPeriod","FifoQueue","ContentBasedDeduplication","ReceiveMessageWaitTimeSeconds","VisibilityTimeout","RedrivePolicy","QueueArn","MaximumMessageSize"],"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-9fc11550-d58f-45a2-96f9-99efd4e86520/TestQueue"}'
         form: {}
         headers:
             Amz-Sdk-Invocation-Id:
-                - ffe6e39b-1c4b-4084-b4cc-dab944259422
+                - 7dc593a3-ddd9-4b34-a9ac-5cfc5d331094
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
                 - application/x-amz-json-1.0
             User-Agent:
-                - aws-sdk-go-v2/1.41.5 ua/2.1 os/linux lang/go#1.26.0 md/GOOS#linux md/GOARCH#amd64 api/sqs#1.42.24 m/E,e
+                - aws-sdk-go-v2/1.42.1 ua/2.1 os/linux lang/go#1.26.0 md/GOOS#linux md/GOARCH#amd64 api/sqs#1.44.2 m/E,e
             X-Amz-Date:
-                - 20260504T123949Z
+                - 20260703T151047Z
             X-Amz-Target:
                 - AmazonSQS.GetQueueAttributes
             X-Amzn-Query-Mode:
@@ -1529,19 +1529,19 @@ interactions:
         trailer: {}
         content_length: 229
         uncompressed: false
-        body: '{"Attributes":{"MaximumMessageSize":"262144","MessageRetentionPeriod":"345600","QueueArn":"arn:scw:sqs:fr-par:project-8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8:TestQueue","ReceiveMessageWaitTimeSeconds":"0","VisibilityTimeout":"30"}}'
+        body: '{"Attributes":{"MaximumMessageSize":"262144","MessageRetentionPeriod":"345600","QueueArn":"arn:scw:sqs:fr-par:project-9fc11550-d58f-45a2-96f9-99efd4e86520:TestQueue","ReceiveMessageWaitTimeSeconds":"0","VisibilityTimeout":"30"}}'
         headers:
             Content-Length:
                 - "229"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 04 May 2026 12:39:49 GMT
+                - Fri, 03 Jul 2026 15:10:47 GMT
             X-Amzn-Requestid:
-                - txbb72fae0-2d02-43ab-8f5a-cebba3a49223
+                - tx810a6f44-5e4f-438b-b105-8f0c5ee9e32c
         status: 200 OK
         code: 200
-        duration: 21.669876ms
+        duration: 35.382692ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1558,7 +1558,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/account/v3/projects/8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8
+        url: https://api.scaleway.com/account/v3/projects/9fc11550-d58f-45a2-96f9-99efd4e86520
         method: GET
       response:
         proto: HTTP/2.0
@@ -1568,7 +1568,7 @@ interactions:
         trailer: {}
         content_length: 310
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:56.114381Z","description":"","id":"8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8","name":"tf_tests_function_trigger_sqs","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2026-05-04T12:38:56.114381Z"}'
+        body: '{"created_at":"2026-07-03T15:10:15.545529Z","description":"","id":"9fc11550-d58f-45a2-96f9-99efd4e86520","name":"tf_tests_function_trigger_sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2026-07-03T15:10:15.545529Z"}'
         headers:
             Content-Length:
                 - "310"
@@ -1577,9 +1577,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:50 GMT
+                - Fri, 03 Jul 2026 15:10:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1587,10 +1587,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4edf6114-70bb-4af8-aa69-84ac0fdeaf22
+                - 634f8afe-c237-40b2-8447-4ddcd027d993
         status: 200 OK
         code: 200
-        duration: 52.073958ms
+        duration: 283.746344ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1607,7 +1607,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/c9093822-0b88-46fb-a16e-5af99da04a23
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-info?project_id=9fc11550-d58f-45a2-96f9-99efd4e86520
         method: GET
       response:
         proto: HTTP/2.0
@@ -1615,20 +1615,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 594
+        content_length: 233
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.961631Z","description":"","environment_variables":{},"error_message":null,"id":"c9093822-0b88-46fb-a16e-5af99da04a23","name":"test-function-trigger-sqs","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersim5bvl17","registry_namespace_id":"f4198993-f952-479f-8310-bb8e64f493a4","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:23.753190Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:10:16.389044Z","project_id":"9fc11550-d58f-45a2-96f9-99efd4e86520","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"enabled","updated_at":"2026-07-03T15:10:16.389044Z"}'
         headers:
             Content-Length:
-                - "594"
+                - "233"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:50 GMT
+                - Fri, 03 Jul 2026 15:10:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1636,10 +1636,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 58d00c42-e511-41db-8561-07e224635ada
+                - 8ffe4e9e-5a1e-43f3-b6f2-dab12bf3cf14
         status: 200 OK
         code: 200
-        duration: 39.684573ms
+        duration: 237.485263ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1656,7 +1656,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-info?project_id=8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/47c8f9d2-3565-4e7f-ba42-55aca2ddf6a9
         method: GET
       response:
         proto: HTTP/2.0
@@ -1664,20 +1664,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 233
+        content_length: 594
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:56.385930Z","project_id":"8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"enabled","updated_at":"2026-05-04T12:38:56.385930Z"}'
+        body: '{"created_at":"2026-07-03T15:10:18.273195Z","description":"","environment_variables":{},"error_message":null,"id":"47c8f9d2-3565-4e7f-ba42-55aca2ddf6a9","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"9fc11550-d58f-45a2-96f9-99efd4e86520","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggerskqbuanql","registry_namespace_id":"38d230bc-4612-4eda-8b6b-89d61fe55812","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:10:22.102688Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "233"
+                - "594"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:50 GMT
+                - Fri, 03 Jul 2026 15:10:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1685,10 +1685,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b91d96ed-ba60-4dce-b61b-52858f0971a5
+                - 89ff529f-cd78-47a7-b94b-f3d10ad0cb46
         status: 200 OK
         code: 200
-        duration: 44.850966ms
+        duration: 251.507672ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1705,7 +1705,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/8b507596-7733-484b-82c5-91fecccd814d
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-credentials/e5a29adf-df41-439d-8f65-3a6f402ae04a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1713,20 +1713,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 738
+        content_length: 426
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:28.589595Z","description":"","domain_name":"testfunctiontriggersim5bvl17-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"8b507596-7733-484b-82c5-91fecccd814d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"c9093822-0b88-46fb-a16e-5af99da04a23","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:28.589595Z"}'
+        body: '{"access_key":"f3iOgyMgseJxnRnND0P8","created_at":"2026-07-03T15:10:16.863784Z","id":"e5a29adf-df41-439d-8f65-3a6f402ae04a","name":"tf-sqs-credentials-brave-ellis","permissions":{"can_manage":true,"can_publish":true,"can_receive":true},"project_id":"9fc11550-d58f-45a2-96f9-99efd4e86520","region":"fr-par","secret_checksum":"14bcc6dac53fc75822d52c660628b073625d02a3","secret_key":"00000000-0000-0000-0000-000000000000","updated_at":"2026-07-03T15:10:16.863784Z"}'
         headers:
             Content-Length:
-                - "738"
+                - "426"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:50 GMT
+                - Fri, 03 Jul 2026 15:10:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1734,10 +1734,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0048cbe6-3042-4fb5-8b1d-e7f6e77dd654
+                - 20527974-f91b-4440-a22f-cdd5d8ccffdc
         status: 200 OK
         code: 200
-        duration: 44.385981ms
+        duration: 140.397278ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1754,7 +1754,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-credentials/326dff10-8afb-423e-9717-32e932ce4564
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/56012fe3-d7c9-4b22-a421-e88c3725f15f
         method: GET
       response:
         proto: HTTP/2.0
@@ -1762,20 +1762,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 432
+        content_length: 738
         uncompressed: false
-        body: '{"access_key":"UmZVg8b3FArGhHzfF1Le","created_at":"2026-05-04T12:38:56.533300Z","id":"326dff10-8afb-423e-9717-32e932ce4564","name":"tf-sqs-credentials-friendly-ishizaka","permissions":{"can_manage":true,"can_publish":true,"can_receive":true},"project_id":"8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8","region":"fr-par","secret_checksum":"4c5b0023f0b4b1a3d909580a465910c1989eca53","secret_key":"00000000-0000-0000-0000-000000000000","updated_at":"2026-05-04T12:38:56.533300Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:10:24.369154Z","description":"","domain_name":"testfunctiontriggerskqbuanql-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"56012fe3-d7c9-4b22-a421-e88c3725f15f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"47c8f9d2-3565-4e7f-ba42-55aca2ddf6a9","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:10:24.369154Z"}'
         headers:
             Content-Length:
-                - "432"
+                - "738"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:50 GMT
+                - Fri, 03 Jul 2026 15:10:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1783,10 +1783,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4566555e-66fe-4566-b6f5-2d45f2c89d40
+                - 778b4b6f-8f65-428d-be1f-c4a193ad549a
         status: 200 OK
         code: 200
-        duration: 249.133112ms
+        duration: 164.079335ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1802,15 +1802,15 @@ interactions:
         form: {}
         headers:
             Amz-Sdk-Invocation-Id:
-                - 90a832e2-a5d5-4c17-a750-1aef9368f76e
+                - fd619891-b41b-4928-8fd2-5a8d5e0806a8
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
                 - application/x-amz-json-1.0
             User-Agent:
-                - aws-sdk-go-v2/1.41.5 ua/2.1 os/linux lang/go#1.26.0 md/GOOS#linux md/GOARCH#amd64 api/sqs#1.42.24 m/E,e
+                - aws-sdk-go-v2/1.42.1 ua/2.1 os/linux lang/go#1.26.0 md/GOOS#linux md/GOARCH#amd64 api/sqs#1.44.2 m/E,e
             X-Amz-Date:
-                - 20260504T123950Z
+                - 20260703T151048Z
             X-Amz-Target:
                 - AmazonSQS.GetQueueUrl
             X-Amzn-Query-Mode:
@@ -1825,20 +1825,71 @@ interactions:
         trailer: {}
         content_length: 106
         uncompressed: false
-        body: '{"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8/TestQueue"}'
+        body: '{"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-9fc11550-d58f-45a2-96f9-99efd4e86520/TestQueue"}'
         headers:
             Content-Length:
                 - "106"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 04 May 2026 12:39:50 GMT
+                - Fri, 03 Jul 2026 15:10:48 GMT
             X-Amzn-Requestid:
-                - txf516715f-5a63-44ee-98e6-2a273ad23303
+                - tx95ec85b3-2439-456b-9905-bb94d594831c
         status: 200 OK
         code: 200
-        duration: 32.090935ms
+        duration: 37.021293ms
     - id: 37
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 289
+        transfer_encoding: []
+        trailer: {}
+        host: sqs.mnq.fr-par.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"AttributeNames":["VisibilityTimeout","RedrivePolicy","QueueArn","MaximumMessageSize","MessageRetentionPeriod","FifoQueue","ContentBasedDeduplication","ReceiveMessageWaitTimeSeconds"],"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-9fc11550-d58f-45a2-96f9-99efd4e86520/TestQueue"}'
+        form: {}
+        headers:
+            Amz-Sdk-Invocation-Id:
+                - db814978-5051-4023-97a5-82cc4764ce41
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            Content-Type:
+                - application/x-amz-json-1.0
+            User-Agent:
+                - aws-sdk-go-v2/1.42.1 ua/2.1 os/linux lang/go#1.26.0 md/GOOS#linux md/GOARCH#amd64 api/sqs#1.44.2 m/E,e
+            X-Amz-Date:
+                - 20260703T151048Z
+            X-Amz-Target:
+                - AmazonSQS.GetQueueAttributes
+            X-Amzn-Query-Mode:
+                - "true"
+        url: https://sqs.mnq.fr-par.scaleway.com/
+        method: POST
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        transfer_encoding: []
+        trailer: {}
+        content_length: 229
+        uncompressed: false
+        body: '{"Attributes":{"MaximumMessageSize":"262144","MessageRetentionPeriod":"345600","QueueArn":"arn:scw:sqs:fr-par:project-9fc11550-d58f-45a2-96f9-99efd4e86520:TestQueue","ReceiveMessageWaitTimeSeconds":"0","VisibilityTimeout":"30"}}'
+        headers:
+            Content-Length:
+                - "229"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 03 Jul 2026 15:10:48 GMT
+            X-Amzn-Requestid:
+                - txe167c681-3b09-4918-a676-a12e945fbd43
+        status: 200 OK
+        code: 200
+        duration: 50.9044ms
+    - id: 38
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1854,7 +1905,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/af5909c0-8109-46d7-bcb1-dfc7d75d6444
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/e37815fb-e326-47ad-9b30-e2a50ac6be7f
         method: GET
       response:
         proto: HTTP/2.0
@@ -1864,7 +1915,7 @@ interactions:
         trailer: {}
         content_length: 387
         uncompressed: false
-        body: '{"description":"","error_message":null,"function_id":"8b507596-7733-484b-82c5-91fecccd814d","id":"af5909c0-8109-46d7-bcb1-dfc7d75d6444","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"b7639a20-3201-49d9-b875-c9704d3b009a","mnq_project_id":"8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
+        body: '{"description":"","error_message":null,"function_id":"56012fe3-d7c9-4b22-a421-e88c3725f15f","id":"e37815fb-e326-47ad-9b30-e2a50ac6be7f","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"308c7bd6-99c9-4920-b446-991b77a61425","mnq_project_id":"9fc11550-d58f-45a2-96f9-99efd4e86520","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
         headers:
             Content-Length:
                 - "387"
@@ -1873,9 +1924,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:50 GMT
+                - Fri, 03 Jul 2026 15:10:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1883,61 +1934,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - be387953-6598-4140-aa60-d305f134a7f8
+                - c798db30-62df-49a2-983f-c08e7d6afcfb
         status: 200 OK
         code: 200
-        duration: 37.112084ms
-    - id: 38
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 289
-        transfer_encoding: []
-        trailer: {}
-        host: sqs.mnq.fr-par.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"AttributeNames":["MessageRetentionPeriod","FifoQueue","ContentBasedDeduplication","ReceiveMessageWaitTimeSeconds","VisibilityTimeout","RedrivePolicy","QueueArn","MaximumMessageSize"],"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8/TestQueue"}'
-        form: {}
-        headers:
-            Amz-Sdk-Invocation-Id:
-                - da53dd6f-464e-43e2-b8dc-5f531bfd198c
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            Content-Type:
-                - application/x-amz-json-1.0
-            User-Agent:
-                - aws-sdk-go-v2/1.41.5 ua/2.1 os/linux lang/go#1.26.0 md/GOOS#linux md/GOARCH#amd64 api/sqs#1.42.24 m/E,e
-            X-Amz-Date:
-                - 20260504T123950Z
-            X-Amz-Target:
-                - AmazonSQS.GetQueueAttributes
-            X-Amzn-Query-Mode:
-                - "true"
-        url: https://sqs.mnq.fr-par.scaleway.com/
-        method: POST
-      response:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        transfer_encoding: []
-        trailer: {}
-        content_length: 229
-        uncompressed: false
-        body: '{"Attributes":{"MaximumMessageSize":"262144","MessageRetentionPeriod":"345600","QueueArn":"arn:scw:sqs:fr-par:project-8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8:TestQueue","ReceiveMessageWaitTimeSeconds":"0","VisibilityTimeout":"30"}}'
-        headers:
-            Content-Length:
-                - "229"
-            Content-Type:
-                - application/json; charset=utf-8
-            Date:
-                - Mon, 04 May 2026 12:39:50 GMT
-            X-Amzn-Requestid:
-                - tx18a29eb9-6dcb-41e8-841d-19a499cef253
-        status: 200 OK
-        code: 200
-        duration: 27.245417ms
+        duration: 140.625887ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1953,15 +1953,15 @@ interactions:
         form: {}
         headers:
             Amz-Sdk-Invocation-Id:
-                - 1a6d1814-c3d2-4150-ab76-3ab00ea7fc8c
+                - f3e8e547-cb5b-451d-83da-79621a19b852
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
                 - application/x-amz-json-1.0
             User-Agent:
-                - aws-sdk-go-v2/1.41.5 ua/2.1 os/linux lang/go#1.26.0 md/GOOS#linux md/GOARCH#amd64 api/sqs#1.42.24 m/E,e
+                - aws-sdk-go-v2/1.42.1 ua/2.1 os/linux lang/go#1.26.0 md/GOOS#linux md/GOARCH#amd64 api/sqs#1.44.2 m/E,e
             X-Amz-Date:
-                - 20260504T123950Z
+                - 20260703T151048Z
             X-Amz-Target:
                 - AmazonSQS.GetQueueUrl
             X-Amzn-Query-Mode:
@@ -1976,69 +1976,20 @@ interactions:
         trailer: {}
         content_length: 106
         uncompressed: false
-        body: '{"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8/TestQueue"}'
+        body: '{"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-9fc11550-d58f-45a2-96f9-99efd4e86520/TestQueue"}'
         headers:
             Content-Length:
                 - "106"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 04 May 2026 12:39:50 GMT
+                - Fri, 03 Jul 2026 15:10:48 GMT
             X-Amzn-Requestid:
-                - tx98e9dfd6-bf7d-4784-b5f0-4eda08eb4abe
+                - tx9d6e6046-4172-42d1-97ff-178cb38491d0
         status: 200 OK
         code: 200
-        duration: 60.22222ms
+        duration: 33.816197ms
     - id: 40
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/af5909c0-8109-46d7-bcb1-dfc7d75d6444
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 387
-        uncompressed: false
-        body: '{"description":"","error_message":null,"function_id":"8b507596-7733-484b-82c5-91fecccd814d","id":"af5909c0-8109-46d7-bcb1-dfc7d75d6444","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"b7639a20-3201-49d9-b875-c9704d3b009a","mnq_project_id":"8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
-        headers:
-            Content-Length:
-                - "387"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 04 May 2026 12:39:50 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - fe2356c3-f6b5-4643-971f-97c95ff19ef3
-        status: 200 OK
-        code: 200
-        duration: 70.825402ms
-    - id: 41
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2049,19 +2000,19 @@ interactions:
         host: sqs.mnq.fr-par.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8/TestQueue"}'
+        body: '{"QueueUrl":"https://sqs.mnq.fr-par.scaleway.com/project-9fc11550-d58f-45a2-96f9-99efd4e86520/TestQueue"}'
         form: {}
         headers:
             Amz-Sdk-Invocation-Id:
-                - e82b8f59-f63f-45cb-8371-6f2718d55c03
+                - 427ed9ca-f3d4-4152-bd21-d4b273c3d731
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
                 - application/x-amz-json-1.0
             User-Agent:
-                - aws-sdk-go-v2/1.41.5 ua/2.1 os/linux lang/go#1.26.0 md/GOOS#linux md/GOARCH#amd64 api/sqs#1.42.24 m/E,e
+                - aws-sdk-go-v2/1.42.1 ua/2.1 os/linux lang/go#1.26.0 md/GOOS#linux md/GOARCH#amd64 api/sqs#1.44.2 m/E,e
             X-Amz-Date:
-                - 20260504T123950Z
+                - 20260703T151048Z
             X-Amz-Target:
                 - AmazonSQS.DeleteQueue
             X-Amzn-Query-Mode:
@@ -2083,13 +2034,13 @@ interactions:
             Content-Type:
                 - application/x-amz-json-1.0; charset=utf-8
             Date:
-                - Mon, 04 May 2026 12:39:50 GMT
+                - Fri, 03 Jul 2026 15:10:48 GMT
             X-Amzn-Requestid:
-                - tx8523d767-650e-4835-adf6-6fb781ce974f
+                - txb6bd559b-4e33-4e90-a269-aebaffaaf4e5
         status: 200 OK
         code: 200
-        duration: 32.568684ms
-    - id: 42
+        duration: 49.755361ms
+    - id: 41
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2104,15 +2055,15 @@ interactions:
         form: {}
         headers:
             Amz-Sdk-Invocation-Id:
-                - 50aacf94-b8e4-4235-89bf-86bb9bb72d81
+                - 8e5a4a9f-14ed-44a9-92ef-45a4cc5544c8
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
                 - application/x-amz-json-1.0
             User-Agent:
-                - aws-sdk-go-v2/1.41.5 ua/2.1 os/linux lang/go#1.26.0 md/GOOS#linux md/GOARCH#amd64 api/sqs#1.42.24 m/E,e
+                - aws-sdk-go-v2/1.42.1 ua/2.1 os/linux lang/go#1.26.0 md/GOOS#linux md/GOARCH#amd64 api/sqs#1.44.2 m/E,e
             X-Amz-Date:
-                - 20260504T123950Z
+                - 20260703T151048Z
             X-Amz-Target:
                 - AmazonSQS.GetQueueUrl
             X-Amzn-Query-Mode:
@@ -2134,14 +2085,63 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 04 May 2026 12:39:50 GMT
+                - Fri, 03 Jul 2026 15:10:48 GMT
             X-Amzn-Query-Error:
                 - AWS.SimpleQueueService.NonExistentQueue;Sender
             X-Amzn-Requestid:
-                - tx3eb37d09-f18d-49b2-b50f-2629775d54ea
+                - tx9bcd7022-f5d6-47e9-acf3-6f962a8216d2
         status: 404 Not Found
         code: 404
-        duration: 24.08992ms
+        duration: 23.612286ms
+    - id: 42
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/e37815fb-e326-47ad-9b30-e2a50ac6be7f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 387
+        uncompressed: false
+        body: '{"description":"","error_message":null,"function_id":"56012fe3-d7c9-4b22-a421-e88c3725f15f","id":"e37815fb-e326-47ad-9b30-e2a50ac6be7f","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"308c7bd6-99c9-4920-b446-991b77a61425","mnq_project_id":"9fc11550-d58f-45a2-96f9-99efd4e86520","mnq_region":"fr-par","queue":"TestQueue"},"status":"ready"}'
+        headers:
+            Content-Length:
+                - "387"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:10:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 873d663a-a85c-4845-b06f-10f9a1abd204
+        status: 200 OK
+        code: 200
+        duration: 148.316777ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -2158,7 +2158,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/af5909c0-8109-46d7-bcb1-dfc7d75d6444
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/e37815fb-e326-47ad-9b30-e2a50ac6be7f
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2168,7 +2168,7 @@ interactions:
         trailer: {}
         content_length: 390
         uncompressed: false
-        body: '{"description":"","error_message":null,"function_id":"8b507596-7733-484b-82c5-91fecccd814d","id":"af5909c0-8109-46d7-bcb1-dfc7d75d6444","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"b7639a20-3201-49d9-b875-c9704d3b009a","mnq_project_id":"8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8","mnq_region":"fr-par","queue":"TestQueue"},"status":"deleting"}'
+        body: '{"description":"","error_message":null,"function_id":"56012fe3-d7c9-4b22-a421-e88c3725f15f","id":"e37815fb-e326-47ad-9b30-e2a50ac6be7f","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"308c7bd6-99c9-4920-b446-991b77a61425","mnq_project_id":"9fc11550-d58f-45a2-96f9-99efd4e86520","mnq_region":"fr-par","queue":"TestQueue"},"status":"deleting"}'
         headers:
             Content-Length:
                 - "390"
@@ -2177,9 +2177,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:50 GMT
+                - Fri, 03 Jul 2026 15:10:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2187,10 +2187,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d4c17fc5-1e58-47c7-a9bd-0eab5c11c175
+                - 1d1d0fa4-d486-49ea-8590-5edfbefd7976
         status: 200 OK
         code: 200
-        duration: 172.567508ms
+        duration: 212.593049ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -2207,7 +2207,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/af5909c0-8109-46d7-bcb1-dfc7d75d6444
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/e37815fb-e326-47ad-9b30-e2a50ac6be7f
         method: GET
       response:
         proto: HTTP/2.0
@@ -2217,7 +2217,7 @@ interactions:
         trailer: {}
         content_length: 390
         uncompressed: false
-        body: '{"description":"","error_message":null,"function_id":"8b507596-7733-484b-82c5-91fecccd814d","id":"af5909c0-8109-46d7-bcb1-dfc7d75d6444","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"b7639a20-3201-49d9-b875-c9704d3b009a","mnq_project_id":"8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8","mnq_region":"fr-par","queue":"TestQueue"},"status":"deleting"}'
+        body: '{"description":"","error_message":null,"function_id":"56012fe3-d7c9-4b22-a421-e88c3725f15f","id":"e37815fb-e326-47ad-9b30-e2a50ac6be7f","input_type":"scw_sqs","name":"test-function-trigger-sqs","scw_sqs_config":{"mnq_credential_id":"308c7bd6-99c9-4920-b446-991b77a61425","mnq_project_id":"9fc11550-d58f-45a2-96f9-99efd4e86520","mnq_region":"fr-par","queue":"TestQueue"},"status":"deleting"}'
         headers:
             Content-Length:
                 - "390"
@@ -2226,9 +2226,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:51 GMT
+                - Fri, 03 Jul 2026 15:10:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2236,10 +2236,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8778c98a-5080-41ce-8ef5-f97693a6cdf0
+                - 3ce1ca61-aef9-44e6-81bc-bf9f3734a5dc
         status: 200 OK
         code: 200
-        duration: 50.09299ms
+        duration: 149.332674ms
     - id: 45
       request:
         proto: HTTP/1.1
@@ -2256,7 +2256,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/af5909c0-8109-46d7-bcb1-dfc7d75d6444
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/e37815fb-e326-47ad-9b30-e2a50ac6be7f
         method: GET
       response:
         proto: HTTP/2.0
@@ -2275,9 +2275,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:40:11 GMT
+                - Fri, 03 Jul 2026 15:11:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2285,10 +2285,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 42accfd2-7a65-4cfe-9a71-41c34f483c70
+                - cbcd3972-9545-46bb-9700-3464124b0fed
         status: 404 Not Found
         code: 404
-        duration: 26.15006ms
+        duration: 27.499664ms
     - id: 46
       request:
         proto: HTTP/1.1
@@ -2305,7 +2305,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/8b507596-7733-484b-82c5-91fecccd814d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/56012fe3-d7c9-4b22-a421-e88c3725f15f
         method: GET
       response:
         proto: HTTP/2.0
@@ -2315,7 +2315,7 @@ interactions:
         trailer: {}
         content_length: 738
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:28.589595Z","description":"","domain_name":"testfunctiontriggersim5bvl17-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"8b507596-7733-484b-82c5-91fecccd814d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"c9093822-0b88-46fb-a16e-5af99da04a23","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:28.589595Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:10:24.369154Z","description":"","domain_name":"testfunctiontriggerskqbuanql-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"56012fe3-d7c9-4b22-a421-e88c3725f15f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"47c8f9d2-3565-4e7f-ba42-55aca2ddf6a9","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:10:24.369154Z"}'
         headers:
             Content-Length:
                 - "738"
@@ -2324,9 +2324,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:40:11 GMT
+                - Fri, 03 Jul 2026 15:11:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2334,10 +2334,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9c1e0364-6ceb-4445-a48b-d465bb3e2ec3
+                - 1d0d55d6-1cc4-48a0-a140-e576e6a9277c
         status: 200 OK
         code: 200
-        duration: 54.706688ms
+        duration: 143.945162ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -2354,7 +2354,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-credentials/326dff10-8afb-423e-9717-32e932ce4564
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-credentials/e5a29adf-df41-439d-8f65-3a6f402ae04a
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2371,9 +2371,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:40:11 GMT
+                - Fri, 03 Jul 2026 15:11:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2381,10 +2381,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0c3f8bea-e0f3-4a99-8747-8aa3f1ad7a60
+                - 92414906-4245-4f7e-bf99-daa5726801d7
         status: 204 No Content
         code: 204
-        duration: 63.926479ms
+        duration: 220.660322ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -2401,7 +2401,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-info?project_id=8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8
+        url: https://api.scaleway.com/mnq/v1beta1/regions/fr-par/sqs-info?project_id=9fc11550-d58f-45a2-96f9-99efd4e86520
         method: GET
       response:
         proto: HTTP/2.0
@@ -2411,7 +2411,7 @@ interactions:
         trailer: {}
         content_length: 233
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:56.385930Z","project_id":"8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"enabled","updated_at":"2026-05-04T12:38:56.385930Z"}'
+        body: '{"created_at":"2026-07-03T15:10:16.389044Z","project_id":"9fc11550-d58f-45a2-96f9-99efd4e86520","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"enabled","updated_at":"2026-07-03T15:10:16.389044Z"}'
         headers:
             Content-Length:
                 - "233"
@@ -2420,9 +2420,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:40:11 GMT
+                - Fri, 03 Jul 2026 15:11:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2430,10 +2430,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 20effb5e-4402-4b42-803d-37ce9ef1292c
+                - 94eb0b77-d9ac-4586-b70f-3213f9a09d9b
         status: 200 OK
         code: 200
-        duration: 37.744168ms
+        duration: 105.964836ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -2450,7 +2450,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/8b507596-7733-484b-82c5-91fecccd814d
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/56012fe3-d7c9-4b22-a421-e88c3725f15f
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2460,7 +2460,7 @@ interactions:
         trailer: {}
         content_length: 742
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:28.589595Z","description":"","domain_name":"testfunctiontriggersim5bvl17-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"8b507596-7733-484b-82c5-91fecccd814d","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"c9093822-0b88-46fb-a16e-5af99da04a23","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node22","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:40:11.379253275Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:10:24.369154Z","description":"","domain_name":"testfunctiontriggerskqbuanql-test-function-trigger-sqs.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"handler.handle","http_option":"enabled","id":"56012fe3-d7c9-4b22-a421-e88c3725f15f","max_scale":20,"memory_limit":256,"min_scale":0,"name":"test-function-trigger-sqs","namespace_id":"47c8f9d2-3565-4e7f-ba42-55aca2ddf6a9","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"node26","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:11:10.268100167Z"}'
         headers:
             Content-Length:
                 - "742"
@@ -2469,9 +2469,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:40:11 GMT
+                - Fri, 03 Jul 2026 15:11:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2479,11 +2479,60 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b494b14a-d164-4c4e-8cce-5fbf129c5f97
+                - c7a6caf0-7436-44f9-a024-4033e2c7b255
         status: 200 OK
         code: 200
-        duration: 136.564692ms
+        duration: 342.735111ms
     - id: 50
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/47c8f9d2-3565-4e7f-ba42-55aca2ddf6a9
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 594
+        uncompressed: false
+        body: '{"created_at":"2026-07-03T15:10:18.273195Z","description":"","environment_variables":{},"error_message":null,"id":"47c8f9d2-3565-4e7f-ba42-55aca2ddf6a9","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"9fc11550-d58f-45a2-96f9-99efd4e86520","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggerskqbuanql","registry_namespace_id":"38d230bc-4612-4eda-8b6b-89d61fe55812","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:10:22.102688Z","vpc_integration_activated":false}'
+        headers:
+            Content-Length:
+                - "594"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 03 Jul 2026 15:11:10 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3634e3e9-2b29-4266-949e-43be3996f217
+        status: 200 OK
+        code: 200
+        duration: 130.403396ms
+    - id: 51
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2494,7 +2543,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"project_id":"8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8"}'
+        body: '{"project_id":"9fc11550-d58f-45a2-96f9-99efd4e86520"}'
         form: {}
         headers:
             Content-Type:
@@ -2511,7 +2560,7 @@ interactions:
         trailer: {}
         content_length: 184
         uncompressed: false
-        body: '{"created_at":null,"project_id":"8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"disabled","updated_at":null}'
+        body: '{"created_at":null,"project_id":"9fc11550-d58f-45a2-96f9-99efd4e86520","region":"fr-par","sqs_endpoint_url":"https://sqs.mnq.fr-par.scaleway.com","status":"disabled","updated_at":null}'
         headers:
             Content-Length:
                 - "184"
@@ -2520,9 +2569,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:40:11 GMT
+                - Fri, 03 Jul 2026 15:11:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2530,59 +2579,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 422376e9-f3b4-4c65-b46d-bdc8b5a4de98
+                - 00b757fc-b639-487c-a34b-6af91a108e8c
         status: 200 OK
         code: 200
-        duration: 132.693186ms
-    - id: 51
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/c9093822-0b88-46fb-a16e-5af99da04a23
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 594
-        uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.961631Z","description":"","environment_variables":{},"error_message":null,"id":"c9093822-0b88-46fb-a16e-5af99da04a23","name":"test-function-trigger-sqs","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersim5bvl17","registry_namespace_id":"f4198993-f952-479f-8310-bb8e64f493a4","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:23.753190Z","vpc_integration_activated":false}'
-        headers:
-            Content-Length:
-                - "594"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 04 May 2026 12:40:11 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 9d573af8-5b37-41fc-a0dd-e7c1250215c3
-        status: 200 OK
-        code: 200
-        duration: 44.136447ms
+        duration: 356.26732ms
     - id: 52
       request:
         proto: HTTP/1.1
@@ -2599,7 +2599,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/c9093822-0b88-46fb-a16e-5af99da04a23
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/47c8f9d2-3565-4e7f-ba42-55aca2ddf6a9
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2609,7 +2609,7 @@ interactions:
         trailer: {}
         content_length: 600
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.961631Z","description":"","environment_variables":{},"error_message":null,"id":"c9093822-0b88-46fb-a16e-5af99da04a23","name":"test-function-trigger-sqs","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersim5bvl17","registry_namespace_id":"f4198993-f952-479f-8310-bb8e64f493a4","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-05-04T12:40:11.579674684Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:10:18.273195Z","description":"","environment_variables":{},"error_message":null,"id":"47c8f9d2-3565-4e7f-ba42-55aca2ddf6a9","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"9fc11550-d58f-45a2-96f9-99efd4e86520","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggerskqbuanql","registry_namespace_id":"38d230bc-4612-4eda-8b6b-89d61fe55812","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-07-03T15:11:10.708209004Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "600"
@@ -2618,9 +2618,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:40:11 GMT
+                - Fri, 03 Jul 2026 15:11:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2628,10 +2628,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - af54aa55-c463-464f-978c-2fb1bded0686
+                - 32674c2c-16dd-4af6-9460-4b473c057f4e
         status: 200 OK
         code: 200
-        duration: 447.515448ms
+        duration: 335.72295ms
     - id: 53
       request:
         proto: HTTP/1.1
@@ -2648,7 +2648,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/c9093822-0b88-46fb-a16e-5af99da04a23
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/47c8f9d2-3565-4e7f-ba42-55aca2ddf6a9
         method: GET
       response:
         proto: HTTP/2.0
@@ -2658,7 +2658,7 @@ interactions:
         trailer: {}
         content_length: 597
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.961631Z","description":"","environment_variables":{},"error_message":null,"id":"c9093822-0b88-46fb-a16e-5af99da04a23","name":"test-function-trigger-sqs","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggersim5bvl17","registry_namespace_id":"f4198993-f952-479f-8310-bb8e64f493a4","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-05-04T12:40:11.579675Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:10:18.273195Z","description":"","environment_variables":{},"error_message":null,"id":"47c8f9d2-3565-4e7f-ba42-55aca2ddf6a9","name":"test-function-trigger-sqs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"9fc11550-d58f-45a2-96f9-99efd4e86520","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestfunctiontriggerskqbuanql","registry_namespace_id":"38d230bc-4612-4eda-8b6b-89d61fe55812","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-07-03T15:11:10.708209Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
                 - "597"
@@ -2667,9 +2667,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:40:12 GMT
+                - Fri, 03 Jul 2026 15:11:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2677,10 +2677,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 97929400-bb52-4378-93f4-521422740929
+                - 1135343c-fcab-497e-b3d2-343e6c6b88d0
         status: 200 OK
         code: 200
-        duration: 31.466885ms
+        duration: 156.946943ms
     - id: 54
       request:
         proto: HTTP/1.1
@@ -2697,7 +2697,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/c9093822-0b88-46fb-a16e-5af99da04a23
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/47c8f9d2-3565-4e7f-ba42-55aca2ddf6a9
         method: GET
       response:
         proto: HTTP/2.0
@@ -2716,9 +2716,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:40:42 GMT
+                - Fri, 03 Jul 2026 15:11:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2726,10 +2726,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b4ccac1d-d56b-474c-a362-f4e594349c39
+                - e64e4771-c5c0-4c45-8912-3f30a6a894a7
         status: 404 Not Found
         code: 404
-        duration: 22.247079ms
+        duration: 24.008111ms
     - id: 55
       request:
         proto: HTTP/1.1
@@ -2746,7 +2746,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/account/v3/projects/8cdbfab3-ef18-40fd-9a54-67d13d4ec8a8
+        url: https://api.scaleway.com/account/v3/projects/9fc11550-d58f-45a2-96f9-99efd4e86520
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2763,9 +2763,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:40:43 GMT
+                - Fri, 03 Jul 2026 15:11:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2773,10 +2773,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7fe5c08b-d831-4b01-aced-be30517cd8c6
+                - 56b28f65-3680-4c84-a7c2-ea7d24426b25
         status: 204 No Content
         code: 204
-        duration: 1.455395829s
+        duration: 1.638817534s
     - id: 56
       request:
         proto: HTTP/1.1
@@ -2793,7 +2793,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/af5909c0-8109-46d7-bcb1-dfc7d75d6444
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/triggers/e37815fb-e326-47ad-9b30-e2a50ac6be7f
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2803,7 +2803,7 @@ interactions:
         trailer: {}
         content_length: 105
         uncompressed: false
-        body: '{"message":"trigger does not exist: could not find trigger with id af5909c0-8109-46d7-bcb1-dfc7d75d6444"}'
+        body: '{"message":"trigger does not exist: could not find trigger with id e37815fb-e326-47ad-9b30-e2a50ac6be7f"}'
         headers:
             Content-Length:
                 - "105"
@@ -2812,9 +2812,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:40:43 GMT
+                - Fri, 03 Jul 2026 15:11:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2822,7 +2822,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4e52a544-5f59-45d7-99ab-64c78f01621d
+                - 03490637-6a94-412f-9937-9e43fc7e893f
         status: 404 Not Found
         code: 404
-        duration: 29.455987ms
+        duration: 35.3118ms

--- a/internal/services/function/testdata/function-upload.cassette.yaml
+++ b/internal/services/function/testdata/function-upload.cassette.yaml
@@ -6,13 +6,13 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 158
+        content_length: 157
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-func-clever-lalande","environment_variables":{},"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","secret_environment_variables":[],"tags":null}'
+        body: '{"name":"tf-func-cocky-hodgkin","environment_variables":{},"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","secret_environment_variables":[],"tags":null}'
         form: {}
         headers:
             Content-Type:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 508
+        content_length: 507
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.886111169Z","description":"","environment_variables":{},"error_message":null,"id":"4164012c-df2f-4dd5-88e5-e5585453f051","name":"tf-func-clever-lalande","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-05-04T12:38:57.886111169Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:02:16.408786508Z","description":"","environment_variables":{},"error_message":null,"id":"d266190b-2d04-4537-b091-fd05297366fe","name":"tf-func-cocky-hodgkin","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-07-03T15:02:16.408786508Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "508"
+                - "507"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:38:57 GMT
+                - Fri, 03 Jul 2026 15:02:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c7759a21-fdf7-4c56-9c24-ac288ba6d052
+                - 9f23b9b4-157a-4d77-8d45-cc49634803cc
         status: 200 OK
         code: 200
-        duration: 1.898081106s
+        duration: 5.402082057s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -68,7 +68,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/4164012c-df2f-4dd5-88e5-e5585453f051
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d266190b-2d04-4537-b091-fd05297366fe
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 502
+        content_length: 501
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.886111Z","description":"","environment_variables":{},"error_message":null,"id":"4164012c-df2f-4dd5-88e5-e5585453f051","name":"tf-func-clever-lalande","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-05-04T12:38:57.886111Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:02:16.408787Z","description":"","environment_variables":{},"error_message":null,"id":"d266190b-2d04-4537-b091-fd05297366fe","name":"tf-func-cocky-hodgkin","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending","tags":[],"updated_at":"2026-07-03T15:02:16.408787Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "502"
+                - "501"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:38:57 GMT
+                - Fri, 03 Jul 2026 15:02:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 99486ca2-92db-40ba-ab85-a2205a1f5707
+                - 21dce444-eb02-4d23-9aa0-e65d9800477e
         status: 200 OK
         code: 200
-        duration: 37.91995ms
+        duration: 36.876413ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -117,7 +117,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/4164012c-df2f-4dd5-88e5-e5585453f051
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d266190b-2d04-4537-b091-fd05297366fe
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,20 +125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 590
+        content_length: 588
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.886111Z","description":"","environment_variables":{},"error_message":null,"id":"4164012c-df2f-4dd5-88e5-e5585453f051","name":"tf-func-clever-lalande","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunccleverlalandebwjjhkuj","registry_namespace_id":"93bb0b0d-e417-4ac6-bafd-05897385bd70","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:17.299845Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:02:16.408787Z","description":"","environment_variables":{},"error_message":null,"id":"d266190b-2d04-4537-b091-fd05297366fe","name":"tf-func-cocky-hodgkin","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunccockyhodgkincm5fqssj","registry_namespace_id":"a7122c0c-57b0-4966-9965-589811c85003","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:18.372954Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "590"
+                - "588"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:18 GMT
+                - Fri, 03 Jul 2026 15:02:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1bb66bd2-5b38-44f0-a460-89df7cd00163
+                - e978041c-f2f9-4b66-876a-48d6cc9f7103
         status: 200 OK
         code: 200
-        duration: 36.533757ms
+        duration: 33.325755ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -166,7 +166,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/4164012c-df2f-4dd5-88e5-e5585453f051
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d266190b-2d04-4537-b091-fd05297366fe
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,20 +174,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 590
+        content_length: 588
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.886111Z","description":"","environment_variables":{},"error_message":null,"id":"4164012c-df2f-4dd5-88e5-e5585453f051","name":"tf-func-clever-lalande","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunccleverlalandebwjjhkuj","registry_namespace_id":"93bb0b0d-e417-4ac6-bafd-05897385bd70","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:17.299845Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:02:16.408787Z","description":"","environment_variables":{},"error_message":null,"id":"d266190b-2d04-4537-b091-fd05297366fe","name":"tf-func-cocky-hodgkin","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunccockyhodgkincm5fqssj","registry_namespace_id":"a7122c0c-57b0-4966-9965-589811c85003","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:18.372954Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "590"
+                - "588"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:18 GMT
+                - Fri, 03 Jul 2026 15:02:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,10 +195,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 185a160e-73ca-4ef1-a65b-b8ab2f2ab917
+                - 1981e7d7-c94a-4234-b85d-a7a15c5f41ed
         status: 200 OK
         code: 200
-        duration: 224.96214ms
+        duration: 36.233023ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -210,7 +210,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"foobar","namespace_id":"4164012c-df2f-4dd5-88e5-e5585453f051","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"go122","memory_limit":256,"handler":"Handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox","tags":null}'
+        body: '{"name":"foobar","namespace_id":"d266190b-2d04-4537-b091-fd05297366fe","environment_variables":{},"min_scale":0,"max_scale":20,"runtime":"go126","memory_limit":256,"handler":"Handle","privacy":"private","secret_environment_variables":[],"http_option":"enabled","sandbox":"unknown_sandbox","tags":null}'
         form: {}
         headers:
             Content-Type:
@@ -225,20 +225,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 696
+        content_length: 695
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:18.401494202Z","description":"","domain_name":"tffunccleverlalandebwjjhkuj-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"4c70f24b-bf88-4ab7-8cbe-e4f7b58551a2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"4164012c-df2f-4dd5-88e5-e5585453f051","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:18.401494202Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:21.619921447Z","description":"","domain_name":"tffunccockyhodgkincm5fqssj-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"5a20b944-9a0d-4ba2-8ab2-72b2cff70a03","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"d266190b-2d04-4537-b091-fd05297366fe","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:21.619921447Z"}'
         headers:
             Content-Length:
-                - "696"
+                - "695"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:18 GMT
+                - Fri, 03 Jul 2026 15:02:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -246,10 +246,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0c1920ae-e1b5-4e57-8aae-eba7a50206ef
+                - 8798fbec-f007-4c14-b2f8-fb6e0841ccbe
         status: 200 OK
         code: 200
-        duration: 87.091811ms
+        duration: 82.720712ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -266,7 +266,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4c70f24b-bf88-4ab7-8cbe-e4f7b58551a2/upload-url?content_length=780
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/5a20b944-9a0d-4ba2-8ab2-72b2cff70a03/upload-url?content_length=780
         method: GET
       response:
         proto: HTTP/2.0
@@ -276,7 +276,7 @@ interactions:
         trailer: {}
         content_length: 510
         uncompressed: false
-        body: '{"headers":{"content-length":["780"],"content-type":["application/octet-stream"]},"url":"https://s3.fr-par.scw.cloud/serverless-functions-code-prod-fr-par/uploads/function-4c70f24b-bf88-4ab7-8cbe-e4f7b58551a2.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=SCW0KAMQFQV1YYSZK2PF%2F20260504%2Ffr-par%2Fs3%2Faws4_request\u0026X-Amz-Date=20260504T123918Z\u0026X-Amz-Expires=3600\u0026X-Amz-SignedHeaders=content-length%3Bcontent-type%3Bhost\u0026X-Amz-Signature=ac4b02b7475dc6934d47db8a5b309ad427f41aaa5cbda3934f626c6991aae582"}'
+        body: '{"headers":{"content-length":["780"],"content-type":["application/octet-stream"]},"url":"https://s3.fr-par.scw.cloud/serverless-functions-code-prod-fr-par/uploads/function-5a20b944-9a0d-4ba2-8ab2-72b2cff70a03.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=SCW0KAMQFQV1YYSZK2PF%2F20260703%2Ffr-par%2Fs3%2Faws4_request\u0026X-Amz-Date=20260703T150221Z\u0026X-Amz-Expires=3600\u0026X-Amz-SignedHeaders=content-length%3Bcontent-type%3Bhost\u0026X-Amz-Signature=2fcbcd16ed3a3765370a1e870ebe04a9a6f40c9c388c2e58134c2797ac03037e"}'
         headers:
             Content-Length:
                 - "510"
@@ -285,9 +285,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:18 GMT
+                - Fri, 03 Jul 2026 15:02:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -295,10 +295,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a0fe4c5f-b107-487b-bf88-6e48aacb85c7
+                - a8f19818-5fc4-48d6-a287-77494c7b8b94
         status: 200 OK
         code: 200
-        duration: 61.311316ms
+        duration: 48.866022ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -332,7 +332,7 @@ interactions:
                 - "780"
             Content-Type:
                 - application/octet-stream
-        url: https://s3.fr-par.scw.cloud/serverless-functions-code-prod-fr-par/uploads/function-4c70f24b-bf88-4ab7-8cbe-e4f7b58551a2.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=SCW0KAMQFQV1YYSZK2PF%2F20260504%2Ffr-par%2Fs3%2Faws4_request&X-Amz-Date=20260504T123918Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=content-length%3Bcontent-type%3Bhost&X-Amz-Signature=ac4b02b7475dc6934d47db8a5b309ad427f41aaa5cbda3934f626c6991aae582
+        url: https://s3.fr-par.scw.cloud/serverless-functions-code-prod-fr-par/uploads/function-5a20b944-9a0d-4ba2-8ab2-72b2cff70a03.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=SCW0KAMQFQV1YYSZK2PF%2F20260703%2Ffr-par%2Fs3%2Faws4_request&X-Amz-Date=20260703T150221Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=content-length%3Bcontent-type%3Bhost&X-Amz-Signature=2fcbcd16ed3a3765370a1e870ebe04a9a6f40c9c388c2e58134c2797ac03037e
         method: PUT
       response:
         proto: HTTP/2.0
@@ -347,16 +347,16 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 04 May 2026 12:39:18 GMT
+                - Fri, 03 Jul 2026 15:02:21 GMT
             Etag:
                 - '"10633bf7a5ff211d8f3eee3856a28101"'
             X-Amz-Id-2:
-                - txg352690cfdf4a4afcb276-0069f89376
+                - txg0ade4eceb78149e293c9-006a47cefd
             X-Amz-Request-Id:
-                - txg352690cfdf4a4afcb276-0069f89376
+                - txg0ade4eceb78149e293c9-006a47cefd
         status: 200 OK
         code: 200
-        duration: 182.525977ms
+        duration: 2.01615043s
     - id: 7
       request:
         proto: HTTP/1.1
@@ -373,7 +373,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4c70f24b-bf88-4ab7-8cbe-e4f7b58551a2
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/5a20b944-9a0d-4ba2-8ab2-72b2cff70a03
         method: GET
       response:
         proto: HTTP/2.0
@@ -381,20 +381,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 690
+        content_length: 689
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:18.401494Z","description":"","domain_name":"tffunccleverlalandebwjjhkuj-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"4c70f24b-bf88-4ab7-8cbe-e4f7b58551a2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"4164012c-df2f-4dd5-88e5-e5585453f051","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:18.401494Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:21.619921Z","description":"","domain_name":"tffunccockyhodgkincm5fqssj-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"5a20b944-9a0d-4ba2-8ab2-72b2cff70a03","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"d266190b-2d04-4537-b091-fd05297366fe","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:21.619921Z"}'
         headers:
             Content-Length:
-                - "690"
+                - "689"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:18 GMT
+                - Fri, 03 Jul 2026 15:02:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -402,10 +402,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 541d1a0e-51a0-41b1-b2b7-31311e7801a6
+                - 02d65f16-c6d7-4732-b6cc-0e240fc1cdf3
         status: 200 OK
         code: 200
-        duration: 45.609813ms
+        duration: 43.0483ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -422,7 +422,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4c70f24b-bf88-4ab7-8cbe-e4f7b58551a2
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/5a20b944-9a0d-4ba2-8ab2-72b2cff70a03
         method: GET
       response:
         proto: HTTP/2.0
@@ -430,20 +430,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 690
+        content_length: 689
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:18.401494Z","description":"","domain_name":"tffunccleverlalandebwjjhkuj-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"4c70f24b-bf88-4ab7-8cbe-e4f7b58551a2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"4164012c-df2f-4dd5-88e5-e5585453f051","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:18.401494Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:21.619921Z","description":"","domain_name":"tffunccockyhodgkincm5fqssj-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"5a20b944-9a0d-4ba2-8ab2-72b2cff70a03","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"d266190b-2d04-4537-b091-fd05297366fe","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:21.619921Z"}'
         headers:
             Content-Length:
-                - "690"
+                - "689"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:18 GMT
+                - Fri, 03 Jul 2026 15:02:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -451,10 +451,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e9888876-5892-4e4c-9c29-161e686e0180
+                - d0734d98-0d24-4f9e-a2b6-71ef8a3efd31
         status: 200 OK
         code: 200
-        duration: 43.8219ms
+        duration: 37.962405ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -471,7 +471,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4c70f24b-bf88-4ab7-8cbe-e4f7b58551a2
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/5a20b944-9a0d-4ba2-8ab2-72b2cff70a03
         method: GET
       response:
         proto: HTTP/2.0
@@ -479,20 +479,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 690
+        content_length: 689
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:18.401494Z","description":"","domain_name":"tffunccleverlalandebwjjhkuj-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"4c70f24b-bf88-4ab7-8cbe-e4f7b58551a2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"4164012c-df2f-4dd5-88e5-e5585453f051","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:18.401494Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:21.619921Z","description":"","domain_name":"tffunccockyhodgkincm5fqssj-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"5a20b944-9a0d-4ba2-8ab2-72b2cff70a03","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"d266190b-2d04-4537-b091-fd05297366fe","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:21.619921Z"}'
         headers:
             Content-Length:
-                - "690"
+                - "689"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:18 GMT
+                - Fri, 03 Jul 2026 15:02:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -500,10 +500,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0e66bdc7-5524-43e4-b7d0-a4ce5f9dd21e
+                - 86be902f-54bb-4391-9058-fbd822aa39a8
         status: 200 OK
         code: 200
-        duration: 42.93971ms
+        duration: 38.104442ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -520,7 +520,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/4164012c-df2f-4dd5-88e5-e5585453f051
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d266190b-2d04-4537-b091-fd05297366fe
         method: GET
       response:
         proto: HTTP/2.0
@@ -528,20 +528,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 590
+        content_length: 588
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.886111Z","description":"","environment_variables":{},"error_message":null,"id":"4164012c-df2f-4dd5-88e5-e5585453f051","name":"tf-func-clever-lalande","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunccleverlalandebwjjhkuj","registry_namespace_id":"93bb0b0d-e417-4ac6-bafd-05897385bd70","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:17.299845Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:02:16.408787Z","description":"","environment_variables":{},"error_message":null,"id":"d266190b-2d04-4537-b091-fd05297366fe","name":"tf-func-cocky-hodgkin","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunccockyhodgkincm5fqssj","registry_namespace_id":"a7122c0c-57b0-4966-9965-589811c85003","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:18.372954Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "590"
+                - "588"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:19 GMT
+                - Fri, 03 Jul 2026 15:02:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -549,10 +549,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 74ed7f1b-edbf-4031-9eb9-6ccf91affca0
+                - 2bbee263-6484-4a49-9e0f-76bd115f6520
         status: 200 OK
         code: 200
-        duration: 41.299324ms
+        duration: 29.211667ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -569,7 +569,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4c70f24b-bf88-4ab7-8cbe-e4f7b58551a2
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/5a20b944-9a0d-4ba2-8ab2-72b2cff70a03
         method: GET
       response:
         proto: HTTP/2.0
@@ -577,20 +577,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 690
+        content_length: 689
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:18.401494Z","description":"","domain_name":"tffunccleverlalandebwjjhkuj-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"4c70f24b-bf88-4ab7-8cbe-e4f7b58551a2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"4164012c-df2f-4dd5-88e5-e5585453f051","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:18.401494Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:21.619921Z","description":"","domain_name":"tffunccockyhodgkincm5fqssj-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"5a20b944-9a0d-4ba2-8ab2-72b2cff70a03","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"d266190b-2d04-4537-b091-fd05297366fe","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:21.619921Z"}'
         headers:
             Content-Length:
-                - "690"
+                - "689"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:19 GMT
+                - Fri, 03 Jul 2026 15:02:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -598,10 +598,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f43e1c93-12e0-4a68-ae1d-85ffdf82962b
+                - ffdac8b7-2549-405e-a521-56de05f22b2d
         status: 200 OK
         code: 200
-        duration: 41.263236ms
+        duration: 47.672667ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -618,7 +618,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4c70f24b-bf88-4ab7-8cbe-e4f7b58551a2
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/5a20b944-9a0d-4ba2-8ab2-72b2cff70a03
         method: GET
       response:
         proto: HTTP/2.0
@@ -626,20 +626,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 690
+        content_length: 689
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:18.401494Z","description":"","domain_name":"tffunccleverlalandebwjjhkuj-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"4c70f24b-bf88-4ab7-8cbe-e4f7b58551a2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"4164012c-df2f-4dd5-88e5-e5585453f051","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:18.401494Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:21.619921Z","description":"","domain_name":"tffunccockyhodgkincm5fqssj-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"5a20b944-9a0d-4ba2-8ab2-72b2cff70a03","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"d266190b-2d04-4537-b091-fd05297366fe","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"created","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:21.619921Z"}'
         headers:
             Content-Length:
-                - "690"
+                - "689"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:19 GMT
+                - Fri, 03 Jul 2026 15:02:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -647,10 +647,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 88f99bfb-c260-4cf4-9bba-f0f0b787ac23
+                - 336edde1-16ce-46ef-a3e2-e399978aabee
         status: 200 OK
         code: 200
-        duration: 46.155591ms
+        duration: 32.088238ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -667,7 +667,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4c70f24b-bf88-4ab7-8cbe-e4f7b58551a2
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/5a20b944-9a0d-4ba2-8ab2-72b2cff70a03
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -675,20 +675,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 694
+        content_length: 693
         uncompressed: false
-        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-05-04T12:39:18.401494Z","description":"","domain_name":"tffunccleverlalandebwjjhkuj-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"4c70f24b-bf88-4ab7-8cbe-e4f7b58551a2","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"4164012c-df2f-4dd5-88e5-e5585453f051","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go122","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2026-05-04T12:39:19.557098304Z"}'
+        body: '{"build_message":null,"cpu_limit":140,"created_at":"2026-07-03T15:02:21.619921Z","description":"","domain_name":"tffunccockyhodgkincm5fqssj-foobar.functions.fnc.fr-par.scw.cloud","environment_variables":{},"error_message":null,"handler":"Handle","http_option":"enabled","id":"5a20b944-9a0d-4ba2-8ab2-72b2cff70a03","max_scale":20,"memory_limit":256,"min_scale":0,"name":"foobar","namespace_id":"d266190b-2d04-4537-b091-fd05297366fe","privacy":"private","private_network_id":null,"ready_at":null,"region":"fr-par","runtime":"go126","runtime_message":"","sandbox":"v2","secret_environment_variables":[],"status":"deleting","tags":[],"timeout":"300s","updated_at":"2026-07-03T15:02:24.576708265Z"}'
         headers:
             Content-Length:
-                - "694"
+                - "693"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:19 GMT
+                - Fri, 03 Jul 2026 15:02:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -696,10 +696,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1757de3f-b124-4524-9c75-5cd755c76a95
+                - e07ab85d-230b-4059-b0be-aab3934189c3
         status: 200 OK
         code: 200
-        duration: 167.531297ms
+        duration: 216.953088ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -716,7 +716,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/4164012c-df2f-4dd5-88e5-e5585453f051
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d266190b-2d04-4537-b091-fd05297366fe
         method: GET
       response:
         proto: HTTP/2.0
@@ -724,20 +724,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 590
+        content_length: 588
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.886111Z","description":"","environment_variables":{},"error_message":null,"id":"4164012c-df2f-4dd5-88e5-e5585453f051","name":"tf-func-clever-lalande","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunccleverlalandebwjjhkuj","registry_namespace_id":"93bb0b0d-e417-4ac6-bafd-05897385bd70","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-05-04T12:39:17.299845Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:02:16.408787Z","description":"","environment_variables":{},"error_message":null,"id":"d266190b-2d04-4537-b091-fd05297366fe","name":"tf-func-cocky-hodgkin","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunccockyhodgkincm5fqssj","registry_namespace_id":"a7122c0c-57b0-4966-9965-589811c85003","secret_environment_variables":[],"status":"ready","tags":[],"updated_at":"2026-07-03T15:02:18.372954Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "590"
+                - "588"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:19 GMT
+                - Fri, 03 Jul 2026 15:02:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -745,10 +745,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - df02114a-d680-46f6-8fd1-788f02fef981
+                - 80b737a6-3733-44fe-97db-d3b0669b7839
         status: 200 OK
         code: 200
-        duration: 27.717771ms
+        duration: 26.85722ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -765,7 +765,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/4164012c-df2f-4dd5-88e5-e5585453f051
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d266190b-2d04-4537-b091-fd05297366fe
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -773,20 +773,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 596
+        content_length: 594
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.886111Z","description":"","environment_variables":{},"error_message":null,"id":"4164012c-df2f-4dd5-88e5-e5585453f051","name":"tf-func-clever-lalande","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunccleverlalandebwjjhkuj","registry_namespace_id":"93bb0b0d-e417-4ac6-bafd-05897385bd70","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-05-04T12:39:19.736861699Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:02:16.408787Z","description":"","environment_variables":{},"error_message":null,"id":"d266190b-2d04-4537-b091-fd05297366fe","name":"tf-func-cocky-hodgkin","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunccockyhodgkincm5fqssj","registry_namespace_id":"a7122c0c-57b0-4966-9965-589811c85003","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-07-03T15:02:24.811336754Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "596"
+                - "594"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:20 GMT
+                - Fri, 03 Jul 2026 15:02:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -794,10 +794,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ae5b2dfa-38c0-46d9-82ad-feb85011c881
+                - 1f406f92-795d-45c7-9e31-c13e79b2e26a
         status: 200 OK
         code: 200
-        duration: 750.771054ms
+        duration: 303.560309ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -814,7 +814,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/4164012c-df2f-4dd5-88e5-e5585453f051
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d266190b-2d04-4537-b091-fd05297366fe
         method: GET
       response:
         proto: HTTP/2.0
@@ -822,20 +822,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 593
+        content_length: 591
         uncompressed: false
-        body: '{"created_at":"2026-05-04T12:38:57.886111Z","description":"","environment_variables":{},"error_message":null,"id":"4164012c-df2f-4dd5-88e5-e5585453f051","name":"tf-func-clever-lalande","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunccleverlalandebwjjhkuj","registry_namespace_id":"93bb0b0d-e417-4ac6-bafd-05897385bd70","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-05-04T12:39:19.736862Z","vpc_integration_activated":false}'
+        body: '{"created_at":"2026-07-03T15:02:16.408787Z","description":"","environment_variables":{},"error_message":null,"id":"d266190b-2d04-4537-b091-fd05297366fe","name":"tf-func-cocky-hodgkin","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","registry_endpoint":"rg.fr-par.scw.cloud/funcscwtffunccockyhodgkincm5fqssj","registry_namespace_id":"a7122c0c-57b0-4966-9965-589811c85003","secret_environment_variables":[],"status":"deleting","tags":[],"updated_at":"2026-07-03T15:02:24.811337Z","vpc_integration_activated":false}'
         headers:
             Content-Length:
-                - "593"
+                - "591"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:20 GMT
+                - Fri, 03 Jul 2026 15:02:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -843,10 +843,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7a0fe9e0-4fa0-46cc-9186-a459ad015bc7
+                - 1d645a77-d4f6-4781-b714-9da277e1c047
         status: 200 OK
         code: 200
-        duration: 35.493941ms
+        duration: 34.305978ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -863,7 +863,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/4164012c-df2f-4dd5-88e5-e5585453f051
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/namespaces/d266190b-2d04-4537-b091-fd05297366fe
         method: GET
       response:
         proto: HTTP/2.0
@@ -882,9 +882,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:50 GMT
+                - Fri, 03 Jul 2026 15:02:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -892,10 +892,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4bab5780-f10e-4495-8b83-e1db01e9d5ab
+                - fcf15791-efe3-4153-aea8-94ce61f95b3e
         status: 404 Not Found
         code: 404
-        duration: 22.045422ms
+        duration: 25.440906ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -912,7 +912,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/4c70f24b-bf88-4ab7-8cbe-e4f7b58551a2
+        url: https://api.scaleway.com/functions/v1beta1/regions/fr-par/functions/5a20b944-9a0d-4ba2-8ab2-72b2cff70a03
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -931,9 +931,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 04 May 2026 12:39:50 GMT
+                - Fri, 03 Jul 2026 15:02:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -941,7 +941,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9752ac70-122d-463f-b7dc-6e017c890736
+                - e3d101e3-13c9-48f6-9a91-b8fb6e178eb3
         status: 404 Not Found
         code: 404
-        duration: 20.815578ms
+        duration: 20.282034ms

--- a/internal/services/function/token_test.go
+++ b/internal/services/function/token_test.go
@@ -36,7 +36,7 @@ func TestAccFunctionToken_Basic(t *testing.T) {
 
 					resource scaleway_function main {
 						namespace_id = scaleway_function_namespace.main.id
-						runtime = "node22"
+						runtime = "node26"
 						privacy = "private"
 						handler = "handler.handle"
 					}

--- a/internal/services/function/token_test.go
+++ b/internal/services/function/token_test.go
@@ -21,7 +21,7 @@ func TestAccFunctionToken_Basic(t *testing.T) {
 	if !*acctest.UpdateCassettes {
 		// This hardcoded value has to be replaced with the expiration in cassettes.
 		// Should be in the first "POST /tokens" request.
-		expiresAt = "2026-05-05T14:37:48+02:00"
+		expiresAt = "2026-07-04T18:49:39+02:00"
 	}
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/services/function/trigger_test.go
+++ b/internal/services/function/trigger_test.go
@@ -29,7 +29,7 @@ func TestAccFunctionTrigger_SQS(t *testing.T) {
 					resource scaleway_function main {
 						name = "test-function-trigger-sqs"
 						namespace_id = scaleway_function_namespace.main.id
-						runtime = "node22"
+						runtime = "node26"
 						privacy = "private"
 						handler = "handler.handle"
 					}
@@ -100,7 +100,7 @@ func TestAccFunctionTrigger_Nats(t *testing.T) {
 					resource scaleway_function main {
 						name = "test-function-trigger-sqs"
 						namespace_id = scaleway_function_namespace.main.id
-						runtime = "node22"
+						runtime = "node26"
 						privacy = "private"
 						handler = "handler.handle"
 					}
@@ -159,7 +159,7 @@ func TestAccFunctionTrigger_Error(t *testing.T) {
 					resource scaleway_function main {
 						name = "test-function-trigger-error"
 						namespace_id = scaleway_function_namespace.main.id
-						runtime = "node22"
+						runtime = "node26"
 						privacy = "private"
 						handler = "handler.handle"
 					}


### PR DESCRIPTION
This PR updates all the function runtimes in the tests since most have reached End Of Life.
This should fix the nightly tests for the `function` package.