### PR TITLE
fix(k8s): make new autoscaler fields computed

### DIFF
--- a/internal/services/k8s/cluster.go
+++ b/internal/services/k8s/cluster.go
@@ -1117,12 +1117,14 @@ func autoscalerConfigSchema() *schema.Resource {
 			"skip_nodes_with_local_storage": {
 				Type:        schema.TypeBool,
 				Optional:    true,
+				Computed:    true,
 				ForceNew:    true,
 				Description: "If true, the autoscaler will never delete nodes with pods with local storage, e.g. EmptyDir or HostPath.",
 			},
 			"log_level": {
 				Type:        schema.TypeInt,
 				Optional:    true,
+				Computed:    true,
 				ForceNew:    true,
 				Description: "Autoscaler logging level expressed from 0 to 4 (4 being the more verbose).",
 			},


### PR DESCRIPTION
#4132 did not fix the issue because Terraform still detects unwanted changes, but with a null value this time :
```
      ~ autoscaler_config {
          - log_level                        = 2 -> null # forces replacement
          - skip_nodes_with_local_storage    = true -> null # forces replacement
            # (10 unchanged attributes hidden)
        }
```

This PR makes the fields computed so that Terraform takes the value from the API when not set.