### PR TITLE
chore: bump sdk go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/nats-io/jwt/v2 v2.8.1
 	github.com/nats-io/nats.go v1.52.0
 	github.com/robfig/cron/v3 v3.0.1
-	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.36.0.20260619072639-abd6ee9c3b3a
+	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.36.0.20260703162743-f8787d0d7041
 	github.com/stretchr/testify v1.11.1
 	go.yaml.in/yaml/v4 v4.0.0-rc.6
 	golang.org/x/crypto v0.52.0

--- a/go.sum
+++ b/go.sum
@@ -459,8 +459,8 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/scaleway/scaleway-sdk-go v1.0.0-beta.36.0.20260619072639-abd6ee9c3b3a h1:yFio/CqDs1fZWl2pua1OgDJTCw+ydF7T64A/N4wb2m0=
-github.com/scaleway/scaleway-sdk-go v1.0.0-beta.36.0.20260619072639-abd6ee9c3b3a/go.mod h1:Q02gKOXqKfaCTpImuDgOLzlGin79ZoxxKKEhXHKSrPw=
+github.com/scaleway/scaleway-sdk-go v1.0.0-beta.36.0.20260703162743-f8787d0d7041 h1:Na9Yob/d/qd4jxef1ioJ7gEDTTvUYBhmnHtiYNlhj5o=
+github.com/scaleway/scaleway-sdk-go v1.0.0-beta.36.0.20260703162743-f8787d0d7041/go.mod h1:GcpvOrlfiLMvJ4A5uduDAy33PlppHKnYYDIjMib76+4=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=

--- a/internal/services/keymanager/testdata/action-rotate-key-basic.cassette.yaml
+++ b/internal/services/keymanager/testdata/action-rotate-key-basic.cassette.yaml
@@ -6,9 +6,9 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 278
+        content_length: 232
         host: api.scaleway.com
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation-action","usage":{"symmetric_encryption":"aes_256_gcm"},"description":"Test key","tags":["tf","test"],"unprotected":true,"origin":"unknown_origin","protection_level":"unknown_protection_level"}'
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation-action","usage":{"symmetric_encryption":"aes_256_gcm"},"description":"Test key","tags":["tf","test"],"unprotected":true,"origin":"unknown_origin"}'
         headers:
             Content-Type:
                 - application/json
@@ -21,21 +21,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 554
-        body: '{"id":"866337c1-b045-426a-91c8-6d3ab6194e9e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation-action","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:23.813688Z","updated_at":"2026-07-03T15:28:23.818427Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:23.818427Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"c6345a8f-86a4-429d-8bb0-338f4320e065","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation-action","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:09.306386Z","updated_at":"2026-07-07T07:46:09.311240Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-07T07:46:09.311240Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "554"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - f9187ec5-f51c-4c93-9340-a0cb36608421
+                - 216fab02-045a-456c-9eb7-6f0d65ad8058
         status: 200 OK
         code: 200
-        duration: 95.780472ms
+        duration: 78.337011ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -46,28 +46,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/866337c1-b045-426a-91c8-6d3ab6194e9e
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/c6345a8f-86a4-429d-8bb0-338f4320e065
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 554
-        body: '{"id":"866337c1-b045-426a-91c8-6d3ab6194e9e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation-action","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:23.813688Z","updated_at":"2026-07-03T15:28:23.818427Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:23.818427Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"c6345a8f-86a4-429d-8bb0-338f4320e065","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation-action","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:09.306386Z","updated_at":"2026-07-07T07:46:09.311240Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-07T07:46:09.311240Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "554"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 8af8cc78-f618-4063-b205-f9c807a98701
+                - 72e358e2-5cb9-4aa7-a32f-5394c0345dd8
         status: 200 OK
         code: 200
-        duration: 52.104116ms
+        duration: 46.849121ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -81,28 +81,28 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/866337c1-b045-426a-91c8-6d3ab6194e9e/rotate
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/c6345a8f-86a4-429d-8bb0-338f4320e065/rotate
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 554
-        body: '{"id":"866337c1-b045-426a-91c8-6d3ab6194e9e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation-action","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":2,"created_at":"2026-07-03T15:28:23.813688Z","updated_at":"2026-07-03T15:28:24.080715Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:24.080715Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"c6345a8f-86a4-429d-8bb0-338f4320e065","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation-action","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":2,"created_at":"2026-07-07T07:46:09.306386Z","updated_at":"2026-07-07T07:46:09.492477Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-07T07:46:09.492477Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "554"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:24 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 42cf769c-81b8-4482-8bc9-7d02a92ff24c
+                - e9335332-df81-46e8-98f2-fb1fcc783437
         status: 200 OK
         code: 200
-        duration: 198.452669ms
+        duration: 132.174449ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -113,28 +113,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/866337c1-b045-426a-91c8-6d3ab6194e9e
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/c6345a8f-86a4-429d-8bb0-338f4320e065
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 554
-        body: '{"id":"866337c1-b045-426a-91c8-6d3ab6194e9e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation-action","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":2,"created_at":"2026-07-03T15:28:23.813688Z","updated_at":"2026-07-03T15:28:24.080715Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:24.080715Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"c6345a8f-86a4-429d-8bb0-338f4320e065","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation-action","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":2,"created_at":"2026-07-07T07:46:09.306386Z","updated_at":"2026-07-07T07:46:09.492477Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-07T07:46:09.492477Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "554"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:24 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 1e451726-8985-4e39-9d8f-ef3dfbf3e914
+                - 55fc27de-728f-4d3d-b1e8-5499261035b3
         status: 200 OK
         code: 200
-        duration: 47.925818ms
+        duration: 136.409824ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -145,28 +145,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/866337c1-b045-426a-91c8-6d3ab6194e9e
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/c6345a8f-86a4-429d-8bb0-338f4320e065
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 554
-        body: '{"id":"866337c1-b045-426a-91c8-6d3ab6194e9e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation-action","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":2,"created_at":"2026-07-03T15:28:23.813688Z","updated_at":"2026-07-03T15:28:24.080715Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:24.080715Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"c6345a8f-86a4-429d-8bb0-338f4320e065","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation-action","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":2,"created_at":"2026-07-07T07:46:09.306386Z","updated_at":"2026-07-07T07:46:09.492477Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-07T07:46:09.492477Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "554"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:25 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - d9a8d5d7-111e-45fc-84cd-d9d02bd1b8a0
+                - 023884e6-1b3b-48bb-bc65-05a988866c68
         status: 200 OK
         code: 200
-        duration: 41.041067ms
+        duration: 45.277477ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -177,28 +177,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/866337c1-b045-426a-91c8-6d3ab6194e9e
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/c6345a8f-86a4-429d-8bb0-338f4320e065
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 554
-        body: '{"id":"866337c1-b045-426a-91c8-6d3ab6194e9e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation-action","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":2,"created_at":"2026-07-03T15:28:23.813688Z","updated_at":"2026-07-03T15:28:24.080715Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:24.080715Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"c6345a8f-86a4-429d-8bb0-338f4320e065","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation-action","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":2,"created_at":"2026-07-07T07:46:09.306386Z","updated_at":"2026-07-07T07:46:09.492477Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-07T07:46:09.492477Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "554"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:25 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - b8c402b5-6676-4258-9807-e1f31f7a554b
+                - 70de5ce1-ea82-491f-a915-8fad200ae6ca
         status: 200 OK
         code: 200
-        duration: 51.891096ms
+        duration: 156.05433ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -209,28 +209,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/866337c1-b045-426a-91c8-6d3ab6194e9e
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/c6345a8f-86a4-429d-8bb0-338f4320e065
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 554
-        body: '{"id":"866337c1-b045-426a-91c8-6d3ab6194e9e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation-action","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":2,"created_at":"2026-07-03T15:28:23.813688Z","updated_at":"2026-07-03T15:28:24.080715Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:24.080715Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"c6345a8f-86a4-429d-8bb0-338f4320e065","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation-action","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":2,"created_at":"2026-07-07T07:46:09.306386Z","updated_at":"2026-07-07T07:46:09.492477Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-07T07:46:09.492477Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "554"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:25 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 03f16cce-4f4b-45ec-83c7-f7004280e6d5
+                - 5172abe9-0184-4e20-850f-7f02fc717efb
         status: 200 OK
         code: 200
-        duration: 43.066721ms
+        duration: 51.91797ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -241,28 +241,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/866337c1-b045-426a-91c8-6d3ab6194e9e
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/c6345a8f-86a4-429d-8bb0-338f4320e065
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 554
-        body: '{"id":"866337c1-b045-426a-91c8-6d3ab6194e9e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation-action","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":2,"created_at":"2026-07-03T15:28:23.813688Z","updated_at":"2026-07-03T15:28:24.080715Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:24.080715Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"c6345a8f-86a4-429d-8bb0-338f4320e065","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation-action","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":2,"created_at":"2026-07-07T07:46:09.306386Z","updated_at":"2026-07-07T07:46:09.492477Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-07T07:46:09.492477Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "554"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:25 GMT
+                - Tue, 07 Jul 2026 07:46:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 16a4e346-cd4e-402e-a6f5-a62501969c17
+                - 45c8def8-b796-4f9e-af69-0a9be991fa7a
         status: 200 OK
         code: 200
-        duration: 44.835343ms
+        duration: 115.065979ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -273,28 +273,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/866337c1-b045-426a-91c8-6d3ab6194e9e
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/c6345a8f-86a4-429d-8bb0-338f4320e065
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 554
-        body: '{"id":"866337c1-b045-426a-91c8-6d3ab6194e9e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation-action","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":2,"created_at":"2026-07-03T15:28:23.813688Z","updated_at":"2026-07-03T15:28:24.080715Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:24.080715Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"c6345a8f-86a4-429d-8bb0-338f4320e065","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation-action","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":2,"created_at":"2026-07-07T07:46:09.306386Z","updated_at":"2026-07-07T07:46:09.492477Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-07T07:46:09.492477Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "554"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:25 GMT
+                - Tue, 07 Jul 2026 07:46:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - ab1ef72d-a0f0-4ade-9925-a6c5331c0dbe
+                - 079dd31c-946a-413e-90f7-79525b5a3cfb
         status: 200 OK
         code: 200
-        duration: 46.461808ms
+        duration: 50.005798ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -305,7 +305,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/866337c1-b045-426a-91c8-6d3ab6194e9e
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/c6345a8f-86a4-429d-8bb0-338f4320e065
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -317,14 +317,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:26 GMT
+                - Tue, 07 Jul 2026 07:46:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 240a32e9-1435-4ccf-9034-9c61a7ae2b56
+                - 556f7890-f5c2-408c-b852-26933d3972c8
         status: 204 No Content
         code: 204
-        duration: 70.866317ms
+        duration: 62.864956ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -335,28 +335,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/866337c1-b045-426a-91c8-6d3ab6194e9e
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/c6345a8f-86a4-429d-8bb0-338f4320e065
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 594
-        body: '{"id":"866337c1-b045-426a-91c8-6d3ab6194e9e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation-action","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":2,"created_at":"2026-07-03T15:28:23.813688Z","updated_at":"2026-07-03T15:28:26.130567Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:24.080715Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-03T15:28:26.130566Z","protection_level":"software","region":"fr-par"}'
+        body: '{"id":"c6345a8f-86a4-429d-8bb0-338f4320e065","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation-action","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":2,"created_at":"2026-07-07T07:46:09.306386Z","updated_at":"2026-07-07T07:46:11.301605Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-07T07:46:09.492477Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-07T07:46:11.301605Z","protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "594"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:26 GMT
+                - Tue, 07 Jul 2026 07:46:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 1122f6b0-fb72-41a6-8e32-67b73326cd43
+                - e10e6e32-1ca2-41f6-a4d1-253ed3220247
         status: 200 OK
         code: 200
-        duration: 48.180887ms
+        duration: 109.439226ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -367,25 +367,25 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/866337c1-b045-426a-91c8-6d3ab6194e9e
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/c6345a8f-86a4-429d-8bb0-338f4320e065
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 594
-        body: '{"id":"866337c1-b045-426a-91c8-6d3ab6194e9e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation-action","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":2,"created_at":"2026-07-03T15:28:23.813688Z","updated_at":"2026-07-03T15:28:26.130567Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:24.080715Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-03T15:28:26.130566Z","protection_level":"software","region":"fr-par"}'
+        body: '{"id":"c6345a8f-86a4-429d-8bb0-338f4320e065","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation-action","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":2,"created_at":"2026-07-07T07:46:09.306386Z","updated_at":"2026-07-07T07:46:11.301605Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-07T07:46:09.492477Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-07T07:46:11.301605Z","protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "594"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:26 GMT
+                - Tue, 07 Jul 2026 07:46:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 015da37b-89b0-41a9-be97-5a934ec5c30c
+                - b11c80cc-0755-4b2a-b4ec-1c275ebb2eb9
         status: 200 OK
         code: 200
-        duration: 35.355016ms
+        duration: 43.100826ms

--- a/internal/services/keymanager/testdata/data-source-key-basic.cassette.yaml
+++ b/internal/services/keymanager/testdata/data-source-key-basic.cassette.yaml
@@ -6,9 +6,9 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 265
+        content_length: 219
         host: api.scaleway.com
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-ds","usage":{"symmetric_encryption":"aes_256_gcm"},"description":"Test key","tags":["tf","test"],"unprotected":true,"origin":"unknown_origin","protection_level":"unknown_protection_level"}'
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-ds","usage":{"symmetric_encryption":"aes_256_gcm"},"description":"Test key","tags":["tf","test"],"unprotected":true,"origin":"unknown_origin"}'
         headers:
             Content-Type:
                 - application/json
@@ -21,21 +21,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 541
-        body: '{"id":"3ce11279-c8b9-4f12-aaaf-e26766a2967c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-ds","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:21.508255Z","updated_at":"2026-07-03T15:28:21.511698Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:21.511698Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"69f533d2-2b1c-4943-be59-0ec66be8f088","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-ds","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:05.866222Z","updated_at":"2026-07-07T07:46:05.874934Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-07T07:46:05.874934Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "541"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
+                - Tue, 07 Jul 2026 07:46:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - fa215b5d-104d-4a47-be2d-f2cb3bf9d59c
+                - f6cd767a-41b2-4f2f-95ce-2e13cd1443c2
         status: 200 OK
         code: 200
-        duration: 266.596542ms
+        duration: 3.775062263s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -46,28 +46,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/3ce11279-c8b9-4f12-aaaf-e26766a2967c
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/69f533d2-2b1c-4943-be59-0ec66be8f088
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 541
-        body: '{"id":"3ce11279-c8b9-4f12-aaaf-e26766a2967c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-ds","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:21.508255Z","updated_at":"2026-07-03T15:28:21.511698Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:21.511698Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"69f533d2-2b1c-4943-be59-0ec66be8f088","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-ds","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:05.866222Z","updated_at":"2026-07-07T07:46:05.874934Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-07T07:46:05.874934Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "541"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
+                - Tue, 07 Jul 2026 07:46:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - fb97c1c0-925b-40b3-9769-fdbb072b1ea7
+                - 25a59782-9418-4845-8d70-341624cc446b
         status: 200 OK
         code: 200
-        duration: 47.061705ms
+        duration: 79.984606ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -78,28 +78,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/3ce11279-c8b9-4f12-aaaf-e26766a2967c
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/69f533d2-2b1c-4943-be59-0ec66be8f088
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 541
-        body: '{"id":"3ce11279-c8b9-4f12-aaaf-e26766a2967c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-ds","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:21.508255Z","updated_at":"2026-07-03T15:28:21.511698Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:21.511698Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"69f533d2-2b1c-4943-be59-0ec66be8f088","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-ds","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:05.866222Z","updated_at":"2026-07-07T07:46:05.874934Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-07T07:46:05.874934Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "541"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
+                - Tue, 07 Jul 2026 07:46:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 5e1126e5-f3ee-44a3-b9f4-8247de777059
+                - 06387940-903e-4728-815f-0fe9b3c2d2c8
         status: 200 OK
         code: 200
-        duration: 51.001575ms
+        duration: 49.82883ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -110,28 +110,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/3ce11279-c8b9-4f12-aaaf-e26766a2967c
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/69f533d2-2b1c-4943-be59-0ec66be8f088
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 541
-        body: '{"id":"3ce11279-c8b9-4f12-aaaf-e26766a2967c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-ds","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:21.508255Z","updated_at":"2026-07-03T15:28:21.511698Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:21.511698Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"69f533d2-2b1c-4943-be59-0ec66be8f088","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-ds","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:05.866222Z","updated_at":"2026-07-07T07:46:05.874934Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-07T07:46:05.874934Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "541"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
+                - Tue, 07 Jul 2026 07:46:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 5ae63f97-04e5-46cb-a2f0-3fb724a48748
+                - 32ce4239-634d-453b-99e1-c127c31c62bc
         status: 200 OK
         code: 200
-        duration: 34.258436ms
+        duration: 40.555206ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -142,28 +142,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/3ce11279-c8b9-4f12-aaaf-e26766a2967c
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/69f533d2-2b1c-4943-be59-0ec66be8f088
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 541
-        body: '{"id":"3ce11279-c8b9-4f12-aaaf-e26766a2967c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-ds","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:21.508255Z","updated_at":"2026-07-03T15:28:21.511698Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:21.511698Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"69f533d2-2b1c-4943-be59-0ec66be8f088","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-ds","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:05.866222Z","updated_at":"2026-07-07T07:46:05.874934Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-07T07:46:05.874934Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "541"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:22 GMT
+                - Tue, 07 Jul 2026 07:46:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 8ded4ea3-88ff-46aa-8b18-771470ea9588
+                - 92157a78-34ff-449b-aff7-049f11d2ab4d
         status: 200 OK
         code: 200
-        duration: 45.031823ms
+        duration: 33.837105ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -174,28 +174,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/3ce11279-c8b9-4f12-aaaf-e26766a2967c
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/69f533d2-2b1c-4943-be59-0ec66be8f088
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 541
-        body: '{"id":"3ce11279-c8b9-4f12-aaaf-e26766a2967c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-ds","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:21.508255Z","updated_at":"2026-07-03T15:28:21.511698Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:21.511698Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"69f533d2-2b1c-4943-be59-0ec66be8f088","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-ds","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:05.866222Z","updated_at":"2026-07-07T07:46:05.874934Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-07T07:46:05.874934Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "541"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:22 GMT
+                - Tue, 07 Jul 2026 07:46:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - eaedcbab-d617-466d-881f-ec8b5232a2de
+                - f397f51b-aeaf-468f-be5a-f6177e79c97d
         status: 200 OK
         code: 200
-        duration: 49.704358ms
+        duration: 45.211428ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -206,7 +206,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/3ce11279-c8b9-4f12-aaaf-e26766a2967c
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/69f533d2-2b1c-4943-be59-0ec66be8f088
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -218,14 +218,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 50768a69-04a0-4c97-9988-e6ab41b949ff
+                - af7c6b4b-c8db-4c4d-b73e-fd5d2633b192
         status: 204 No Content
         code: 204
-        duration: 150.215626ms
+        duration: 120.201163ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -236,28 +236,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/3ce11279-c8b9-4f12-aaaf-e26766a2967c
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/69f533d2-2b1c-4943-be59-0ec66be8f088
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 581
-        body: '{"id":"3ce11279-c8b9-4f12-aaaf-e26766a2967c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-ds","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-03T15:28:21.508255Z","updated_at":"2026-07-03T15:28:23.104417Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:21.511698Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-03T15:28:23.104417Z","protection_level":"software","region":"fr-par"}'
+        body: '{"id":"69f533d2-2b1c-4943-be59-0ec66be8f088","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-ds","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-07T07:46:05.866222Z","updated_at":"2026-07-07T07:46:07.374747Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-07T07:46:05.874934Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-07T07:46:07.374747Z","protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "581"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 99ba9850-c01a-449c-b511-d6d4367779a0
+                - ead21c3a-64f4-4135-a25a-225aae8981fe
         status: 200 OK
         code: 200
-        duration: 41.837182ms
+        duration: 47.318072ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -268,25 +268,25 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/3ce11279-c8b9-4f12-aaaf-e26766a2967c
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/69f533d2-2b1c-4943-be59-0ec66be8f088
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 581
-        body: '{"id":"3ce11279-c8b9-4f12-aaaf-e26766a2967c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-ds","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-03T15:28:21.508255Z","updated_at":"2026-07-03T15:28:23.104417Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:21.511698Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-03T15:28:23.104417Z","protection_level":"software","region":"fr-par"}'
+        body: '{"id":"69f533d2-2b1c-4943-be59-0ec66be8f088","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-ds","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-07T07:46:05.866222Z","updated_at":"2026-07-07T07:46:07.374747Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-07T07:46:05.874934Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-07T07:46:07.374747Z","protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "581"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 3882cb86-e3d5-4b7e-873f-a01b96eea161
+                - 2935bdff-adce-48ae-a3ea-ce240e4a1193
         status: 200 OK
         code: 200
-        duration: 34.513827ms
+        duration: 58.441413ms

--- a/internal/services/keymanager/testdata/data-source-verify-basic.cassette.yaml
+++ b/internal/services/keymanager/testdata/data-source-verify-basic.cassette.yaml
@@ -21,21 +21,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 432
-        body: '{"id":"fd998353-a9be-444d-afec-f8546785aac4","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-verify-secret","status":"ready","created_at":"2026-07-03T15:28:18.803210Z","updated_at":"2026-07-03T15:28:18.803210Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"6afb549e-80a6-4433-bead-ef1e9fb3887f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-verify-secret","status":"ready","created_at":"2026-07-07T07:46:02.418967Z","updated_at":"2026-07-07T07:46:02.418967Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "432"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:18 GMT
+                - Tue, 07 Jul 2026 07:46:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - df4b2d91-a7ca-4b2b-a47d-06079d1fa781
+                - ffe7bcd7-03a6-40fe-8643-3d893fdb2130
         status: 200 OK
         code: 200
-        duration: 185.190779ms
+        duration: 277.794834ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -46,28 +46,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/fd998353-a9be-444d-afec-f8546785aac4
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6afb549e-80a6-4433-bead-ef1e9fb3887f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 432
-        body: '{"id":"fd998353-a9be-444d-afec-f8546785aac4","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-verify-secret","status":"ready","created_at":"2026-07-03T15:28:18.803210Z","updated_at":"2026-07-03T15:28:18.803210Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"6afb549e-80a6-4433-bead-ef1e9fb3887f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-verify-secret","status":"ready","created_at":"2026-07-07T07:46:02.418967Z","updated_at":"2026-07-07T07:46:02.418967Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "432"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:18 GMT
+                - Tue, 07 Jul 2026 07:46:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 0441e972-feaf-4223-a8cf-c544e6991577
+                - 245a87b0-5695-46f5-af6e-d8582b323d70
         status: 200 OK
         code: 200
-        duration: 45.750392ms
+        duration: 83.545756ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -81,7 +81,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/fd998353-a9be-444d-afec-f8546785aac4/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6afb549e-80a6-4433-bead-ef1e9fb3887f/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -95,22 +95,22 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:18 GMT
+                - Tue, 07 Jul 2026 07:46:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 91f23282-e4c9-48b9-836f-12d6142b3e5a
+                - 1ac935e5-6f7e-46f4-996d-59d1b2c92a17
         status: 200 OK
         code: 200
-        duration: 44.152991ms
+        duration: 114.926116ms
     - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 237
+        content_length: 191
         host: api.scaleway.com
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"tags":null,"unprotected":true,"origin":"unknown_origin","protection_level":"unknown_protection_level"}'
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"tags":null,"unprotected":true,"origin":"unknown_origin"}'
         headers:
             Content-Type:
                 - application/json
@@ -123,21 +123,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 530
-        body: '{"id":"7e6da60c-5bfa-475c-851d-c7cf98923041","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.283852Z","updated_at":"2026-07-03T15:28:19.368507Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.368507Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"8a83f62f-2b00-4e17-9bef-bc10faef3098","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:04.804893Z","updated_at":"2026-07-07T07:46:05.170115Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:05.170115Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "530"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:19 GMT
+                - Tue, 07 Jul 2026 07:46:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - df1184e2-6c60-4e52-9dd5-b7eaf4c63971
+                - bdf8d5f4-9336-476c-b376-aa39d9d752e2
         status: 200 OK
         code: 200
-        duration: 755.031225ms
+        duration: 3.037935454s
     - id: 4
       request:
         proto: HTTP/1.1
@@ -148,28 +148,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/7e6da60c-5bfa-475c-851d-c7cf98923041
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/8a83f62f-2b00-4e17-9bef-bc10faef3098
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 530
-        body: '{"id":"7e6da60c-5bfa-475c-851d-c7cf98923041","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.283852Z","updated_at":"2026-07-03T15:28:19.368507Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.368507Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"8a83f62f-2b00-4e17-9bef-bc10faef3098","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:04.804893Z","updated_at":"2026-07-07T07:46:05.170115Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:05.170115Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "530"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:19 GMT
+                - Tue, 07 Jul 2026 07:46:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 836781c0-e21c-4c8a-97e6-f57653c04b92
+                - 76b19a92-5958-48c1-b389-5539bd7f3f71
         status: 200 OK
         code: 200
-        duration: 145.915629ms
+        duration: 95.263037ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -183,28 +183,28 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/7e6da60c-5bfa-475c-851d-c7cf98923041/sign
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/8a83f62f-2b00-4e17-9bef-bc10faef3098/sign
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 408
-        body: '{"key_id":"7e6da60c-5bfa-475c-851d-c7cf98923041","signature":"Dub3a7I4vAHU2uTpV/sZ1Zt1m2qrq2I1xzseAU9uTXwMTk5nsy/NHKxW1RP4TmRiVE1lJLXmO8E2R8lJlCn+JGWWCWSyFj9RZviiAFdFwXRlrhAclpo5ntDDbATk9WOA3DFmJ8KUkZAUXlDYyOc4Mf1uBhAC6hqUlNoBzcCmsmG8JJuJLqAODSZqhZWFqcMZTncdyPPXHuB/NeWsQA1IXi/4UBsexNmMku9AuzvWQMnMmBR9hd0NsUckuLqtWYWsCeDhuTSrx2eFphX4O4ewdp0Bepj5WdDYvx+kvv98+FwDklSotx68pIT8E2sl7+W16qtlRDqsmzLlf46/9lAG1A=="}'
+        body: '{"key_id":"8a83f62f-2b00-4e17-9bef-bc10faef3098","signature":"QPgt28fkqVkGQz6TN+1EJOz9rtY1e1uu2Xg6figxAMHuMh/Q0sB8Y6LbpAG2JiElWPP9NFO7TYfuR7Vj+PVhPuH7sAgQUtR7mqCQClTGcltI/rrHCUve60rFFw2hksbYreTD+iI7j0su4aIlApWatnu7DgyonGaZdbVyT4ja0lZxywjQmwh8WDNmLEoAJDraXzRaz30TOgN7YF5bb4BgDclWlKLHUeBn5UaK6KxtpsxK5lUk7CeM0s7QemKL+H/rNWJviy3JeahCAk/09ZLkKoRqyuhY68xq9pLyXjLNSUCkVAaYO9U2KaKx6d811vZK3k9cKG4+t7EWhYKzu0y1Nw=="}'
         headers:
             Content-Length:
                 - "408"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:19 GMT
+                - Tue, 07 Jul 2026 07:46:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 42472701-4303-4c78-b9e7-e6013dd0def6
+                - 64a0b685-05ae-47cc-be97-3dbfcb041a71
         status: 200 OK
         code: 200
-        duration: 110.355288ms
+        duration: 114.114021ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -212,34 +212,34 @@ interactions:
         proto_minor: 1
         content_length: 496
         host: api.scaleway.com
-        body: '{"data":"RHViM2E3STR2QUhVMnVUcFYvc1oxWnQxbTJxcnEySTF4enNlQVU5dVRYd01UazVuc3kvTkhLeFcxUlA0VG1SaVZFMWxKTFhtTzhFMlI4bEpsQ24rSkdXV0NXU3lGajlSWnZpaUFGZEZ3WFJscmhBY2xwbzVudEREYkFUazlXT0EzREZtSjhLVWtaQVVYbERZeU9jNE1mMXVCaEFDNmhxVWxOb0J6Y0Ntc21HOEpKdUpMcUFPRFNacWhaV0ZxY01aVG5jZHlQUFhIdUIvTmVXc1FBMUlYaS80VUJzZXhObU1rdTlBdXp2V1FNbk1tQlI5aGQwTnNVY2t1THF0V1lXc0NlRGh1VFNyeDJlRnBoWDRPNGV3ZHAwQmVwajVXZERZdngra3Z2OTgrRndEa2xTb3R4NjhwSVQ4RTJzbDcrVzE2cXRsUkRxc216TGxmNDYvOWxBRzFBPT0=","description":"version1"}'
+        body: '{"data":"UVBndDI4ZmtxVmtHUXo2VE4rMUVKT3o5cnRZMWUxdXUyWGc2ZmlneEFNSHVNaC9RMHNCOFk2TGJwQUcySmlFbFdQUDlORk83VFlmdVI3VmorUFZoUHVIN3NBZ1FVdFI3bXFDUUNsVEdjbHRJL3JySENVdmU2MHJGRncyaGtzYllyZVREK2lJN2owc3U0YUlsQXBXYXRudTdEZ3lvbkdhWmRiVnlUNGphMGxaeHl3alFtd2g4V0RObUxFb0FKRHJhWHpSYXozMFRPZ043WUY1YmI0QmdEY2xXbEtMSFVlQm41VWFLNkt4dHBzeEs1bFVrN0NlTTBzN1FlbUtMK0gvck5XSnZpeTNKZWFoQ0FrLzA5WkxrS29ScXl1aFk2OHhxOXBMeVhqTE5TVUNrVkFhWU85VTJLYUt4NmQ4MTF2WkszazljS0c0K3Q3RVdoWUt6dTB5MU53PT0=","description":"version1"}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/fd998353-a9be-444d-afec-f8546785aac4/versions
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6afb549e-80a6-4433-bead-ef1e9fb3887f/versions
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"fd998353-a9be-444d-afec-f8546785aac4","status":"enabled","created_at":"2026-07-03T15:28:19.949555Z","updated_at":"2026-07-03T15:28:19.949555Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"6afb549e-80a6-4433-bead-ef1e9fb3887f","status":"enabled","created_at":"2026-07-07T07:46:06.064424Z","updated_at":"2026-07-07T07:46:06.064424Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:19 GMT
+                - Tue, 07 Jul 2026 07:46:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - dbb1024b-603e-4973-bfeb-a23eabf57d94
+                - c894b443-5f80-4e6d-84d8-59611ff50531
         status: 200 OK
         code: 200
-        duration: 312.379965ms
+        duration: 674.180858ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -250,28 +250,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/fd998353-a9be-444d-afec-f8546785aac4/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6afb549e-80a6-4433-bead-ef1e9fb3887f/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"fd998353-a9be-444d-afec-f8546785aac4","status":"enabled","created_at":"2026-07-03T15:28:19.949555Z","updated_at":"2026-07-03T15:28:19.949555Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"6afb549e-80a6-4433-bead-ef1e9fb3887f","status":"enabled","created_at":"2026-07-07T07:46:06.064424Z","updated_at":"2026-07-07T07:46:06.064424Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:20 GMT
+                - Tue, 07 Jul 2026 07:46:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - e844af64-9d14-4f0b-91e6-137fe7e44735
+                - 39bb7fc1-eb90-4f6f-9d5c-60de83c0f096
         status: 200 OK
         code: 200
-        duration: 53.776037ms
+        duration: 88.009006ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -282,28 +282,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/fd998353-a9be-444d-afec-f8546785aac4/versions/1/access
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6afb549e-80a6-4433-bead-ef1e9fb3887f/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 569
-        body: '{"secret_id":"fd998353-a9be-444d-afec-f8546785aac4","revision":1,"data":"RHViM2E3STR2QUhVMnVUcFYvc1oxWnQxbTJxcnEySTF4enNlQVU5dVRYd01UazVuc3kvTkhLeFcxUlA0VG1SaVZFMWxKTFhtTzhFMlI4bEpsQ24rSkdXV0NXU3lGajlSWnZpaUFGZEZ3WFJscmhBY2xwbzVudEREYkFUazlXT0EzREZtSjhLVWtaQVVYbERZeU9jNE1mMXVCaEFDNmhxVWxOb0J6Y0Ntc21HOEpKdUpMcUFPRFNacWhaV0ZxY01aVG5jZHlQUFhIdUIvTmVXc1FBMUlYaS80VUJzZXhObU1rdTlBdXp2V1FNbk1tQlI5aGQwTnNVY2t1THF0V1lXc0NlRGh1VFNyeDJlRnBoWDRPNGV3ZHAwQmVwajVXZERZdngra3Z2OTgrRndEa2xTb3R4NjhwSVQ4RTJzbDcrVzE2cXRsUkRxc216TGxmNDYvOWxBRzFBPT0=","data_crc32":null,"type":"opaque"}'
+        body: '{"secret_id":"6afb549e-80a6-4433-bead-ef1e9fb3887f","revision":1,"data":"UVBndDI4ZmtxVmtHUXo2VE4rMUVKT3o5cnRZMWUxdXUyWGc2ZmlneEFNSHVNaC9RMHNCOFk2TGJwQUcySmlFbFdQUDlORk83VFlmdVI3VmorUFZoUHVIN3NBZ1FVdFI3bXFDUUNsVEdjbHRJL3JySENVdmU2MHJGRncyaGtzYllyZVREK2lJN2owc3U0YUlsQXBXYXRudTdEZ3lvbkdhWmRiVnlUNGphMGxaeHl3alFtd2g4V0RObUxFb0FKRHJhWHpSYXozMFRPZ043WUY1YmI0QmdEY2xXbEtMSFVlQm41VWFLNkt4dHBzeEs1bFVrN0NlTTBzN1FlbUtMK0gvck5XSnZpeTNKZWFoQ0FrLzA5WkxrS29ScXl1aFk2OHhxOXBMeVhqTE5TVUNrVkFhWU85VTJLYUt4NmQ4MTF2WkszazljS0c0K3Q3RVdoWUt6dTB5MU53PT0=","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
                 - "569"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:20 GMT
+                - Tue, 07 Jul 2026 07:46:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - c05bdae9-e510-430d-b745-9b48b3156bb4
+                - 7b88f7c2-87b9-43c7-a4ec-d16d54b2a77d
         status: 200 OK
         code: 200
-        duration: 272.737065ms
+        duration: 116.291492ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -314,28 +314,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/fd998353-a9be-444d-afec-f8546785aac4/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6afb549e-80a6-4433-bead-ef1e9fb3887f/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"fd998353-a9be-444d-afec-f8546785aac4","status":"enabled","created_at":"2026-07-03T15:28:19.949555Z","updated_at":"2026-07-03T15:28:19.949555Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"6afb549e-80a6-4433-bead-ef1e9fb3887f","status":"enabled","created_at":"2026-07-07T07:46:06.064424Z","updated_at":"2026-07-07T07:46:06.064424Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:20 GMT
+                - Tue, 07 Jul 2026 07:46:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - c663e1ab-56a2-4cb2-bce1-69bb59b0bcb0
+                - 50439128-afb3-4b4c-84a3-e808ebc0b578
         status: 200 OK
         code: 200
-        duration: 52.127009ms
+        duration: 44.326005ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -343,34 +343,34 @@ interactions:
         proto_minor: 1
         content_length: 416
         host: api.scaleway.com
-        body: '{"digest":"+wxGDJPL0C0K00FBHoXsjM0xaYYPTtIHSfdfjlvQEMs=","signature":"Dub3a7I4vAHU2uTpV/sZ1Zt1m2qrq2I1xzseAU9uTXwMTk5nsy/NHKxW1RP4TmRiVE1lJLXmO8E2R8lJlCn+JGWWCWSyFj9RZviiAFdFwXRlrhAclpo5ntDDbATk9WOA3DFmJ8KUkZAUXlDYyOc4Mf1uBhAC6hqUlNoBzcCmsmG8JJuJLqAODSZqhZWFqcMZTncdyPPXHuB/NeWsQA1IXi/4UBsexNmMku9AuzvWQMnMmBR9hd0NsUckuLqtWYWsCeDhuTSrx2eFphX4O4ewdp0Bepj5WdDYvx+kvv98+FwDklSotx68pIT8E2sl7+W16qtlRDqsmzLlf46/9lAG1A=="}'
+        body: '{"digest":"+wxGDJPL0C0K00FBHoXsjM0xaYYPTtIHSfdfjlvQEMs=","signature":"QPgt28fkqVkGQz6TN+1EJOz9rtY1e1uu2Xg6figxAMHuMh/Q0sB8Y6LbpAG2JiElWPP9NFO7TYfuR7Vj+PVhPuH7sAgQUtR7mqCQClTGcltI/rrHCUve60rFFw2hksbYreTD+iI7j0su4aIlApWatnu7DgyonGaZdbVyT4ja0lZxywjQmwh8WDNmLEoAJDraXzRaz30TOgN7YF5bb4BgDclWlKLHUeBn5UaK6KxtpsxK5lUk7CeM0s7QemKL+H/rNWJviy3JeahCAk/09ZLkKoRqyuhY68xq9pLyXjLNSUCkVAaYO9U2KaKx6d811vZK3k9cKG4+t7EWhYKzu0y1Nw=="}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/7e6da60c-5bfa-475c-851d-c7cf98923041/verify
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/8a83f62f-2b00-4e17-9bef-bc10faef3098/verify
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 62
-        body: '{"key_id":"7e6da60c-5bfa-475c-851d-c7cf98923041","valid":true}'
+        body: '{"key_id":"8a83f62f-2b00-4e17-9bef-bc10faef3098","valid":true}'
         headers:
             Content-Length:
                 - "62"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:20 GMT
+                - Tue, 07 Jul 2026 07:46:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 9e104f01-e370-43a3-9540-d64164a14812
+                - b764ff5b-da30-43fd-bdfc-4553dbec4353
         status: 200 OK
         code: 200
-        duration: 106.6884ms
+        duration: 89.451419ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -384,28 +384,28 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/7e6da60c-5bfa-475c-851d-c7cf98923041/sign
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/8a83f62f-2b00-4e17-9bef-bc10faef3098/sign
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 408
-        body: '{"key_id":"7e6da60c-5bfa-475c-851d-c7cf98923041","signature":"a/V7hvaqo0XfE9pM7ntzeO1rfzzfdAzPI/X2hy4AsjLlgZeVVpXJ56glZSX86mddx+DQIKmY3FxgmVRVb2ZhEtCsb6X/ntIsa1eRq9+OjTr4sFn2CZ/uqPVFK7+5Zgl3XfIWZpigMAyBppKSo+qXrGJ0j7PXuCxDLYx5BkYI5MSjeQvlaWQum0JsyHX8AF8fdA6XpbZ86XxFOKy1b+e1xFXFa/hHsezVV8ddJ9jk5h2MgZt6VvM4aQf+iSkt/jwZCCwk9mJgHwamOIQLuN/k4W8JaWP6vSMDGdwAWaVryQSokBVFuHAsubSjKqgJAC8LUySkFGb27UoOz6qwYYACSA=="}'
+        body: '{"key_id":"8a83f62f-2b00-4e17-9bef-bc10faef3098","signature":"FfdimDxdqUGV5pjPJHNeBsHrl51u4JKPgg49cqiBaMAQQeFxT3vMs2Q36zT6ckIr87kna1vqEGMfM1LfAtmMq7ySwynhXfLCspVIigq4bnwRTkxgz1+KkCFhJwfKqtUFaSk02G69xY3z6HB9df69M1ZvABLFC5vCyESFoCszIMKGRkJmDS3yruqK8Ytwo9Ij20HsnBoSkTLwtNJp/hZh5Q6ymD43KzItRn4WN/mgUjsnJexELu+mD6kYM5V06S6qo1jl29sd/1TubHJv0u20p+4oL7oproOXKNTLO+zWmXKIOhexUC4YThRNsjxuytR9/nK1x9QG5pCcvfV55Z1lZw=="}'
         headers:
             Content-Length:
                 - "408"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:20 GMT
+                - Tue, 07 Jul 2026 07:46:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 60238588-e5d1-4301-a69c-b64c03a43af2
+                - 0c6a1db6-3043-4edc-8c2a-4987a0c1c8c5
         status: 200 OK
         code: 200
-        duration: 62.274218ms
+        duration: 110.998079ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -416,28 +416,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/fd998353-a9be-444d-afec-f8546785aac4/versions/1/access
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6afb549e-80a6-4433-bead-ef1e9fb3887f/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 569
-        body: '{"secret_id":"fd998353-a9be-444d-afec-f8546785aac4","revision":1,"data":"RHViM2E3STR2QUhVMnVUcFYvc1oxWnQxbTJxcnEySTF4enNlQVU5dVRYd01UazVuc3kvTkhLeFcxUlA0VG1SaVZFMWxKTFhtTzhFMlI4bEpsQ24rSkdXV0NXU3lGajlSWnZpaUFGZEZ3WFJscmhBY2xwbzVudEREYkFUazlXT0EzREZtSjhLVWtaQVVYbERZeU9jNE1mMXVCaEFDNmhxVWxOb0J6Y0Ntc21HOEpKdUpMcUFPRFNacWhaV0ZxY01aVG5jZHlQUFhIdUIvTmVXc1FBMUlYaS80VUJzZXhObU1rdTlBdXp2V1FNbk1tQlI5aGQwTnNVY2t1THF0V1lXc0NlRGh1VFNyeDJlRnBoWDRPNGV3ZHAwQmVwajVXZERZdngra3Z2OTgrRndEa2xTb3R4NjhwSVQ4RTJzbDcrVzE2cXRsUkRxc216TGxmNDYvOWxBRzFBPT0=","data_crc32":null,"type":"opaque"}'
+        body: '{"secret_id":"6afb549e-80a6-4433-bead-ef1e9fb3887f","revision":1,"data":"UVBndDI4ZmtxVmtHUXo2VE4rMUVKT3o5cnRZMWUxdXUyWGc2ZmlneEFNSHVNaC9RMHNCOFk2TGJwQUcySmlFbFdQUDlORk83VFlmdVI3VmorUFZoUHVIN3NBZ1FVdFI3bXFDUUNsVEdjbHRJL3JySENVdmU2MHJGRncyaGtzYllyZVREK2lJN2owc3U0YUlsQXBXYXRudTdEZ3lvbkdhWmRiVnlUNGphMGxaeHl3alFtd2g4V0RObUxFb0FKRHJhWHpSYXozMFRPZ043WUY1YmI0QmdEY2xXbEtMSFVlQm41VWFLNkt4dHBzeEs1bFVrN0NlTTBzN1FlbUtMK0gvck5XSnZpeTNKZWFoQ0FrLzA5WkxrS29ScXl1aFk2OHhxOXBMeVhqTE5TVUNrVkFhWU85VTJLYUt4NmQ4MTF2WkszazljS0c0K3Q3RVdoWUt6dTB5MU53PT0=","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
                 - "569"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:20 GMT
+                - Tue, 07 Jul 2026 07:46:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 426cdb50-7fcc-408a-8de7-ef6e35baa9a8
+                - b70ff97e-0fea-4659-ad5e-d2175ac3516e
         status: 200 OK
         code: 200
-        duration: 38.762967ms
+        duration: 46.54883ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -448,28 +448,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/fd998353-a9be-444d-afec-f8546785aac4/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6afb549e-80a6-4433-bead-ef1e9fb3887f/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"fd998353-a9be-444d-afec-f8546785aac4","status":"enabled","created_at":"2026-07-03T15:28:19.949555Z","updated_at":"2026-07-03T15:28:19.949555Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"6afb549e-80a6-4433-bead-ef1e9fb3887f","status":"enabled","created_at":"2026-07-07T07:46:06.064424Z","updated_at":"2026-07-07T07:46:06.064424Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:20 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 71c2fd10-4e3e-4eea-b7ae-ae5f4c808d66
+                - b6dec08c-0b07-4ee8-9579-e61bd0496301
         status: 200 OK
         code: 200
-        duration: 38.001618ms
+        duration: 93.615734ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -477,34 +477,34 @@ interactions:
         proto_minor: 1
         content_length: 416
         host: api.scaleway.com
-        body: '{"digest":"+wxGDJPL0C0K00FBHoXsjM0xaYYPTtIHSfdfjlvQEMs=","signature":"Dub3a7I4vAHU2uTpV/sZ1Zt1m2qrq2I1xzseAU9uTXwMTk5nsy/NHKxW1RP4TmRiVE1lJLXmO8E2R8lJlCn+JGWWCWSyFj9RZviiAFdFwXRlrhAclpo5ntDDbATk9WOA3DFmJ8KUkZAUXlDYyOc4Mf1uBhAC6hqUlNoBzcCmsmG8JJuJLqAODSZqhZWFqcMZTncdyPPXHuB/NeWsQA1IXi/4UBsexNmMku9AuzvWQMnMmBR9hd0NsUckuLqtWYWsCeDhuTSrx2eFphX4O4ewdp0Bepj5WdDYvx+kvv98+FwDklSotx68pIT8E2sl7+W16qtlRDqsmzLlf46/9lAG1A=="}'
+        body: '{"digest":"+wxGDJPL0C0K00FBHoXsjM0xaYYPTtIHSfdfjlvQEMs=","signature":"QPgt28fkqVkGQz6TN+1EJOz9rtY1e1uu2Xg6figxAMHuMh/Q0sB8Y6LbpAG2JiElWPP9NFO7TYfuR7Vj+PVhPuH7sAgQUtR7mqCQClTGcltI/rrHCUve60rFFw2hksbYreTD+iI7j0su4aIlApWatnu7DgyonGaZdbVyT4ja0lZxywjQmwh8WDNmLEoAJDraXzRaz30TOgN7YF5bb4BgDclWlKLHUeBn5UaK6KxtpsxK5lUk7CeM0s7QemKL+H/rNWJviy3JeahCAk/09ZLkKoRqyuhY68xq9pLyXjLNSUCkVAaYO9U2KaKx6d811vZK3k9cKG4+t7EWhYKzu0y1Nw=="}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/7e6da60c-5bfa-475c-851d-c7cf98923041/verify
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/8a83f62f-2b00-4e17-9bef-bc10faef3098/verify
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 62
-        body: '{"key_id":"7e6da60c-5bfa-475c-851d-c7cf98923041","valid":true}'
+        body: '{"key_id":"8a83f62f-2b00-4e17-9bef-bc10faef3098","valid":true}'
         headers:
             Content-Length:
                 - "62"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - d52c17c6-88b9-4207-9dca-593fa5ad1022
+                - be6afd73-d650-4037-8372-3d5e6d6ea500
         status: 200 OK
         code: 200
-        duration: 97.401286ms
+        duration: 139.442002ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -515,28 +515,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/fd998353-a9be-444d-afec-f8546785aac4
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6afb549e-80a6-4433-bead-ef1e9fb3887f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 432
-        body: '{"id":"fd998353-a9be-444d-afec-f8546785aac4","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-verify-secret","status":"ready","created_at":"2026-07-03T15:28:18.803210Z","updated_at":"2026-07-03T15:28:18.803210Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"6afb549e-80a6-4433-bead-ef1e9fb3887f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-verify-secret","status":"ready","created_at":"2026-07-07T07:46:02.418967Z","updated_at":"2026-07-07T07:46:02.418967Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "432"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 9a4af264-ced8-474b-81f0-b44367a2e441
+                - 0876d001-22b2-4539-b131-72ef44d8787e
         status: 200 OK
         code: 200
-        duration: 42.443471ms
+        duration: 48.093576ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -547,28 +547,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/7e6da60c-5bfa-475c-851d-c7cf98923041
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/8a83f62f-2b00-4e17-9bef-bc10faef3098
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 530
-        body: '{"id":"7e6da60c-5bfa-475c-851d-c7cf98923041","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.283852Z","updated_at":"2026-07-03T15:28:19.368507Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.368507Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"8a83f62f-2b00-4e17-9bef-bc10faef3098","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:04.804893Z","updated_at":"2026-07-07T07:46:05.170115Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:05.170115Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "530"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - e816029b-e157-4e3e-9897-4b3db11f68d3
+                - 9448b6dd-5dfd-40b4-b468-a7236bf45a99
         status: 200 OK
         code: 200
-        duration: 51.961077ms
+        duration: 52.561488ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -582,28 +582,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/fd998353-a9be-444d-afec-f8546785aac4/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6afb549e-80a6-4433-bead-ef1e9fb3887f/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 333
-        body: '{"versions":[{"revision":1,"secret_id":"fd998353-a9be-444d-afec-f8546785aac4","status":"enabled","created_at":"2026-07-03T15:28:19.949555Z","updated_at":"2026-07-03T15:28:19.949555Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        body: '{"versions":[{"revision":1,"secret_id":"6afb549e-80a6-4433-bead-ef1e9fb3887f","status":"enabled","created_at":"2026-07-07T07:46:06.064424Z","updated_at":"2026-07-07T07:46:06.064424Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "333"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - f3230e50-85ad-4b54-901d-08abd43d1d66
+                - 39551f47-0e3d-49c5-bb09-c9007f9417c3
         status: 200 OK
         code: 200
-        duration: 50.287303ms
+        duration: 70.6409ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -617,28 +617,28 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/7e6da60c-5bfa-475c-851d-c7cf98923041/sign
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/8a83f62f-2b00-4e17-9bef-bc10faef3098/sign
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 408
-        body: '{"key_id":"7e6da60c-5bfa-475c-851d-c7cf98923041","signature":"AHp0KxsxML2O1aW6aIlQTmAhnZ9sKtSKXidw613Xw9uBcrHKlVi19N7zzOxsXeDzjld4E9HerfxEsNvE946zNLRSxd0rbyDFnmsnPTc7HSWDo0lZcnpiFcfXPoeR7riO3ns0JP+fuAW6CDDcK9wRU31P9S9A3ObewJkHNjG8dN8H36VJuVeCQvkutWoGyV1nq0kraufqsn5pz/COTstTWXAk1yoENG0MeZSNI+d+tp6AHW7KyXJC0p0MG+8jm9haGh2QONIOY0lLKAwgr3lyz90TycZMkrfYC0uCZzib/EI6d9f17ubJeI6hDIJMhJkdaxOL8GelEDHtK1hM/KQZJA=="}'
+        body: '{"key_id":"8a83f62f-2b00-4e17-9bef-bc10faef3098","signature":"DO/zBJKbR4/0V5BXbijYE/BXjBYh60KE2aK/k/KXGCdFFFzsvGmDyHZ7X6vuC+fzxmfa1s0LNs/uEm9/GkGxPTjY80yBBP7n6OKISYTzJxZulnCR8wgQoPNlIUXy1AK7Gvr8CQGGw/BicpIBCNwMAclQ4MZ04TOLzpKT//Rr6q4yY6WTbXXTx1MXfUtNH6h9VXEDrpljNcomxaIUtRWpeoGcBxoCc3BKdxLXQs24Qr9YwIF3qs3Qw8HptYz+UCtofz75ysau/bW8nar4RNjsyEgoVgUOEc3FKIHOSP1kQoS37NTIQcHnm3TPxgi03r4XZYg77jc9VoHvu+GFclu0yQ=="}'
         headers:
             Content-Length:
                 - "408"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 4b2f973f-8635-4e59-ac53-0c8ddf31c57b
+                - 80e0b52a-d7a5-4cb9-99eb-235b764667b0
         status: 200 OK
         code: 200
-        duration: 71.091449ms
+        duration: 137.269734ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -649,28 +649,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/fd998353-a9be-444d-afec-f8546785aac4/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6afb549e-80a6-4433-bead-ef1e9fb3887f/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"fd998353-a9be-444d-afec-f8546785aac4","status":"enabled","created_at":"2026-07-03T15:28:19.949555Z","updated_at":"2026-07-03T15:28:19.949555Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"6afb549e-80a6-4433-bead-ef1e9fb3887f","status":"enabled","created_at":"2026-07-07T07:46:06.064424Z","updated_at":"2026-07-07T07:46:06.064424Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 10249862-f978-42ad-b859-fc047bd52af3
+                - 1bec738c-ff5d-4ccc-8e36-368a2a41d471
         status: 200 OK
         code: 200
-        duration: 36.84754ms
+        duration: 43.030153ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -681,28 +681,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/fd998353-a9be-444d-afec-f8546785aac4/versions/1/access
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6afb549e-80a6-4433-bead-ef1e9fb3887f/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 569
-        body: '{"secret_id":"fd998353-a9be-444d-afec-f8546785aac4","revision":1,"data":"RHViM2E3STR2QUhVMnVUcFYvc1oxWnQxbTJxcnEySTF4enNlQVU5dVRYd01UazVuc3kvTkhLeFcxUlA0VG1SaVZFMWxKTFhtTzhFMlI4bEpsQ24rSkdXV0NXU3lGajlSWnZpaUFGZEZ3WFJscmhBY2xwbzVudEREYkFUazlXT0EzREZtSjhLVWtaQVVYbERZeU9jNE1mMXVCaEFDNmhxVWxOb0J6Y0Ntc21HOEpKdUpMcUFPRFNacWhaV0ZxY01aVG5jZHlQUFhIdUIvTmVXc1FBMUlYaS80VUJzZXhObU1rdTlBdXp2V1FNbk1tQlI5aGQwTnNVY2t1THF0V1lXc0NlRGh1VFNyeDJlRnBoWDRPNGV3ZHAwQmVwajVXZERZdngra3Z2OTgrRndEa2xTb3R4NjhwSVQ4RTJzbDcrVzE2cXRsUkRxc216TGxmNDYvOWxBRzFBPT0=","data_crc32":null,"type":"opaque"}'
+        body: '{"secret_id":"6afb549e-80a6-4433-bead-ef1e9fb3887f","revision":1,"data":"UVBndDI4ZmtxVmtHUXo2VE4rMUVKT3o5cnRZMWUxdXUyWGc2ZmlneEFNSHVNaC9RMHNCOFk2TGJwQUcySmlFbFdQUDlORk83VFlmdVI3VmorUFZoUHVIN3NBZ1FVdFI3bXFDUUNsVEdjbHRJL3JySENVdmU2MHJGRncyaGtzYllyZVREK2lJN2owc3U0YUlsQXBXYXRudTdEZ3lvbkdhWmRiVnlUNGphMGxaeHl3alFtd2g4V0RObUxFb0FKRHJhWHpSYXozMFRPZ043WUY1YmI0QmdEY2xXbEtMSFVlQm41VWFLNkt4dHBzeEs1bFVrN0NlTTBzN1FlbUtMK0gvck5XSnZpeTNKZWFoQ0FrLzA5WkxrS29ScXl1aFk2OHhxOXBMeVhqTE5TVUNrVkFhWU85VTJLYUt4NmQ4MTF2WkszazljS0c0K3Q3RVdoWUt6dTB5MU53PT0=","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
                 - "569"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 543dfdfb-43b3-4f1c-9189-56c49d874102
+                - c28f9b0e-048e-42eb-9232-623376d87ea9
         status: 200 OK
         code: 200
-        duration: 42.67204ms
+        duration: 34.421611ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -713,28 +713,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/fd998353-a9be-444d-afec-f8546785aac4/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6afb549e-80a6-4433-bead-ef1e9fb3887f/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"fd998353-a9be-444d-afec-f8546785aac4","status":"enabled","created_at":"2026-07-03T15:28:19.949555Z","updated_at":"2026-07-03T15:28:19.949555Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"6afb549e-80a6-4433-bead-ef1e9fb3887f","status":"enabled","created_at":"2026-07-07T07:46:06.064424Z","updated_at":"2026-07-07T07:46:06.064424Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - ae74c00f-5661-43f3-8220-c74f8864967e
+                - 7fb0f309-f61a-4beb-a19f-d6c53d89297f
         status: 200 OK
         code: 200
-        duration: 46.864054ms
+        duration: 51.244445ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -742,34 +742,34 @@ interactions:
         proto_minor: 1
         content_length: 416
         host: api.scaleway.com
-        body: '{"digest":"+wxGDJPL0C0K00FBHoXsjM0xaYYPTtIHSfdfjlvQEMs=","signature":"Dub3a7I4vAHU2uTpV/sZ1Zt1m2qrq2I1xzseAU9uTXwMTk5nsy/NHKxW1RP4TmRiVE1lJLXmO8E2R8lJlCn+JGWWCWSyFj9RZviiAFdFwXRlrhAclpo5ntDDbATk9WOA3DFmJ8KUkZAUXlDYyOc4Mf1uBhAC6hqUlNoBzcCmsmG8JJuJLqAODSZqhZWFqcMZTncdyPPXHuB/NeWsQA1IXi/4UBsexNmMku9AuzvWQMnMmBR9hd0NsUckuLqtWYWsCeDhuTSrx2eFphX4O4ewdp0Bepj5WdDYvx+kvv98+FwDklSotx68pIT8E2sl7+W16qtlRDqsmzLlf46/9lAG1A=="}'
+        body: '{"digest":"+wxGDJPL0C0K00FBHoXsjM0xaYYPTtIHSfdfjlvQEMs=","signature":"QPgt28fkqVkGQz6TN+1EJOz9rtY1e1uu2Xg6figxAMHuMh/Q0sB8Y6LbpAG2JiElWPP9NFO7TYfuR7Vj+PVhPuH7sAgQUtR7mqCQClTGcltI/rrHCUve60rFFw2hksbYreTD+iI7j0su4aIlApWatnu7DgyonGaZdbVyT4ja0lZxywjQmwh8WDNmLEoAJDraXzRaz30TOgN7YF5bb4BgDclWlKLHUeBn5UaK6KxtpsxK5lUk7CeM0s7QemKL+H/rNWJviy3JeahCAk/09ZLkKoRqyuhY68xq9pLyXjLNSUCkVAaYO9U2KaKx6d811vZK3k9cKG4+t7EWhYKzu0y1Nw=="}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/7e6da60c-5bfa-475c-851d-c7cf98923041/verify
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/8a83f62f-2b00-4e17-9bef-bc10faef3098/verify
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 62
-        body: '{"key_id":"7e6da60c-5bfa-475c-851d-c7cf98923041","valid":true}'
+        body: '{"key_id":"8a83f62f-2b00-4e17-9bef-bc10faef3098","valid":true}'
         headers:
             Content-Length:
                 - "62"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - debfadbe-0a64-404c-a984-6b417cbbe428
+                - 5b24ba4b-a436-41be-b194-dd7bea25a257
         status: 200 OK
         code: 200
-        duration: 94.548007ms
+        duration: 71.194561ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -780,7 +780,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/fd998353-a9be-444d-afec-f8546785aac4/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6afb549e-80a6-4433-bead-ef1e9fb3887f/versions/1
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -792,14 +792,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:22 GMT
+                - Tue, 07 Jul 2026 07:46:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - c88c148e-c7cf-4bfb-b7e1-1ef14aa1c65e
+                - 02a6981e-5d12-4178-bd14-dd7b5dfa47a5
         status: 204 No Content
         code: 204
-        duration: 69.242797ms
+        duration: 112.059281ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -810,7 +810,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/fd998353-a9be-444d-afec-f8546785aac4
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/8a83f62f-2b00-4e17-9bef-bc10faef3098
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -822,14 +822,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:22 GMT
+                - Tue, 07 Jul 2026 07:46:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 66693c61-95ff-47e4-b4e8-840890e4ac4a
+                - 93ccd58d-0e65-4d8b-b1bd-a242798ca161
         status: 204 No Content
         code: 204
-        duration: 73.485757ms
+        duration: 80.834699ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -840,7 +840,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/7e6da60c-5bfa-475c-851d-c7cf98923041
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6afb549e-80a6-4433-bead-ef1e9fb3887f
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -852,14 +852,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:22 GMT
+                - Tue, 07 Jul 2026 07:46:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 8b9e62d4-4489-4eb3-8303-33404ac04e85
+                - 2bcbd3e6-f270-48aa-b25e-29b91e173649
         status: 204 No Content
         code: 204
-        duration: 75.608734ms
+        duration: 101.113773ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -870,28 +870,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/7e6da60c-5bfa-475c-851d-c7cf98923041
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/8a83f62f-2b00-4e17-9bef-bc10faef3098
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 570
-        body: '{"id":"7e6da60c-5bfa-475c-851d-c7cf98923041","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-03T15:28:19.283852Z","updated_at":"2026-07-03T15:28:22.411426Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.368507Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-03T15:28:22.411425Z","protection_level":"software","region":"fr-par"}'
+        body: '{"id":"8a83f62f-2b00-4e17-9bef-bc10faef3098","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-07T07:46:04.804893Z","updated_at":"2026-07-07T07:46:08.576247Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:05.170115Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-07T07:46:08.576247Z","protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "570"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:22 GMT
+                - Tue, 07 Jul 2026 07:46:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 92630ff4-bd87-4a4b-a776-35557e55f2c8
+                - c935daff-c5aa-4931-95aa-91dda6d4d632
         status: 200 OK
         code: 200
-        duration: 47.582363ms
+        duration: 52.33252ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -902,25 +902,25 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/fd998353-a9be-444d-afec-f8546785aac4
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6afb549e-80a6-4433-bead-ef1e9fb3887f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 457
-        body: '{"id":"fd998353-a9be-444d-afec-f8546785aac4","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-verify-secret","status":"ready","created_at":"2026-07-03T15:28:18.803210Z","updated_at":"2026-07-03T15:28:22.407282Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-07-03T15:28:22.407282Z","key_id":null,"region":"fr-par"}'
+        body: '{"id":"6afb549e-80a6-4433-bead-ef1e9fb3887f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-verify-secret","status":"ready","created_at":"2026-07-07T07:46:02.418967Z","updated_at":"2026-07-07T07:46:08.609429Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-07-07T07:46:08.609429Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "457"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:22 GMT
+                - Tue, 07 Jul 2026 07:46:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - f570a598-484c-4de3-b36e-3aefbf8c0b6d
+                - 5f1f26fb-41fe-4f5e-add3-01962f6d93b7
         status: 200 OK
         code: 200
-        duration: 47.878909ms
+        duration: 49.254272ms

--- a/internal/services/keymanager/testdata/data-source-verify-invalid.cassette.yaml
+++ b/internal/services/keymanager/testdata/data-source-verify-invalid.cassette.yaml
@@ -21,21 +21,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 440
-        body: '{"id":"5222f140-1459-45f1-a13d-9fe4cd7f1517","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-verify-secret-invalid","status":"ready","created_at":"2026-07-03T15:28:18.729628Z","updated_at":"2026-07-03T15:28:18.729628Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"1499e144-b8c4-48b4-b5e2-66c8f8782e7b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-verify-secret-invalid","status":"ready","created_at":"2026-07-07T07:46:02.460736Z","updated_at":"2026-07-07T07:46:02.460736Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "440"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:18 GMT
+                - Tue, 07 Jul 2026 07:46:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 2dc6e086-bc59-4c41-a7f5-63a9b3b7c856
+                - 17bc0402-d293-44bf-ac6c-cde75fb51794
         status: 200 OK
         code: 200
-        duration: 130.190613ms
+        duration: 337.956366ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -46,28 +46,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5222f140-1459-45f1-a13d-9fe4cd7f1517
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1499e144-b8c4-48b4-b5e2-66c8f8782e7b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 440
-        body: '{"id":"5222f140-1459-45f1-a13d-9fe4cd7f1517","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-verify-secret-invalid","status":"ready","created_at":"2026-07-03T15:28:18.729628Z","updated_at":"2026-07-03T15:28:18.729628Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"1499e144-b8c4-48b4-b5e2-66c8f8782e7b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-verify-secret-invalid","status":"ready","created_at":"2026-07-07T07:46:02.460736Z","updated_at":"2026-07-07T07:46:02.460736Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "440"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:18 GMT
+                - Tue, 07 Jul 2026 07:46:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 124480cf-29f2-492d-9772-71723dae3da0
+                - 0d47cb16-5907-4111-8781-01873d2f7dde
         status: 200 OK
         code: 200
-        duration: 61.195983ms
+        duration: 38.872905ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -81,7 +81,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5222f140-1459-45f1-a13d-9fe4cd7f1517/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1499e144-b8c4-48b4-b5e2-66c8f8782e7b/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -95,22 +95,22 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:18 GMT
+                - Tue, 07 Jul 2026 07:46:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - f0665d49-c900-4570-bf6b-d4885e602a70
+                - 5e2b1280-bf5e-4846-a621-de4a963908e1
         status: 200 OK
         code: 200
-        duration: 50.93496ms
+        duration: 87.631461ms
     - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 245
+        content_length: 199
         host: api.scaleway.com
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-key-invalid","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"tags":null,"unprotected":true,"origin":"unknown_origin","protection_level":"unknown_protection_level"}'
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-key-invalid","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"tags":null,"unprotected":true,"origin":"unknown_origin"}'
         headers:
             Content-Type:
                 - application/json
@@ -123,21 +123,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 538
-        body: '{"id":"969b2333-caec-45d2-99b0-aef0b1d49d12","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-key-invalid","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.543164Z","updated_at":"2026-07-03T15:28:19.841001Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.841001Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"5d6d4534-252a-419d-a05c-c8c46ca78bc8","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-key-invalid","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:04.605646Z","updated_at":"2026-07-07T07:46:04.766080Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:04.766080Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "538"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:19 GMT
+                - Tue, 07 Jul 2026 07:46:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 02ec31a4-d5f2-4ded-b931-29fbb6569e79
+                - 139b05b4-bda9-4436-ada7-018162dd21d5
         status: 200 OK
         code: 200
-        duration: 1.251528081s
+        duration: 2.670326764s
     - id: 4
       request:
         proto: HTTP/1.1
@@ -148,28 +148,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/969b2333-caec-45d2-99b0-aef0b1d49d12
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/5d6d4534-252a-419d-a05c-c8c46ca78bc8
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 538
-        body: '{"id":"969b2333-caec-45d2-99b0-aef0b1d49d12","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-key-invalid","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.543164Z","updated_at":"2026-07-03T15:28:19.841001Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.841001Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"5d6d4534-252a-419d-a05c-c8c46ca78bc8","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-key-invalid","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:04.605646Z","updated_at":"2026-07-07T07:46:04.766080Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:04.766080Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "538"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:19 GMT
+                - Tue, 07 Jul 2026 07:46:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 0591e447-7ee6-4a7d-a272-c5fd3c690da1
+                - f8eaa1c1-6740-41e5-9602-b25cf91b5070
         status: 200 OK
         code: 200
-        duration: 48.154878ms
+        duration: 48.532423ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -183,36 +183,167 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/969b2333-caec-45d2-99b0-aef0b1d49d12/sign
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/5d6d4534-252a-419d-a05c-c8c46ca78bc8/sign
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 408
-        body: '{"key_id":"969b2333-caec-45d2-99b0-aef0b1d49d12","signature":"AQwmaiVMqUfFmrA1Sp+7pNDMWHDD8OPnu7wxOLG6crBrPQqrwV+QF4ERZxdYvnZ/c9qqfa0WOf8eeoWuJso0TBrZbnd6VQb2DDxgXXKTMiCQew5Z93rWnSiEtV2xqtgQ7r3SCxuqlD5e8fqI88eVGrawhFTd5rhZVcKSOZpXtYkcMRgKk8KeFUiEavJPlOxIEg+qmor/cn7BXq24YrOMIVjVLDZllbLajVJ1DtM4dqP/URNCB1mN4i249qBC9tHTIhRkQDwDpsdNajtxsHtx7FPbo3+5DmAKLia3Qcuzt9J+jM9NjkKdV/yPVB8FG6eUZzC9BRl8N4vOYagvxDFRvQ=="}'
+        body: '{"key_id":"5d6d4534-252a-419d-a05c-c8c46ca78bc8","signature":"dnP9LrVXxVxioaZxItQ0Ax0WtMzai3bRxD+n7e3li8BJj5kkRDKBh2O2bKWO+DStYxJL8IHoTGhgQuTnToahnz715CedG7LJebI01K8sLUn8QQG8eu0InV9Nm1KhO52Ag3hSsPxvJGt1Kjnn8b3BkX13JUUyiusljCFKZI/d6PZ0bOT+5kt3HDWZS5/VMrWf4NYsvLVSns73g1iFz4pq6ajNBXLZxB+M4b6NEMNHySrUpsBnEBsMjwey/2ScGLZNzf72zXLfnreg7fNfW2jeipGh1W4dLTGgdYxU1vYj5E3P6aiEyRdnQSPXWoKtrbH+wiveYjq/MXUUyghbqNhw7g=="}'
         headers:
             Content-Length:
                 - "408"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:20 GMT
+                - Tue, 07 Jul 2026 07:46:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 3b8212c2-2013-4cd5-a7d5-44f215dfc356
+                - f7a8abbb-e95e-42d6-8e66-6d29660f743c
         status: 200 OK
         code: 200
-        duration: 99.203581ms
+        duration: 120.426116ms
     - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 243
+        content_length: 496
         host: api.scaleway.com
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-other-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"tags":null,"unprotected":true,"origin":"unknown_origin","protection_level":"unknown_protection_level"}'
+        body: '{"data":"ZG5QOUxyVlh4Vnhpb2FaeEl0UTBBeDBXdE16YWkzYlJ4RCtuN2UzbGk4QkpqNWtrUkRLQmgyTzJiS1dPK0RTdFl4Skw4SUhvVEdoZ1F1VG5Ub2Fobno3MTVDZWRHN0xKZWJJMDFLOHNMVW44UVFHOGV1MEluVjlObTFLaE81MkFnM2hTc1B4dkpHdDFLam5uOGIzQmtYMTNKVVV5aXVzbGpDRktaSS9kNlBaMGJPVCs1a3QzSERXWlM1L1ZNcldmNE5Zc3ZMVlNuczczZzFpRno0cHE2YWpOQlhMWnhCK000YjZORU1OSHlTclVwc0JuRUJzTWp3ZXkvMlNjR0xaTnpmNzJ6WExmbnJlZzdmTmZXMmplaXBHaDFXNGRMVEdnZFl4VTF2WWo1RTNQNmFpRXlSZG5RU1BYV29LdHJiSCt3aXZlWWpxL01YVVV5Z2hicU5odzdnPT0=","description":"version1"}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1499e144-b8c4-48b4-b5e2-66c8f8782e7b/versions
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 302
+        body: '{"revision":1,"secret_id":"1499e144-b8c4-48b4-b5e2-66c8f8782e7b","status":"enabled","created_at":"2026-07-07T07:46:05.508490Z","updated_at":"2026-07-07T07:46:05.508490Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "302"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 07 Jul 2026 07:46:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - c5124b42-09ef-4876-8e7a-057e8910b239
+        status: 200 OK
+        code: 200
+        duration: 538.544494ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1499e144-b8c4-48b4-b5e2-66c8f8782e7b/versions/1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 302
+        body: '{"revision":1,"secret_id":"1499e144-b8c4-48b4-b5e2-66c8f8782e7b","status":"enabled","created_at":"2026-07-07T07:46:05.508490Z","updated_at":"2026-07-07T07:46:05.508490Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "302"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 07 Jul 2026 07:46:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 1bdbe181-931e-4b6c-a2b3-eb66a5fae320
+        status: 200 OK
+        code: 200
+        duration: 79.904534ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1499e144-b8c4-48b4-b5e2-66c8f8782e7b/versions/1/access
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 569
+        body: '{"secret_id":"1499e144-b8c4-48b4-b5e2-66c8f8782e7b","revision":1,"data":"ZG5QOUxyVlh4Vnhpb2FaeEl0UTBBeDBXdE16YWkzYlJ4RCtuN2UzbGk4QkpqNWtrUkRLQmgyTzJiS1dPK0RTdFl4Skw4SUhvVEdoZ1F1VG5Ub2Fobno3MTVDZWRHN0xKZWJJMDFLOHNMVW44UVFHOGV1MEluVjlObTFLaE81MkFnM2hTc1B4dkpHdDFLam5uOGIzQmtYMTNKVVV5aXVzbGpDRktaSS9kNlBaMGJPVCs1a3QzSERXWlM1L1ZNcldmNE5Zc3ZMVlNuczczZzFpRno0cHE2YWpOQlhMWnhCK000YjZORU1OSHlTclVwc0JuRUJzTWp3ZXkvMlNjR0xaTnpmNzJ6WExmbnJlZzdmTmZXMmplaXBHaDFXNGRMVEdnZFl4VTF2WWo1RTNQNmFpRXlSZG5RU1BYV29LdHJiSCt3aXZlWWpxL01YVVV5Z2hicU5odzdnPT0=","data_crc32":null,"type":"opaque"}'
+        headers:
+            Content-Length:
+                - "569"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 07 Jul 2026 07:46:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 508052c5-89a2-4c3a-bc64-7690bb263be0
+        status: 200 OK
+        code: 200
+        duration: 188.196805ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1499e144-b8c4-48b4-b5e2-66c8f8782e7b/versions/1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 302
+        body: '{"revision":1,"secret_id":"1499e144-b8c4-48b4-b5e2-66c8f8782e7b","status":"enabled","created_at":"2026-07-07T07:46:05.508490Z","updated_at":"2026-07-07T07:46:05.508490Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "302"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 07 Jul 2026 07:46:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 11e9562e-d927-420e-b4df-af2401b46170
+        status: 200 OK
+        code: 200
+        duration: 78.28796ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 197
+        host: api.scaleway.com
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-other-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"tags":null,"unprotected":true,"origin":"unknown_origin"}'
         headers:
             Content-Type:
                 - application/json
@@ -225,152 +356,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 536
-        body: '{"id":"b1132c2b-01d9-4c6c-950c-b4b15d787780","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-other-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.995464Z","updated_at":"2026-07-03T15:28:20.337904Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:20.337904Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"f688d12f-fd78-4d61-b983-28316cef6d5f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-other-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:05.931361Z","updated_at":"2026-07-07T07:46:06.055912Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:06.055912Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "536"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:20 GMT
+                - Tue, 07 Jul 2026 07:46:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 6b827a7d-ad93-42fe-bf6e-20a56100bca8
+                - f65a37fc-0229-48f9-b2a2-af5c3e6f7f01
         status: 200 OK
         code: 200
-        duration: 420.474165ms
-    - id: 7
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 496
-        host: api.scaleway.com
-        body: '{"data":"QVF3bWFpVk1xVWZGbXJBMVNwKzdwTkRNV0hERDhPUG51N3d4T0xHNmNyQnJQUXFyd1YrUUY0RVJaeGRZdm5aL2M5cXFmYTBXT2Y4ZWVvV3VKc28wVEJyWmJuZDZWUWIyRER4Z1hYS1RNaUNRZXc1WjkzclduU2lFdFYyeHF0Z1E3cjNTQ3h1cWxENWU4ZnFJODhlVkdyYXdoRlRkNXJoWlZjS1NPWnBYdFlrY01SZ0trOEtlRlVpRWF2SlBsT3hJRWcrcW1vci9jbjdCWHEyNFlyT01JVmpWTERabGxiTGFqVkoxRHRNNGRxUC9VUk5DQjFtTjRpMjQ5cUJDOXRIVEloUmtRRHdEcHNkTmFqdHhzSHR4N0ZQYm8zKzVEbUFLTGlhM1FjdXp0OUorak05TmprS2RWL3lQVkI4Rkc2ZVVaekM5QlJsOE40dk9ZYWd2eERGUnZRPT0=","description":"version1"}'
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5222f140-1459-45f1-a13d-9fe4cd7f1517/versions
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 302
-        body: '{"revision":1,"secret_id":"5222f140-1459-45f1-a13d-9fe4cd7f1517","status":"enabled","created_at":"2026-07-03T15:28:20.360180Z","updated_at":"2026-07-03T15:28:20.360180Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "302"
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 03 Jul 2026 15:28:20 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            X-Request-Id:
-                - fa7ddbbc-54d7-40a7-89b4-3e5fa1c5a5a7
-        status: 200 OK
-        code: 200
-        duration: 349.52301ms
-    - id: 8
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/b1132c2b-01d9-4c6c-950c-b4b15d787780
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 536
-        body: '{"id":"b1132c2b-01d9-4c6c-950c-b4b15d787780","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-other-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.995464Z","updated_at":"2026-07-03T15:28:20.337904Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:20.337904Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "536"
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 03 Jul 2026 15:28:20 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            X-Request-Id:
-                - d0bf6142-2596-4d55-927e-f66a7f477c4d
-        status: 200 OK
-        code: 200
-        duration: 45.910412ms
-    - id: 9
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5222f140-1459-45f1-a13d-9fe4cd7f1517/versions/1
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 302
-        body: '{"revision":1,"secret_id":"5222f140-1459-45f1-a13d-9fe4cd7f1517","status":"enabled","created_at":"2026-07-03T15:28:20.360180Z","updated_at":"2026-07-03T15:28:20.360180Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "302"
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 03 Jul 2026 15:28:20 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            X-Request-Id:
-                - faca93d1-674d-41eb-a573-39fb27797a1a
-        status: 200 OK
-        code: 200
-        duration: 42.541324ms
-    - id: 10
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5222f140-1459-45f1-a13d-9fe4cd7f1517/versions/1/access
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 569
-        body: '{"secret_id":"5222f140-1459-45f1-a13d-9fe4cd7f1517","revision":1,"data":"QVF3bWFpVk1xVWZGbXJBMVNwKzdwTkRNV0hERDhPUG51N3d4T0xHNmNyQnJQUXFyd1YrUUY0RVJaeGRZdm5aL2M5cXFmYTBXT2Y4ZWVvV3VKc28wVEJyWmJuZDZWUWIyRER4Z1hYS1RNaUNRZXc1WjkzclduU2lFdFYyeHF0Z1E3cjNTQ3h1cWxENWU4ZnFJODhlVkdyYXdoRlRkNXJoWlZjS1NPWnBYdFlrY01SZ0trOEtlRlVpRWF2SlBsT3hJRWcrcW1vci9jbjdCWHEyNFlyT01JVmpWTERabGxiTGFqVkoxRHRNNGRxUC9VUk5DQjFtTjRpMjQ5cUJDOXRIVEloUmtRRHdEcHNkTmFqdHhzSHR4N0ZQYm8zKzVEbUFLTGlhM1FjdXp0OUorak05TmprS2RWL3lQVkI4Rkc2ZVVaekM5QlJsOE40dk9ZYWd2eERGUnZRPT0=","data_crc32":null,"type":"opaque"}'
-        headers:
-            Content-Length:
-                - "569"
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 03 Jul 2026 15:28:20 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            X-Request-Id:
-                - b8d47c20-dea9-43dc-a21e-c373740945ed
-        status: 200 OK
-        code: 200
-        duration: 155.451921ms
+        duration: 1.220355804s
     - id: 11
       request:
         proto: HTTP/1.1
@@ -381,28 +381,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5222f140-1459-45f1-a13d-9fe4cd7f1517/versions/1
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/f688d12f-fd78-4d61-b983-28316cef6d5f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 302
-        body: '{"revision":1,"secret_id":"5222f140-1459-45f1-a13d-9fe4cd7f1517","status":"enabled","created_at":"2026-07-03T15:28:20.360180Z","updated_at":"2026-07-03T15:28:20.360180Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 536
+        body: '{"id":"f688d12f-fd78-4d61-b983-28316cef6d5f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-other-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:05.931361Z","updated_at":"2026-07-07T07:46:06.055912Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:06.055912Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "302"
+                - "536"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:20 GMT
+                - Tue, 07 Jul 2026 07:46:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 6af2c7ee-a353-4aac-8212-8fd6c3de13dd
+                - 34ccd8ea-cc14-42d0-abfd-6c9ae06bcf80
         status: 200 OK
         code: 200
-        duration: 54.424844ms
+        duration: 49.945788ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -410,34 +410,34 @@ interactions:
         proto_minor: 1
         content_length: 416
         host: api.scaleway.com
-        body: '{"digest":"+wxGDJPL0C0K00FBHoXsjM0xaYYPTtIHSfdfjlvQEMs=","signature":"AQwmaiVMqUfFmrA1Sp+7pNDMWHDD8OPnu7wxOLG6crBrPQqrwV+QF4ERZxdYvnZ/c9qqfa0WOf8eeoWuJso0TBrZbnd6VQb2DDxgXXKTMiCQew5Z93rWnSiEtV2xqtgQ7r3SCxuqlD5e8fqI88eVGrawhFTd5rhZVcKSOZpXtYkcMRgKk8KeFUiEavJPlOxIEg+qmor/cn7BXq24YrOMIVjVLDZllbLajVJ1DtM4dqP/URNCB1mN4i249qBC9tHTIhRkQDwDpsdNajtxsHtx7FPbo3+5DmAKLia3Qcuzt9J+jM9NjkKdV/yPVB8FG6eUZzC9BRl8N4vOYagvxDFRvQ=="}'
+        body: '{"digest":"+wxGDJPL0C0K00FBHoXsjM0xaYYPTtIHSfdfjlvQEMs=","signature":"dnP9LrVXxVxioaZxItQ0Ax0WtMzai3bRxD+n7e3li8BJj5kkRDKBh2O2bKWO+DStYxJL8IHoTGhgQuTnToahnz715CedG7LJebI01K8sLUn8QQG8eu0InV9Nm1KhO52Ag3hSsPxvJGt1Kjnn8b3BkX13JUUyiusljCFKZI/d6PZ0bOT+5kt3HDWZS5/VMrWf4NYsvLVSns73g1iFz4pq6ajNBXLZxB+M4b6NEMNHySrUpsBnEBsMjwey/2ScGLZNzf72zXLfnreg7fNfW2jeipGh1W4dLTGgdYxU1vYj5E3P6aiEyRdnQSPXWoKtrbH+wiveYjq/MXUUyghbqNhw7g=="}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/b1132c2b-01d9-4c6c-950c-b4b15d787780/verify
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/f688d12f-fd78-4d61-b983-28316cef6d5f/verify
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 63
-        body: '{"key_id":"b1132c2b-01d9-4c6c-950c-b4b15d787780","valid":false}'
+        body: '{"key_id":"f688d12f-fd78-4d61-b983-28316cef6d5f","valid":false}'
         headers:
             Content-Length:
                 - "63"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:20 GMT
+                - Tue, 07 Jul 2026 07:46:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 8b68b98a-6ab6-44bc-b058-a9ab549322f5
+                - 82fe8768-9bc2-4e3d-9f43-f131b54764e6
         status: 200 OK
         code: 200
-        duration: 264.730215ms
+        duration: 115.855242ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -451,28 +451,28 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/969b2333-caec-45d2-99b0-aef0b1d49d12/sign
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/5d6d4534-252a-419d-a05c-c8c46ca78bc8/sign
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 408
-        body: '{"key_id":"969b2333-caec-45d2-99b0-aef0b1d49d12","signature":"kpQmMuyN5wF151mt2NPDrPWhnVW2Y/vNfYsfnpQYD75dfwuEgmN3ahbXvwHnv99LnxOBQAkqV/r0jlf3X4sqUgFL3XiuPYqxZpXa6mka7tkRw0WMo1/U8WUUM9KXctqQrENNQfJBMsnAVbgwY+1+x2fUuMIckNMoggRgMwTCTK8Bc9E4CuaiYVCUFR6ui1AUqqIv+DIKIHpK2AyU9rE8JbHKGJnrDB0MFnI7SDpPewZrv8cmADEEhvALwUXPCKmfcVhB8WI7qvwnQzJtUdI5U7fAqiOjgAeiDjWSpXgS/xltZDQU4QcogTmg9eXTVQ0LhixZBchyn9oZO1sQVjbMRA=="}'
+        body: '{"key_id":"5d6d4534-252a-419d-a05c-c8c46ca78bc8","signature":"WTJYAkYZ2Zqr2fnSI7rc0dl7GY9wkcmsGPy+6cdQKhEmzEOjYfdSXr72trHmO0mY0+Zb25nwZ573qZ+gD9aS/kccolm9fPMFGO99eS7ODe3xsyc6ZgdjxtPDyzt6+Jz5ztXPWS5Ks9eGsqBPaXDNP8C21vhHhUK7s3emQ4cwFrn9aywaHFSLACxT6LMAUJX21U7NWYJHKVHPV1ucr/TI9B7uq9NvtyFIEc49QbNt9HviQFvaxBBb2PCFudSB25AeQrkHSXu2hjBxPAFLRdL0Ni1suvbID+9GCU/yBLbEfe1Ed0m4/Q2YlM+8kRpWRwgCS7DNlsABT/4WqDauMNdC4A=="}'
         headers:
             Content-Length:
                 - "408"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
+                - Tue, 07 Jul 2026 07:46:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 56958b8a-51d5-4bbc-b442-75a61100031d
+                - 20ad5abc-e30a-4fec-a237-c44e18e3e1bf
         status: 200 OK
         code: 200
-        duration: 171.826317ms
+        duration: 107.698407ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -483,28 +483,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5222f140-1459-45f1-a13d-9fe4cd7f1517/versions/1/access
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1499e144-b8c4-48b4-b5e2-66c8f8782e7b/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 569
-        body: '{"secret_id":"5222f140-1459-45f1-a13d-9fe4cd7f1517","revision":1,"data":"QVF3bWFpVk1xVWZGbXJBMVNwKzdwTkRNV0hERDhPUG51N3d4T0xHNmNyQnJQUXFyd1YrUUY0RVJaeGRZdm5aL2M5cXFmYTBXT2Y4ZWVvV3VKc28wVEJyWmJuZDZWUWIyRER4Z1hYS1RNaUNRZXc1WjkzclduU2lFdFYyeHF0Z1E3cjNTQ3h1cWxENWU4ZnFJODhlVkdyYXdoRlRkNXJoWlZjS1NPWnBYdFlrY01SZ0trOEtlRlVpRWF2SlBsT3hJRWcrcW1vci9jbjdCWHEyNFlyT01JVmpWTERabGxiTGFqVkoxRHRNNGRxUC9VUk5DQjFtTjRpMjQ5cUJDOXRIVEloUmtRRHdEcHNkTmFqdHhzSHR4N0ZQYm8zKzVEbUFLTGlhM1FjdXp0OUorak05TmprS2RWL3lQVkI4Rkc2ZVVaekM5QlJsOE40dk9ZYWd2eERGUnZRPT0=","data_crc32":null,"type":"opaque"}'
+        body: '{"secret_id":"1499e144-b8c4-48b4-b5e2-66c8f8782e7b","revision":1,"data":"ZG5QOUxyVlh4Vnhpb2FaeEl0UTBBeDBXdE16YWkzYlJ4RCtuN2UzbGk4QkpqNWtrUkRLQmgyTzJiS1dPK0RTdFl4Skw4SUhvVEdoZ1F1VG5Ub2Fobno3MTVDZWRHN0xKZWJJMDFLOHNMVW44UVFHOGV1MEluVjlObTFLaE81MkFnM2hTc1B4dkpHdDFLam5uOGIzQmtYMTNKVVV5aXVzbGpDRktaSS9kNlBaMGJPVCs1a3QzSERXWlM1L1ZNcldmNE5Zc3ZMVlNuczczZzFpRno0cHE2YWpOQlhMWnhCK000YjZORU1OSHlTclVwc0JuRUJzTWp3ZXkvMlNjR0xaTnpmNzJ6WExmbnJlZzdmTmZXMmplaXBHaDFXNGRMVEdnZFl4VTF2WWo1RTNQNmFpRXlSZG5RU1BYV29LdHJiSCt3aXZlWWpxL01YVVV5Z2hicU5odzdnPT0=","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
                 - "569"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
+                - Tue, 07 Jul 2026 07:46:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - c00c2105-e12e-4964-b9bd-c3b183fc1fac
+                - 03460f03-8272-48d6-b787-40b34c033d6a
         status: 200 OK
         code: 200
-        duration: 73.877221ms
+        duration: 87.417732ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -515,28 +515,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5222f140-1459-45f1-a13d-9fe4cd7f1517/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1499e144-b8c4-48b4-b5e2-66c8f8782e7b/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"5222f140-1459-45f1-a13d-9fe4cd7f1517","status":"enabled","created_at":"2026-07-03T15:28:20.360180Z","updated_at":"2026-07-03T15:28:20.360180Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"1499e144-b8c4-48b4-b5e2-66c8f8782e7b","status":"enabled","created_at":"2026-07-07T07:46:05.508490Z","updated_at":"2026-07-07T07:46:05.508490Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
+                - Tue, 07 Jul 2026 07:46:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 554d7e66-e817-4323-af89-df630ce427ac
+                - 86af0dbd-2500-4699-9d4d-6e0f325a599d
         status: 200 OK
         code: 200
-        duration: 43.978333ms
+        duration: 85.804816ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -544,34 +544,34 @@ interactions:
         proto_minor: 1
         content_length: 416
         host: api.scaleway.com
-        body: '{"digest":"+wxGDJPL0C0K00FBHoXsjM0xaYYPTtIHSfdfjlvQEMs=","signature":"AQwmaiVMqUfFmrA1Sp+7pNDMWHDD8OPnu7wxOLG6crBrPQqrwV+QF4ERZxdYvnZ/c9qqfa0WOf8eeoWuJso0TBrZbnd6VQb2DDxgXXKTMiCQew5Z93rWnSiEtV2xqtgQ7r3SCxuqlD5e8fqI88eVGrawhFTd5rhZVcKSOZpXtYkcMRgKk8KeFUiEavJPlOxIEg+qmor/cn7BXq24YrOMIVjVLDZllbLajVJ1DtM4dqP/URNCB1mN4i249qBC9tHTIhRkQDwDpsdNajtxsHtx7FPbo3+5DmAKLia3Qcuzt9J+jM9NjkKdV/yPVB8FG6eUZzC9BRl8N4vOYagvxDFRvQ=="}'
+        body: '{"digest":"+wxGDJPL0C0K00FBHoXsjM0xaYYPTtIHSfdfjlvQEMs=","signature":"dnP9LrVXxVxioaZxItQ0Ax0WtMzai3bRxD+n7e3li8BJj5kkRDKBh2O2bKWO+DStYxJL8IHoTGhgQuTnToahnz715CedG7LJebI01K8sLUn8QQG8eu0InV9Nm1KhO52Ag3hSsPxvJGt1Kjnn8b3BkX13JUUyiusljCFKZI/d6PZ0bOT+5kt3HDWZS5/VMrWf4NYsvLVSns73g1iFz4pq6ajNBXLZxB+M4b6NEMNHySrUpsBnEBsMjwey/2ScGLZNzf72zXLfnreg7fNfW2jeipGh1W4dLTGgdYxU1vYj5E3P6aiEyRdnQSPXWoKtrbH+wiveYjq/MXUUyghbqNhw7g=="}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/b1132c2b-01d9-4c6c-950c-b4b15d787780/verify
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/f688d12f-fd78-4d61-b983-28316cef6d5f/verify
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 63
-        body: '{"key_id":"b1132c2b-01d9-4c6c-950c-b4b15d787780","valid":false}'
+        body: '{"key_id":"f688d12f-fd78-4d61-b983-28316cef6d5f","valid":false}'
         headers:
             Content-Length:
                 - "63"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
+                - Tue, 07 Jul 2026 07:46:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 566020ef-451f-42a6-8007-2fd70b1d64e2
+                - 3fdd1d8f-300c-4a51-973b-2e0fe8bc4af6
         status: 200 OK
         code: 200
-        duration: 73.534688ms
+        duration: 97.660725ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -582,28 +582,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5222f140-1459-45f1-a13d-9fe4cd7f1517
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1499e144-b8c4-48b4-b5e2-66c8f8782e7b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 440
-        body: '{"id":"5222f140-1459-45f1-a13d-9fe4cd7f1517","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-verify-secret-invalid","status":"ready","created_at":"2026-07-03T15:28:18.729628Z","updated_at":"2026-07-03T15:28:18.729628Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"1499e144-b8c4-48b4-b5e2-66c8f8782e7b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-verify-secret-invalid","status":"ready","created_at":"2026-07-07T07:46:02.460736Z","updated_at":"2026-07-07T07:46:02.460736Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "440"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:22 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - d5839dde-bb67-4aa8-9826-3937f822c50c
+                - fbfc22be-9e4b-47f9-8bd1-5d928d30a5ad
         status: 200 OK
         code: 200
-        duration: 42.820689ms
+        duration: 36.160817ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -614,28 +614,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/969b2333-caec-45d2-99b0-aef0b1d49d12
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/5d6d4534-252a-419d-a05c-c8c46ca78bc8
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 538
-        body: '{"id":"969b2333-caec-45d2-99b0-aef0b1d49d12","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-key-invalid","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.543164Z","updated_at":"2026-07-03T15:28:19.841001Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.841001Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"5d6d4534-252a-419d-a05c-c8c46ca78bc8","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-key-invalid","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:04.605646Z","updated_at":"2026-07-07T07:46:04.766080Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:04.766080Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "538"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:22 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - f827ce67-9250-491f-a0a9-136061c27b16
+                - 26d15141-faf6-4fac-86e2-8d57414c73af
         status: 200 OK
         code: 200
-        duration: 45.961178ms
+        duration: 49.851577ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -649,28 +649,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5222f140-1459-45f1-a13d-9fe4cd7f1517/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1499e144-b8c4-48b4-b5e2-66c8f8782e7b/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 333
-        body: '{"versions":[{"revision":1,"secret_id":"5222f140-1459-45f1-a13d-9fe4cd7f1517","status":"enabled","created_at":"2026-07-03T15:28:20.360180Z","updated_at":"2026-07-03T15:28:20.360180Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        body: '{"versions":[{"revision":1,"secret_id":"1499e144-b8c4-48b4-b5e2-66c8f8782e7b","status":"enabled","created_at":"2026-07-07T07:46:05.508490Z","updated_at":"2026-07-07T07:46:05.508490Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "333"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:22 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - be24d6c0-76fc-4be2-aed7-18e9d1999ab9
+                - 42a584f6-81bb-453e-a8fd-4fb39c7c4524
         status: 200 OK
         code: 200
-        duration: 41.319079ms
+        duration: 59.959108ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -681,28 +681,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/b1132c2b-01d9-4c6c-950c-b4b15d787780
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/f688d12f-fd78-4d61-b983-28316cef6d5f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 536
-        body: '{"id":"b1132c2b-01d9-4c6c-950c-b4b15d787780","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-other-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.995464Z","updated_at":"2026-07-03T15:28:20.337904Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:20.337904Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"f688d12f-fd78-4d61-b983-28316cef6d5f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-other-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:05.931361Z","updated_at":"2026-07-07T07:46:06.055912Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:06.055912Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "536"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:22 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 8e4f5b98-6cae-4d2c-84d4-80907f0487d8
+                - cd9825da-3f92-4e04-b3b0-c7a3c3fe8c79
         status: 200 OK
         code: 200
-        duration: 49.473956ms
+        duration: 41.30815ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -716,28 +716,28 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/969b2333-caec-45d2-99b0-aef0b1d49d12/sign
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/5d6d4534-252a-419d-a05c-c8c46ca78bc8/sign
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 408
-        body: '{"key_id":"969b2333-caec-45d2-99b0-aef0b1d49d12","signature":"1oOdw6HoGDtuZRVVJonjRbs773xb7TFtxJT4c6xAyFt6o22p1hkAFcLL57yUw9sIrRFvGgYNfmgU3cnoWYPmHqIz6obSs0mb+Xzf53GfsyoAyQDylKghwbnbjoS0wN7p7dWmkQlDGkTlTGxdbUaOx5XEFu3sF5VBe3eyKMvq6rrCl8rbaGTSRFoVpomiJ6nBkqAAE9J2oT5/4pVMm3mvjurGa838IqhftfYS9NKTgGbdV+4TcmD9FUuk0+4SzVTGZS8SoHCqDsVZ1wdPNfrmqrWNTwjnha2+h/KXZrcRbUh0iz1bjUfG2ho/HwhWKymhtoRHshO7G5hTy7Hx+OKzOg=="}'
+        body: '{"key_id":"5d6d4534-252a-419d-a05c-c8c46ca78bc8","signature":"Bfg59L/0eUd+qvnDKhARPTUBvTSz0R8osCyj1/HIYZRPjEskDglnOwJHZmMQ5X0ZEmAmdeTbU83nbT1FbZr4gtmOQSahpPH93358xL5jfm9vlgmzGigVHgv+bxUnC0ZLk5NSHipo2PwEXaTzS8x9cwgvPvNgH4X4uffHR7qScfGHa8Jv6dr9fhg0U64Z9CitGN2MjlfABM50wjeRYePydFvT0t9TN4buLyNWuSHL+4om9LpQFOJ7x5t8rw9px9gQfP5MRxIduUe08oSd5P/fgOK7c1C8VfzncGzA2n6duWglF1l/h1ziHRTt0rlbOlmzmiDmSI+qE/UGAJS2L2LsvA=="}'
         headers:
             Content-Length:
                 - "408"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:22 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 578a3386-d1a7-40fa-a348-84acbc99e129
+                - 13b4499c-7315-4f30-9334-12b80a8c9e01
         status: 200 OK
         code: 200
-        duration: 63.43607ms
+        duration: 89.874184ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -748,28 +748,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5222f140-1459-45f1-a13d-9fe4cd7f1517/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1499e144-b8c4-48b4-b5e2-66c8f8782e7b/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"5222f140-1459-45f1-a13d-9fe4cd7f1517","status":"enabled","created_at":"2026-07-03T15:28:20.360180Z","updated_at":"2026-07-03T15:28:20.360180Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"1499e144-b8c4-48b4-b5e2-66c8f8782e7b","status":"enabled","created_at":"2026-07-07T07:46:05.508490Z","updated_at":"2026-07-07T07:46:05.508490Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:22 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 201ffb66-a4da-4330-b49f-3efce4d4ab3e
+                - 3107267d-5159-4a7c-9d75-2daf003eeefe
         status: 200 OK
         code: 200
-        duration: 53.052417ms
+        duration: 63.497443ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -780,28 +780,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5222f140-1459-45f1-a13d-9fe4cd7f1517/versions/1/access
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1499e144-b8c4-48b4-b5e2-66c8f8782e7b/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 569
-        body: '{"secret_id":"5222f140-1459-45f1-a13d-9fe4cd7f1517","revision":1,"data":"QVF3bWFpVk1xVWZGbXJBMVNwKzdwTkRNV0hERDhPUG51N3d4T0xHNmNyQnJQUXFyd1YrUUY0RVJaeGRZdm5aL2M5cXFmYTBXT2Y4ZWVvV3VKc28wVEJyWmJuZDZWUWIyRER4Z1hYS1RNaUNRZXc1WjkzclduU2lFdFYyeHF0Z1E3cjNTQ3h1cWxENWU4ZnFJODhlVkdyYXdoRlRkNXJoWlZjS1NPWnBYdFlrY01SZ0trOEtlRlVpRWF2SlBsT3hJRWcrcW1vci9jbjdCWHEyNFlyT01JVmpWTERabGxiTGFqVkoxRHRNNGRxUC9VUk5DQjFtTjRpMjQ5cUJDOXRIVEloUmtRRHdEcHNkTmFqdHhzSHR4N0ZQYm8zKzVEbUFLTGlhM1FjdXp0OUorak05TmprS2RWL3lQVkI4Rkc2ZVVaekM5QlJsOE40dk9ZYWd2eERGUnZRPT0=","data_crc32":null,"type":"opaque"}'
+        body: '{"secret_id":"1499e144-b8c4-48b4-b5e2-66c8f8782e7b","revision":1,"data":"ZG5QOUxyVlh4Vnhpb2FaeEl0UTBBeDBXdE16YWkzYlJ4RCtuN2UzbGk4QkpqNWtrUkRLQmgyTzJiS1dPK0RTdFl4Skw4SUhvVEdoZ1F1VG5Ub2Fobno3MTVDZWRHN0xKZWJJMDFLOHNMVW44UVFHOGV1MEluVjlObTFLaE81MkFnM2hTc1B4dkpHdDFLam5uOGIzQmtYMTNKVVV5aXVzbGpDRktaSS9kNlBaMGJPVCs1a3QzSERXWlM1L1ZNcldmNE5Zc3ZMVlNuczczZzFpRno0cHE2YWpOQlhMWnhCK000YjZORU1OSHlTclVwc0JuRUJzTWp3ZXkvMlNjR0xaTnpmNzJ6WExmbnJlZzdmTmZXMmplaXBHaDFXNGRMVEdnZFl4VTF2WWo1RTNQNmFpRXlSZG5RU1BYV29LdHJiSCt3aXZlWWpxL01YVVV5Z2hicU5odzdnPT0=","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
                 - "569"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:22 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 79c98512-fc97-4965-8f60-44da9a39bc61
+                - e7b43874-0360-4c49-b4f6-9402851cecb6
         status: 200 OK
         code: 200
-        duration: 44.031763ms
+        duration: 91.90293ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -812,28 +812,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5222f140-1459-45f1-a13d-9fe4cd7f1517/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1499e144-b8c4-48b4-b5e2-66c8f8782e7b/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"5222f140-1459-45f1-a13d-9fe4cd7f1517","status":"enabled","created_at":"2026-07-03T15:28:20.360180Z","updated_at":"2026-07-03T15:28:20.360180Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"1499e144-b8c4-48b4-b5e2-66c8f8782e7b","status":"enabled","created_at":"2026-07-07T07:46:05.508490Z","updated_at":"2026-07-07T07:46:05.508490Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:22 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 76370ccc-4b9d-4a37-baef-c4e3fa234103
+                - 7814c2c9-c7a2-4882-a921-409f29437010
         status: 200 OK
         code: 200
-        duration: 50.24804ms
+        duration: 45.712992ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -841,34 +841,34 @@ interactions:
         proto_minor: 1
         content_length: 416
         host: api.scaleway.com
-        body: '{"digest":"+wxGDJPL0C0K00FBHoXsjM0xaYYPTtIHSfdfjlvQEMs=","signature":"AQwmaiVMqUfFmrA1Sp+7pNDMWHDD8OPnu7wxOLG6crBrPQqrwV+QF4ERZxdYvnZ/c9qqfa0WOf8eeoWuJso0TBrZbnd6VQb2DDxgXXKTMiCQew5Z93rWnSiEtV2xqtgQ7r3SCxuqlD5e8fqI88eVGrawhFTd5rhZVcKSOZpXtYkcMRgKk8KeFUiEavJPlOxIEg+qmor/cn7BXq24YrOMIVjVLDZllbLajVJ1DtM4dqP/URNCB1mN4i249qBC9tHTIhRkQDwDpsdNajtxsHtx7FPbo3+5DmAKLia3Qcuzt9J+jM9NjkKdV/yPVB8FG6eUZzC9BRl8N4vOYagvxDFRvQ=="}'
+        body: '{"digest":"+wxGDJPL0C0K00FBHoXsjM0xaYYPTtIHSfdfjlvQEMs=","signature":"dnP9LrVXxVxioaZxItQ0Ax0WtMzai3bRxD+n7e3li8BJj5kkRDKBh2O2bKWO+DStYxJL8IHoTGhgQuTnToahnz715CedG7LJebI01K8sLUn8QQG8eu0InV9Nm1KhO52Ag3hSsPxvJGt1Kjnn8b3BkX13JUUyiusljCFKZI/d6PZ0bOT+5kt3HDWZS5/VMrWf4NYsvLVSns73g1iFz4pq6ajNBXLZxB+M4b6NEMNHySrUpsBnEBsMjwey/2ScGLZNzf72zXLfnreg7fNfW2jeipGh1W4dLTGgdYxU1vYj5E3P6aiEyRdnQSPXWoKtrbH+wiveYjq/MXUUyghbqNhw7g=="}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/b1132c2b-01d9-4c6c-950c-b4b15d787780/verify
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/f688d12f-fd78-4d61-b983-28316cef6d5f/verify
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 63
-        body: '{"key_id":"b1132c2b-01d9-4c6c-950c-b4b15d787780","valid":false}'
+        body: '{"key_id":"f688d12f-fd78-4d61-b983-28316cef6d5f","valid":false}'
         headers:
             Content-Length:
                 - "63"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:22 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 4409c359-1ffd-4713-bc32-cfb2cde52d69
+                - ea5c39dd-8891-449c-8622-bdcd48bd3fb9
         status: 200 OK
         code: 200
-        duration: 90.20003ms
+        duration: 96.770061ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -879,7 +879,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/b1132c2b-01d9-4c6c-950c-b4b15d787780
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/f688d12f-fd78-4d61-b983-28316cef6d5f
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -891,14 +891,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - f9547466-f325-4257-b5f1-61c7b8ed1084
+                - 9a3473fd-9294-47b7-a48a-184d2e0ccf89
         status: 204 No Content
         code: 204
-        duration: 81.55909ms
+        duration: 74.55157ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -909,7 +909,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5222f140-1459-45f1-a13d-9fe4cd7f1517/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1499e144-b8c4-48b4-b5e2-66c8f8782e7b/versions/1
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -921,14 +921,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 6fd54347-59eb-4fc5-97eb-f2233cd69c46
+                - f3f83d19-ed61-4e5d-b133-6924975fd09d
         status: 204 No Content
         code: 204
-        duration: 99.772481ms
+        duration: 118.98998ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -939,7 +939,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5222f140-1459-45f1-a13d-9fe4cd7f1517
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1499e144-b8c4-48b4-b5e2-66c8f8782e7b
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -951,14 +951,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 0fd5389b-56ec-4a2c-b7d0-ebc5179aee97
+                - 5026a7ea-1a42-4fc5-962b-1096000b1e5b
         status: 204 No Content
         code: 204
-        duration: 105.224711ms
+        duration: 115.383148ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -969,7 +969,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/969b2333-caec-45d2-99b0-aef0b1d49d12
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/5d6d4534-252a-419d-a05c-c8c46ca78bc8
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -981,14 +981,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - dee45a7a-4701-4166-8d06-360dd9f88a05
+                - ce82b2c2-0fc7-489b-ae24-39a5edc2d416
         status: 204 No Content
         code: 204
-        duration: 105.315852ms
+        duration: 128.589031ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -999,28 +999,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/b1132c2b-01d9-4c6c-950c-b4b15d787780
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/5d6d4534-252a-419d-a05c-c8c46ca78bc8
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 576
-        body: '{"id":"b1132c2b-01d9-4c6c-950c-b4b15d787780","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-other-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-03T15:28:19.995464Z","updated_at":"2026-07-03T15:28:23.026381Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:20.337904Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-03T15:28:23.026381Z","protection_level":"software","region":"fr-par"}'
+        content_length: 578
+        body: '{"id":"5d6d4534-252a-419d-a05c-c8c46ca78bc8","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-key-invalid","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-07T07:46:04.605646Z","updated_at":"2026-07-07T07:46:08.518432Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:04.766080Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-07T07:46:08.518432Z","protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "576"
+                - "578"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - fda1c16f-c611-4018-a611-85cd18a958a7
+                - 75e3667d-a6a8-47e6-bc82-457a66b80e28
         status: 200 OK
         code: 200
-        duration: 55.292445ms
+        duration: 40.750372ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1031,28 +1031,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/969b2333-caec-45d2-99b0-aef0b1d49d12
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/f688d12f-fd78-4d61-b983-28316cef6d5f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 578
-        body: '{"id":"969b2333-caec-45d2-99b0-aef0b1d49d12","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-key-invalid","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-03T15:28:19.543164Z","updated_at":"2026-07-03T15:28:23.125848Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.841001Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-03T15:28:23.125848Z","protection_level":"software","region":"fr-par"}'
+        content_length: 576
+        body: '{"id":"f688d12f-fd78-4d61-b983-28316cef6d5f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-other-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-07T07:46:05.931361Z","updated_at":"2026-07-07T07:46:08.347102Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:06.055912Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-07T07:46:08.347102Z","protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "578"
+                - "576"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 52c9277a-54fa-4657-b956-d20c968fd0ca
+                - b2689fdd-380e-4fd9-9de6-442722eda241
         status: 200 OK
         code: 200
-        duration: 48.434693ms
+        duration: 44.549501ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1063,25 +1063,25 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5222f140-1459-45f1-a13d-9fe4cd7f1517
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1499e144-b8c4-48b4-b5e2-66c8f8782e7b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 465
-        body: '{"id":"5222f140-1459-45f1-a13d-9fe4cd7f1517","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-verify-secret-invalid","status":"ready","created_at":"2026-07-03T15:28:18.729628Z","updated_at":"2026-07-03T15:28:23.133471Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-07-03T15:28:23.133471Z","key_id":null,"region":"fr-par"}'
+        body: '{"id":"1499e144-b8c4-48b4-b5e2-66c8f8782e7b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-verify-secret-invalid","status":"ready","created_at":"2026-07-07T07:46:02.460736Z","updated_at":"2026-07-07T07:46:08.519917Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-07-07T07:46:08.519917Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "465"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - f1343c68-8139-450f-ac49-86ed700c637a
+                - fd61786a-2685-476d-8066-549af0613f6f
         status: 200 OK
         code: 200
-        duration: 48.382806ms
+        duration: 43.882745ms

--- a/internal/services/keymanager/testdata/decrypt-ephemeral-resource-basic.cassette.yaml
+++ b/internal/services/keymanager/testdata/decrypt-ephemeral-resource-basic.cassette.yaml
@@ -21,21 +21,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 433
-        body: '{"id":"3bb46cf5-824b-45b1-b249-6690e16b6742","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-decrypt-secret","status":"ready","created_at":"2026-07-03T15:28:18.762250Z","updated_at":"2026-07-03T15:28:18.762250Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"6ff9e059-796b-4b06-b6a8-390812c4c506","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-decrypt-secret","status":"ready","created_at":"2026-07-07T07:46:02.393690Z","updated_at":"2026-07-07T07:46:02.393690Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "433"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:18 GMT
+                - Tue, 07 Jul 2026 07:46:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 855905d0-5efd-4d78-b9d6-2170f94ec00d
+                - 022f3e17-ce86-46ec-a9eb-2ee81a19f08b
         status: 200 OK
         code: 200
-        duration: 141.144477ms
+        duration: 291.857031ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -46,28 +46,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bb46cf5-824b-45b1-b249-6690e16b6742
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6ff9e059-796b-4b06-b6a8-390812c4c506
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 433
-        body: '{"id":"3bb46cf5-824b-45b1-b249-6690e16b6742","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-decrypt-secret","status":"ready","created_at":"2026-07-03T15:28:18.762250Z","updated_at":"2026-07-03T15:28:18.762250Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"6ff9e059-796b-4b06-b6a8-390812c4c506","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-decrypt-secret","status":"ready","created_at":"2026-07-07T07:46:02.393690Z","updated_at":"2026-07-07T07:46:02.393690Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "433"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:18 GMT
+                - Tue, 07 Jul 2026 07:46:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 58256c49-a2f6-48bd-9bd8-04add01cd0af
+                - 3c498834-ea5c-45aa-9c82-283ebf8b8c1c
         status: 200 OK
         code: 200
-        duration: 55.496328ms
+        duration: 76.991856ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -81,7 +81,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bb46cf5-824b-45b1-b249-6690e16b6742/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6ff9e059-796b-4b06-b6a8-390812c4c506/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -95,22 +95,22 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:18 GMT
+                - Tue, 07 Jul 2026 07:46:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - fcb8d000-3000-4ed4-bfae-c38a1c2bb0b8
+                - 69f0291b-3e1b-4518-be9d-f87d432d162c
         status: 200 OK
         code: 200
-        duration: 53.849544ms
+        duration: 97.067115ms
     - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 232
+        content_length: 186
         host: api.scaleway.com
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-decrypt-key","usage":{"symmetric_encryption":"aes_256_gcm"},"tags":null,"unprotected":true,"origin":"unknown_origin","protection_level":"unknown_protection_level"}'
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-decrypt-key","usage":{"symmetric_encryption":"aes_256_gcm"},"tags":null,"unprotected":true,"origin":"unknown_origin"}'
         headers:
             Content-Type:
                 - application/json
@@ -123,21 +123,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 525
-        body: '{"id":"f8880c35-46bf-4ecd-8185-c816231f0d78","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-decrypt-key","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.387100Z","updated_at":"2026-07-03T15:28:19.391480Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.391480Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"4e278f73-dff7-462f-98da-60f527e9cc1b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-decrypt-key","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:05.258556Z","updated_at":"2026-07-07T07:46:05.274407Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:05.274407Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "525"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:19 GMT
+                - Tue, 07 Jul 2026 07:46:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 80f11f3a-1aa4-43bb-822f-7d58423f5d78
+                - beb69f86-0b00-465e-8177-ccc295201e4c
         status: 200 OK
         code: 200
-        duration: 773.315126ms
+        duration: 3.168481942s
     - id: 4
       request:
         proto: HTTP/1.1
@@ -148,28 +148,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/f8880c35-46bf-4ecd-8185-c816231f0d78
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/4e278f73-dff7-462f-98da-60f527e9cc1b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 525
-        body: '{"id":"f8880c35-46bf-4ecd-8185-c816231f0d78","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-decrypt-key","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.387100Z","updated_at":"2026-07-03T15:28:19.391480Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.391480Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"4e278f73-dff7-462f-98da-60f527e9cc1b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-decrypt-key","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:05.258556Z","updated_at":"2026-07-07T07:46:05.274407Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:05.274407Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "525"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:19 GMT
+                - Tue, 07 Jul 2026 07:46:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 8e04d28d-481d-4e52-b9bd-63a71a7bef12
+                - 1475e090-2ea4-4906-9f79-df08af08ed58
         status: 200 OK
         code: 200
-        duration: 46.633901ms
+        duration: 103.262818ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -183,28 +183,28 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/f8880c35-46bf-4ecd-8185-c816231f0d78/encrypt
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/4e278f73-dff7-462f-98da-60f527e9cc1b/encrypt
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 141
-        body: '{"key_id":"f8880c35-46bf-4ecd-8185-c816231f0d78","ciphertext":"AQAAAAHh0SpRwFRhgrqq4KZorrtG/Rtr8prBZviXJlDE7DlbHMXsd4aOjzDTM07Dd7AhGodmN5PY"}'
+        body: '{"key_id":"4e278f73-dff7-462f-98da-60f527e9cc1b","ciphertext":"AQAAAAGuozyRXRNM3flc8JvrW8uP3uJ26mkL0fx7oACvb4fgzPGGn1NVHZLM/drO4BDI27vy5yNW"}'
         headers:
             Content-Length:
                 - "141"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:19 GMT
+                - Tue, 07 Jul 2026 07:46:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 0cbe467f-2bd1-4cdd-805a-8850f694be0b
+                - dcafe467-123e-44f5-87f3-a692583fde41
         status: 200 OK
         code: 200
-        duration: 121.549704ms
+        duration: 97.676917ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -212,34 +212,34 @@ interactions:
         proto_minor: 1
         content_length: 116
         host: api.scaleway.com
-        body: '{"ciphertext":"AQAAAAHh0SpRwFRhgrqq4KZorrtG/Rtr8prBZviXJlDE7DlbHMXsd4aOjzDTM07Dd7AhGodmN5PY","associated_data":null}'
+        body: '{"ciphertext":"AQAAAAGuozyRXRNM3flc8JvrW8uP3uJ26mkL0fx7oACvb4fgzPGGn1NVHZLM/drO4BDI27vy5yNW","associated_data":null}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/f8880c35-46bf-4ecd-8185-c816231f0d78/decrypt
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/4e278f73-dff7-462f-98da-60f527e9cc1b/decrypt
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 114
-        body: '{"key_id":"f8880c35-46bf-4ecd-8185-c816231f0d78","plaintext":"dGhpcyBpcyBzb21lIHNlY3JldCBkYXRh","ciphertext":null}'
+        body: '{"key_id":"4e278f73-dff7-462f-98da-60f527e9cc1b","plaintext":"dGhpcyBpcyBzb21lIHNlY3JldCBkYXRh","ciphertext":null}'
         headers:
             Content-Length:
                 - "114"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:19 GMT
+                - Tue, 07 Jul 2026 07:46:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 75727582-fcc5-47a3-a6a1-7cc5ec06f408
+                - 8cc4c14a-3606-49cb-a2bb-99c511ecdd1b
         status: 200 OK
         code: 200
-        duration: 113.159655ms
+        duration: 102.773117ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -253,28 +253,28 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bb46cf5-824b-45b1-b249-6690e16b6742/versions
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6ff9e059-796b-4b06-b6a8-390812c4c506/versions
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 308
-        body: '{"revision":1,"secret_id":"3bb46cf5-824b-45b1-b249-6690e16b6742","status":"enabled","created_at":"2026-07-03T15:28:20.088597Z","updated_at":"2026-07-03T15:28:20.088597Z","deleted_at":null,"description":"test decrypted","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"6ff9e059-796b-4b06-b6a8-390812c4c506","status":"enabled","created_at":"2026-07-07T07:46:06.080386Z","updated_at":"2026-07-07T07:46:06.080386Z","deleted_at":null,"description":"test decrypted","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "308"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:20 GMT
+                - Tue, 07 Jul 2026 07:46:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - f7fef8b7-839c-4fb2-a56e-8552c58fb75e
+                - 381ea65b-8e39-418e-bd1a-2424ddf3b2eb
         status: 200 OK
         code: 200
-        duration: 397.696362ms
+        duration: 485.04958ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -285,28 +285,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bb46cf5-824b-45b1-b249-6690e16b6742/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6ff9e059-796b-4b06-b6a8-390812c4c506/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 308
-        body: '{"revision":1,"secret_id":"3bb46cf5-824b-45b1-b249-6690e16b6742","status":"enabled","created_at":"2026-07-03T15:28:20.088597Z","updated_at":"2026-07-03T15:28:20.088597Z","deleted_at":null,"description":"test decrypted","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"6ff9e059-796b-4b06-b6a8-390812c4c506","status":"enabled","created_at":"2026-07-07T07:46:06.080386Z","updated_at":"2026-07-07T07:46:06.080386Z","deleted_at":null,"description":"test decrypted","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "308"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:20 GMT
+                - Tue, 07 Jul 2026 07:46:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - ee4d2116-0d3b-4702-8b7e-7160bc77deba
+                - 67d31dfc-567b-4812-ae1b-2263e57be210
         status: 200 OK
         code: 200
-        duration: 56.136429ms
+        duration: 92.400585ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -317,28 +317,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bb46cf5-824b-45b1-b249-6690e16b6742/versions/1/access
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6ff9e059-796b-4b06-b6a8-390812c4c506/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 141
-        body: '{"secret_id":"3bb46cf5-824b-45b1-b249-6690e16b6742","revision":1,"data":"dGhpcyBpcyBzb21lIHNlY3JldCBkYXRh","data_crc32":null,"type":"opaque"}'
+        body: '{"secret_id":"6ff9e059-796b-4b06-b6a8-390812c4c506","revision":1,"data":"dGhpcyBpcyBzb21lIHNlY3JldCBkYXRh","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
                 - "141"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:20 GMT
+                - Tue, 07 Jul 2026 07:46:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 3851b9fc-491c-44f8-b80a-bbfeba5ec0d8
+                - f9d4cf8d-0505-4870-9e61-5fc7b6a2f7bc
         status: 200 OK
         code: 200
-        duration: 110.502895ms
+        duration: 50.519659ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -349,28 +349,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bb46cf5-824b-45b1-b249-6690e16b6742/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6ff9e059-796b-4b06-b6a8-390812c4c506/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 308
-        body: '{"revision":1,"secret_id":"3bb46cf5-824b-45b1-b249-6690e16b6742","status":"enabled","created_at":"2026-07-03T15:28:20.088597Z","updated_at":"2026-07-03T15:28:20.088597Z","deleted_at":null,"description":"test decrypted","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"6ff9e059-796b-4b06-b6a8-390812c4c506","status":"enabled","created_at":"2026-07-07T07:46:06.080386Z","updated_at":"2026-07-07T07:46:06.080386Z","deleted_at":null,"description":"test decrypted","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "308"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:20 GMT
+                - Tue, 07 Jul 2026 07:46:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 655a4c73-de10-4a27-93aa-c400da5aed7e
+                - e80fe08f-cb3c-4bfc-a8e5-5a93df460d3b
         status: 200 OK
         code: 200
-        duration: 45.516562ms
+        duration: 47.691322ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -384,28 +384,28 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/f8880c35-46bf-4ecd-8185-c816231f0d78/encrypt
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/4e278f73-dff7-462f-98da-60f527e9cc1b/encrypt
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 141
-        body: '{"key_id":"f8880c35-46bf-4ecd-8185-c816231f0d78","ciphertext":"AQAAAAFLgCV6ib+VbWexq4+5STwMXhlGkssg+vloxZLtMaxt+WlTGYDjXRNUP2QfeXGekgTCvF/l"}'
+        body: '{"key_id":"4e278f73-dff7-462f-98da-60f527e9cc1b","ciphertext":"AQAAAAGim0ZsJ+oxGqPY1sMIYxTxP0+etUGR29tq2NAWHT4CLqCw5dPvp6witT/B091wj6hHRuiS"}'
         headers:
             Content-Length:
                 - "141"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:20 GMT
+                - Tue, 07 Jul 2026 07:46:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 80dfd9cf-8225-46aa-979e-f39faf8ec468
+                - eac0d641-e391-4bbe-9db4-d3326b7b7425
         status: 200 OK
         code: 200
-        duration: 61.246007ms
+        duration: 92.006255ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -413,34 +413,34 @@ interactions:
         proto_minor: 1
         content_length: 116
         host: api.scaleway.com
-        body: '{"ciphertext":"AQAAAAFLgCV6ib+VbWexq4+5STwMXhlGkssg+vloxZLtMaxt+WlTGYDjXRNUP2QfeXGekgTCvF/l","associated_data":null}'
+        body: '{"ciphertext":"AQAAAAGim0ZsJ+oxGqPY1sMIYxTxP0+etUGR29tq2NAWHT4CLqCw5dPvp6witT/B091wj6hHRuiS","associated_data":null}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/f8880c35-46bf-4ecd-8185-c816231f0d78/decrypt
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/4e278f73-dff7-462f-98da-60f527e9cc1b/decrypt
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 114
-        body: '{"key_id":"f8880c35-46bf-4ecd-8185-c816231f0d78","plaintext":"dGhpcyBpcyBzb21lIHNlY3JldCBkYXRh","ciphertext":null}'
+        body: '{"key_id":"4e278f73-dff7-462f-98da-60f527e9cc1b","plaintext":"dGhpcyBpcyBzb21lIHNlY3JldCBkYXRh","ciphertext":null}'
         headers:
             Content-Length:
                 - "114"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:20 GMT
+                - Tue, 07 Jul 2026 07:46:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - e36bd4b5-caee-4c2d-bb93-8a4d186f91c8
+                - 25b5fa35-6f05-4faa-bfcb-44bdc05281be
         status: 200 OK
         code: 200
-        duration: 86.61093ms
+        duration: 90.303478ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -451,28 +451,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bb46cf5-824b-45b1-b249-6690e16b6742/versions/1/access
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6ff9e059-796b-4b06-b6a8-390812c4c506/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 141
-        body: '{"secret_id":"3bb46cf5-824b-45b1-b249-6690e16b6742","revision":1,"data":"dGhpcyBpcyBzb21lIHNlY3JldCBkYXRh","data_crc32":null,"type":"opaque"}'
+        body: '{"secret_id":"6ff9e059-796b-4b06-b6a8-390812c4c506","revision":1,"data":"dGhpcyBpcyBzb21lIHNlY3JldCBkYXRh","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
                 - "141"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:20 GMT
+                - Tue, 07 Jul 2026 07:46:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 287d83b4-ef82-4809-94fd-b0ca9d630dc5
+                - 33e39fee-c57e-44c9-ab60-0d1afcc8659c
         status: 200 OK
         code: 200
-        duration: 51.881097ms
+        duration: 116.112642ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -483,28 +483,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bb46cf5-824b-45b1-b249-6690e16b6742/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6ff9e059-796b-4b06-b6a8-390812c4c506/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 308
-        body: '{"revision":1,"secret_id":"3bb46cf5-824b-45b1-b249-6690e16b6742","status":"enabled","created_at":"2026-07-03T15:28:20.088597Z","updated_at":"2026-07-03T15:28:20.088597Z","deleted_at":null,"description":"test decrypted","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"6ff9e059-796b-4b06-b6a8-390812c4c506","status":"enabled","created_at":"2026-07-07T07:46:06.080386Z","updated_at":"2026-07-07T07:46:06.080386Z","deleted_at":null,"description":"test decrypted","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "308"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:20 GMT
+                - Tue, 07 Jul 2026 07:46:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 4d5906de-8b94-4372-8d99-b1c77b0c74e7
+                - a2ebd90e-5d41-4fb1-aef3-c67939f06ebe
         status: 200 OK
         code: 200
-        duration: 36.992552ms
+        duration: 49.246338ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -515,28 +515,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/f8880c35-46bf-4ecd-8185-c816231f0d78
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6ff9e059-796b-4b06-b6a8-390812c4c506
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 525
-        body: '{"id":"f8880c35-46bf-4ecd-8185-c816231f0d78","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-decrypt-key","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.387100Z","updated_at":"2026-07-03T15:28:19.391480Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.391480Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        content_length: 433
+        body: '{"id":"6ff9e059-796b-4b06-b6a8-390812c4c506","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-decrypt-secret","status":"ready","created_at":"2026-07-07T07:46:02.393690Z","updated_at":"2026-07-07T07:46:02.393690Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "525"
+                - "433"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - a86cb6af-70ef-4026-9c8e-8cbb7b9ad192
+                - 4939cef9-54f2-4cde-b040-ed340792551e
         status: 200 OK
         code: 200
-        duration: 46.139743ms
+        duration: 38.858734ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -547,28 +547,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bb46cf5-824b-45b1-b249-6690e16b6742
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/4e278f73-dff7-462f-98da-60f527e9cc1b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 433
-        body: '{"id":"3bb46cf5-824b-45b1-b249-6690e16b6742","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-decrypt-secret","status":"ready","created_at":"2026-07-03T15:28:18.762250Z","updated_at":"2026-07-03T15:28:18.762250Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        content_length: 525
+        body: '{"id":"4e278f73-dff7-462f-98da-60f527e9cc1b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-decrypt-key","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:05.258556Z","updated_at":"2026-07-07T07:46:05.274407Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:05.274407Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "433"
+                - "525"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 949bbba1-6037-409a-8abd-1ec5c30c6ac6
+                - 37b965a4-3cdb-49bc-aa5e-31bc5bc6402d
         status: 200 OK
         code: 200
-        duration: 59.264665ms
+        duration: 43.031795ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -582,28 +582,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bb46cf5-824b-45b1-b249-6690e16b6742/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6ff9e059-796b-4b06-b6a8-390812c4c506/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 339
-        body: '{"versions":[{"revision":1,"secret_id":"3bb46cf5-824b-45b1-b249-6690e16b6742","status":"enabled","created_at":"2026-07-03T15:28:20.088597Z","updated_at":"2026-07-03T15:28:20.088597Z","deleted_at":null,"description":"test decrypted","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        body: '{"versions":[{"revision":1,"secret_id":"6ff9e059-796b-4b06-b6a8-390812c4c506","status":"enabled","created_at":"2026-07-07T07:46:06.080386Z","updated_at":"2026-07-07T07:46:06.080386Z","deleted_at":null,"description":"test decrypted","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "339"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - d441b70b-0674-4ba5-8886-9fad5156bdea
+                - 4d2d4a2e-a28c-481b-a108-53a5c1d14122
         status: 200 OK
         code: 200
-        duration: 53.833695ms
+        duration: 90.000995ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -617,28 +617,28 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/f8880c35-46bf-4ecd-8185-c816231f0d78/encrypt
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/4e278f73-dff7-462f-98da-60f527e9cc1b/encrypt
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 141
-        body: '{"key_id":"f8880c35-46bf-4ecd-8185-c816231f0d78","ciphertext":"AQAAAAHqBHv085GRfqt5g7la8Jb4zL1oCTRlSkilytBAhuz0HpDZ3JC1yutNBnsmV0H1/kloO6ul"}'
+        body: '{"key_id":"4e278f73-dff7-462f-98da-60f527e9cc1b","ciphertext":"AQAAAAF6WRhvH4DK5fO8v0uiJXKV8qXdUSGH4dz7xKTgQ3SKqU2GK2hbG63YtCHwrLowc+3D6rKg"}'
         headers:
             Content-Length:
                 - "141"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 5440a586-8152-4dbe-a056-5d76ae5091e9
+                - ca20e237-19e4-424e-9140-6a77d0a4e89e
         status: 200 OK
         code: 200
-        duration: 87.044794ms
+        duration: 100.25873ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -646,34 +646,34 @@ interactions:
         proto_minor: 1
         content_length: 116
         host: api.scaleway.com
-        body: '{"ciphertext":"AQAAAAHqBHv085GRfqt5g7la8Jb4zL1oCTRlSkilytBAhuz0HpDZ3JC1yutNBnsmV0H1/kloO6ul","associated_data":null}'
+        body: '{"ciphertext":"AQAAAAF6WRhvH4DK5fO8v0uiJXKV8qXdUSGH4dz7xKTgQ3SKqU2GK2hbG63YtCHwrLowc+3D6rKg","associated_data":null}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/f8880c35-46bf-4ecd-8185-c816231f0d78/decrypt
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/4e278f73-dff7-462f-98da-60f527e9cc1b/decrypt
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 114
-        body: '{"key_id":"f8880c35-46bf-4ecd-8185-c816231f0d78","plaintext":"dGhpcyBpcyBzb21lIHNlY3JldCBkYXRh","ciphertext":null}'
+        body: '{"key_id":"4e278f73-dff7-462f-98da-60f527e9cc1b","plaintext":"dGhpcyBpcyBzb21lIHNlY3JldCBkYXRh","ciphertext":null}'
         headers:
             Content-Length:
                 - "114"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - d486b48b-cbea-41d0-95af-b9ade3dfb18e
+                - 79f11006-adb3-4b9a-8268-d933f5f16a00
         status: 200 OK
         code: 200
-        duration: 87.903787ms
+        duration: 80.12244ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -684,28 +684,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bb46cf5-824b-45b1-b249-6690e16b6742/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6ff9e059-796b-4b06-b6a8-390812c4c506/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 308
-        body: '{"revision":1,"secret_id":"3bb46cf5-824b-45b1-b249-6690e16b6742","status":"enabled","created_at":"2026-07-03T15:28:20.088597Z","updated_at":"2026-07-03T15:28:20.088597Z","deleted_at":null,"description":"test decrypted","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"6ff9e059-796b-4b06-b6a8-390812c4c506","status":"enabled","created_at":"2026-07-07T07:46:06.080386Z","updated_at":"2026-07-07T07:46:06.080386Z","deleted_at":null,"description":"test decrypted","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "308"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - c6b69dea-40da-434e-8512-8fef3d6c7a75
+                - 3a7df520-0604-4fab-b8c8-50ec4262e924
         status: 200 OK
         code: 200
-        duration: 35.624763ms
+        duration: 52.470334ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -716,28 +716,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bb46cf5-824b-45b1-b249-6690e16b6742/versions/1/access
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6ff9e059-796b-4b06-b6a8-390812c4c506/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 141
-        body: '{"secret_id":"3bb46cf5-824b-45b1-b249-6690e16b6742","revision":1,"data":"dGhpcyBpcyBzb21lIHNlY3JldCBkYXRh","data_crc32":null,"type":"opaque"}'
+        body: '{"secret_id":"6ff9e059-796b-4b06-b6a8-390812c4c506","revision":1,"data":"dGhpcyBpcyBzb21lIHNlY3JldCBkYXRh","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
                 - "141"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 5f7776fd-1672-4e88-89b7-1292aedc551b
+                - 4f2589df-af3e-4a0d-bf22-b6454269d2c1
         status: 200 OK
         code: 200
-        duration: 45.615969ms
+        duration: 97.965321ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -748,28 +748,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bb46cf5-824b-45b1-b249-6690e16b6742/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6ff9e059-796b-4b06-b6a8-390812c4c506/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 308
-        body: '{"revision":1,"secret_id":"3bb46cf5-824b-45b1-b249-6690e16b6742","status":"enabled","created_at":"2026-07-03T15:28:20.088597Z","updated_at":"2026-07-03T15:28:20.088597Z","deleted_at":null,"description":"test decrypted","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"6ff9e059-796b-4b06-b6a8-390812c4c506","status":"enabled","created_at":"2026-07-07T07:46:06.080386Z","updated_at":"2026-07-07T07:46:06.080386Z","deleted_at":null,"description":"test decrypted","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "308"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 04c3c220-52b3-43c6-9176-ff8ce0c459bd
+                - 3275aca1-61d3-4224-9ca7-8c65ed7c35f8
         status: 200 OK
         code: 200
-        duration: 48.205162ms
+        duration: 50.751788ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -780,7 +780,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bb46cf5-824b-45b1-b249-6690e16b6742/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6ff9e059-796b-4b06-b6a8-390812c4c506/versions/1
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -792,14 +792,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:22 GMT
+                - Tue, 07 Jul 2026 07:46:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - e8dc5307-9a81-47e0-8a9a-243dc12e79fc
+                - e7971087-d881-4835-b5b2-475e7a2bd3b6
         status: 204 No Content
         code: 204
-        duration: 85.14712ms
+        duration: 132.249556ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -810,7 +810,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bb46cf5-824b-45b1-b249-6690e16b6742
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6ff9e059-796b-4b06-b6a8-390812c4c506
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -822,14 +822,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:22 GMT
+                - Tue, 07 Jul 2026 07:46:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 034737e7-0adf-4cd6-b5af-d6a4272b8a9d
+                - 07a8bd8c-f886-4378-ae57-1bb1a6d079cd
         status: 204 No Content
         code: 204
-        duration: 59.611457ms
+        duration: 59.085963ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -840,7 +840,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/f8880c35-46bf-4ecd-8185-c816231f0d78
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/4e278f73-dff7-462f-98da-60f527e9cc1b
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -852,14 +852,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:22 GMT
+                - Tue, 07 Jul 2026 07:46:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 668414bd-8f9b-4956-bb8d-a07e435c846a
+                - 0e5e26f4-0e00-44b2-9ee5-fa4d976fa188
         status: 204 No Content
         code: 204
-        duration: 132.037092ms
+        duration: 66.44099ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -870,28 +870,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3bb46cf5-824b-45b1-b249-6690e16b6742
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6ff9e059-796b-4b06-b6a8-390812c4c506
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 458
-        body: '{"id":"3bb46cf5-824b-45b1-b249-6690e16b6742","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-decrypt-secret","status":"ready","created_at":"2026-07-03T15:28:18.762250Z","updated_at":"2026-07-03T15:28:22.238364Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-07-03T15:28:22.238364Z","key_id":null,"region":"fr-par"}'
+        body: '{"id":"6ff9e059-796b-4b06-b6a8-390812c4c506","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-decrypt-secret","status":"ready","created_at":"2026-07-07T07:46:02.393690Z","updated_at":"2026-07-07T07:46:08.463014Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-07-07T07:46:08.463014Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "458"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:22 GMT
+                - Tue, 07 Jul 2026 07:46:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 88e84b89-8dc5-4e36-bd88-d914626ee54e
+                - 36dc5eb0-a765-4d2c-bf08-124aa388af72
         status: 200 OK
         code: 200
-        duration: 48.004005ms
+        duration: 46.408054ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -902,25 +902,25 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/f8880c35-46bf-4ecd-8185-c816231f0d78
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/4e278f73-dff7-462f-98da-60f527e9cc1b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 565
-        body: '{"id":"f8880c35-46bf-4ecd-8185-c816231f0d78","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-decrypt-key","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-03T15:28:19.387100Z","updated_at":"2026-07-03T15:28:22.304500Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.391480Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-03T15:28:22.304500Z","protection_level":"software","region":"fr-par"}'
+        body: '{"id":"4e278f73-dff7-462f-98da-60f527e9cc1b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-decrypt-key","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-07T07:46:05.258556Z","updated_at":"2026-07-07T07:46:08.472232Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:05.274407Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-07T07:46:08.472232Z","protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "565"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:22 GMT
+                - Tue, 07 Jul 2026 07:46:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 17b36121-77eb-40e9-947f-6946a9e66977
+                - c35ca252-3f89-49cd-bde5-d706e0891cc3
         status: 200 OK
         code: 200
-        duration: 42.44319ms
+        duration: 40.785159ms

--- a/internal/services/keymanager/testdata/decrypt-ephemeral-resource-invalid-associated-data.cassette.yaml
+++ b/internal/services/keymanager/testdata/decrypt-ephemeral-resource-invalid-associated-data.cassette.yaml
@@ -6,9 +6,9 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 240
+        content_length: 194
         host: api.scaleway.com
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-decrypt-key-invalid","usage":{"symmetric_encryption":"aes_256_gcm"},"tags":null,"unprotected":true,"origin":"unknown_origin","protection_level":"unknown_protection_level"}'
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-decrypt-key-invalid","usage":{"symmetric_encryption":"aes_256_gcm"},"tags":null,"unprotected":true,"origin":"unknown_origin"}'
         headers:
             Content-Type:
                 - application/json
@@ -21,21 +21,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 533
-        body: '{"id":"ef551897-6a4b-4965-9d18-e9aa50f4917a","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-decrypt-key-invalid","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:23.133861Z","updated_at":"2026-07-03T15:28:23.137162Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:23.137162Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"17201e86-698c-4fc4-ae8a-bb1f3ef3fa1e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-decrypt-key-invalid","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:09.146809Z","updated_at":"2026-07-07T07:46:09.149902Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:09.149902Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "533"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 6e0213c4-271f-4a90-80d3-30999995380b
+                - bc3a0215-e9e8-46b1-8013-cd6965a7112c
         status: 200 OK
         code: 200
-        duration: 107.655286ms
+        duration: 94.576421ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -46,28 +46,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/ef551897-6a4b-4965-9d18-e9aa50f4917a
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/17201e86-698c-4fc4-ae8a-bb1f3ef3fa1e
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 533
-        body: '{"id":"ef551897-6a4b-4965-9d18-e9aa50f4917a","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-decrypt-key-invalid","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:23.133861Z","updated_at":"2026-07-03T15:28:23.137162Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:23.137162Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"17201e86-698c-4fc4-ae8a-bb1f3ef3fa1e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-decrypt-key-invalid","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:09.146809Z","updated_at":"2026-07-07T07:46:09.149902Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:09.149902Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "533"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 36114b8f-b56e-417d-b2fa-bbd1b852c63e
+                - 72d5a044-ac91-430a-9f00-cd475a94cac1
         status: 200 OK
         code: 200
-        duration: 44.236207ms
+        duration: 51.580541ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -81,28 +81,28 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/ef551897-6a4b-4965-9d18-e9aa50f4917a/encrypt
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/17201e86-698c-4fc4-ae8a-bb1f3ef3fa1e/encrypt
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 129
-        body: '{"key_id":"ef551897-6a4b-4965-9d18-e9aa50f4917a","ciphertext":"AQAAAAFjN4NslHWdQ//M1QRcsn/OKy0IsfNjnk9cUsUzCnP8qltNrFE5jnoSUQA="}'
+        body: '{"key_id":"17201e86-698c-4fc4-ae8a-bb1f3ef3fa1e","ciphertext":"AQAAAAG+zQBkO3cf3jDaM6HC23CR/BeaDhK32XWgkZT7g/Blx+AO+xLwGthKHlg="}'
         headers:
             Content-Length:
                 - "129"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 3ace15dc-5a4b-4b2e-9801-1dd030b0a1d1
+                - 4c2e6b85-8b22-441e-b6ee-d2ab380be13b
         status: 200 OK
         code: 200
-        duration: 89.837469ms
+        duration: 44.667477ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -110,13 +110,13 @@ interactions:
         proto_minor: 1
         content_length: 110
         host: api.scaleway.com
-        body: '{"ciphertext":"AQAAAAFjN4NslHWdQ//M1QRcsn/OKy0IsfNjnk9cUsUzCnP8qltNrFE5jnoSUQA=","associated_data":"cXdlcnR5"}'
+        body: '{"ciphertext":"AQAAAAG+zQBkO3cf3jDaM6HC23CR/BeaDhK32XWgkZT7g/Blx+AO+xLwGthKHlg=","associated_data":"cXdlcnR5"}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/ef551897-6a4b-4965-9d18-e9aa50f4917a/decrypt
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/17201e86-698c-4fc4-ae8a-bb1f3ef3fa1e/decrypt
         method: POST
       response:
         proto: HTTP/2.0
@@ -130,14 +130,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 7aa57896-e75a-4622-936b-87a8f830edc8
+                - 5c64a07e-115b-4ba6-96e6-e48ef95a3795
         status: 400 Bad Request
         code: 400
-        duration: 43.229737ms
+        duration: 51.119214ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -148,7 +148,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/ef551897-6a4b-4965-9d18-e9aa50f4917a
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/17201e86-698c-4fc4-ae8a-bb1f3ef3fa1e
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -160,14 +160,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 2e80b9f5-8d13-4405-bdcb-7ba7b0730e77
+                - e213e421-49ec-4c1b-865c-b959c2344725
         status: 204 No Content
         code: 204
-        duration: 73.623105ms
+        duration: 70.699602ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -178,25 +178,25 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/ef551897-6a4b-4965-9d18-e9aa50f4917a
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/17201e86-698c-4fc4-ae8a-bb1f3ef3fa1e
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 573
-        body: '{"id":"ef551897-6a4b-4965-9d18-e9aa50f4917a","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-decrypt-key-invalid","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-03T15:28:23.133861Z","updated_at":"2026-07-03T15:28:23.719584Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:23.137162Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-03T15:28:23.719583Z","protection_level":"software","region":"fr-par"}'
+        body: '{"id":"17201e86-698c-4fc4-ae8a-bb1f3ef3fa1e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-decrypt-key-invalid","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-07T07:46:09.146809Z","updated_at":"2026-07-07T07:46:09.606100Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:09.149902Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-07T07:46:09.606100Z","protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "573"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - d48f4914-eb61-418e-857e-8bb7db0b7268
+                - 707f3ac2-4b35-4f11-89f1-41ab1abf3cf4
         status: 200 OK
         code: 200
-        duration: 37.641992ms
+        duration: 43.050124ms

--- a/internal/services/keymanager/testdata/decrypt-ephemeral-resource-with-associated-data.cassette.yaml
+++ b/internal/services/keymanager/testdata/decrypt-ephemeral-resource-with-associated-data.cassette.yaml
@@ -6,41 +6,6 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 235
-        host: api.scaleway.com
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-decrypt-key-ad","usage":{"symmetric_encryption":"aes_256_gcm"},"tags":null,"unprotected":true,"origin":"unknown_origin","protection_level":"unknown_protection_level"}'
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 528
-        body: '{"id":"2c3026cf-38d3-4155-a38a-09fbd05249d0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-decrypt-key-ad","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:23.280724Z","updated_at":"2026-07-03T15:28:23.284017Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:23.284017Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "528"
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            X-Request-Id:
-                - 03b8fba1-e1ee-4213-9a07-41d5f4b1d260
-        status: 200 OK
-        code: 200
-        duration: 77.943579ms
-    - id: 1
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
         content_length: 142
         host: api.scaleway.com
         body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-decrypt-secret-ad","tags":null,"type":"opaque","path":"/","protected":false}'
@@ -56,21 +21,56 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 436
-        body: '{"id":"6fe76d8f-9b19-42a6-a13c-d37d9f7e1050","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-decrypt-secret-ad","status":"ready","created_at":"2026-07-03T15:28:23.295981Z","updated_at":"2026-07-03T15:28:23.295981Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"01aeac4c-cfc7-4383-8a19-9fb8cf59b392","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-decrypt-secret-ad","status":"ready","created_at":"2026-07-07T07:46:09.335350Z","updated_at":"2026-07-07T07:46:09.335350Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "436"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - a4ff6aad-e264-4128-92e4-b56832247ef7
+                - 259d9189-89df-4367-9415-8f6b3217b1d6
         status: 200 OK
         code: 200
-        duration: 82.423684ms
+        duration: 93.130284ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 189
+        host: api.scaleway.com
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-decrypt-key-ad","usage":{"symmetric_encryption":"aes_256_gcm"},"tags":null,"unprotected":true,"origin":"unknown_origin"}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 528
+        body: '{"id":"278f8b55-19be-4193-bc44-ae05d00ee8eb","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-decrypt-key-ad","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:09.338590Z","updated_at":"2026-07-07T07:46:09.342697Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:09.342697Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "528"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 07 Jul 2026 07:46:09 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - de7e3a59-7486-4877-8af0-1a99b7acf841
+        status: 200 OK
+        code: 200
+        duration: 110.080175ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -81,28 +81,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/2c3026cf-38d3-4155-a38a-09fbd05249d0
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/01aeac4c-cfc7-4383-8a19-9fb8cf59b392
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 528
-        body: '{"id":"2c3026cf-38d3-4155-a38a-09fbd05249d0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-decrypt-key-ad","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:23.280724Z","updated_at":"2026-07-03T15:28:23.284017Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:23.284017Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        content_length: 436
+        body: '{"id":"01aeac4c-cfc7-4383-8a19-9fb8cf59b392","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-decrypt-secret-ad","status":"ready","created_at":"2026-07-07T07:46:09.335350Z","updated_at":"2026-07-07T07:46:09.335350Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "528"
+                - "436"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 49d0de49-d8c3-413e-942d-1d8c87b59bd4
+                - 92fe0b3f-81fe-4f34-a280-4af34df285e6
         status: 200 OK
         code: 200
-        duration: 38.249333ms
+        duration: 53.217069ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -113,28 +113,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6fe76d8f-9b19-42a6-a13c-d37d9f7e1050
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/278f8b55-19be-4193-bc44-ae05d00ee8eb
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 436
-        body: '{"id":"6fe76d8f-9b19-42a6-a13c-d37d9f7e1050","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-decrypt-secret-ad","status":"ready","created_at":"2026-07-03T15:28:23.295981Z","updated_at":"2026-07-03T15:28:23.295981Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        content_length: 528
+        body: '{"id":"278f8b55-19be-4193-bc44-ae05d00ee8eb","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-decrypt-key-ad","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:09.338590Z","updated_at":"2026-07-07T07:46:09.342697Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:09.342697Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "436"
+                - "528"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 111a0299-999e-4464-abce-49f9a1e6dac3
+                - fe61cfd8-362a-4c4a-8e19-27272d56b2ee
         status: 200 OK
         code: 200
-        duration: 44.257928ms
+        duration: 50.118903ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -148,7 +148,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6fe76d8f-9b19-42a6-a13c-d37d9f7e1050/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/01aeac4c-cfc7-4383-8a19-9fb8cf59b392/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -162,14 +162,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 7fad7cb2-5d2e-4c11-bae1-bc648822d093
+                - 59b503db-7e19-4851-aa0b-5a4dfc2f20ec
         status: 200 OK
         code: 200
-        duration: 48.856686ms
+        duration: 95.957365ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -183,28 +183,28 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/2c3026cf-38d3-4155-a38a-09fbd05249d0/encrypt
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/278f8b55-19be-4193-bc44-ae05d00ee8eb/encrypt
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 141
-        body: '{"key_id":"2c3026cf-38d3-4155-a38a-09fbd05249d0","ciphertext":"AQAAAAGQLZrsTwm+ah6b9RCHvR0jkjAFYZsj7qQ6A4i+f5ycYEH2OQ9QI4RvqFGntvSxeh1FCaQK"}'
+        body: '{"key_id":"278f8b55-19be-4193-bc44-ae05d00ee8eb","ciphertext":"AQAAAAFdeQkGG9tj5NCdmxqx9M6B1G9fZU4iEm15WVfFTvBL+eVrbpPDBRGJYUAQUvlK1VM33SbT"}'
         headers:
             Content-Length:
                 - "141"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - cabddf4a-1744-4eb3-bd2a-6442dff46774
+                - 54c33667-40ef-4948-8eb6-c172514f4e7f
         status: 200 OK
         code: 200
-        duration: 84.437046ms
+        duration: 96.097731ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -212,34 +212,34 @@ interactions:
         proto_minor: 1
         content_length: 142
         host: api.scaleway.com
-        body: '{"ciphertext":"AQAAAAGQLZrsTwm+ah6b9RCHvR0jkjAFYZsj7qQ6A4i+f5ycYEH2OQ9QI4RvqFGntvSxeh1FCaQK","associated_data":"c29tZSBhc3NvY2lhdGVkIGRhdGE="}'
+        body: '{"ciphertext":"AQAAAAFdeQkGG9tj5NCdmxqx9M6B1G9fZU4iEm15WVfFTvBL+eVrbpPDBRGJYUAQUvlK1VM33SbT","associated_data":"c29tZSBhc3NvY2lhdGVkIGRhdGE="}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/2c3026cf-38d3-4155-a38a-09fbd05249d0/decrypt
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/278f8b55-19be-4193-bc44-ae05d00ee8eb/decrypt
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 114
-        body: '{"key_id":"2c3026cf-38d3-4155-a38a-09fbd05249d0","plaintext":"dGhpcyBpcyBzb21lIHNlY3JldCBkYXRh","ciphertext":null}'
+        body: '{"key_id":"278f8b55-19be-4193-bc44-ae05d00ee8eb","plaintext":"dGhpcyBpcyBzb21lIHNlY3JldCBkYXRh","ciphertext":null}'
         headers:
             Content-Length:
                 - "114"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - f1c83f93-e5ee-475f-934b-3b68979eefa0
+                - 78e445d6-ce25-42a8-9832-dd08fbbe58dd
         status: 200 OK
         code: 200
-        duration: 42.22503ms
+        duration: 50.7169ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -253,28 +253,28 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6fe76d8f-9b19-42a6-a13c-d37d9f7e1050/versions
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/01aeac4c-cfc7-4383-8a19-9fb8cf59b392/versions
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 313
-        body: '{"revision":1,"secret_id":"6fe76d8f-9b19-42a6-a13c-d37d9f7e1050","status":"enabled","created_at":"2026-07-03T15:28:23.759013Z","updated_at":"2026-07-03T15:28:23.759013Z","deleted_at":null,"description":"test decrypted data","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"01aeac4c-cfc7-4383-8a19-9fb8cf59b392","status":"enabled","created_at":"2026-07-07T07:46:10.116474Z","updated_at":"2026-07-07T07:46:10.116474Z","deleted_at":null,"description":"test decrypted data","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "313"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 2f29d1a4-6b68-4623-b615-1b0865a0850d
+                - 07e4f93d-edf8-43db-b7b0-66de59fcc4ab
         status: 200 OK
         code: 200
-        duration: 293.831096ms
+        duration: 564.658869ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -285,93 +285,29 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6fe76d8f-9b19-42a6-a13c-d37d9f7e1050/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/01aeac4c-cfc7-4383-8a19-9fb8cf59b392/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 313
-        body: '{"revision":1,"secret_id":"6fe76d8f-9b19-42a6-a13c-d37d9f7e1050","status":"enabled","created_at":"2026-07-03T15:28:23.759013Z","updated_at":"2026-07-03T15:28:23.759013Z","deleted_at":null,"description":"test decrypted data","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"01aeac4c-cfc7-4383-8a19-9fb8cf59b392","status":"enabled","created_at":"2026-07-07T07:46:10.116474Z","updated_at":"2026-07-07T07:46:10.116474Z","deleted_at":null,"description":"test decrypted data","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "313"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - cc9a690a-052c-432e-8208-237f29e2e884
+                - 9911f234-c55a-4dfd-9ea0-e2ca0bfbbad4
         status: 200 OK
         code: 200
-        duration: 36.949451ms
+        duration: 46.928242ms
     - id: 9
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6fe76d8f-9b19-42a6-a13c-d37d9f7e1050/versions/1/access
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 141
-        body: '{"secret_id":"6fe76d8f-9b19-42a6-a13c-d37d9f7e1050","revision":1,"data":"dGhpcyBpcyBzb21lIHNlY3JldCBkYXRh","data_crc32":null,"type":"opaque"}'
-        headers:
-            Content-Length:
-                - "141"
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            X-Request-Id:
-                - b52ddbbe-3d02-4ccb-8c8f-b62533ad11e3
-        status: 200 OK
-        code: 200
-        duration: 48.409657ms
-    - id: 10
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6fe76d8f-9b19-42a6-a13c-d37d9f7e1050/versions/1
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 313
-        body: '{"revision":1,"secret_id":"6fe76d8f-9b19-42a6-a13c-d37d9f7e1050","status":"enabled","created_at":"2026-07-03T15:28:23.759013Z","updated_at":"2026-07-03T15:28:23.759013Z","deleted_at":null,"description":"test decrypted data","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "313"
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            X-Request-Id:
-                - c12c540d-636b-4b18-a025-02b43c91a3ac
-        status: 200 OK
-        code: 200
-        duration: 32.76455ms
-    - id: 11
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -384,28 +320,92 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6fe76d8f-9b19-42a6-a13c-d37d9f7e1050/versions
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/01aeac4c-cfc7-4383-8a19-9fb8cf59b392/versions
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 324
-        body: '{"revision":2,"secret_id":"6fe76d8f-9b19-42a6-a13c-d37d9f7e1050","status":"enabled","created_at":"2026-07-03T15:28:23.962815Z","updated_at":"2026-07-03T15:28:23.962815Z","deleted_at":null,"description":"test decrypted associated data","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":2,"secret_id":"01aeac4c-cfc7-4383-8a19-9fb8cf59b392","status":"enabled","created_at":"2026-07-07T07:46:10.262008Z","updated_at":"2026-07-07T07:46:10.262008Z","deleted_at":null,"description":"test decrypted associated data","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "324"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 48fc3a07-8b3f-4374-b68d-c8ea024ab7c7
+                - 15a871db-3c11-4d5c-ae68-d11f56956c72
         status: 200 OK
         code: 200
-        duration: 164.621545ms
+        duration: 76.236328ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/01aeac4c-cfc7-4383-8a19-9fb8cf59b392/versions/1/access
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 141
+        body: '{"secret_id":"01aeac4c-cfc7-4383-8a19-9fb8cf59b392","revision":1,"data":"dGhpcyBpcyBzb21lIHNlY3JldCBkYXRh","data_crc32":null,"type":"opaque"}'
+        headers:
+            Content-Length:
+                - "141"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 07 Jul 2026 07:46:10 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 540b59e2-6b74-49d0-bd66-b6bd7f2f9295
+        status: 200 OK
+        code: 200
+        duration: 78.565371ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/01aeac4c-cfc7-4383-8a19-9fb8cf59b392/versions/2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 324
+        body: '{"revision":2,"secret_id":"01aeac4c-cfc7-4383-8a19-9fb8cf59b392","status":"enabled","created_at":"2026-07-07T07:46:10.262008Z","updated_at":"2026-07-07T07:46:10.262008Z","deleted_at":null,"description":"test decrypted associated data","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "324"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 07 Jul 2026 07:46:10 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 4d1e387f-d852-450b-a97c-86344582ea9f
+        status: 200 OK
+        code: 200
+        duration: 56.486026ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -416,28 +416,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6fe76d8f-9b19-42a6-a13c-d37d9f7e1050/versions/2
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/01aeac4c-cfc7-4383-8a19-9fb8cf59b392/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 324
-        body: '{"revision":2,"secret_id":"6fe76d8f-9b19-42a6-a13c-d37d9f7e1050","status":"enabled","created_at":"2026-07-03T15:28:23.962815Z","updated_at":"2026-07-03T15:28:23.962815Z","deleted_at":null,"description":"test decrypted associated data","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 314
+        body: '{"revision":1,"secret_id":"01aeac4c-cfc7-4383-8a19-9fb8cf59b392","status":"enabled","created_at":"2026-07-07T07:46:10.116474Z","updated_at":"2026-07-07T07:46:10.116474Z","deleted_at":null,"description":"test decrypted data","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "324"
+                - "314"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:24 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 53b98fb3-3b4e-4f14-ba6b-6a2971cd6379
+                - 4fb60c52-5ddf-4944-8205-b8016a057341
         status: 200 OK
         code: 200
-        duration: 34.054364ms
+        duration: 55.584975ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -448,28 +448,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6fe76d8f-9b19-42a6-a13c-d37d9f7e1050/versions/2/access
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/01aeac4c-cfc7-4383-8a19-9fb8cf59b392/versions/2/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 137
-        body: '{"secret_id":"6fe76d8f-9b19-42a6-a13c-d37d9f7e1050","revision":2,"data":"c29tZSBhc3NvY2lhdGVkIGRhdGE=","data_crc32":null,"type":"opaque"}'
+        body: '{"secret_id":"01aeac4c-cfc7-4383-8a19-9fb8cf59b392","revision":2,"data":"c29tZSBhc3NvY2lhdGVkIGRhdGE=","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
                 - "137"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:24 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 1bd7e03b-b290-4f1b-9c12-1d57442984b1
+                - 60e1d982-fec7-4f01-9774-083a9ecf4639
         status: 200 OK
         code: 200
-        duration: 45.852624ms
+        duration: 189.610584ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -480,28 +480,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6fe76d8f-9b19-42a6-a13c-d37d9f7e1050/versions/2
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/01aeac4c-cfc7-4383-8a19-9fb8cf59b392/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 324
-        body: '{"revision":2,"secret_id":"6fe76d8f-9b19-42a6-a13c-d37d9f7e1050","status":"enabled","created_at":"2026-07-03T15:28:23.962815Z","updated_at":"2026-07-03T15:28:23.962815Z","deleted_at":null,"description":"test decrypted associated data","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":2,"secret_id":"01aeac4c-cfc7-4383-8a19-9fb8cf59b392","status":"enabled","created_at":"2026-07-07T07:46:10.262008Z","updated_at":"2026-07-07T07:46:10.262008Z","deleted_at":null,"description":"test decrypted associated data","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "324"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:24 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - f72c4184-2e02-44fc-bd02-60048a59854b
+                - 929799fe-c78b-4af2-8726-17a126223c59
         status: 200 OK
         code: 200
-        duration: 57.25456ms
+        duration: 47.994377ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -515,28 +515,28 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/2c3026cf-38d3-4155-a38a-09fbd05249d0/encrypt
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/278f8b55-19be-4193-bc44-ae05d00ee8eb/encrypt
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 141
-        body: '{"key_id":"2c3026cf-38d3-4155-a38a-09fbd05249d0","ciphertext":"AQAAAAE8qm55MeAEjfAPNAoA5kbCDJH+PWUCe1HqPdn6fudyTdhwybY8KYqJZ1LwmmpPZf0KnyI7"}'
+        body: '{"key_id":"278f8b55-19be-4193-bc44-ae05d00ee8eb","ciphertext":"AQAAAAFQA064gNwIoVcoDYIVn/SFepl33flo8kc0tBhJYw0vTjjet9F4Yll3hFUdqIUNyssEtE4t"}'
         headers:
             Content-Length:
                 - "141"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:24 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 4a6e89c5-fa5e-4693-a2e5-51de76612ce8
+                - f790a0f6-0600-4a62-9d12-e214588bac9e
         status: 200 OK
         code: 200
-        duration: 46.7287ms
+        duration: 49.055092ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -544,34 +544,34 @@ interactions:
         proto_minor: 1
         content_length: 142
         host: api.scaleway.com
-        body: '{"ciphertext":"AQAAAAE8qm55MeAEjfAPNAoA5kbCDJH+PWUCe1HqPdn6fudyTdhwybY8KYqJZ1LwmmpPZf0KnyI7","associated_data":"c29tZSBhc3NvY2lhdGVkIGRhdGE="}'
+        body: '{"ciphertext":"AQAAAAFQA064gNwIoVcoDYIVn/SFepl33flo8kc0tBhJYw0vTjjet9F4Yll3hFUdqIUNyssEtE4t","associated_data":"c29tZSBhc3NvY2lhdGVkIGRhdGE="}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/2c3026cf-38d3-4155-a38a-09fbd05249d0/decrypt
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/278f8b55-19be-4193-bc44-ae05d00ee8eb/decrypt
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 114
-        body: '{"key_id":"2c3026cf-38d3-4155-a38a-09fbd05249d0","plaintext":"dGhpcyBpcyBzb21lIHNlY3JldCBkYXRh","ciphertext":null}'
+        body: '{"key_id":"278f8b55-19be-4193-bc44-ae05d00ee8eb","plaintext":"dGhpcyBpcyBzb21lIHNlY3JldCBkYXRh","ciphertext":null}'
         headers:
             Content-Length:
                 - "114"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:24 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 89938142-aba5-4f14-841c-1e5ebaf79833
+                - 0f151aff-695b-423b-908d-3bfc525fbcb9
         status: 200 OK
         code: 200
-        duration: 97.847384ms
+        duration: 197.007182ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -582,28 +582,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6fe76d8f-9b19-42a6-a13c-d37d9f7e1050/versions/2/access
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/01aeac4c-cfc7-4383-8a19-9fb8cf59b392/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 137
-        body: '{"secret_id":"6fe76d8f-9b19-42a6-a13c-d37d9f7e1050","revision":2,"data":"c29tZSBhc3NvY2lhdGVkIGRhdGE=","data_crc32":null,"type":"opaque"}'
+        content_length: 141
+        body: '{"secret_id":"01aeac4c-cfc7-4383-8a19-9fb8cf59b392","revision":1,"data":"dGhpcyBpcyBzb21lIHNlY3JldCBkYXRh","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "137"
+                - "141"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:24 GMT
+                - Tue, 07 Jul 2026 07:46:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 9357d453-7476-43a1-aee2-de4fa291255a
+                - a0f95130-42ee-4738-b42c-b098189663c6
         status: 200 OK
         code: 200
-        duration: 41.321042ms
+        duration: 64.078036ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -614,28 +614,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6fe76d8f-9b19-42a6-a13c-d37d9f7e1050/versions/1/access
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/01aeac4c-cfc7-4383-8a19-9fb8cf59b392/versions/2/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 141
-        body: '{"secret_id":"6fe76d8f-9b19-42a6-a13c-d37d9f7e1050","revision":1,"data":"dGhpcyBpcyBzb21lIHNlY3JldCBkYXRh","data_crc32":null,"type":"opaque"}'
+        content_length: 137
+        body: '{"secret_id":"01aeac4c-cfc7-4383-8a19-9fb8cf59b392","revision":2,"data":"c29tZSBhc3NvY2lhdGVkIGRhdGE=","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "141"
+                - "137"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:24 GMT
+                - Tue, 07 Jul 2026 07:46:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 6d84b379-99c5-4e6d-ac35-d68527fe78b3
+                - 1147a02c-a721-45cc-a127-b90bb46cd33f
         status: 200 OK
         code: 200
-        duration: 84.595483ms
+        duration: 71.076726ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -646,28 +646,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6fe76d8f-9b19-42a6-a13c-d37d9f7e1050/versions/2
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/01aeac4c-cfc7-4383-8a19-9fb8cf59b392/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 324
-        body: '{"revision":2,"secret_id":"6fe76d8f-9b19-42a6-a13c-d37d9f7e1050","status":"enabled","created_at":"2026-07-03T15:28:23.962815Z","updated_at":"2026-07-03T15:28:23.962815Z","deleted_at":null,"description":"test decrypted associated data","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 314
+        body: '{"revision":1,"secret_id":"01aeac4c-cfc7-4383-8a19-9fb8cf59b392","status":"enabled","created_at":"2026-07-07T07:46:10.116474Z","updated_at":"2026-07-07T07:46:10.116474Z","deleted_at":null,"description":"test decrypted data","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "324"
+                - "314"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:24 GMT
+                - Tue, 07 Jul 2026 07:46:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 558f3341-0d00-42fe-9abf-71ae002a2ec1
+                - be7ad758-3c72-4bbd-a37b-26c8f5cc952b
         status: 200 OK
         code: 200
-        duration: 38.569404ms
+        duration: 47.737991ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -678,28 +678,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6fe76d8f-9b19-42a6-a13c-d37d9f7e1050/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/01aeac4c-cfc7-4383-8a19-9fb8cf59b392/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 314
-        body: '{"revision":1,"secret_id":"6fe76d8f-9b19-42a6-a13c-d37d9f7e1050","status":"enabled","created_at":"2026-07-03T15:28:23.759013Z","updated_at":"2026-07-03T15:28:23.759013Z","deleted_at":null,"description":"test decrypted data","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 324
+        body: '{"revision":2,"secret_id":"01aeac4c-cfc7-4383-8a19-9fb8cf59b392","status":"enabled","created_at":"2026-07-07T07:46:10.262008Z","updated_at":"2026-07-07T07:46:10.262008Z","deleted_at":null,"description":"test decrypted associated data","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "314"
+                - "324"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:24 GMT
+                - Tue, 07 Jul 2026 07:46:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - d00fabfc-16ec-4aa7-8fbc-599e76f7cd9f
+                - 9537ddb5-25fe-47cb-b7c1-c78049c89c86
         status: 200 OK
         code: 200
-        duration: 41.342242ms
+        duration: 44.314139ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -710,28 +710,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/2c3026cf-38d3-4155-a38a-09fbd05249d0
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/01aeac4c-cfc7-4383-8a19-9fb8cf59b392
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 528
-        body: '{"id":"2c3026cf-38d3-4155-a38a-09fbd05249d0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-decrypt-key-ad","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:23.280724Z","updated_at":"2026-07-03T15:28:23.284017Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:23.284017Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        content_length: 436
+        body: '{"id":"01aeac4c-cfc7-4383-8a19-9fb8cf59b392","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-decrypt-secret-ad","status":"ready","created_at":"2026-07-07T07:46:09.335350Z","updated_at":"2026-07-07T07:46:09.335350Z","tags":[],"version_count":2,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "528"
+                - "436"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:25 GMT
+                - Tue, 07 Jul 2026 07:46:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - d39bb2c7-a67d-4519-a03b-7ebbb966a7c1
+                - c4ac6884-3160-44c5-8d80-e63d44e92cef
         status: 200 OK
         code: 200
-        duration: 46.289184ms
+        duration: 33.324009ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -742,64 +742,29 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6fe76d8f-9b19-42a6-a13c-d37d9f7e1050
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/278f8b55-19be-4193-bc44-ae05d00ee8eb
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 436
-        body: '{"id":"6fe76d8f-9b19-42a6-a13c-d37d9f7e1050","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-decrypt-secret-ad","status":"ready","created_at":"2026-07-03T15:28:23.295981Z","updated_at":"2026-07-03T15:28:23.295981Z","tags":[],"version_count":2,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        content_length: 528
+        body: '{"id":"278f8b55-19be-4193-bc44-ae05d00ee8eb","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-decrypt-key-ad","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:09.338590Z","updated_at":"2026-07-07T07:46:09.342697Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:09.342697Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "436"
+                - "528"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:25 GMT
+                - Tue, 07 Jul 2026 07:46:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 7b5eb86c-5325-41e0-bb78-c720b412571a
+                - 0dfa222f-9291-4996-b1e0-28a107901f13
         status: 200 OK
         code: 200
-        duration: 53.760397ms
+        duration: 57.1485ms
     - id: 23
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 97
-        host: api.scaleway.com
-        body: '{"plaintext":"dGhpcyBpcyBzb21lIHNlY3JldCBkYXRh","associated_data":"c29tZSBhc3NvY2lhdGVkIGRhdGE="}'
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/2c3026cf-38d3-4155-a38a-09fbd05249d0/encrypt
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 141
-        body: '{"key_id":"2c3026cf-38d3-4155-a38a-09fbd05249d0","ciphertext":"AQAAAAGOyXnjAgsIW0csUMoir0fo0EAM92X2mh9V/T57u0SYu7+jlsGv7Jrl9o2XVJPIQcUh5B2d"}'
-        headers:
-            Content-Length:
-                - "141"
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 03 Jul 2026 15:28:25 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            X-Request-Id:
-                - 5030a43b-263d-4948-9f11-b92a1ec1b6c8
-        status: 200 OK
-        code: 200
-        duration: 46.563119ms
-    - id: 24
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -812,28 +777,63 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6fe76d8f-9b19-42a6-a13c-d37d9f7e1050/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/01aeac4c-cfc7-4383-8a19-9fb8cf59b392/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 670
-        body: '{"versions":[{"revision":2,"secret_id":"6fe76d8f-9b19-42a6-a13c-d37d9f7e1050","status":"enabled","created_at":"2026-07-03T15:28:23.962815Z","updated_at":"2026-07-03T15:28:23.962815Z","deleted_at":null,"description":"test decrypted associated data","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"6fe76d8f-9b19-42a6-a13c-d37d9f7e1050","status":"enabled","created_at":"2026-07-03T15:28:23.759013Z","updated_at":"2026-07-03T15:28:23.759013Z","deleted_at":null,"description":"test decrypted data","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":2}'
+        body: '{"versions":[{"revision":2,"secret_id":"01aeac4c-cfc7-4383-8a19-9fb8cf59b392","status":"enabled","created_at":"2026-07-07T07:46:10.262008Z","updated_at":"2026-07-07T07:46:10.262008Z","deleted_at":null,"description":"test decrypted associated data","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"01aeac4c-cfc7-4383-8a19-9fb8cf59b392","status":"enabled","created_at":"2026-07-07T07:46:10.116474Z","updated_at":"2026-07-07T07:46:10.116474Z","deleted_at":null,"description":"test decrypted data","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":2}'
         headers:
             Content-Length:
                 - "670"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:25 GMT
+                - Tue, 07 Jul 2026 07:46:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 12f6f50b-c9da-425e-b8d4-b6e28f6eff7a
+                - a3b38622-50ab-4bf0-94f2-1c040b5663e3
         status: 200 OK
         code: 200
-        duration: 58.664949ms
+        duration: 65.832721ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 97
+        host: api.scaleway.com
+        body: '{"plaintext":"dGhpcyBpcyBzb21lIHNlY3JldCBkYXRh","associated_data":"c29tZSBhc3NvY2lhdGVkIGRhdGE="}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/278f8b55-19be-4193-bc44-ae05d00ee8eb/encrypt
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 141
+        body: '{"key_id":"278f8b55-19be-4193-bc44-ae05d00ee8eb","ciphertext":"AQAAAAHCnnny85MHTx4J+tGJnQzjo2FDsF8HCLGW4EX76oKInjuonngcbmfdFS7FkkKYr8G7r9bb"}'
+        headers:
+            Content-Length:
+                - "141"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 07 Jul 2026 07:46:11 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 36f4debe-768a-4e85-b8e1-d04418cb18aa
+        status: 200 OK
+        code: 200
+        duration: 132.520326ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -841,34 +841,34 @@ interactions:
         proto_minor: 1
         content_length: 142
         host: api.scaleway.com
-        body: '{"ciphertext":"AQAAAAGOyXnjAgsIW0csUMoir0fo0EAM92X2mh9V/T57u0SYu7+jlsGv7Jrl9o2XVJPIQcUh5B2d","associated_data":"c29tZSBhc3NvY2lhdGVkIGRhdGE="}'
+        body: '{"ciphertext":"AQAAAAHCnnny85MHTx4J+tGJnQzjo2FDsF8HCLGW4EX76oKInjuonngcbmfdFS7FkkKYr8G7r9bb","associated_data":"c29tZSBhc3NvY2lhdGVkIGRhdGE="}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/2c3026cf-38d3-4155-a38a-09fbd05249d0/decrypt
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/278f8b55-19be-4193-bc44-ae05d00ee8eb/decrypt
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 114
-        body: '{"key_id":"2c3026cf-38d3-4155-a38a-09fbd05249d0","plaintext":"dGhpcyBpcyBzb21lIHNlY3JldCBkYXRh","ciphertext":null}'
+        body: '{"key_id":"278f8b55-19be-4193-bc44-ae05d00ee8eb","plaintext":"dGhpcyBpcyBzb21lIHNlY3JldCBkYXRh","ciphertext":null}'
         headers:
             Content-Length:
                 - "114"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:25 GMT
+                - Tue, 07 Jul 2026 07:46:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 816cbea1-dfc6-4c3b-a60e-60c2fb8b9bac
+                - b4975545-8396-464e-b239-2e81601a5527
         status: 200 OK
         code: 200
-        duration: 51.701379ms
+        duration: 82.911894ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -879,28 +879,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6fe76d8f-9b19-42a6-a13c-d37d9f7e1050/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/01aeac4c-cfc7-4383-8a19-9fb8cf59b392/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 314
-        body: '{"revision":1,"secret_id":"6fe76d8f-9b19-42a6-a13c-d37d9f7e1050","status":"enabled","created_at":"2026-07-03T15:28:23.759013Z","updated_at":"2026-07-03T15:28:23.759013Z","deleted_at":null,"description":"test decrypted data","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"01aeac4c-cfc7-4383-8a19-9fb8cf59b392","status":"enabled","created_at":"2026-07-07T07:46:10.116474Z","updated_at":"2026-07-07T07:46:10.116474Z","deleted_at":null,"description":"test decrypted data","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "314"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:25 GMT
+                - Tue, 07 Jul 2026 07:46:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - de352869-4b1c-4579-ba6d-ce62bf75031d
+                - be85aa18-ac2d-4fab-8e59-bd512f2057a8
         status: 200 OK
         code: 200
-        duration: 51.60034ms
+        duration: 39.240795ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -911,28 +911,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6fe76d8f-9b19-42a6-a13c-d37d9f7e1050/versions/2
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/01aeac4c-cfc7-4383-8a19-9fb8cf59b392/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 324
-        body: '{"revision":2,"secret_id":"6fe76d8f-9b19-42a6-a13c-d37d9f7e1050","status":"enabled","created_at":"2026-07-03T15:28:23.962815Z","updated_at":"2026-07-03T15:28:23.962815Z","deleted_at":null,"description":"test decrypted associated data","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":2,"secret_id":"01aeac4c-cfc7-4383-8a19-9fb8cf59b392","status":"enabled","created_at":"2026-07-07T07:46:10.262008Z","updated_at":"2026-07-07T07:46:10.262008Z","deleted_at":null,"description":"test decrypted associated data","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "324"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:25 GMT
+                - Tue, 07 Jul 2026 07:46:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - b8b08460-19b5-4810-abc0-573a020022d7
+                - 0659a163-e09f-408c-b53e-0774439d7a2b
         status: 200 OK
         code: 200
-        duration: 34.27597ms
+        duration: 44.713037ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -943,28 +943,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6fe76d8f-9b19-42a6-a13c-d37d9f7e1050/versions/2/access
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/01aeac4c-cfc7-4383-8a19-9fb8cf59b392/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 137
-        body: '{"secret_id":"6fe76d8f-9b19-42a6-a13c-d37d9f7e1050","revision":2,"data":"c29tZSBhc3NvY2lhdGVkIGRhdGE=","data_crc32":null,"type":"opaque"}'
+        content_length: 141
+        body: '{"secret_id":"01aeac4c-cfc7-4383-8a19-9fb8cf59b392","revision":1,"data":"dGhpcyBpcyBzb21lIHNlY3JldCBkYXRh","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "137"
+                - "141"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:25 GMT
+                - Tue, 07 Jul 2026 07:46:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - d5947a5b-f6dd-406b-9c05-904435cdd358
+                - ef70643d-b895-4e72-ab06-e84aa80c1f3c
         status: 200 OK
         code: 200
-        duration: 36.491321ms
+        duration: 56.250385ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -975,28 +975,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6fe76d8f-9b19-42a6-a13c-d37d9f7e1050/versions/2
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/01aeac4c-cfc7-4383-8a19-9fb8cf59b392/versions/2/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 324
-        body: '{"revision":2,"secret_id":"6fe76d8f-9b19-42a6-a13c-d37d9f7e1050","status":"enabled","created_at":"2026-07-03T15:28:23.962815Z","updated_at":"2026-07-03T15:28:23.962815Z","deleted_at":null,"description":"test decrypted associated data","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 137
+        body: '{"secret_id":"01aeac4c-cfc7-4383-8a19-9fb8cf59b392","revision":2,"data":"c29tZSBhc3NvY2lhdGVkIGRhdGE=","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "324"
+                - "137"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:25 GMT
+                - Tue, 07 Jul 2026 07:46:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 419bcf7a-1fc8-46d8-a3af-e103006921ef
+                - 10879bb3-ec7a-441e-a6c9-bd9ad43fb847
         status: 200 OK
         code: 200
-        duration: 35.077095ms
+        duration: 49.206299ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1007,28 +1007,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6fe76d8f-9b19-42a6-a13c-d37d9f7e1050/versions/1/access
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/01aeac4c-cfc7-4383-8a19-9fb8cf59b392/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 141
-        body: '{"secret_id":"6fe76d8f-9b19-42a6-a13c-d37d9f7e1050","revision":1,"data":"dGhpcyBpcyBzb21lIHNlY3JldCBkYXRh","data_crc32":null,"type":"opaque"}'
+        content_length: 314
+        body: '{"revision":1,"secret_id":"01aeac4c-cfc7-4383-8a19-9fb8cf59b392","status":"enabled","created_at":"2026-07-07T07:46:10.116474Z","updated_at":"2026-07-07T07:46:10.116474Z","deleted_at":null,"description":"test decrypted data","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "141"
+                - "314"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:25 GMT
+                - Tue, 07 Jul 2026 07:46:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 8dab9fab-9973-41de-8636-62756a98a910
+                - 2af06b80-8f4b-4d40-a254-0017c8436e60
         status: 200 OK
         code: 200
-        duration: 123.818035ms
+        duration: 57.432159ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1039,28 +1039,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6fe76d8f-9b19-42a6-a13c-d37d9f7e1050/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/01aeac4c-cfc7-4383-8a19-9fb8cf59b392/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 314
-        body: '{"revision":1,"secret_id":"6fe76d8f-9b19-42a6-a13c-d37d9f7e1050","status":"enabled","created_at":"2026-07-03T15:28:23.759013Z","updated_at":"2026-07-03T15:28:23.759013Z","deleted_at":null,"description":"test decrypted data","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 324
+        body: '{"revision":2,"secret_id":"01aeac4c-cfc7-4383-8a19-9fb8cf59b392","status":"enabled","created_at":"2026-07-07T07:46:10.262008Z","updated_at":"2026-07-07T07:46:10.262008Z","deleted_at":null,"description":"test decrypted associated data","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "314"
+                - "324"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:25 GMT
+                - Tue, 07 Jul 2026 07:46:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 102f29af-2590-4601-924a-347a25ef84ba
+                - 1ecf21f3-67cb-44d3-8e2f-1bfb19388849
         status: 200 OK
         code: 200
-        duration: 32.714166ms
+        duration: 44.189232ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1071,7 +1071,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6fe76d8f-9b19-42a6-a13c-d37d9f7e1050/versions/2
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/01aeac4c-cfc7-4383-8a19-9fb8cf59b392/versions/2
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1083,14 +1083,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:25 GMT
+                - Tue, 07 Jul 2026 07:46:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - f2ced07b-f985-41bb-bb6b-8140dc8ebf40
+                - 9afd92f5-21d4-45ab-93f4-8328fd79df94
         status: 204 No Content
         code: 204
-        duration: 61.161088ms
+        duration: 80.537252ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1101,7 +1101,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6fe76d8f-9b19-42a6-a13c-d37d9f7e1050/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/01aeac4c-cfc7-4383-8a19-9fb8cf59b392/versions/1
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1113,14 +1113,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:25 GMT
+                - Tue, 07 Jul 2026 07:46:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 8ad10560-979b-4509-b41b-d51b8b7c0b77
+                - f8aff24e-0b12-4538-b170-5afc37b42d03
         status: 204 No Content
         code: 204
-        duration: 62.840612ms
+        duration: 75.490991ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1131,7 +1131,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6fe76d8f-9b19-42a6-a13c-d37d9f7e1050
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/278f8b55-19be-4193-bc44-ae05d00ee8eb
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1143,14 +1143,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:26 GMT
+                - Tue, 07 Jul 2026 07:46:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - f11d38a5-7da2-4930-9c0c-08374a328901
+                - 4f480ddb-100e-4936-a95b-e202417fe4c3
         status: 204 No Content
         code: 204
-        duration: 63.841903ms
+        duration: 58.381709ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1161,7 +1161,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/2c3026cf-38d3-4155-a38a-09fbd05249d0
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/01aeac4c-cfc7-4383-8a19-9fb8cf59b392
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1173,14 +1173,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:26 GMT
+                - Tue, 07 Jul 2026 07:46:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - d987e034-b942-40b6-a3d7-fd26927f98a0
+                - 3394e8d8-e1a1-4699-abc1-dc4027e00aed
         status: 204 No Content
         code: 204
-        duration: 74.569793ms
+        duration: 74.375493ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1191,28 +1191,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6fe76d8f-9b19-42a6-a13c-d37d9f7e1050
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/01aeac4c-cfc7-4383-8a19-9fb8cf59b392
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 461
-        body: '{"id":"6fe76d8f-9b19-42a6-a13c-d37d9f7e1050","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-decrypt-secret-ad","status":"ready","created_at":"2026-07-03T15:28:23.295981Z","updated_at":"2026-07-03T15:28:26.014972Z","tags":[],"version_count":2,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-07-03T15:28:26.014972Z","key_id":null,"region":"fr-par"}'
+        body: '{"id":"01aeac4c-cfc7-4383-8a19-9fb8cf59b392","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-decrypt-secret-ad","status":"ready","created_at":"2026-07-07T07:46:09.335350Z","updated_at":"2026-07-07T07:46:12.231058Z","tags":[],"version_count":2,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-07-07T07:46:12.231058Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "461"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:26 GMT
+                - Tue, 07 Jul 2026 07:46:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - def55065-feeb-4997-93c4-eb865ffe4cc4
+                - 8cc1da53-a832-4124-80b5-6e48b91f977e
         status: 200 OK
         code: 200
-        duration: 36.231614ms
+        duration: 72.250728ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1223,25 +1223,25 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/2c3026cf-38d3-4155-a38a-09fbd05249d0
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/278f8b55-19be-4193-bc44-ae05d00ee8eb
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 568
-        body: '{"id":"2c3026cf-38d3-4155-a38a-09fbd05249d0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-decrypt-key-ad","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-03T15:28:23.280724Z","updated_at":"2026-07-03T15:28:26.013901Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:23.284017Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-03T15:28:26.013901Z","protection_level":"software","region":"fr-par"}'
+        body: '{"id":"278f8b55-19be-4193-bc44-ae05d00ee8eb","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-decrypt-key-ad","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-07T07:46:09.338590Z","updated_at":"2026-07-07T07:46:12.223006Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:09.342697Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-07T07:46:12.223006Z","protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "568"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:26 GMT
+                - Tue, 07 Jul 2026 07:46:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 9868140a-5d40-4aee-8af4-3de967e615ea
+                - a8b49b2c-4f3c-44e4-9e8f-730cdd79a919
         status: 200 OK
         code: 200
-        duration: 43.425295ms
+        duration: 62.330886ms

--- a/internal/services/keymanager/testdata/encrypt-ephemeral-resource-basic.cassette.yaml
+++ b/internal/services/keymanager/testdata/encrypt-ephemeral-resource-basic.cassette.yaml
@@ -6,9 +6,9 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 232
+        content_length: 186
         host: api.scaleway.com
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-encrypt-key","usage":{"symmetric_encryption":"aes_256_gcm"},"tags":null,"unprotected":true,"origin":"unknown_origin","protection_level":"unknown_protection_level"}'
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-encrypt-key","usage":{"symmetric_encryption":"aes_256_gcm"},"tags":null,"unprotected":true,"origin":"unknown_origin"}'
         headers:
             Content-Type:
                 - application/json
@@ -21,21 +21,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 525
-        body: '{"id":"b746988a-e0e2-4e6a-8bd7-c757769a28ce","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-encrypt-key","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:23.213364Z","updated_at":"2026-07-03T15:28:23.217444Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:23.217444Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"fc7cad12-56ed-4334-8120-6855db657a0b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-encrypt-key","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:07.859941Z","updated_at":"2026-07-07T07:46:07.863185Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:07.863185Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "525"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 36557826-faff-4297-b722-c87fad8c71f9
+                - 8f140e82-6a15-4dbb-a172-2e1d25892b88
         status: 200 OK
         code: 200
-        duration: 62.421034ms
+        duration: 90.647784ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -56,21 +56,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 435
-        body: '{"id":"a21f2b97-7e87-400a-bc96-ede7323c15fb","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-encrypted-secret","status":"ready","created_at":"2026-07-03T15:28:23.255629Z","updated_at":"2026-07-03T15:28:23.255629Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"72f44ba1-f0ae-4cf3-8b3d-7050286984d0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-encrypted-secret","status":"ready","created_at":"2026-07-07T07:46:07.914021Z","updated_at":"2026-07-07T07:46:07.914021Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "435"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 1f957f31-a08b-4d34-a842-53d430959322
+                - 50746bdd-225c-47e0-b8b1-9bb63712518c
         status: 200 OK
         code: 200
-        duration: 108.49318ms
+        duration: 134.774662ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -81,28 +81,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/b746988a-e0e2-4e6a-8bd7-c757769a28ce
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/fc7cad12-56ed-4334-8120-6855db657a0b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 525
-        body: '{"id":"b746988a-e0e2-4e6a-8bd7-c757769a28ce","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-encrypt-key","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:23.213364Z","updated_at":"2026-07-03T15:28:23.217444Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:23.217444Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"fc7cad12-56ed-4334-8120-6855db657a0b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-encrypt-key","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:07.859941Z","updated_at":"2026-07-07T07:46:07.863185Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:07.863185Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "525"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - ed2878c6-b996-46c7-8182-5e43542cf5b2
+                - e030967c-f1d1-4bbf-b2fb-3a93746e8526
         status: 200 OK
         code: 200
-        duration: 48.460182ms
+        duration: 57.72955ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -113,64 +113,29 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a21f2b97-7e87-400a-bc96-ede7323c15fb
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/72f44ba1-f0ae-4cf3-8b3d-7050286984d0
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 435
-        body: '{"id":"a21f2b97-7e87-400a-bc96-ede7323c15fb","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-encrypted-secret","status":"ready","created_at":"2026-07-03T15:28:23.255629Z","updated_at":"2026-07-03T15:28:23.255629Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"72f44ba1-f0ae-4cf3-8b3d-7050286984d0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-encrypted-secret","status":"ready","created_at":"2026-07-07T07:46:07.914021Z","updated_at":"2026-07-07T07:46:07.914021Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "435"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - f090787e-a3ba-4c7d-a235-a3f94a062dd3
+                - 3b267709-faf8-4cc2-95b5-cde316172b72
         status: 200 OK
         code: 200
-        duration: 48.409847ms
+        duration: 50.756628ms
     - id: 4
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 67
-        host: api.scaleway.com
-        body: '{"plaintext":"dGVzdCBwbGFpbnRleHQgZGF0YQ==","associated_data":null}'
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/b746988a-e0e2-4e6a-8bd7-c757769a28ce/encrypt
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 137
-        body: '{"key_id":"b746988a-e0e2-4e6a-8bd7-c757769a28ce","ciphertext":"AQAAAAEXmPppIC/ijYfMTte/ECmqfPezPX0T0Ny2hvQigLAW79EMACZdAUOnY9wNBEPZFw=="}'
-        headers:
-            Content-Length:
-                - "137"
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            X-Request-Id:
-                - ae5c2889-63cb-4acf-bb96-407151b89ab2
-        status: 200 OK
-        code: 200
-        duration: 47.196979ms
-    - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -183,7 +148,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a21f2b97-7e87-400a-bc96-ede7323c15fb/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/72f44ba1-f0ae-4cf3-8b3d-7050286984d0/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -197,14 +162,49 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - e38d6398-3863-4523-9dd2-5171f5402c22
+                - bd54300f-598b-481e-8732-2b16a61a55e4
         status: 200 OK
         code: 200
-        duration: 43.865511ms
+        duration: 49.993163ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 67
+        host: api.scaleway.com
+        body: '{"plaintext":"dGVzdCBwbGFpbnRleHQgZGF0YQ==","associated_data":null}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/fc7cad12-56ed-4334-8120-6855db657a0b/encrypt
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 137
+        body: '{"key_id":"fc7cad12-56ed-4334-8120-6855db657a0b","ciphertext":"AQAAAAF8HFPnyemkCeEQ3GiyUbRqPimTB/9qFjnqIYNxLDPBIck7RL029kwv62QUqs8dww=="}'
+        headers:
+            Content-Length:
+                - "137"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 07 Jul 2026 07:46:08 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - eb6bc288-e406-4725-950d-7849c120ff66
+        status: 200 OK
+        code: 200
+        duration: 82.566741ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -212,34 +212,34 @@ interactions:
         proto_minor: 1
         content_length: 132
         host: api.scaleway.com
-        body: '{"data":"QVFBQUFBRVhtUHBwSUMvaWpZZk1UdGUvRUNtcWZQZXpQWDBUME55Mmh2UWlnTEFXNzlFTUFDWmRBVU9uWTl3TkJFUFpGdz09","description":"version1"}'
+        body: '{"data":"QVFBQUFBRjhIRlBueWVta0NlRVEzR2l5VWJScVBpbVRCLzlxRmpucUlZTnhMRFBCSWNrN1JMMDI5a3d2NjJRVXFzOGR3dz09","description":"version1"}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a21f2b97-7e87-400a-bc96-ede7323c15fb/versions
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/72f44ba1-f0ae-4cf3-8b3d-7050286984d0/versions
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"a21f2b97-7e87-400a-bc96-ede7323c15fb","status":"enabled","created_at":"2026-07-03T15:28:23.647646Z","updated_at":"2026-07-03T15:28:23.647646Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"72f44ba1-f0ae-4cf3-8b3d-7050286984d0","status":"enabled","created_at":"2026-07-07T07:46:08.362864Z","updated_at":"2026-07-07T07:46:08.362864Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - ec43b200-48af-41a9-a2d7-95808f84f594
+                - 942d1811-715d-446c-91f7-6247de07263c
         status: 200 OK
         code: 200
-        duration: 278.9526ms
+        duration: 342.892273ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -250,28 +250,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a21f2b97-7e87-400a-bc96-ede7323c15fb/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/72f44ba1-f0ae-4cf3-8b3d-7050286984d0/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"a21f2b97-7e87-400a-bc96-ede7323c15fb","status":"enabled","created_at":"2026-07-03T15:28:23.647646Z","updated_at":"2026-07-03T15:28:23.647646Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"72f44ba1-f0ae-4cf3-8b3d-7050286984d0","status":"enabled","created_at":"2026-07-07T07:46:08.362864Z","updated_at":"2026-07-07T07:46:08.362864Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 762c4b3d-c3ea-425b-a81a-08f1b72dd818
+                - 38a83af0-c22b-4201-97fb-ee38e79d5b61
         status: 200 OK
         code: 200
-        duration: 34.964533ms
+        duration: 48.204677ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -282,28 +282,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a21f2b97-7e87-400a-bc96-ede7323c15fb/versions/1/access
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/72f44ba1-f0ae-4cf3-8b3d-7050286984d0/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 205
-        body: '{"secret_id":"a21f2b97-7e87-400a-bc96-ede7323c15fb","revision":1,"data":"QVFBQUFBRVhtUHBwSUMvaWpZZk1UdGUvRUNtcWZQZXpQWDBUME55Mmh2UWlnTEFXNzlFTUFDWmRBVU9uWTl3TkJFUFpGdz09","data_crc32":null,"type":"opaque"}'
+        body: '{"secret_id":"72f44ba1-f0ae-4cf3-8b3d-7050286984d0","revision":1,"data":"QVFBQUFBRjhIRlBueWVta0NlRVEzR2l5VWJScVBpbVRCLzlxRmpucUlZTnhMRFBCSWNrN1JMMDI5a3d2NjJRVXFzOGR3dz09","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
                 - "205"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 2c05483b-d8bb-467b-bc09-711f5c113d1b
+                - 80bc06f8-c8aa-454e-aeb8-696f634cfd9c
         status: 200 OK
         code: 200
-        duration: 48.452146ms
+        duration: 88.745481ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -314,28 +314,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a21f2b97-7e87-400a-bc96-ede7323c15fb/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/72f44ba1-f0ae-4cf3-8b3d-7050286984d0/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"a21f2b97-7e87-400a-bc96-ede7323c15fb","status":"enabled","created_at":"2026-07-03T15:28:23.647646Z","updated_at":"2026-07-03T15:28:23.647646Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"72f44ba1-f0ae-4cf3-8b3d-7050286984d0","status":"enabled","created_at":"2026-07-07T07:46:08.362864Z","updated_at":"2026-07-07T07:46:08.362864Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 3dd30ab5-b85d-4819-a8cf-f04375f711fd
+                - 1dd55ade-f2f9-409d-a85f-b21f24f6454c
         status: 200 OK
         code: 200
-        duration: 43.901169ms
+        duration: 43.504626ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -349,28 +349,28 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/b746988a-e0e2-4e6a-8bd7-c757769a28ce/encrypt
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/fc7cad12-56ed-4334-8120-6855db657a0b/encrypt
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 137
-        body: '{"key_id":"b746988a-e0e2-4e6a-8bd7-c757769a28ce","ciphertext":"AQAAAAG4pGdIHq5DudOE3+AiQj5e7t3yMDzr0lXS9jz/NP502j3dhYL8Z3QoOxg/khxP+A=="}'
+        body: '{"key_id":"fc7cad12-56ed-4334-8120-6855db657a0b","ciphertext":"AQAAAAGQV/eyfFAPyWbu0M0aEmrL6SGDqCcPuazklmSuJyghoIs3NgG7oCluwEMzxediNA=="}'
         headers:
             Content-Length:
                 - "137"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:24 GMT
+                - Tue, 07 Jul 2026 07:46:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 6ed52e5e-48e8-4ea2-95d7-3b3a308f20ba
+                - c2dcb412-d7cb-4d24-a719-bbe27a4139a2
         status: 200 OK
         code: 200
-        duration: 47.43691ms
+        duration: 92.625785ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -381,28 +381,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a21f2b97-7e87-400a-bc96-ede7323c15fb/versions/1/access
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/72f44ba1-f0ae-4cf3-8b3d-7050286984d0/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 205
-        body: '{"secret_id":"a21f2b97-7e87-400a-bc96-ede7323c15fb","revision":1,"data":"QVFBQUFBRVhtUHBwSUMvaWpZZk1UdGUvRUNtcWZQZXpQWDBUME55Mmh2UWlnTEFXNzlFTUFDWmRBVU9uWTl3TkJFUFpGdz09","data_crc32":null,"type":"opaque"}'
+        body: '{"secret_id":"72f44ba1-f0ae-4cf3-8b3d-7050286984d0","revision":1,"data":"QVFBQUFBRjhIRlBueWVta0NlRVEzR2l5VWJScVBpbVRCLzlxRmpucUlZTnhMRFBCSWNrN1JMMDI5a3d2NjJRVXFzOGR3dz09","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
                 - "205"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:24 GMT
+                - Tue, 07 Jul 2026 07:46:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - a51397d1-03b8-4e2f-a6d1-22987548f81e
+                - 5da7ee12-22bc-493f-bc8d-be7b099451fe
         status: 200 OK
         code: 200
-        duration: 74.020852ms
+        duration: 86.990216ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -413,28 +413,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a21f2b97-7e87-400a-bc96-ede7323c15fb/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/72f44ba1-f0ae-4cf3-8b3d-7050286984d0/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"a21f2b97-7e87-400a-bc96-ede7323c15fb","status":"enabled","created_at":"2026-07-03T15:28:23.647646Z","updated_at":"2026-07-03T15:28:23.647646Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"72f44ba1-f0ae-4cf3-8b3d-7050286984d0","status":"enabled","created_at":"2026-07-07T07:46:08.362864Z","updated_at":"2026-07-07T07:46:08.362864Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:24 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - e4842d69-c303-4651-850b-4c05cede9a9a
+                - 109c60c1-65e4-4f9b-bcde-55d486962cf6
         status: 200 OK
         code: 200
-        duration: 35.669227ms
+        duration: 38.788406ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -445,28 +445,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a21f2b97-7e87-400a-bc96-ede7323c15fb
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/72f44ba1-f0ae-4cf3-8b3d-7050286984d0
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 435
-        body: '{"id":"a21f2b97-7e87-400a-bc96-ede7323c15fb","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-encrypted-secret","status":"ready","created_at":"2026-07-03T15:28:23.255629Z","updated_at":"2026-07-03T15:28:23.255629Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"72f44ba1-f0ae-4cf3-8b3d-7050286984d0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-encrypted-secret","status":"ready","created_at":"2026-07-07T07:46:07.914021Z","updated_at":"2026-07-07T07:46:07.914021Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "435"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:24 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - f3094af0-c7cf-4492-aab5-b5ad2174e67e
+                - e67fabfd-aedf-44b1-8f32-7525c74d9880
         status: 200 OK
         code: 200
-        duration: 41.904308ms
+        duration: 40.803967ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -477,64 +477,29 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/b746988a-e0e2-4e6a-8bd7-c757769a28ce
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/fc7cad12-56ed-4334-8120-6855db657a0b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 525
-        body: '{"id":"b746988a-e0e2-4e6a-8bd7-c757769a28ce","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-encrypt-key","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:23.213364Z","updated_at":"2026-07-03T15:28:23.217444Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:23.217444Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"fc7cad12-56ed-4334-8120-6855db657a0b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-encrypt-key","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:07.859941Z","updated_at":"2026-07-07T07:46:07.863185Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:07.863185Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "525"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:24 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 9042811f-3a72-4983-aa7d-18ff597b187a
+                - b5147fc5-d2b8-4764-b1f5-b14a022a2573
         status: 200 OK
         code: 200
-        duration: 41.941818ms
+        duration: 56.264107ms
     - id: 15
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        form:
-            page:
-                - "1"
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a21f2b97-7e87-400a-bc96-ede7323c15fb/versions?page=1
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 333
-        body: '{"versions":[{"revision":1,"secret_id":"a21f2b97-7e87-400a-bc96-ede7323c15fb","status":"enabled","created_at":"2026-07-03T15:28:23.647646Z","updated_at":"2026-07-03T15:28:23.647646Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
-        headers:
-            Content-Length:
-                - "333"
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 03 Jul 2026 15:28:24 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            X-Request-Id:
-                - 47076942-a87a-41a3-8438-46f87c40c565
-        status: 200 OK
-        code: 200
-        duration: 47.217738ms
-    - id: 16
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -547,28 +512,63 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/b746988a-e0e2-4e6a-8bd7-c757769a28ce/encrypt
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/fc7cad12-56ed-4334-8120-6855db657a0b/encrypt
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 137
-        body: '{"key_id":"b746988a-e0e2-4e6a-8bd7-c757769a28ce","ciphertext":"AQAAAAEpTTn4u4EcItYC3rVxW9P2azINymmwvYuF0QKGj1QHKFF+uSepbkfnaAzG7qwnLQ=="}'
+        body: '{"key_id":"fc7cad12-56ed-4334-8120-6855db657a0b","ciphertext":"AQAAAAER4zSitKtHjv4rEyWnjZlr+rL7jkGWUoL4wNPN9M1vag96aWkDyIjiqJlcGCMRnA=="}'
         headers:
             Content-Length:
                 - "137"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:24 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - b5253609-d62e-41c0-bca6-733732c85bfd
+                - ea0e4bcb-defb-4719-acd3-0041312e9fdd
         status: 200 OK
         code: 200
-        duration: 47.288421ms
+        duration: 41.749544ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/72f44ba1-f0ae-4cf3-8b3d-7050286984d0/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 333
+        body: '{"versions":[{"revision":1,"secret_id":"72f44ba1-f0ae-4cf3-8b3d-7050286984d0","status":"enabled","created_at":"2026-07-07T07:46:08.362864Z","updated_at":"2026-07-07T07:46:08.362864Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "333"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 07 Jul 2026 07:46:09 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - d368de7c-46d4-4cde-8c0a-e9435251262b
+        status: 200 OK
+        code: 200
+        duration: 76.782387ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -579,28 +579,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a21f2b97-7e87-400a-bc96-ede7323c15fb/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/72f44ba1-f0ae-4cf3-8b3d-7050286984d0/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"a21f2b97-7e87-400a-bc96-ede7323c15fb","status":"enabled","created_at":"2026-07-03T15:28:23.647646Z","updated_at":"2026-07-03T15:28:23.647646Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"72f44ba1-f0ae-4cf3-8b3d-7050286984d0","status":"enabled","created_at":"2026-07-07T07:46:08.362864Z","updated_at":"2026-07-07T07:46:08.362864Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:24 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - afbf99cd-09bc-4ab2-a57e-d3ea3c3b1527
+                - 33c6ca64-3954-4f81-bcae-dbbd9cba7cdf
         status: 200 OK
         code: 200
-        duration: 48.69368ms
+        duration: 47.093486ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -611,28 +611,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a21f2b97-7e87-400a-bc96-ede7323c15fb/versions/1/access
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/72f44ba1-f0ae-4cf3-8b3d-7050286984d0/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 205
-        body: '{"secret_id":"a21f2b97-7e87-400a-bc96-ede7323c15fb","revision":1,"data":"QVFBQUFBRVhtUHBwSUMvaWpZZk1UdGUvRUNtcWZQZXpQWDBUME55Mmh2UWlnTEFXNzlFTUFDWmRBVU9uWTl3TkJFUFpGdz09","data_crc32":null,"type":"opaque"}'
+        body: '{"secret_id":"72f44ba1-f0ae-4cf3-8b3d-7050286984d0","revision":1,"data":"QVFBQUFBRjhIRlBueWVta0NlRVEzR2l5VWJScVBpbVRCLzlxRmpucUlZTnhMRFBCSWNrN1JMMDI5a3d2NjJRVXFzOGR3dz09","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
                 - "205"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:24 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 8c24cfae-6452-4253-88c2-926484a26dae
+                - 69865699-fb45-43f3-a84f-94b07859918b
         status: 200 OK
         code: 200
-        duration: 52.342022ms
+        duration: 116.135829ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -643,28 +643,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a21f2b97-7e87-400a-bc96-ede7323c15fb/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/72f44ba1-f0ae-4cf3-8b3d-7050286984d0/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"a21f2b97-7e87-400a-bc96-ede7323c15fb","status":"enabled","created_at":"2026-07-03T15:28:23.647646Z","updated_at":"2026-07-03T15:28:23.647646Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"72f44ba1-f0ae-4cf3-8b3d-7050286984d0","status":"enabled","created_at":"2026-07-07T07:46:08.362864Z","updated_at":"2026-07-07T07:46:08.362864Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:24 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 850f63d6-03a4-4dcb-a872-a35c447f90cc
+                - 3b47ded4-8840-4bb0-b685-3549017d2fa7
         status: 200 OK
         code: 200
-        duration: 34.656394ms
+        duration: 36.349886ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -675,7 +675,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a21f2b97-7e87-400a-bc96-ede7323c15fb/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/72f44ba1-f0ae-4cf3-8b3d-7050286984d0/versions/1
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -687,14 +687,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:25 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - bd232f29-ebd2-4d23-94ab-31c1c44b7576
+                - f7397e86-f726-4524-8c13-d26a005475f9
         status: 204 No Content
         code: 204
-        duration: 59.866436ms
+        duration: 70.861209ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -705,7 +705,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/b746988a-e0e2-4e6a-8bd7-c757769a28ce
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/72f44ba1-f0ae-4cf3-8b3d-7050286984d0
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -717,14 +717,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:25 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 8a444731-cd93-480a-ba9d-1209f236803a
+                - cc15a707-62aa-4ae3-ad10-0e20ed00e7b7
         status: 204 No Content
         code: 204
-        duration: 62.34966ms
+        duration: 107.593807ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -735,7 +735,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a21f2b97-7e87-400a-bc96-ede7323c15fb
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/fc7cad12-56ed-4334-8120-6855db657a0b
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -747,14 +747,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:25 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 82ade117-d166-4820-813a-09e4fc9c9ea6
+                - 6abc2c5d-6b9b-49ad-96c8-03635f7ad86a
         status: 204 No Content
         code: 204
-        duration: 72.168994ms
+        duration: 343.507525ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -765,28 +765,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/a21f2b97-7e87-400a-bc96-ede7323c15fb
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/72f44ba1-f0ae-4cf3-8b3d-7050286984d0
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 460
-        body: '{"id":"a21f2b97-7e87-400a-bc96-ede7323c15fb","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-encrypted-secret","status":"ready","created_at":"2026-07-03T15:28:23.255629Z","updated_at":"2026-07-03T15:28:25.473293Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-07-03T15:28:25.473293Z","key_id":null,"region":"fr-par"}'
+        body: '{"id":"72f44ba1-f0ae-4cf3-8b3d-7050286984d0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-encrypted-secret","status":"ready","created_at":"2026-07-07T07:46:07.914021Z","updated_at":"2026-07-07T07:46:10.186439Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-07-07T07:46:10.186439Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "460"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:25 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 79fcb67a-6aaa-4bca-bd2f-d71c6d27b3cf
+                - f931d81c-51e8-4dfa-ba62-807003066f2c
         status: 200 OK
         code: 200
-        duration: 32.92876ms
+        duration: 37.017348ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -797,25 +797,25 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/b746988a-e0e2-4e6a-8bd7-c757769a28ce
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/fc7cad12-56ed-4334-8120-6855db657a0b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 565
-        body: '{"id":"b746988a-e0e2-4e6a-8bd7-c757769a28ce","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-encrypt-key","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-03T15:28:23.213364Z","updated_at":"2026-07-03T15:28:25.470868Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:23.217444Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-03T15:28:25.470868Z","protection_level":"software","region":"fr-par"}'
+        body: '{"id":"fc7cad12-56ed-4334-8120-6855db657a0b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-encrypt-key","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-07T07:46:07.859941Z","updated_at":"2026-07-07T07:46:10.272589Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:07.863185Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-07T07:46:10.272589Z","protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "565"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:25 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - abe04d9b-1649-4041-ae45-065f18c38a67
+                - 97e237f5-0e11-451e-b2e3-f544ec025508
         status: 200 OK
         code: 200
-        duration: 41.55432ms
+        duration: 51.641213ms

--- a/internal/services/keymanager/testdata/generate-data-key-ephemeral-resource-basic.cassette.yaml
+++ b/internal/services/keymanager/testdata/generate-data-key-ephemeral-resource-basic.cassette.yaml
@@ -6,6 +6,41 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
+        content_length: 192
+        host: api.scaleway.com
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-generate-data-key","usage":{"symmetric_encryption":"aes_256_gcm"},"tags":null,"unprotected":true,"origin":"unknown_origin"}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 531
+        body: '{"id":"ae023895-cd70-4bc6-808e-e135d21d469a","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-generate-data-key","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:08.427013Z","updated_at":"2026-07-07T07:46:08.432841Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:08.432841Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "531"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 07 Jul 2026 07:46:08 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 2a7af87c-3b11-41f4-9990-291361f40377
+        status: 200 OK
+        code: 200
+        duration: 76.381809ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
         content_length: 140
         host: api.scaleway.com
         body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-data-key-secret","tags":null,"type":"opaque","path":"/","protected":false}'
@@ -21,22 +56,22 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 434
-        body: '{"id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-data-key-secret","status":"ready","created_at":"2026-07-03T15:28:21.122392Z","updated_at":"2026-07-03T15:28:21.122392Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"ce7692df-de8a-47c0-9a62-7972f081bcf2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-data-key-secret","status":"ready","created_at":"2026-07-07T07:46:08.464267Z","updated_at":"2026-07-07T07:46:08.464267Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "434"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
+                - Tue, 07 Jul 2026 07:46:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - cbabf27d-be9d-4434-9274-c6f98d37ae5e
+                - 0d987f9d-1311-4128-be55-ea6b4b58abdb
         status: 200 OK
         code: 200
-        duration: 108.462773ms
-    - id: 1
+        duration: 104.194657ms
+    - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -46,29 +81,96 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/ae023895-cd70-4bc6-808e-e135d21d469a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 531
+        body: '{"id":"ae023895-cd70-4bc6-808e-e135d21d469a","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-generate-data-key","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:08.427013Z","updated_at":"2026-07-07T07:46:08.432841Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:08.432841Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "531"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 07 Jul 2026 07:46:08 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 9f89e09d-685e-492d-8656-d2691183540a
+        status: 200 OK
+        code: 200
+        duration: 50.389058ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ce7692df-de8a-47c0-9a62-7972f081bcf2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 434
-        body: '{"id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-data-key-secret","status":"ready","created_at":"2026-07-03T15:28:21.122392Z","updated_at":"2026-07-03T15:28:21.122392Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"ce7692df-de8a-47c0-9a62-7972f081bcf2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-data-key-secret","status":"ready","created_at":"2026-07-07T07:46:08.464267Z","updated_at":"2026-07-07T07:46:08.464267Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "434"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
+                - Tue, 07 Jul 2026 07:46:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 97240b40-cc81-4010-9aef-a5bf4e38407b
+                - 50990350-4156-4e84-b7ce-34d200d85f83
         status: 200 OK
         code: 200
-        duration: 49.26912ms
-    - id: 2
+        duration: 44.595298ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 53
+        host: api.scaleway.com
+        body: '{"algorithm":"aes_256_gcm","without_plaintext":false}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/ae023895-cd70-4bc6-808e-e135d21d469a/generate-data-key
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 284
+        body: '{"key_id":"ae023895-cd70-4bc6-808e-e135d21d469a","algorithm":"aes_256_gcm","ciphertext":"AQAAAAH7tqc6JDlnPV/krBtRDCND/GJPQ8ZBQOYJ0FTlGBRAp+VT+ObzvgRNl7x7FghUDf9eewldhIiT8B/LabE=","plaintext":"G4E8BtpdUGZXdqBilpsEDCasQCs92gzBagU1+nRQ9gw=","created_at":"2026-07-07T07:46:08.576401298Z"}'
+        headers:
+            Content-Length:
+                - "284"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 07 Jul 2026 07:46:08 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 19bada25-6c37-4afa-a58e-510104f8875a
+        status: 200 OK
+        code: 200
+        duration: 61.035348ms
+    - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -81,7 +183,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ce7692df-de8a-47c0-9a62-7972f081bcf2/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -95,116 +197,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
+                - Tue, 07 Jul 2026 07:46:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 728590d0-c95e-4243-af90-02e5203c2d6f
+                - d33b5171-7be5-4ff0-8b44-fb62dfee84af
         status: 200 OK
         code: 200
-        duration: 49.255605ms
-    - id: 3
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 238
-        host: api.scaleway.com
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-generate-data-key","usage":{"symmetric_encryption":"aes_256_gcm"},"tags":null,"unprotected":true,"origin":"unknown_origin","protection_level":"unknown_protection_level"}'
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 531
-        body: '{"id":"eb04b054-d2ff-4deb-9d9e-c3b297c9a814","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-generate-data-key","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:21.457910Z","updated_at":"2026-07-03T15:28:21.463281Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:21.463281Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "531"
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            X-Request-Id:
-                - 977fb914-18ac-4773-9437-920d07d0d53b
-        status: 200 OK
-        code: 200
-        duration: 455.611834ms
-    - id: 4
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/eb04b054-d2ff-4deb-9d9e-c3b297c9a814
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 531
-        body: '{"id":"eb04b054-d2ff-4deb-9d9e-c3b297c9a814","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-generate-data-key","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:21.457910Z","updated_at":"2026-07-03T15:28:21.463281Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:21.463281Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "531"
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            X-Request-Id:
-                - 57c16659-c972-4ff5-9558-5db293de4170
-        status: 200 OK
-        code: 200
-        duration: 47.09628ms
-    - id: 5
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 53
-        host: api.scaleway.com
-        body: '{"algorithm":"aes_256_gcm","without_plaintext":false}'
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/eb04b054-d2ff-4deb-9d9e-c3b297c9a814/generate-data-key
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 284
-        body: '{"key_id":"eb04b054-d2ff-4deb-9d9e-c3b297c9a814","algorithm":"aes_256_gcm","ciphertext":"AQAAAAEUGAFMTAyAWC00hLs5M97uE30RZBwuUD+Pru4GHUkPfBb+ou9pe8MZsNEugmq14RKzLNHa0+jLS2oRXI0=","plaintext":"LvdnBKEFJEGqQIi+LCXCI+dpZWlELeWfFTzVl/DmGgI=","created_at":"2026-07-03T15:28:21.636549274Z"}'
-        headers:
-            Content-Length:
-                - "284"
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            X-Request-Id:
-                - 26c6d754-9c44-4a5c-8ed2-2fc6c85a4ac0
-        status: 200 OK
-        code: 200
-        duration: 95.155337ms
+        duration: 89.125293ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -212,34 +212,34 @@ interactions:
         proto_minor: 1
         content_length: 128
         host: api.scaleway.com
-        body: '{"ciphertext":"AQAAAAEUGAFMTAyAWC00hLs5M97uE30RZBwuUD+Pru4GHUkPfBb+ou9pe8MZsNEugmq14RKzLNHa0+jLS2oRXI0=","associated_data":null}'
+        body: '{"ciphertext":"AQAAAAH7tqc6JDlnPV/krBtRDCND/GJPQ8ZBQOYJ0FTlGBRAp+VT+ObzvgRNl7x7FghUDf9eewldhIiT8B/LabE=","associated_data":null}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/eb04b054-d2ff-4deb-9d9e-c3b297c9a814/decrypt
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/ae023895-cd70-4bc6-808e-e135d21d469a/decrypt
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 126
-        body: '{"key_id":"eb04b054-d2ff-4deb-9d9e-c3b297c9a814","plaintext":"LvdnBKEFJEGqQIi+LCXCI+dpZWlELeWfFTzVl/DmGgI=","ciphertext":null}'
+        body: '{"key_id":"ae023895-cd70-4bc6-808e-e135d21d469a","plaintext":"G4E8BtpdUGZXdqBilpsEDCasQCs92gzBagU1+nRQ9gw=","ciphertext":null}'
         headers:
             Content-Length:
                 - "126"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
+                - Tue, 07 Jul 2026 07:46:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 488ea255-abee-4086-b734-cd457016863a
+                - d364d40f-32a8-4f03-b017-cfa9ac00ab08
         status: 200 OK
         code: 200
-        duration: 81.208983ms
+        duration: 46.73821ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -247,34 +247,34 @@ interactions:
         proto_minor: 1
         content_length: 156
         host: api.scaleway.com
-        body: '{"data":"QVFBQUFBRVVHQUZNVEF5QVdDMDBoTHM1TTk3dUUzMFJaQnd1VUQrUHJ1NEdIVWtQZkJiK291OXBlOE1ac05FdWdtcTE0Ukt6TE5IYTArakxTMm9SWEkwPQ==","description":"version1"}'
+        body: '{"data":"QVFBQUFBSDd0cWM2SkRsblBWL2tyQnRSRENORC9HSlBROFpCUU9ZSjBGVGxHQlJBcCtWVCtPYnp2Z1JObDd4N0ZnaFVEZjllZXdsZGhJaVQ4Qi9MYWJFPQ==","description":"version1"}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ce7692df-de8a-47c0-9a62-7972f081bcf2/versions
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","status":"enabled","created_at":"2026-07-03T15:28:21.922749Z","updated_at":"2026-07-03T15:28:21.922749Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"ce7692df-de8a-47c0-9a62-7972f081bcf2","status":"enabled","created_at":"2026-07-07T07:46:08.987897Z","updated_at":"2026-07-07T07:46:08.987897Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 2fb8cfdf-b6c8-4fe1-8450-e3030fd66efb
+                - 705ec26f-63ec-4385-afb6-248887f141f3
         status: 200 OK
         code: 200
-        duration: 300.921122ms
+        duration: 373.617224ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -285,28 +285,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ce7692df-de8a-47c0-9a62-7972f081bcf2/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","status":"enabled","created_at":"2026-07-03T15:28:21.922749Z","updated_at":"2026-07-03T15:28:21.922749Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"ce7692df-de8a-47c0-9a62-7972f081bcf2","status":"enabled","created_at":"2026-07-07T07:46:08.987897Z","updated_at":"2026-07-07T07:46:08.987897Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - e08a9e41-e2d8-428b-a794-6d3d634a4d68
+                - cd3d697a-af58-43dd-94ef-ffd4743b7072
         status: 200 OK
         code: 200
-        duration: 51.176142ms
+        duration: 48.77489ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -317,28 +317,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions/1/access
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ce7692df-de8a-47c0-9a62-7972f081bcf2/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 229
-        body: '{"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","revision":1,"data":"QVFBQUFBRVVHQUZNVEF5QVdDMDBoTHM1TTk3dUUzMFJaQnd1VUQrUHJ1NEdIVWtQZkJiK291OXBlOE1ac05FdWdtcTE0Ukt6TE5IYTArakxTMm9SWEkwPQ==","data_crc32":null,"type":"opaque"}'
+        body: '{"secret_id":"ce7692df-de8a-47c0-9a62-7972f081bcf2","revision":1,"data":"QVFBQUFBSDd0cWM2SkRsblBWL2tyQnRSRENORC9HSlBROFpCUU9ZSjBGVGxHQlJBcCtWVCtPYnp2Z1JObDd4N0ZnaFVEZjllZXdsZGhJaVQ4Qi9MYWJFPQ==","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
                 - "229"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:22 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - a19654a6-6af2-49f0-aaa5-5a536e767f01
+                - 848640e8-ce5d-4482-8f79-a3220d05c07a
         status: 200 OK
         code: 200
-        duration: 93.346991ms
+        duration: 131.958628ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -349,28 +349,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ce7692df-de8a-47c0-9a62-7972f081bcf2/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","status":"enabled","created_at":"2026-07-03T15:28:21.922749Z","updated_at":"2026-07-03T15:28:21.922749Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"ce7692df-de8a-47c0-9a62-7972f081bcf2","status":"enabled","created_at":"2026-07-07T07:46:08.987897Z","updated_at":"2026-07-07T07:46:08.987897Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:22 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 7a657127-74c9-41d3-a6ef-fa8082579f60
+                - 5683e9ac-f757-462e-879c-77e2c083e8da
         status: 200 OK
         code: 200
-        duration: 36.05441ms
+        duration: 52.978065ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -378,34 +378,34 @@ interactions:
         proto_minor: 1
         content_length: 108
         host: api.scaleway.com
-        body: '{"data":"Lu+/vWcE77+9BSRB77+9QO+/ve+/vSwl77+9I++/vWllaUQt77+977+9FTzVl++/ve+/vRoC","description":"version2"}'
+        body: '{"data":"G++/vTwG77+9XVBmV3bvv71i77+977+9BAwm77+9QCs977+9DO+/vWoFNe+/vXRQ77+9DA==","description":"version2"}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ce7692df-de8a-47c0-9a62-7972f081bcf2/versions
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":2,"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","status":"enabled","created_at":"2026-07-03T15:28:22.122929Z","updated_at":"2026-07-03T15:28:22.122929Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":2,"secret_id":"ce7692df-de8a-47c0-9a62-7972f081bcf2","status":"enabled","created_at":"2026-07-07T07:46:09.231315Z","updated_at":"2026-07-07T07:46:09.231315Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:22 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 0b499655-769b-42f1-be4c-289b4df6d110
+                - 06e77ce9-1a1c-4ca8-828f-30fa1779cfa1
         status: 200 OK
         code: 200
-        duration: 139.239029ms
+        duration: 190.364425ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -416,28 +416,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions/2
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ce7692df-de8a-47c0-9a62-7972f081bcf2/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":2,"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","status":"enabled","created_at":"2026-07-03T15:28:22.122929Z","updated_at":"2026-07-03T15:28:22.122929Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":2,"secret_id":"ce7692df-de8a-47c0-9a62-7972f081bcf2","status":"enabled","created_at":"2026-07-07T07:46:09.231315Z","updated_at":"2026-07-07T07:46:09.231315Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:22 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 69e1c994-9137-4bf2-9f2a-ca57995b75b7
+                - 2e2bad66-d1f4-4eac-9077-ab603f6b9a89
         status: 200 OK
         code: 200
-        duration: 57.186873ms
+        duration: 42.917803ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -448,64 +448,29 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions/2/access
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ce7692df-de8a-47c0-9a62-7972f081bcf2/versions/2/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 181
-        body: '{"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","revision":2,"data":"Lu+/vWcE77+9BSRB77+9QO+/ve+/vSwl77+9I++/vWllaUQt77+977+9FTzVl++/ve+/vRoC","data_crc32":null,"type":"opaque"}'
+        body: '{"secret_id":"ce7692df-de8a-47c0-9a62-7972f081bcf2","revision":2,"data":"G++/vTwG77+9XVBmV3bvv71i77+977+9BAwm77+9QCs977+9DO+/vWoFNe+/vXRQ77+9DA==","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
                 - "181"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:22 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - ddd39684-6616-4536-ba05-e416f93fa4e5
+                - e562fb64-bf8c-4649-aafb-f9aaf8768bf4
         status: 200 OK
         code: 200
-        duration: 64.965493ms
+        duration: 74.349505ms
     - id: 14
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 108
-        host: api.scaleway.com
-        body: '{"data":"Lu+/vWcE77+9BSRB77+9QO+/ve+/vSwl77+9I++/vWllaUQt77+977+9FTzVl++/ve+/vRoC","description":"version3"}'
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 302
-        body: '{"revision":3,"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","status":"enabled","created_at":"2026-07-03T15:28:22.280312Z","updated_at":"2026-07-03T15:28:22.280312Z","deleted_at":null,"description":"version3","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "302"
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 03 Jul 2026 15:28:22 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            X-Request-Id:
-                - c952ec07-edfb-4047-a554-600ab865d1c6
-        status: 200 OK
-        code: 200
-        duration: 86.124876ms
-    - id: 15
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -515,28 +480,63 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions/2
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ce7692df-de8a-47c0-9a62-7972f081bcf2/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 303
-        body: '{"revision":2,"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","status":"enabled","created_at":"2026-07-03T15:28:22.122929Z","updated_at":"2026-07-03T15:28:22.122929Z","deleted_at":null,"description":"version2","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":2,"secret_id":"ce7692df-de8a-47c0-9a62-7972f081bcf2","status":"enabled","created_at":"2026-07-07T07:46:09.231315Z","updated_at":"2026-07-07T07:46:09.231315Z","deleted_at":null,"description":"version2","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "303"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:22 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 2cece84a-e8cc-423d-8bf5-096998d1fad0
+                - 5a7bbcec-23f2-4380-b353-5e46874ba3bf
         status: 200 OK
         code: 200
-        duration: 49.839492ms
+        duration: 33.180856ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 108
+        host: api.scaleway.com
+        body: '{"data":"G++/vTwG77+9XVBmV3bvv71i77+977+9BAwm77+9QCs977+9DO+/vWoFNe+/vXRQ77+9DA==","description":"version3"}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ce7692df-de8a-47c0-9a62-7972f081bcf2/versions
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 302
+        body: '{"revision":3,"secret_id":"ce7692df-de8a-47c0-9a62-7972f081bcf2","status":"enabled","created_at":"2026-07-07T07:46:09.394372Z","updated_at":"2026-07-07T07:46:09.394372Z","deleted_at":null,"description":"version3","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "302"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 07 Jul 2026 07:46:09 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - ccc89263-9e5b-4964-8863-323127f19cff
+        status: 200 OK
+        code: 200
+        duration: 107.368724ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -547,28 +547,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions/3
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ce7692df-de8a-47c0-9a62-7972f081bcf2/versions/3
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":3,"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","status":"enabled","created_at":"2026-07-03T15:28:22.280312Z","updated_at":"2026-07-03T15:28:22.280312Z","deleted_at":null,"description":"version3","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":3,"secret_id":"ce7692df-de8a-47c0-9a62-7972f081bcf2","status":"enabled","created_at":"2026-07-07T07:46:09.394372Z","updated_at":"2026-07-07T07:46:09.394372Z","deleted_at":null,"description":"version3","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:22 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - aa941cc9-9264-475d-99a4-5f75352c7297
+                - e39ff1b3-5ce7-4c6b-9fe9-c565bfb6cf34
         status: 200 OK
         code: 200
-        duration: 43.156861ms
+        duration: 29.480485ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -579,28 +579,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions/3/access
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ce7692df-de8a-47c0-9a62-7972f081bcf2/versions/3/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 181
-        body: '{"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","revision":3,"data":"Lu+/vWcE77+9BSRB77+9QO+/ve+/vSwl77+9I++/vWllaUQt77+977+9FTzVl++/ve+/vRoC","data_crc32":null,"type":"opaque"}'
+        body: '{"secret_id":"ce7692df-de8a-47c0-9a62-7972f081bcf2","revision":3,"data":"G++/vTwG77+9XVBmV3bvv71i77+977+9BAwm77+9QCs977+9DO+/vWoFNe+/vXRQ77+9DA==","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
                 - "181"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:22 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 89e1e510-f6e4-407c-af68-b1f0b8526e17
+                - e7b8029f-6c92-40ba-be04-56d93413962d
         status: 200 OK
         code: 200
-        duration: 46.988176ms
+        duration: 77.661016ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -611,28 +611,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions/3
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ce7692df-de8a-47c0-9a62-7972f081bcf2/versions/3
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":3,"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","status":"enabled","created_at":"2026-07-03T15:28:22.280312Z","updated_at":"2026-07-03T15:28:22.280312Z","deleted_at":null,"description":"version3","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":3,"secret_id":"ce7692df-de8a-47c0-9a62-7972f081bcf2","status":"enabled","created_at":"2026-07-07T07:46:09.394372Z","updated_at":"2026-07-07T07:46:09.394372Z","deleted_at":null,"description":"version3","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:22 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - c041158d-2bb2-4062-8c76-e8283f048a8d
+                - 8d8ed96d-1fa9-4acd-af7e-9538264b8a6a
         status: 200 OK
         code: 200
-        duration: 39.708814ms
+        duration: 53.40688ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -646,28 +646,28 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/eb04b054-d2ff-4deb-9d9e-c3b297c9a814/generate-data-key
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/ae023895-cd70-4bc6-808e-e135d21d469a/generate-data-key
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 284
-        body: '{"key_id":"eb04b054-d2ff-4deb-9d9e-c3b297c9a814","algorithm":"aes_256_gcm","ciphertext":"AQAAAAHPEtEhiRruGiRXxODWg8Q2Oacu2ASP7C+iSkIXXrr5WZL5cXqggNYp2LWHQpysgC21d6YdJGK0sEwlKOk=","plaintext":"eV5g4IJjCPfSqDLlXXalCqkSx+y8K8PiYGSzbbA6quA=","created_at":"2026-07-03T15:28:22.891834439Z"}'
+        body: '{"key_id":"ae023895-cd70-4bc6-808e-e135d21d469a","algorithm":"aes_256_gcm","ciphertext":"AQAAAAE1OBRP7jDGSoI1kCv6extmJrG616KH8ahNrSnH7IJaPPFczu0vkoKar8vVEiUxsSdBoxuH1nlB02urkNo=","plaintext":"mT4iykYhZdJ56QH7Lw6wPAfk+/mG2nl62s9ikuSq05A=","created_at":"2026-07-07T07:46:09.917940152Z"}'
         headers:
             Content-Length:
                 - "284"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:22 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 6c2b31db-7219-4b4c-9519-3ace9c6532dc
+                - 9d4e93e4-545b-4f11-a9ee-8ce46686c6dd
         status: 200 OK
         code: 200
-        duration: 57.846252ms
+        duration: 58.120664ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -678,28 +678,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions/1/access
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ce7692df-de8a-47c0-9a62-7972f081bcf2/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 229
-        body: '{"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","revision":1,"data":"QVFBQUFBRVVHQUZNVEF5QVdDMDBoTHM1TTk3dUUzMFJaQnd1VUQrUHJ1NEdIVWtQZkJiK291OXBlOE1ac05FdWdtcTE0Ukt6TE5IYTArakxTMm9SWEkwPQ==","data_crc32":null,"type":"opaque"}'
+        body: '{"secret_id":"ce7692df-de8a-47c0-9a62-7972f081bcf2","revision":1,"data":"QVFBQUFBSDd0cWM2SkRsblBWL2tyQnRSRENORC9HSlBROFpCUU9ZSjBGVGxHQlJBcCtWVCtPYnp2Z1JObDd4N0ZnaFVEZjllZXdsZGhJaVQ4Qi9MYWJFPQ==","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
                 - "229"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:22 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - aff828d6-73ad-4baa-8e5d-c531fe44cb90
+                - 511474e0-f1a8-431d-82e6-ad02aada8214
         status: 200 OK
         code: 200
-        duration: 41.310823ms
+        duration: 70.065887ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -710,63 +710,60 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions/2/access
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ce7692df-de8a-47c0-9a62-7972f081bcf2/versions/2/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 181
-        body: '{"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","revision":2,"data":"Lu+/vWcE77+9BSRB77+9QO+/ve+/vSwl77+9I++/vWllaUQt77+977+9FTzVl++/ve+/vRoC","data_crc32":null,"type":"opaque"}'
+        body: '{"secret_id":"ce7692df-de8a-47c0-9a62-7972f081bcf2","revision":2,"data":"G++/vTwG77+9XVBmV3bvv71i77+977+9BAwm77+9QCs977+9DO+/vWoFNe+/vXRQ77+9DA==","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
                 - "181"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:22 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 2fa6382f-3107-4055-8d36-8ffdf8bea074
+                - 6d9e74c6-c5cc-4f44-af5a-f9cdd80ece5c
         status: 200 OK
         code: 200
-        duration: 41.402475ms
+        duration: 65.547392ms
     - id: 22
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 128
+        content_length: 0
         host: api.scaleway.com
-        body: '{"ciphertext":"AQAAAAHPEtEhiRruGiRXxODWg8Q2Oacu2ASP7C+iSkIXXrr5WZL5cXqggNYp2LWHQpysgC21d6YdJGK0sEwlKOk=","associated_data":null}'
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/eb04b054-d2ff-4deb-9d9e-c3b297c9a814/decrypt
-        method: POST
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ce7692df-de8a-47c0-9a62-7972f081bcf2/versions/1
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 126
-        body: '{"key_id":"eb04b054-d2ff-4deb-9d9e-c3b297c9a814","plaintext":"eV5g4IJjCPfSqDLlXXalCqkSx+y8K8PiYGSzbbA6quA=","ciphertext":null}'
+        content_length: 303
+        body: '{"revision":1,"secret_id":"ce7692df-de8a-47c0-9a62-7972f081bcf2","status":"enabled","created_at":"2026-07-07T07:46:08.987897Z","updated_at":"2026-07-07T07:46:08.987897Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "126"
+                - "303"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:22 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 0d13aa58-d228-45ae-805e-7fcbcb6ae7a4
+                - a8a5ca30-5fc7-4b52-9128-f42701e0ad28
         status: 200 OK
         code: 200
-        duration: 80.984581ms
+        duration: 48.3438ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -777,60 +774,63 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ce7692df-de8a-47c0-9a62-7972f081bcf2/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 303
-        body: '{"revision":1,"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","status":"enabled","created_at":"2026-07-03T15:28:21.922749Z","updated_at":"2026-07-03T15:28:21.922749Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":2,"secret_id":"ce7692df-de8a-47c0-9a62-7972f081bcf2","status":"enabled","created_at":"2026-07-07T07:46:09.231315Z","updated_at":"2026-07-07T07:46:09.231315Z","deleted_at":null,"description":"version2","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "303"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:22 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 8cebe839-dba9-4427-b4c8-e244a6ec5a52
+                - 4f7c4714-6717-4cae-a84e-5fb9395fa946
         status: 200 OK
         code: 200
-        duration: 39.131129ms
+        duration: 48.578227ms
     - id: 24
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 128
         host: api.scaleway.com
+        body: '{"ciphertext":"AQAAAAE1OBRP7jDGSoI1kCv6extmJrG616KH8ahNrSnH7IJaPPFczu0vkoKar8vVEiUxsSdBoxuH1nlB02urkNo=","associated_data":null}'
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions/2
-        method: GET
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/ae023895-cd70-4bc6-808e-e135d21d469a/decrypt
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 303
-        body: '{"revision":2,"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","status":"enabled","created_at":"2026-07-03T15:28:22.122929Z","updated_at":"2026-07-03T15:28:22.122929Z","deleted_at":null,"description":"version2","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 126
+        body: '{"key_id":"ae023895-cd70-4bc6-808e-e135d21d469a","plaintext":"mT4iykYhZdJ56QH7Lw6wPAfk+/mG2nl62s9ikuSq05A=","ciphertext":null}'
         headers:
             Content-Length:
-                - "303"
+                - "126"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 68625260-1e88-4379-bdbc-029d896f6d8e
+                - 3244dd52-eb67-408a-9cff-22cb53ccc419
         status: 200 OK
         code: 200
-        duration: 47.673213ms
+        duration: 148.259765ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -841,28 +841,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions/3/access
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ce7692df-de8a-47c0-9a62-7972f081bcf2/versions/3/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 181
-        body: '{"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","revision":3,"data":"Lu+/vWcE77+9BSRB77+9QO+/ve+/vSwl77+9I++/vWllaUQt77+977+9FTzVl++/ve+/vRoC","data_crc32":null,"type":"opaque"}'
+        body: '{"secret_id":"ce7692df-de8a-47c0-9a62-7972f081bcf2","revision":3,"data":"G++/vTwG77+9XVBmV3bvv71i77+977+9BAwm77+9QCs977+9DO+/vWoFNe+/vXRQ77+9DA==","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
                 - "181"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - aed112c3-e658-4546-8a9b-fa6f764036a9
+                - f130c0c3-a100-4070-97fa-3a4294e56929
         status: 200 OK
         code: 200
-        duration: 60.647924ms
+        duration: 56.671698ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -873,28 +873,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions/3
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ce7692df-de8a-47c0-9a62-7972f081bcf2/versions/3
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":3,"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","status":"enabled","created_at":"2026-07-03T15:28:22.280312Z","updated_at":"2026-07-03T15:28:22.280312Z","deleted_at":null,"description":"version3","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":3,"secret_id":"ce7692df-de8a-47c0-9a62-7972f081bcf2","status":"enabled","created_at":"2026-07-07T07:46:09.394372Z","updated_at":"2026-07-07T07:46:09.394372Z","deleted_at":null,"description":"version3","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - c0e8b7bc-de58-40a1-9dda-78a0dd3c4fed
+                - 2eb46040-1b4a-4496-864c-68147d19310e
         status: 200 OK
         code: 200
-        duration: 49.250295ms
+        duration: 42.905622ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -905,28 +905,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ce7692df-de8a-47c0-9a62-7972f081bcf2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 434
-        body: '{"id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-data-key-secret","status":"ready","created_at":"2026-07-03T15:28:21.122392Z","updated_at":"2026-07-03T15:28:21.122392Z","tags":[],"version_count":3,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"ce7692df-de8a-47c0-9a62-7972f081bcf2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-data-key-secret","status":"ready","created_at":"2026-07-07T07:46:08.464267Z","updated_at":"2026-07-07T07:46:08.464267Z","tags":[],"version_count":3,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "434"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - c3b5f65a-32a6-431f-8b9a-3eb78b59a602
+                - b0b5d038-6d21-4338-bf66-e4ee707a5d95
         status: 200 OK
         code: 200
-        duration: 33.192836ms
+        duration: 35.890939ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -937,28 +937,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/eb04b054-d2ff-4deb-9d9e-c3b297c9a814
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/ae023895-cd70-4bc6-808e-e135d21d469a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 531
-        body: '{"id":"eb04b054-d2ff-4deb-9d9e-c3b297c9a814","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-generate-data-key","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:21.457910Z","updated_at":"2026-07-03T15:28:21.463281Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:21.463281Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"ae023895-cd70-4bc6-808e-e135d21d469a","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-generate-data-key","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:08.427013Z","updated_at":"2026-07-07T07:46:08.432841Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:08.432841Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "531"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 4d95dd51-433c-4f7b-a09c-df0cf33d1c02
+                - 096ec4ef-4311-41bf-83ba-15eca1cdc9d8
         status: 200 OK
         code: 200
-        duration: 43.738353ms
+        duration: 56.876187ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -972,28 +972,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ce7692df-de8a-47c0-9a62-7972f081bcf2/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 941
-        body: '{"versions":[{"revision":3,"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","status":"enabled","created_at":"2026-07-03T15:28:22.280312Z","updated_at":"2026-07-03T15:28:22.280312Z","deleted_at":null,"description":"version3","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":2,"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","status":"enabled","created_at":"2026-07-03T15:28:22.122929Z","updated_at":"2026-07-03T15:28:22.122929Z","deleted_at":null,"description":"version2","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","status":"enabled","created_at":"2026-07-03T15:28:21.922749Z","updated_at":"2026-07-03T15:28:21.922749Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":3}'
+        body: '{"versions":[{"revision":3,"secret_id":"ce7692df-de8a-47c0-9a62-7972f081bcf2","status":"enabled","created_at":"2026-07-07T07:46:09.394372Z","updated_at":"2026-07-07T07:46:09.394372Z","deleted_at":null,"description":"version3","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":2,"secret_id":"ce7692df-de8a-47c0-9a62-7972f081bcf2","status":"enabled","created_at":"2026-07-07T07:46:09.231315Z","updated_at":"2026-07-07T07:46:09.231315Z","deleted_at":null,"description":"version2","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"ce7692df-de8a-47c0-9a62-7972f081bcf2","status":"enabled","created_at":"2026-07-07T07:46:08.987897Z","updated_at":"2026-07-07T07:46:08.987897Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":3}'
         headers:
             Content-Length:
                 - "941"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 859c77d6-13c9-4106-b430-3e7fbb1fd335
+                - 02414b55-d5b1-449a-874d-8136321621a3
         status: 200 OK
         code: 200
-        duration: 41.749336ms
+        duration: 43.597796ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1007,28 +1007,28 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/eb04b054-d2ff-4deb-9d9e-c3b297c9a814/generate-data-key
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/ae023895-cd70-4bc6-808e-e135d21d469a/generate-data-key
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 284
-        body: '{"key_id":"eb04b054-d2ff-4deb-9d9e-c3b297c9a814","algorithm":"aes_256_gcm","ciphertext":"AQAAAAGcYRABqL8zbcZhme/KgKtFZoAmMWWKAHzuUUQ8wjmt9h2khq2+bpbqxJaCBEddatX7bRiZ+d/1QV5oL9A=","plaintext":"lnNAeuC5v/IO49bA1sv5YeN0N9vliIuTt4i8QQv91P0=","created_at":"2026-07-03T15:28:23.465028788Z"}'
+        body: '{"key_id":"ae023895-cd70-4bc6-808e-e135d21d469a","algorithm":"aes_256_gcm","ciphertext":"AQAAAAF8DD3hgjD+UgV7hQ7F7U4+qoIR2XovJ091rnTogg35KYvkLQtBSBE+ZbKJ8I0Im7an8n9Qn6BX3FXA+eI=","plaintext":"7GRGnqWRhovQr+keHAceGalIj+ymmTZgJIXdiq816zE=","created_at":"2026-07-07T07:46:10.474795509Z"}'
         headers:
             Content-Length:
                 - "284"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 77255f97-93c2-4a17-a9f0-2eba762f6044
+                - 9b5aaa4e-e79e-4e75-8fbe-195a0dcc9604
         status: 200 OK
         code: 200
-        duration: 94.985298ms
+        duration: 50.897602ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1039,28 +1039,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ce7692df-de8a-47c0-9a62-7972f081bcf2/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 303
-        body: '{"revision":1,"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","status":"enabled","created_at":"2026-07-03T15:28:21.922749Z","updated_at":"2026-07-03T15:28:21.922749Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"ce7692df-de8a-47c0-9a62-7972f081bcf2","status":"enabled","created_at":"2026-07-07T07:46:08.987897Z","updated_at":"2026-07-07T07:46:08.987897Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "303"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 3f8379bc-760f-43a9-80ba-dfcd8e0c1071
+                - 76b6cd9a-3622-4a0b-9638-2c65898a670e
         status: 200 OK
         code: 200
-        duration: 47.266229ms
+        duration: 39.12423ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1068,34 +1068,34 @@ interactions:
         proto_minor: 1
         content_length: 128
         host: api.scaleway.com
-        body: '{"ciphertext":"AQAAAAGcYRABqL8zbcZhme/KgKtFZoAmMWWKAHzuUUQ8wjmt9h2khq2+bpbqxJaCBEddatX7bRiZ+d/1QV5oL9A=","associated_data":null}'
+        body: '{"ciphertext":"AQAAAAF8DD3hgjD+UgV7hQ7F7U4+qoIR2XovJ091rnTogg35KYvkLQtBSBE+ZbKJ8I0Im7an8n9Qn6BX3FXA+eI=","associated_data":null}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/eb04b054-d2ff-4deb-9d9e-c3b297c9a814/decrypt
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/ae023895-cd70-4bc6-808e-e135d21d469a/decrypt
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 126
-        body: '{"key_id":"eb04b054-d2ff-4deb-9d9e-c3b297c9a814","plaintext":"lnNAeuC5v/IO49bA1sv5YeN0N9vliIuTt4i8QQv91P0=","ciphertext":null}'
+        body: '{"key_id":"ae023895-cd70-4bc6-808e-e135d21d469a","plaintext":"7GRGnqWRhovQr+keHAceGalIj+ymmTZgJIXdiq816zE=","ciphertext":null}'
         headers:
             Content-Length:
                 - "126"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - d3f1dbfc-40e6-4847-9d04-e661a9d99eba
+                - 9f42d4fc-02f9-4cb1-b715-b46a1a1003e5
         status: 200 OK
         code: 200
-        duration: 55.897471ms
+        duration: 54.322477ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1106,28 +1106,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions/2
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ce7692df-de8a-47c0-9a62-7972f081bcf2/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 303
-        body: '{"revision":2,"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","status":"enabled","created_at":"2026-07-03T15:28:22.122929Z","updated_at":"2026-07-03T15:28:22.122929Z","deleted_at":null,"description":"version2","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 229
+        body: '{"secret_id":"ce7692df-de8a-47c0-9a62-7972f081bcf2","revision":1,"data":"QVFBQUFBSDd0cWM2SkRsblBWL2tyQnRSRENORC9HSlBROFpCUU9ZSjBGVGxHQlJBcCtWVCtPYnp2Z1JObDd4N0ZnaFVEZjllZXdsZGhJaVQ4Qi9MYWJFPQ==","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "303"
+                - "229"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - d078b877-2712-4c1d-a437-dc1681509bc4
+                - cf246d85-0128-45a4-b76b-44a1d25e92e6
         status: 200 OK
         code: 200
-        duration: 34.802369ms
+        duration: 52.5711ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1138,28 +1138,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions/1/access
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ce7692df-de8a-47c0-9a62-7972f081bcf2/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 229
-        body: '{"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","revision":1,"data":"QVFBQUFBRVVHQUZNVEF5QVdDMDBoTHM1TTk3dUUzMFJaQnd1VUQrUHJ1NEdIVWtQZkJiK291OXBlOE1ac05FdWdtcTE0Ukt6TE5IYTArakxTMm9SWEkwPQ==","data_crc32":null,"type":"opaque"}'
+        content_length: 303
+        body: '{"revision":2,"secret_id":"ce7692df-de8a-47c0-9a62-7972f081bcf2","status":"enabled","created_at":"2026-07-07T07:46:09.231315Z","updated_at":"2026-07-07T07:46:09.231315Z","deleted_at":null,"description":"version2","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "229"
+                - "303"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 9bd450ad-3f49-4fe7-800d-c09cde19dc75
+                - 2b3f7b1a-3b49-41bb-be63-7f8d63ad88bd
         status: 200 OK
         code: 200
-        duration: 50.927465ms
+        duration: 52.528529ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1170,28 +1170,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions/2/access
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ce7692df-de8a-47c0-9a62-7972f081bcf2/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 181
-        body: '{"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","revision":2,"data":"Lu+/vWcE77+9BSRB77+9QO+/ve+/vSwl77+9I++/vWllaUQt77+977+9FTzVl++/ve+/vRoC","data_crc32":null,"type":"opaque"}'
+        content_length: 303
+        body: '{"revision":1,"secret_id":"ce7692df-de8a-47c0-9a62-7972f081bcf2","status":"enabled","created_at":"2026-07-07T07:46:08.987897Z","updated_at":"2026-07-07T07:46:08.987897Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "181"
+                - "303"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - dff4acc0-486b-4cf8-af85-387c5f5d83ff
+                - 5f7c7805-17a0-473b-a696-42dee40a4fc4
         status: 200 OK
         code: 200
-        duration: 34.129164ms
+        duration: 48.753279ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1202,28 +1202,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions/3
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ce7692df-de8a-47c0-9a62-7972f081bcf2/versions/3
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":3,"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","status":"enabled","created_at":"2026-07-03T15:28:22.280312Z","updated_at":"2026-07-03T15:28:22.280312Z","deleted_at":null,"description":"version3","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":3,"secret_id":"ce7692df-de8a-47c0-9a62-7972f081bcf2","status":"enabled","created_at":"2026-07-07T07:46:09.394372Z","updated_at":"2026-07-07T07:46:09.394372Z","deleted_at":null,"description":"version3","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 5805b27a-ae5e-4b1c-b4ca-8982168eb60e
+                - 9f94ab31-db07-43ca-a451-249825c9825e
         status: 200 OK
         code: 200
-        duration: 38.281894ms
+        duration: 43.989852ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1234,28 +1234,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ce7692df-de8a-47c0-9a62-7972f081bcf2/versions/2/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 303
-        body: '{"revision":1,"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","status":"enabled","created_at":"2026-07-03T15:28:21.922749Z","updated_at":"2026-07-03T15:28:21.922749Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 181
+        body: '{"secret_id":"ce7692df-de8a-47c0-9a62-7972f081bcf2","revision":2,"data":"G++/vTwG77+9XVBmV3bvv71i77+977+9BAwm77+9QCs977+9DO+/vWoFNe+/vXRQ77+9DA==","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "303"
+                - "181"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - ebe0bae6-1009-43e2-94f1-ed2d13a9822e
+                - b4336726-2fb8-4563-9251-a7e3eb67327f
         status: 200 OK
         code: 200
-        duration: 37.087771ms
+        duration: 58.197506ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1266,28 +1266,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions/2
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ce7692df-de8a-47c0-9a62-7972f081bcf2/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 303
-        body: '{"revision":2,"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","status":"enabled","created_at":"2026-07-03T15:28:22.122929Z","updated_at":"2026-07-03T15:28:22.122929Z","deleted_at":null,"description":"version2","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":2,"secret_id":"ce7692df-de8a-47c0-9a62-7972f081bcf2","status":"enabled","created_at":"2026-07-07T07:46:09.231315Z","updated_at":"2026-07-07T07:46:09.231315Z","deleted_at":null,"description":"version2","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "303"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 3137d21a-43e9-4619-bc4c-125a6187f59c
+                - 6ae9a1a2-2076-40e9-8e70-e88bedb49ed4
         status: 200 OK
         code: 200
-        duration: 40.273334ms
+        duration: 38.811667ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1298,28 +1298,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions/3/access
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ce7692df-de8a-47c0-9a62-7972f081bcf2/versions/3/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 181
-        body: '{"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","revision":3,"data":"Lu+/vWcE77+9BSRB77+9QO+/ve+/vSwl77+9I++/vWllaUQt77+977+9FTzVl++/ve+/vRoC","data_crc32":null,"type":"opaque"}'
+        body: '{"secret_id":"ce7692df-de8a-47c0-9a62-7972f081bcf2","revision":3,"data":"G++/vTwG77+9XVBmV3bvv71i77+977+9BAwm77+9QCs977+9DO+/vWoFNe+/vXRQ77+9DA==","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
                 - "181"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 79dad355-7dfb-4493-b7ff-38c997f3e603
+                - d7bd4bc7-0cb0-4502-8c29-b2cc4382c157
         status: 200 OK
         code: 200
-        duration: 41.328056ms
+        duration: 49.995648ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -1330,28 +1330,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions/3
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ce7692df-de8a-47c0-9a62-7972f081bcf2/versions/3
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":3,"secret_id":"f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969","status":"enabled","created_at":"2026-07-03T15:28:22.280312Z","updated_at":"2026-07-03T15:28:22.280312Z","deleted_at":null,"description":"version3","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":3,"secret_id":"ce7692df-de8a-47c0-9a62-7972f081bcf2","status":"enabled","created_at":"2026-07-07T07:46:09.394372Z","updated_at":"2026-07-07T07:46:09.394372Z","deleted_at":null,"description":"version3","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - fe09a149-009c-4df1-92c8-d551f507ea94
+                - b2af940f-5c24-448b-8316-6703741fc13f
         status: 200 OK
         code: 200
-        duration: 36.951465ms
+        duration: 49.618402ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -1362,7 +1362,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions/3
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ce7692df-de8a-47c0-9a62-7972f081bcf2/versions/3
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1374,14 +1374,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:24 GMT
+                - Tue, 07 Jul 2026 07:46:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - b4ed9767-a2e1-4a9c-a1d1-b48fceef391f
+                - 48cf059d-9988-4485-8479-b3b8f5def0ae
         status: 204 No Content
         code: 204
-        duration: 68.708644ms
+        duration: 94.835625ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -1392,7 +1392,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions/2
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ce7692df-de8a-47c0-9a62-7972f081bcf2/versions/2
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1404,14 +1404,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:24 GMT
+                - Tue, 07 Jul 2026 07:46:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 6738a058-96ed-45f4-865a-1b0934fdc20f
+                - e15e74dc-2561-4ca5-aa8b-d8bdc86d91ae
         status: 204 No Content
         code: 204
-        duration: 76.660189ms
+        duration: 76.67513ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -1422,7 +1422,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ce7692df-de8a-47c0-9a62-7972f081bcf2/versions/1
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1434,14 +1434,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:24 GMT
+                - Tue, 07 Jul 2026 07:46:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - b0687318-3ccd-46ea-9d04-26cedecd1e91
+                - 8512215b-32c1-4ce5-9088-866fb65beb76
         status: 204 No Content
         code: 204
-        duration: 60.39015ms
+        duration: 63.884972ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -1452,7 +1452,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f0fc2ac5-81e0-4dd6-96d8-d4e3dca47969
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/ae023895-cd70-4bc6-808e-e135d21d469a
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1464,14 +1464,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:24 GMT
+                - Tue, 07 Jul 2026 07:46:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - bde4f5be-53a8-4702-b565-bed3134ac82a
+                - d30a1b9e-4621-4da1-85cd-2c3b975ae688
         status: 204 No Content
         code: 204
-        duration: 68.479113ms
+        duration: 64.940927ms
     - id: 45
       request:
         proto: HTTP/1.1
@@ -1482,7 +1482,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/eb04b054-d2ff-4deb-9d9e-c3b297c9a814
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ce7692df-de8a-47c0-9a62-7972f081bcf2
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1494,11 +1494,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:24 GMT
+                - Tue, 07 Jul 2026 07:46:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 29c878e2-f5c7-44a1-970c-b3b8b0876ff3
+                - 5a012820-f3d0-4091-91a8-164abe82d694
         status: 204 No Content
         code: 204
-        duration: 71.95949ms
+        duration: 78.683985ms

--- a/internal/services/keymanager/testdata/generate-data-key-ephemeral-resource-without-plaintext.cassette.yaml
+++ b/internal/services/keymanager/testdata/generate-data-key-ephemeral-resource-without-plaintext.cassette.yaml
@@ -6,41 +6,6 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 242
-        host: api.scaleway.com
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-generate-no-plaintext","usage":{"symmetric_encryption":"aes_256_gcm"},"tags":null,"unprotected":true,"origin":"unknown_origin","protection_level":"unknown_protection_level"}'
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 535
-        body: '{"id":"23871059-a682-4a9d-9cc7-f9e5588a7555","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-generate-no-plaintext","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:22.769593Z","updated_at":"2026-07-03T15:28:22.772636Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:22.772636Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "535"
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 03 Jul 2026 15:28:22 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            X-Request-Id:
-                - 6435db61-4cf2-4d3f-81aa-aa9554d5535b
-        status: 200 OK
-        code: 200
-        duration: 97.903429ms
-    - id: 1
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
         content_length: 153
         host: api.scaleway.com
         body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-data-key-secret-no-plaintext","tags":null,"type":"opaque","path":"/","protected":false}'
@@ -56,22 +21,22 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 447
-        body: '{"id":"64b52306-403c-4d7c-be75-1ae72babf99d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-data-key-secret-no-plaintext","status":"ready","created_at":"2026-07-03T15:28:22.792157Z","updated_at":"2026-07-03T15:28:22.792157Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"18d0279f-9a5b-4794-9a9a-f6d386af983e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-data-key-secret-no-plaintext","status":"ready","created_at":"2026-07-07T07:46:08.303970Z","updated_at":"2026-07-07T07:46:08.303970Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "447"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:22 GMT
+                - Tue, 07 Jul 2026 07:46:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - ae31fde5-37b1-4332-8c19-8d104a9821c3
+                - 2563f35b-336c-42d2-95ec-725e37e1fd78
         status: 200 OK
         code: 200
-        duration: 126.964464ms
-    - id: 2
+        duration: 95.031025ms
+    - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -81,96 +46,64 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/23871059-a682-4a9d-9cc7-f9e5588a7555
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 535
-        body: '{"id":"23871059-a682-4a9d-9cc7-f9e5588a7555","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-generate-no-plaintext","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:22.769593Z","updated_at":"2026-07-03T15:28:22.772636Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:22.772636Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "535"
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 03 Jul 2026 15:28:22 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            X-Request-Id:
-                - 1e9e5205-7dbf-403e-8b33-33491d4d1d52
-        status: 200 OK
-        code: 200
-        duration: 45.368264ms
-    - id: 3
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/64b52306-403c-4d7c-be75-1ae72babf99d
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18d0279f-9a5b-4794-9a9a-f6d386af983e
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 447
-        body: '{"id":"64b52306-403c-4d7c-be75-1ae72babf99d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-data-key-secret-no-plaintext","status":"ready","created_at":"2026-07-03T15:28:22.792157Z","updated_at":"2026-07-03T15:28:22.792157Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"18d0279f-9a5b-4794-9a9a-f6d386af983e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-data-key-secret-no-plaintext","status":"ready","created_at":"2026-07-07T07:46:08.303970Z","updated_at":"2026-07-07T07:46:08.303970Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "447"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:22 GMT
+                - Tue, 07 Jul 2026 07:46:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - c7f6d893-318d-456d-a135-2b5e55513926
+                - de172098-a6cc-4320-abd6-d78591c89723
         status: 200 OK
         code: 200
-        duration: 48.322573ms
-    - id: 4
+        duration: 37.680209ms
+    - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 52
+        content_length: 196
         host: api.scaleway.com
-        body: '{"algorithm":"aes_256_gcm","without_plaintext":true}'
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-generate-no-plaintext","usage":{"symmetric_encryption":"aes_256_gcm"},"tags":null,"unprotected":true,"origin":"unknown_origin"}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/23871059-a682-4a9d-9cc7-f9e5588a7555/generate-data-key
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 242
-        body: '{"key_id":"23871059-a682-4a9d-9cc7-f9e5588a7555","algorithm":"aes_256_gcm","ciphertext":"AQAAAAEGUgHxjUD/MrVtJ7GNV+R8iqUwPBD49I8Y9jawCNLQSbLTfu4dvk64yL8hYKIb6fe1O0WCGiwjnByWhug=","plaintext":null,"created_at":"2026-07-03T15:28:22.920607339Z"}'
+        content_length: 535
+        body: '{"id":"d4f12236-7e6e-4042-8693-751f819f2095","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-generate-no-plaintext","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:08.340831Z","updated_at":"2026-07-07T07:46:08.344193Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:08.344193Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "242"
+                - "535"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:22 GMT
+                - Tue, 07 Jul 2026 07:46:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 8b7386ac-ca95-43de-b099-ab4bff88c442
+                - 360ae7fe-10e2-41b1-95a8-ac0476131d2a
         status: 200 OK
         code: 200
-        duration: 57.640474ms
-    - id: 5
+        duration: 145.116676ms
+    - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -183,7 +116,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/64b52306-403c-4d7c-be75-1ae72babf99d/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18d0279f-9a5b-4794-9a9a-f6d386af983e/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -197,14 +130,81 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:22 GMT
+                - Tue, 07 Jul 2026 07:46:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 40e1c0bf-b4c1-4a1c-8d3d-0366440c7049
+                - fb5f026a-c8f7-4463-b61d-16b282c2f958
         status: 200 OK
         code: 200
-        duration: 40.539134ms
+        duration: 45.365191ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/d4f12236-7e6e-4042-8693-751f819f2095
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 535
+        body: '{"id":"d4f12236-7e6e-4042-8693-751f819f2095","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-generate-no-plaintext","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:08.340831Z","updated_at":"2026-07-07T07:46:08.344193Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:08.344193Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "535"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 07 Jul 2026 07:46:08 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - e200a67f-b563-4fcc-9f80-db1fad0e2e98
+        status: 200 OK
+        code: 200
+        duration: 43.69107ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 52
+        host: api.scaleway.com
+        body: '{"algorithm":"aes_256_gcm","without_plaintext":true}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/d4f12236-7e6e-4042-8693-751f819f2095/generate-data-key
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 242
+        body: '{"key_id":"d4f12236-7e6e-4042-8693-751f819f2095","algorithm":"aes_256_gcm","ciphertext":"AQAAAAHuPgWdpYFqkLRzVYrDQ1P0uUVdIaxwtzbMAmW1e+3FW78NSCpNU4rd8m6r0cPE+VJQCz51pPiOCPGNatU=","plaintext":null,"created_at":"2026-07-07T07:46:08.527122639Z"}'
+        headers:
+            Content-Length:
+                - "242"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 07 Jul 2026 07:46:08 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - d46d2d60-81a7-4019-a3e8-091bd329c551
+        status: 200 OK
+        code: 200
+        duration: 118.471246ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -212,34 +212,34 @@ interactions:
         proto_minor: 1
         content_length: 156
         host: api.scaleway.com
-        body: '{"data":"QVFBQUFBRUdVZ0h4alVEL01yVnRKN0dOVitSOGlxVXdQQkQ0OUk4WTlqYXdDTkxRU2JMVGZ1NGR2azY0eUw4aFlLSWI2ZmUxTzBXQ0dpd2puQnlXaHVnPQ==","description":"version1"}'
+        body: '{"data":"QVFBQUFBSHVQZ1dkcFlGcWtMUnpWWXJEUTFQMHVVVmRJYXh3dHpiTUFtVzFlKzNGVzc4TlNDcE5VNHJkOG02cjBjUEUrVkpRQ3o1MXBQaU9DUEdOYXRVPQ==","description":"version1"}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/64b52306-403c-4d7c-be75-1ae72babf99d/versions
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18d0279f-9a5b-4794-9a9a-f6d386af983e/versions
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"64b52306-403c-4d7c-be75-1ae72babf99d","status":"enabled","created_at":"2026-07-03T15:28:23.222459Z","updated_at":"2026-07-03T15:28:23.222459Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"18d0279f-9a5b-4794-9a9a-f6d386af983e","status":"enabled","created_at":"2026-07-07T07:46:08.797567Z","updated_at":"2026-07-07T07:46:08.797567Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 5ece8538-afec-4c07-9319-6d03085f9d1a
+                - 3de6e5e5-2d4b-4402-868a-412144c085de
         status: 200 OK
         code: 200
-        duration: 299.622704ms
+        duration: 288.525567ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -250,28 +250,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/64b52306-403c-4d7c-be75-1ae72babf99d/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18d0279f-9a5b-4794-9a9a-f6d386af983e/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"64b52306-403c-4d7c-be75-1ae72babf99d","status":"enabled","created_at":"2026-07-03T15:28:23.222459Z","updated_at":"2026-07-03T15:28:23.222459Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"18d0279f-9a5b-4794-9a9a-f6d386af983e","status":"enabled","created_at":"2026-07-07T07:46:08.797567Z","updated_at":"2026-07-07T07:46:08.797567Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 616890f9-7e8a-4100-aeff-898e8848a1fd
+                - 13494623-56c9-4721-ae0b-6b5120f007c0
         status: 200 OK
         code: 200
-        duration: 39.750091ms
+        duration: 50.853981ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -282,28 +282,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/64b52306-403c-4d7c-be75-1ae72babf99d/versions/1/access
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18d0279f-9a5b-4794-9a9a-f6d386af983e/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 229
-        body: '{"secret_id":"64b52306-403c-4d7c-be75-1ae72babf99d","revision":1,"data":"QVFBQUFBRUdVZ0h4alVEL01yVnRKN0dOVitSOGlxVXdQQkQ0OUk4WTlqYXdDTkxRU2JMVGZ1NGR2azY0eUw4aFlLSWI2ZmUxTzBXQ0dpd2puQnlXaHVnPQ==","data_crc32":null,"type":"opaque"}'
+        body: '{"secret_id":"18d0279f-9a5b-4794-9a9a-f6d386af983e","revision":1,"data":"QVFBQUFBSHVQZ1dkcFlGcWtMUnpWWXJEUTFQMHVVVmRJYXh3dHpiTUFtVzFlKzNGVzc4TlNDcE5VNHJkOG02cjBjUEUrVkpRQ3o1MXBQaU9DUEdOYXRVPQ==","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
                 - "229"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 9cb83b0b-b07a-49bc-97e7-ebb3a1a97f4d
+                - 5697b8e1-a3af-4881-ad37-651d810bef88
         status: 200 OK
         code: 200
-        duration: 76.031658ms
+        duration: 93.816337ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -314,28 +314,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/64b52306-403c-4d7c-be75-1ae72babf99d/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18d0279f-9a5b-4794-9a9a-f6d386af983e/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"64b52306-403c-4d7c-be75-1ae72babf99d","status":"enabled","created_at":"2026-07-03T15:28:23.222459Z","updated_at":"2026-07-03T15:28:23.222459Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"18d0279f-9a5b-4794-9a9a-f6d386af983e","status":"enabled","created_at":"2026-07-07T07:46:08.797567Z","updated_at":"2026-07-07T07:46:08.797567Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 91813379-f087-4ca1-9012-d06d26ebbad8
+                - 8dc3d132-bf7a-4356-a2cc-060b75cb2ee3
         status: 200 OK
         code: 200
-        duration: 36.188051ms
+        duration: 45.925134ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -349,28 +349,28 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/64b52306-403c-4d7c-be75-1ae72babf99d/versions
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18d0279f-9a5b-4794-9a9a-f6d386af983e/versions
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":2,"secret_id":"64b52306-403c-4d7c-be75-1ae72babf99d","status":"enabled","created_at":"2026-07-03T15:28:23.416588Z","updated_at":"2026-07-03T15:28:23.416588Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":2,"secret_id":"18d0279f-9a5b-4794-9a9a-f6d386af983e","status":"enabled","created_at":"2026-07-07T07:46:09.024337Z","updated_at":"2026-07-07T07:46:09.024337Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - b4b33060-c52a-4d27-93be-99b9a559e135
+                - d497f560-f94e-4cd9-b162-0932eadb3188
         status: 200 OK
         code: 200
-        duration: 144.465476ms
+        duration: 159.788193ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -381,28 +381,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/64b52306-403c-4d7c-be75-1ae72babf99d/versions/2
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18d0279f-9a5b-4794-9a9a-f6d386af983e/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":2,"secret_id":"64b52306-403c-4d7c-be75-1ae72babf99d","status":"enabled","created_at":"2026-07-03T15:28:23.416588Z","updated_at":"2026-07-03T15:28:23.416588Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":2,"secret_id":"18d0279f-9a5b-4794-9a9a-f6d386af983e","status":"enabled","created_at":"2026-07-07T07:46:09.024337Z","updated_at":"2026-07-07T07:46:09.024337Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - f8f8155d-2f78-45ac-ac2d-a81c4bfea295
+                - df57eab8-2a4b-47fd-b3f5-3b59975c810e
         status: 200 OK
         code: 200
-        duration: 40.7397ms
+        duration: 45.541187ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -413,28 +413,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/64b52306-403c-4d7c-be75-1ae72babf99d/versions/2/access
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18d0279f-9a5b-4794-9a9a-f6d386af983e/versions/2/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 137
-        body: '{"secret_id":"64b52306-403c-4d7c-be75-1ae72babf99d","revision":2,"data":"cGxhaW50ZXh0IHdhcyBlbXB0eQ==","data_crc32":null,"type":"opaque"}'
+        body: '{"secret_id":"18d0279f-9a5b-4794-9a9a-f6d386af983e","revision":2,"data":"cGxhaW50ZXh0IHdhcyBlbXB0eQ==","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
                 - "137"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 364a9b50-6f5a-4335-84ce-a21a206a3076
+                - 246ca75e-7928-4ea2-ba33-837ddcee06d4
         status: 200 OK
         code: 200
-        duration: 122.385434ms
+        duration: 53.301379ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -445,28 +445,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/64b52306-403c-4d7c-be75-1ae72babf99d/versions/2
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18d0279f-9a5b-4794-9a9a-f6d386af983e/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":2,"secret_id":"64b52306-403c-4d7c-be75-1ae72babf99d","status":"enabled","created_at":"2026-07-03T15:28:23.416588Z","updated_at":"2026-07-03T15:28:23.416588Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":2,"secret_id":"18d0279f-9a5b-4794-9a9a-f6d386af983e","status":"enabled","created_at":"2026-07-07T07:46:09.024337Z","updated_at":"2026-07-07T07:46:09.024337Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - ae84374a-f129-4dcf-b79b-1b1d9bfe3cd9
+                - 0c872fed-b3dc-4c88-a84f-02689c24cf52
         status: 200 OK
         code: 200
-        duration: 45.701851ms
+        duration: 42.012684ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -480,28 +480,28 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/23871059-a682-4a9d-9cc7-f9e5588a7555/generate-data-key
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/d4f12236-7e6e-4042-8693-751f819f2095/generate-data-key
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 242
-        body: '{"key_id":"23871059-a682-4a9d-9cc7-f9e5588a7555","algorithm":"aes_256_gcm","ciphertext":"AQAAAAHlMIVz7r5O4Ox3i2OABVwlBq9mFsoDiORz1JscCAaYp77d1Ao8wCZI64VeyeidHhxuUwrcJaPyaMa+zhk=","plaintext":null,"created_at":"2026-07-03T15:28:24.001504920Z"}'
+        body: '{"key_id":"d4f12236-7e6e-4042-8693-751f819f2095","algorithm":"aes_256_gcm","ciphertext":"AQAAAAF1G9iS5QhNfIFHHMR3ucfSkdTxHzEkOEshllBLNuumJwf3jlz/1BX7queF0YtYJMMu7ApXXPVMyHAUkeg=","plaintext":null,"created_at":"2026-07-07T07:46:09.502287761Z"}'
         headers:
             Content-Length:
                 - "242"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:24 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 12516d92-baae-45a0-a421-cf74d133ae6f
+                - e99a8c85-2851-4646-95a3-6c227564945f
         status: 200 OK
         code: 200
-        duration: 56.47201ms
+        duration: 46.172827ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -512,28 +512,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/64b52306-403c-4d7c-be75-1ae72babf99d/versions/2/access
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18d0279f-9a5b-4794-9a9a-f6d386af983e/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 137
-        body: '{"secret_id":"64b52306-403c-4d7c-be75-1ae72babf99d","revision":2,"data":"cGxhaW50ZXh0IHdhcyBlbXB0eQ==","data_crc32":null,"type":"opaque"}'
+        content_length: 229
+        body: '{"secret_id":"18d0279f-9a5b-4794-9a9a-f6d386af983e","revision":1,"data":"QVFBQUFBSHVQZ1dkcFlGcWtMUnpWWXJEUTFQMHVVVmRJYXh3dHpiTUFtVzFlKzNGVzc4TlNDcE5VNHJkOG02cjBjUEUrVkpRQ3o1MXBQaU9DUEdOYXRVPQ==","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "137"
+                - "229"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:24 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 0662ceb9-10c1-4891-afe7-a84f3a4f7bb9
+                - e334db53-5c0f-4236-9333-a316183a2979
         status: 200 OK
         code: 200
-        duration: 62.086326ms
+        duration: 68.431513ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -544,28 +544,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/64b52306-403c-4d7c-be75-1ae72babf99d/versions/1/access
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18d0279f-9a5b-4794-9a9a-f6d386af983e/versions/2/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 229
-        body: '{"secret_id":"64b52306-403c-4d7c-be75-1ae72babf99d","revision":1,"data":"QVFBQUFBRUdVZ0h4alVEL01yVnRKN0dOVitSOGlxVXdQQkQ0OUk4WTlqYXdDTkxRU2JMVGZ1NGR2azY0eUw4aFlLSWI2ZmUxTzBXQ0dpd2puQnlXaHVnPQ==","data_crc32":null,"type":"opaque"}'
+        content_length: 137
+        body: '{"secret_id":"18d0279f-9a5b-4794-9a9a-f6d386af983e","revision":2,"data":"cGxhaW50ZXh0IHdhcyBlbXB0eQ==","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "229"
+                - "137"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:24 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - a37044dd-cdef-48fd-bd11-f8075e97ad82
+                - 3f998d11-6d65-4f5f-a441-cc4249e98df1
         status: 200 OK
         code: 200
-        duration: 65.836079ms
+        duration: 89.473468ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -576,28 +576,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/64b52306-403c-4d7c-be75-1ae72babf99d/versions/2
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18d0279f-9a5b-4794-9a9a-f6d386af983e/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 302
-        body: '{"revision":2,"secret_id":"64b52306-403c-4d7c-be75-1ae72babf99d","status":"enabled","created_at":"2026-07-03T15:28:23.416588Z","updated_at":"2026-07-03T15:28:23.416588Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 303
+        body: '{"revision":1,"secret_id":"18d0279f-9a5b-4794-9a9a-f6d386af983e","status":"enabled","created_at":"2026-07-07T07:46:08.797567Z","updated_at":"2026-07-07T07:46:08.797567Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "302"
+                - "303"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:24 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - f77590db-d50e-4c8b-8365-b73dedc41136
+                - 1a145a72-4675-4d1d-aae3-07aeac1871c9
         status: 200 OK
         code: 200
-        duration: 41.112701ms
+        duration: 56.560701ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -608,28 +608,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/64b52306-403c-4d7c-be75-1ae72babf99d/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18d0279f-9a5b-4794-9a9a-f6d386af983e/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 303
-        body: '{"revision":1,"secret_id":"64b52306-403c-4d7c-be75-1ae72babf99d","status":"enabled","created_at":"2026-07-03T15:28:23.222459Z","updated_at":"2026-07-03T15:28:23.222459Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        content_length: 302
+        body: '{"revision":2,"secret_id":"18d0279f-9a5b-4794-9a9a-f6d386af983e","status":"enabled","created_at":"2026-07-07T07:46:09.024337Z","updated_at":"2026-07-07T07:46:09.024337Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "303"
+                - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:24 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - f42b963d-fb3f-4a73-b1b8-dd1178db68db
+                - 76bf8db1-f1c0-4590-844f-671476b6045a
         status: 200 OK
         code: 200
-        duration: 42.120744ms
+        duration: 46.359551ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -640,28 +640,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/64b52306-403c-4d7c-be75-1ae72babf99d
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18d0279f-9a5b-4794-9a9a-f6d386af983e
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 447
-        body: '{"id":"64b52306-403c-4d7c-be75-1ae72babf99d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-data-key-secret-no-plaintext","status":"ready","created_at":"2026-07-03T15:28:22.792157Z","updated_at":"2026-07-03T15:28:22.792157Z","tags":[],"version_count":2,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"18d0279f-9a5b-4794-9a9a-f6d386af983e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-data-key-secret-no-plaintext","status":"ready","created_at":"2026-07-07T07:46:08.303970Z","updated_at":"2026-07-07T07:46:08.303970Z","tags":[],"version_count":2,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "447"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:24 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - da4c3dad-7d10-4bf9-9ebb-5fa8bb07f378
+                - 86e6f8b7-9aae-4b2e-bf64-75a98ead9282
         status: 200 OK
         code: 200
-        duration: 36.802846ms
+        duration: 51.262135ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -672,28 +672,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/23871059-a682-4a9d-9cc7-f9e5588a7555
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/d4f12236-7e6e-4042-8693-751f819f2095
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 535
-        body: '{"id":"23871059-a682-4a9d-9cc7-f9e5588a7555","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-generate-no-plaintext","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:22.769593Z","updated_at":"2026-07-03T15:28:22.772636Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:22.772636Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"d4f12236-7e6e-4042-8693-751f819f2095","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-generate-no-plaintext","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:08.340831Z","updated_at":"2026-07-07T07:46:08.344193Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:08.344193Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "535"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:24 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - b76fc425-2b6f-48ab-988e-d4a0533a644c
+                - 982a20e2-0f1a-4135-8bc7-f19683b7f0fd
         status: 200 OK
         code: 200
-        duration: 46.637559ms
+        duration: 54.707909ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -707,28 +707,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/64b52306-403c-4d7c-be75-1ae72babf99d/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18d0279f-9a5b-4794-9a9a-f6d386af983e/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 637
-        body: '{"versions":[{"revision":2,"secret_id":"64b52306-403c-4d7c-be75-1ae72babf99d","status":"enabled","created_at":"2026-07-03T15:28:23.416588Z","updated_at":"2026-07-03T15:28:23.416588Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"64b52306-403c-4d7c-be75-1ae72babf99d","status":"enabled","created_at":"2026-07-03T15:28:23.222459Z","updated_at":"2026-07-03T15:28:23.222459Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":2}'
+        body: '{"versions":[{"revision":2,"secret_id":"18d0279f-9a5b-4794-9a9a-f6d386af983e","status":"enabled","created_at":"2026-07-07T07:46:09.024337Z","updated_at":"2026-07-07T07:46:09.024337Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"18d0279f-9a5b-4794-9a9a-f6d386af983e","status":"enabled","created_at":"2026-07-07T07:46:08.797567Z","updated_at":"2026-07-07T07:46:08.797567Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":2}'
         headers:
             Content-Length:
                 - "637"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:24 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 077b0593-fb5d-4248-abc6-fe653930fe54
+                - af7f44cb-2b2c-4d98-ae7b-8accfc04e3f2
         status: 200 OK
         code: 200
-        duration: 41.476985ms
+        duration: 52.911907ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -742,28 +742,28 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/23871059-a682-4a9d-9cc7-f9e5588a7555/generate-data-key
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/d4f12236-7e6e-4042-8693-751f819f2095/generate-data-key
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 242
-        body: '{"key_id":"23871059-a682-4a9d-9cc7-f9e5588a7555","algorithm":"aes_256_gcm","ciphertext":"AQAAAAGLdycwGEFXsfGt26yDotp01yTUbx/Y4EfXrtekKNYg6wcc3X+fONq33LRy2Ls1sCEmvMIlKAsXgjhdm0E=","plaintext":null,"created_at":"2026-07-03T15:28:24.605492584Z"}'
+        body: '{"key_id":"d4f12236-7e6e-4042-8693-751f819f2095","algorithm":"aes_256_gcm","ciphertext":"AQAAAAGXK3RfQAYuLTuRr6owkrmntC5v1ofTF4P5qByd8siUhp39em5Y6pOUx785htmfC0QVlht7IVMccyCv+Lc=","plaintext":null,"created_at":"2026-07-07T07:46:10.080849210Z"}'
         headers:
             Content-Length:
                 - "242"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:24 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 57fdc5fc-f624-4f2c-8be5-31c11e3b716d
+                - 13bb01e1-b9a4-4c29-9b5f-3260b7b840d7
         status: 200 OK
         code: 200
-        duration: 54.813214ms
+        duration: 72.391566ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -774,28 +774,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/64b52306-403c-4d7c-be75-1ae72babf99d/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18d0279f-9a5b-4794-9a9a-f6d386af983e/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 303
-        body: '{"revision":1,"secret_id":"64b52306-403c-4d7c-be75-1ae72babf99d","status":"enabled","created_at":"2026-07-03T15:28:23.222459Z","updated_at":"2026-07-03T15:28:23.222459Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"18d0279f-9a5b-4794-9a9a-f6d386af983e","status":"enabled","created_at":"2026-07-07T07:46:08.797567Z","updated_at":"2026-07-07T07:46:08.797567Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "303"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:24 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - b19fb4f7-43e1-4354-8cfc-8dfae0789e08
+                - 73d69287-315d-40c0-a1b1-c698df6ac55e
         status: 200 OK
         code: 200
-        duration: 33.294085ms
+        duration: 38.17166ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -806,28 +806,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/64b52306-403c-4d7c-be75-1ae72babf99d/versions/1/access
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18d0279f-9a5b-4794-9a9a-f6d386af983e/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 229
-        body: '{"secret_id":"64b52306-403c-4d7c-be75-1ae72babf99d","revision":1,"data":"QVFBQUFBRUdVZ0h4alVEL01yVnRKN0dOVitSOGlxVXdQQkQ0OUk4WTlqYXdDTkxRU2JMVGZ1NGR2azY0eUw4aFlLSWI2ZmUxTzBXQ0dpd2puQnlXaHVnPQ==","data_crc32":null,"type":"opaque"}'
+        body: '{"secret_id":"18d0279f-9a5b-4794-9a9a-f6d386af983e","revision":1,"data":"QVFBQUFBSHVQZ1dkcFlGcWtMUnpWWXJEUTFQMHVVVmRJYXh3dHpiTUFtVzFlKzNGVzc4TlNDcE5VNHJkOG02cjBjUEUrVkpRQ3o1MXBQaU9DUEdOYXRVPQ==","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
                 - "229"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:24 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 2a42a9f4-85a0-4764-82b2-c4072f997180
+                - c689616d-24c9-41a8-a31b-9049616d92fe
         status: 200 OK
         code: 200
-        duration: 49.820897ms
+        duration: 45.112674ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -838,28 +838,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/64b52306-403c-4d7c-be75-1ae72babf99d/versions/2
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18d0279f-9a5b-4794-9a9a-f6d386af983e/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":2,"secret_id":"64b52306-403c-4d7c-be75-1ae72babf99d","status":"enabled","created_at":"2026-07-03T15:28:23.416588Z","updated_at":"2026-07-03T15:28:23.416588Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":2,"secret_id":"18d0279f-9a5b-4794-9a9a-f6d386af983e","status":"enabled","created_at":"2026-07-07T07:46:09.024337Z","updated_at":"2026-07-07T07:46:09.024337Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:24 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - e9487c3e-d9fd-4577-b4b6-98e026567831
+                - 5fa89471-7a5e-446f-bb6b-6313817a54cb
         status: 200 OK
         code: 200
-        duration: 53.762171ms
+        duration: 63.387564ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -870,28 +870,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/64b52306-403c-4d7c-be75-1ae72babf99d/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18d0279f-9a5b-4794-9a9a-f6d386af983e/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 303
-        body: '{"revision":1,"secret_id":"64b52306-403c-4d7c-be75-1ae72babf99d","status":"enabled","created_at":"2026-07-03T15:28:23.222459Z","updated_at":"2026-07-03T15:28:23.222459Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"18d0279f-9a5b-4794-9a9a-f6d386af983e","status":"enabled","created_at":"2026-07-07T07:46:08.797567Z","updated_at":"2026-07-07T07:46:08.797567Z","deleted_at":null,"description":"version1","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "303"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:24 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 6aaa39fb-79ed-475f-905b-f1ccb9517f3c
+                - 7e185070-f536-4699-a45e-dafe97755625
         status: 200 OK
         code: 200
-        duration: 37.501858ms
+        duration: 48.11149ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -902,28 +902,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/64b52306-403c-4d7c-be75-1ae72babf99d/versions/2/access
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18d0279f-9a5b-4794-9a9a-f6d386af983e/versions/2/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 137
-        body: '{"secret_id":"64b52306-403c-4d7c-be75-1ae72babf99d","revision":2,"data":"cGxhaW50ZXh0IHdhcyBlbXB0eQ==","data_crc32":null,"type":"opaque"}'
+        body: '{"secret_id":"18d0279f-9a5b-4794-9a9a-f6d386af983e","revision":2,"data":"cGxhaW50ZXh0IHdhcyBlbXB0eQ==","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
                 - "137"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:24 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - e4b5bc7c-f684-41bc-a0dd-870a804930df
+                - 17d29763-84b4-41a1-bb2e-4e07c6277610
         status: 200 OK
         code: 200
-        duration: 50.708385ms
+        duration: 47.370422ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -934,28 +934,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/64b52306-403c-4d7c-be75-1ae72babf99d/versions/2
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18d0279f-9a5b-4794-9a9a-f6d386af983e/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":2,"secret_id":"64b52306-403c-4d7c-be75-1ae72babf99d","status":"enabled","created_at":"2026-07-03T15:28:23.416588Z","updated_at":"2026-07-03T15:28:23.416588Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":2,"secret_id":"18d0279f-9a5b-4794-9a9a-f6d386af983e","status":"enabled","created_at":"2026-07-07T07:46:09.024337Z","updated_at":"2026-07-07T07:46:09.024337Z","deleted_at":null,"description":"version2","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:24 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 060ce88a-9327-4d34-b5e9-90f45e88003f
+                - e34d0744-9f19-4ce9-b05a-9b1135b887b8
         status: 200 OK
         code: 200
-        duration: 40.620237ms
+        duration: 34.427119ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -966,7 +966,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/64b52306-403c-4d7c-be75-1ae72babf99d/versions/2
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18d0279f-9a5b-4794-9a9a-f6d386af983e/versions/2
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -978,14 +978,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:25 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 50a50b38-a47c-41e7-9607-198e4ca297c6
+                - 6a228fef-b9be-4ab2-96ba-f445bcaf901f
         status: 204 No Content
         code: 204
-        duration: 60.711463ms
+        duration: 103.11491ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -996,7 +996,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/64b52306-403c-4d7c-be75-1ae72babf99d/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18d0279f-9a5b-4794-9a9a-f6d386af983e/versions/1
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1008,14 +1008,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:25 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - c0791bbd-33b1-40e6-8f71-9e978fc4a069
+                - a934840a-b754-4d42-ae6a-6c806bc31b97
         status: 204 No Content
         code: 204
-        duration: 64.778693ms
+        duration: 112.841204ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1026,7 +1026,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/23871059-a682-4a9d-9cc7-f9e5588a7555
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/18d0279f-9a5b-4794-9a9a-f6d386af983e
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1038,14 +1038,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:25 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - ce97ca39-bd70-4d75-8e02-340ae3e60872
+                - 6c525ec5-e45d-41ae-af53-10ff0839544b
         status: 204 No Content
         code: 204
-        duration: 65.639088ms
+        duration: 109.192273ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1056,7 +1056,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/64b52306-403c-4d7c-be75-1ae72babf99d
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/d4f12236-7e6e-4042-8693-751f819f2095
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1068,11 +1068,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:25 GMT
+                - Tue, 07 Jul 2026 07:46:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - f29c1631-60f9-4f23-9c5e-72290bfd8baf
+                - f46761d9-6a83-40d6-87af-13c3e23b714a
         status: 204 No Content
         code: 204
-        duration: 79.904713ms
+        duration: 416.936751ms

--- a/internal/services/keymanager/testdata/key-manager-key-basic.cassette.yaml
+++ b/internal/services/keymanager/testdata/key-manager-key-basic.cassette.yaml
@@ -6,9 +6,9 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 274
+        content_length: 228
         host: api.scaleway.com
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-unprotected","usage":{"symmetric_encryption":"aes_256_gcm"},"description":"Test key","tags":["tf","test"],"unprotected":true,"origin":"unknown_origin","protection_level":"unknown_protection_level"}'
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-unprotected","usage":{"symmetric_encryption":"aes_256_gcm"},"description":"Test key","tags":["tf","test"],"unprotected":true,"origin":"unknown_origin"}'
         headers:
             Content-Type:
                 - application/json
@@ -21,21 +21,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 550
-        body: '{"id":"b8ef9b77-3c91-4dba-8e1f-116757ff70f8","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-unprotected","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:24.115257Z","updated_at":"2026-07-03T15:28:24.119858Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:24.119858Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"9d0ae4f2-276f-44d0-b7f5-7631bdf9680f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-unprotected","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:06.350936Z","updated_at":"2026-07-07T07:46:06.355484Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-07T07:46:06.355484Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "550"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:24 GMT
+                - Tue, 07 Jul 2026 07:46:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - dc0cac25-b5b9-4d89-a910-79aa64f30515
+                - d8b7c0ea-a514-40b3-8b37-e8b402e74742
         status: 200 OK
         code: 200
-        duration: 204.280496ms
+        duration: 128.5526ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -46,28 +46,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/b8ef9b77-3c91-4dba-8e1f-116757ff70f8
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/9d0ae4f2-276f-44d0-b7f5-7631bdf9680f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 550
-        body: '{"id":"b8ef9b77-3c91-4dba-8e1f-116757ff70f8","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-unprotected","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:24.115257Z","updated_at":"2026-07-03T15:28:24.119858Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:24.119858Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"9d0ae4f2-276f-44d0-b7f5-7631bdf9680f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-unprotected","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:06.350936Z","updated_at":"2026-07-07T07:46:06.355484Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-07T07:46:06.355484Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "550"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:24 GMT
+                - Tue, 07 Jul 2026 07:46:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 35804dc3-db65-4e2f-888f-aa08e73e7c1b
+                - 7a819204-70e2-46a5-bb1b-dfe716d9a571
         status: 200 OK
         code: 200
-        duration: 48.347299ms
+        duration: 41.743776ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -78,28 +78,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/b8ef9b77-3c91-4dba-8e1f-116757ff70f8
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/9d0ae4f2-276f-44d0-b7f5-7631bdf9680f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 550
-        body: '{"id":"b8ef9b77-3c91-4dba-8e1f-116757ff70f8","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-unprotected","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:24.115257Z","updated_at":"2026-07-03T15:28:24.119858Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:24.119858Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"9d0ae4f2-276f-44d0-b7f5-7631bdf9680f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-unprotected","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:06.350936Z","updated_at":"2026-07-07T07:46:06.355484Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-07T07:46:06.355484Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "550"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:24 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 31e345c2-8102-4db6-b929-80fd8e0b06ad
+                - bc72c76a-8716-433b-a511-d5dd4edfa9b5
         status: 200 OK
         code: 200
-        duration: 45.700669ms
+        duration: 42.649339ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -110,7 +110,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/b8ef9b77-3c91-4dba-8e1f-116757ff70f8
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/9d0ae4f2-276f-44d0-b7f5-7631bdf9680f
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -122,14 +122,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:25 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 9afe390a-8256-470b-9cf3-d117794f1cf8
+                - 29d04f93-fce1-473d-b866-c8630d655186
         status: 204 No Content
         code: 204
-        duration: 64.871496ms
+        duration: 62.546736ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -140,25 +140,25 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/b8ef9b77-3c91-4dba-8e1f-116757ff70f8
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/9d0ae4f2-276f-44d0-b7f5-7631bdf9680f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 590
-        body: '{"id":"b8ef9b77-3c91-4dba-8e1f-116757ff70f8","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-unprotected","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-03T15:28:24.115257Z","updated_at":"2026-07-03T15:28:25.465791Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:24.119858Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-03T15:28:25.465790Z","protection_level":"software","region":"fr-par"}'
+        body: '{"id":"9d0ae4f2-276f-44d0-b7f5-7631bdf9680f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-unprotected","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-07T07:46:06.350936Z","updated_at":"2026-07-07T07:46:07.583189Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-07T07:46:06.355484Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-07T07:46:07.583189Z","protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "590"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:25 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - c769c94a-52ae-411f-ade1-0715b1173200
+                - 336073a7-1635-483a-bccc-b31d708da467
         status: 200 OK
         code: 200
-        duration: 40.056787ms
+        duration: 57.82954ms

--- a/internal/services/keymanager/testdata/key-manager-key-default-algorithm.cassette.yaml
+++ b/internal/services/keymanager/testdata/key-manager-key-default-algorithm.cassette.yaml
@@ -6,9 +6,9 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 299
+        content_length: 253
         host: api.scaleway.com
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-default-alg","usage":{"asymmetric_encryption":"rsa_oaep_3072_sha256"},"description":"Test key with RSA-3072 algorithm","tags":null,"unprotected":true,"origin":"unknown_origin","protection_level":"unknown_protection_level"}'
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-default-alg","usage":{"asymmetric_encryption":"rsa_oaep_3072_sha256"},"description":"Test key with RSA-3072 algorithm","tags":null,"unprotected":true,"origin":"unknown_origin"}'
         headers:
             Content-Type:
                 - application/json
@@ -21,21 +21,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 573
-        body: '{"id":"c8c5298c-7ee8-4e8f-a430-5b5c3d8144c8","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-default-alg","usage":{"asymmetric_encryption":"rsa_oaep_3072_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:18.735474Z","updated_at":"2026-07-03T15:28:19.161311Z","protected":false,"locked":false,"description":"Test key with RSA-3072 algorithm","tags":[],"rotated_at":"2026-07-03T15:28:19.161311Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"c5d9acd5-7ee7-45f4-a4e0-b8cafa8fbbed","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-default-alg","usage":{"asymmetric_encryption":"rsa_oaep_3072_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:05.298737Z","updated_at":"2026-07-07T07:46:05.801108Z","protected":false,"locked":false,"description":"Test key with RSA-3072 algorithm","tags":[],"rotated_at":"2026-07-07T07:46:05.801108Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "573"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:19 GMT
+                - Tue, 07 Jul 2026 07:46:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 884c922d-12a3-43df-9df1-91a02e8aff79
+                - 220c4c68-0c4a-4a63-8767-ff34ca7f782b
         status: 200 OK
         code: 200
-        duration: 705.9361ms
+        duration: 3.695617805s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -46,28 +46,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/c8c5298c-7ee8-4e8f-a430-5b5c3d8144c8
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/c5d9acd5-7ee7-45f4-a4e0-b8cafa8fbbed
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 573
-        body: '{"id":"c8c5298c-7ee8-4e8f-a430-5b5c3d8144c8","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-default-alg","usage":{"asymmetric_encryption":"rsa_oaep_3072_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:18.735474Z","updated_at":"2026-07-03T15:28:19.161311Z","protected":false,"locked":false,"description":"Test key with RSA-3072 algorithm","tags":[],"rotated_at":"2026-07-03T15:28:19.161311Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"c5d9acd5-7ee7-45f4-a4e0-b8cafa8fbbed","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-default-alg","usage":{"asymmetric_encryption":"rsa_oaep_3072_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:05.298737Z","updated_at":"2026-07-07T07:46:05.801108Z","protected":false,"locked":false,"description":"Test key with RSA-3072 algorithm","tags":[],"rotated_at":"2026-07-07T07:46:05.801108Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "573"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:19 GMT
+                - Tue, 07 Jul 2026 07:46:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 5514f908-0898-4dcb-8682-330e63e4cdbb
+                - df22ff48-838a-4f69-9a66-0baf84ea953a
         status: 200 OK
         code: 200
-        duration: 87.571593ms
+        duration: 85.04031ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -78,28 +78,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/c8c5298c-7ee8-4e8f-a430-5b5c3d8144c8
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/c5d9acd5-7ee7-45f4-a4e0-b8cafa8fbbed
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 573
-        body: '{"id":"c8c5298c-7ee8-4e8f-a430-5b5c3d8144c8","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-default-alg","usage":{"asymmetric_encryption":"rsa_oaep_3072_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:18.735474Z","updated_at":"2026-07-03T15:28:19.161311Z","protected":false,"locked":false,"description":"Test key with RSA-3072 algorithm","tags":[],"rotated_at":"2026-07-03T15:28:19.161311Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"c5d9acd5-7ee7-45f4-a4e0-b8cafa8fbbed","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-default-alg","usage":{"asymmetric_encryption":"rsa_oaep_3072_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:05.298737Z","updated_at":"2026-07-07T07:46:05.801108Z","protected":false,"locked":false,"description":"Test key with RSA-3072 algorithm","tags":[],"rotated_at":"2026-07-07T07:46:05.801108Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "573"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:19 GMT
+                - Tue, 07 Jul 2026 07:46:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 57b5b742-65b4-4896-a051-504f313b1506
+                - 7c1e1bbf-811e-42ee-a2dd-e82603f876a3
         status: 200 OK
         code: 200
-        duration: 46.720323ms
+        duration: 56.583507ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -110,7 +110,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/c8c5298c-7ee8-4e8f-a430-5b5c3d8144c8
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/c5d9acd5-7ee7-45f4-a4e0-b8cafa8fbbed
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -122,14 +122,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:20 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 83feeac2-9cc4-46d4-be0e-6aee687f283f
+                - f28393c1-2bfc-4dfd-8e05-be2e97a4fb96
         status: 204 No Content
         code: 204
-        duration: 102.37005ms
+        duration: 160.418563ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -140,25 +140,25 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/c8c5298c-7ee8-4e8f-a430-5b5c3d8144c8
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/c5d9acd5-7ee7-45f4-a4e0-b8cafa8fbbed
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 613
-        body: '{"id":"c8c5298c-7ee8-4e8f-a430-5b5c3d8144c8","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-default-alg","usage":{"asymmetric_encryption":"rsa_oaep_3072_sha256"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-03T15:28:18.735474Z","updated_at":"2026-07-03T15:28:20.321046Z","protected":false,"locked":false,"description":"Test key with RSA-3072 algorithm","tags":[],"rotated_at":"2026-07-03T15:28:19.161311Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-03T15:28:20.321046Z","protection_level":"software","region":"fr-par"}'
+        body: '{"id":"c5d9acd5-7ee7-45f4-a4e0-b8cafa8fbbed","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-default-alg","usage":{"asymmetric_encryption":"rsa_oaep_3072_sha256"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-07T07:46:05.298737Z","updated_at":"2026-07-07T07:46:07.104633Z","protected":false,"locked":false,"description":"Test key with RSA-3072 algorithm","tags":[],"rotated_at":"2026-07-07T07:46:05.801108Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-07T07:46:07.104633Z","protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "613"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:20 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - a00ea9cd-88e6-40e0-8b57-e582f8c82aa8
+                - afa84193-0f65-45a2-af8c-2278d7bd378d
         status: 200 OK
         code: 200
-        duration: 59.857118ms
+        duration: 57.107788ms

--- a/internal/services/keymanager/testdata/key-manager-key-update.cassette.yaml
+++ b/internal/services/keymanager/testdata/key-manager-key-update.cassette.yaml
@@ -6,9 +6,9 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 269
+        content_length: 223
         host: api.scaleway.com
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-update","usage":{"symmetric_encryption":"aes_256_gcm"},"description":"Test key","tags":["tf","test"],"unprotected":true,"origin":"unknown_origin","protection_level":"unknown_protection_level"}'
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-update","usage":{"symmetric_encryption":"aes_256_gcm"},"description":"Test key","tags":["tf","test"],"unprotected":true,"origin":"unknown_origin"}'
         headers:
             Content-Type:
                 - application/json
@@ -21,21 +21,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 545
-        body: '{"id":"727f3036-5b41-4ff2-ba78-b622b07430ab","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-update","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:23.841284Z","updated_at":"2026-07-03T15:28:23.844354Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:23.844354Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"3283da5a-09a0-4296-9d55-4af129b6f36d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-update","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:05.823624Z","updated_at":"2026-07-07T07:46:05.832730Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-07T07:46:05.832730Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "545"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 616a2b9e-b801-44be-9144-1c884eae6681
+                - d5858243-4b57-46d4-ba7b-570d7e32722a
         status: 200 OK
         code: 200
-        duration: 91.357785ms
+        duration: 3.756460863s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -46,28 +46,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/727f3036-5b41-4ff2-ba78-b622b07430ab
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/3283da5a-09a0-4296-9d55-4af129b6f36d
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 545
-        body: '{"id":"727f3036-5b41-4ff2-ba78-b622b07430ab","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-update","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:23.841284Z","updated_at":"2026-07-03T15:28:23.844354Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:23.844354Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"3283da5a-09a0-4296-9d55-4af129b6f36d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-update","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:05.823624Z","updated_at":"2026-07-07T07:46:05.832730Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-07T07:46:05.832730Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "545"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 1daf77e4-19c1-421d-a673-298bdfe51905
+                - 6b5025bb-3f11-4ab3-8b0a-cd6c3ede70a6
         status: 200 OK
         code: 200
-        duration: 45.265661ms
+        duration: 126.362972ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -78,28 +78,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/727f3036-5b41-4ff2-ba78-b622b07430ab
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/3283da5a-09a0-4296-9d55-4af129b6f36d
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 545
-        body: '{"id":"727f3036-5b41-4ff2-ba78-b622b07430ab","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-update","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:23.841284Z","updated_at":"2026-07-03T15:28:23.844354Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:23.844354Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"3283da5a-09a0-4296-9d55-4af129b6f36d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-update","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:05.823624Z","updated_at":"2026-07-07T07:46:05.832730Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-07T07:46:05.832730Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "545"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:24 GMT
+                - Tue, 07 Jul 2026 07:46:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - af9c86b3-c73f-4ea2-807c-39a39ea1dbde
+                - 37c9aac0-1490-4faa-bfc7-661867c3bf5e
         status: 200 OK
         code: 200
-        duration: 47.143519ms
+        duration: 57.416599ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -110,28 +110,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/727f3036-5b41-4ff2-ba78-b622b07430ab
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/3283da5a-09a0-4296-9d55-4af129b6f36d
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 545
-        body: '{"id":"727f3036-5b41-4ff2-ba78-b622b07430ab","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-update","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:23.841284Z","updated_at":"2026-07-03T15:28:23.844354Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:23.844354Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"3283da5a-09a0-4296-9d55-4af129b6f36d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-update","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:05.823624Z","updated_at":"2026-07-07T07:46:05.832730Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-07T07:46:05.832730Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "545"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:24 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 287f6099-f4b0-48f2-8fa1-a3169033f171
+                - 65110453-845e-47d8-afde-5a89caf707e1
         status: 200 OK
         code: 200
-        duration: 50.082468ms
+        duration: 59.335376ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -145,28 +145,28 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/727f3036-5b41-4ff2-ba78-b622b07430ab
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/3283da5a-09a0-4296-9d55-4af129b6f36d
         method: PATCH
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 557
-        body: '{"id":"727f3036-5b41-4ff2-ba78-b622b07430ab","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-updated","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:23.841284Z","updated_at":"2026-07-03T15:28:25.302477Z","protected":false,"locked":false,"description":"Test key updated","tags":["tf","updated"],"rotated_at":"2026-07-03T15:28:23.844354Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"3283da5a-09a0-4296-9d55-4af129b6f36d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-updated","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:05.823624Z","updated_at":"2026-07-07T07:46:07.448560Z","protected":false,"locked":false,"description":"Test key updated","tags":["tf","updated"],"rotated_at":"2026-07-07T07:46:05.832730Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "557"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:25 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 2d10a794-bdee-4b75-a806-df221cbb1edb
+                - f517bb9a-3377-47c7-9859-91e1a7546dec
         status: 200 OK
         code: 200
-        duration: 91.364458ms
+        duration: 85.988158ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -177,28 +177,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/727f3036-5b41-4ff2-ba78-b622b07430ab
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/3283da5a-09a0-4296-9d55-4af129b6f36d
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 557
-        body: '{"id":"727f3036-5b41-4ff2-ba78-b622b07430ab","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-updated","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:23.841284Z","updated_at":"2026-07-03T15:28:25.302477Z","protected":false,"locked":false,"description":"Test key updated","tags":["tf","updated"],"rotated_at":"2026-07-03T15:28:23.844354Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"3283da5a-09a0-4296-9d55-4af129b6f36d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-updated","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:05.823624Z","updated_at":"2026-07-07T07:46:07.448560Z","protected":false,"locked":false,"description":"Test key updated","tags":["tf","updated"],"rotated_at":"2026-07-07T07:46:05.832730Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "557"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:25 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 9ae8f715-3d43-4dc7-8b01-499c47cb282b
+                - 53dcf84c-3c8c-4327-8d23-538b125682d1
         status: 200 OK
         code: 200
-        duration: 39.36582ms
+        duration: 56.441382ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -209,28 +209,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/727f3036-5b41-4ff2-ba78-b622b07430ab
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/3283da5a-09a0-4296-9d55-4af129b6f36d
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 557
-        body: '{"id":"727f3036-5b41-4ff2-ba78-b622b07430ab","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-updated","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:23.841284Z","updated_at":"2026-07-03T15:28:25.302477Z","protected":false,"locked":false,"description":"Test key updated","tags":["tf","updated"],"rotated_at":"2026-07-03T15:28:23.844354Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"3283da5a-09a0-4296-9d55-4af129b6f36d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-updated","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:05.823624Z","updated_at":"2026-07-07T07:46:07.448560Z","protected":false,"locked":false,"description":"Test key updated","tags":["tf","updated"],"rotated_at":"2026-07-07T07:46:05.832730Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "557"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:25 GMT
+                - Tue, 07 Jul 2026 07:46:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 4ab26d69-43d3-4b4d-8250-27418af82daa
+                - 5c593dd5-5d74-415f-942c-d05cbb2db9b7
         status: 200 OK
         code: 200
-        duration: 52.759757ms
+        duration: 55.477828ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -241,7 +241,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/727f3036-5b41-4ff2-ba78-b622b07430ab
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/3283da5a-09a0-4296-9d55-4af129b6f36d
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -253,14 +253,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:26 GMT
+                - Tue, 07 Jul 2026 07:46:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 7715483a-572c-4295-9002-2c460754f4c9
+                - 4a23f4e3-1d47-4e3b-aba2-3a036d91a35f
         status: 204 No Content
         code: 204
-        duration: 63.379364ms
+        duration: 114.242089ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -271,25 +271,25 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/727f3036-5b41-4ff2-ba78-b622b07430ab
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/3283da5a-09a0-4296-9d55-4af129b6f36d
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 597
-        body: '{"id":"727f3036-5b41-4ff2-ba78-b622b07430ab","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-updated","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-03T15:28:23.841284Z","updated_at":"2026-07-03T15:28:26.091009Z","protected":false,"locked":false,"description":"Test key updated","tags":["tf","updated"],"rotated_at":"2026-07-03T15:28:23.844354Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-03T15:28:26.091009Z","protection_level":"software","region":"fr-par"}'
+        body: '{"id":"3283da5a-09a0-4296-9d55-4af129b6f36d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-updated","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-07T07:46:05.823624Z","updated_at":"2026-07-07T07:46:08.619389Z","protected":false,"locked":false,"description":"Test key updated","tags":["tf","updated"],"rotated_at":"2026-07-07T07:46:05.832730Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-07T07:46:08.619389Z","protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "597"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:26 GMT
+                - Tue, 07 Jul 2026 07:46:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - e0ccaf61-f810-4ac5-881a-fc2b980e0310
+                - 5642bead-b44b-4a4a-bb55-ac813847bb22
         status: 200 OK
         code: 200
-        duration: 31.545431ms
+        duration: 43.067896ms

--- a/internal/services/keymanager/testdata/key-manager-key-with-custom-algorithm.cassette.yaml
+++ b/internal/services/keymanager/testdata/key-manager-key-with-custom-algorithm.cassette.yaml
@@ -6,9 +6,9 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 295
+        content_length: 249
         host: api.scaleway.com
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rsa4096","usage":{"asymmetric_encryption":"rsa_oaep_4096_sha256"},"description":"Test key with RSA-4096 algorithm","tags":null,"unprotected":true,"origin":"unknown_origin","protection_level":"unknown_protection_level"}'
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rsa4096","usage":{"asymmetric_encryption":"rsa_oaep_4096_sha256"},"description":"Test key with RSA-4096 algorithm","tags":null,"unprotected":true,"origin":"unknown_origin"}'
         headers:
             Content-Type:
                 - application/json
@@ -21,21 +21,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 569
-        body: '{"id":"886e4b8a-67b9-4e2b-afd2-2db763ca34ad","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rsa4096","usage":{"asymmetric_encryption":"rsa_oaep_4096_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:23.867332Z","updated_at":"2026-07-03T15:28:24.075023Z","protected":false,"locked":false,"description":"Test key with RSA-4096 algorithm","tags":[],"rotated_at":"2026-07-03T15:28:24.075023Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"4c6e1f5c-d8a6-43d1-a8d6-ebae694fdf95","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rsa4096","usage":{"asymmetric_encryption":"rsa_oaep_4096_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:02.404700Z","updated_at":"2026-07-07T07:46:04.558426Z","protected":false,"locked":false,"description":"Test key with RSA-4096 algorithm","tags":[],"rotated_at":"2026-07-07T07:46:04.558426Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "569"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:24 GMT
+                - Tue, 07 Jul 2026 07:46:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 9ae680c2-5213-47c0-bb7a-018e232d1109
+                - 4ad2cb9e-fa83-4415-a0ff-c51756af28f1
         status: 200 OK
         code: 200
-        duration: 281.298035ms
+        duration: 2.534318657s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -46,28 +46,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/886e4b8a-67b9-4e2b-afd2-2db763ca34ad
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/4c6e1f5c-d8a6-43d1-a8d6-ebae694fdf95
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 569
-        body: '{"id":"886e4b8a-67b9-4e2b-afd2-2db763ca34ad","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rsa4096","usage":{"asymmetric_encryption":"rsa_oaep_4096_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:23.867332Z","updated_at":"2026-07-03T15:28:24.075023Z","protected":false,"locked":false,"description":"Test key with RSA-4096 algorithm","tags":[],"rotated_at":"2026-07-03T15:28:24.075023Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"4c6e1f5c-d8a6-43d1-a8d6-ebae694fdf95","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rsa4096","usage":{"asymmetric_encryption":"rsa_oaep_4096_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:02.404700Z","updated_at":"2026-07-07T07:46:04.558426Z","protected":false,"locked":false,"description":"Test key with RSA-4096 algorithm","tags":[],"rotated_at":"2026-07-07T07:46:04.558426Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "569"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:24 GMT
+                - Tue, 07 Jul 2026 07:46:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 4d9989f3-f228-4194-a15a-93a6d1241d07
+                - 985410ef-2f85-4eb9-9b82-5ebb5e386704
         status: 200 OK
         code: 200
-        duration: 52.880705ms
+        duration: 76.697779ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -78,28 +78,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/886e4b8a-67b9-4e2b-afd2-2db763ca34ad
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/4c6e1f5c-d8a6-43d1-a8d6-ebae694fdf95
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 569
-        body: '{"id":"886e4b8a-67b9-4e2b-afd2-2db763ca34ad","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rsa4096","usage":{"asymmetric_encryption":"rsa_oaep_4096_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:23.867332Z","updated_at":"2026-07-03T15:28:24.075023Z","protected":false,"locked":false,"description":"Test key with RSA-4096 algorithm","tags":[],"rotated_at":"2026-07-03T15:28:24.075023Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"4c6e1f5c-d8a6-43d1-a8d6-ebae694fdf95","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rsa4096","usage":{"asymmetric_encryption":"rsa_oaep_4096_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:02.404700Z","updated_at":"2026-07-07T07:46:04.558426Z","protected":false,"locked":false,"description":"Test key with RSA-4096 algorithm","tags":[],"rotated_at":"2026-07-07T07:46:04.558426Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "569"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:24 GMT
+                - Tue, 07 Jul 2026 07:46:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - e3dc39b6-028d-475b-9616-537601c3e4ad
+                - 56c4d0de-fbec-4679-846c-1e0dd345bd94
         status: 200 OK
         code: 200
-        duration: 45.411585ms
+        duration: 99.66632ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -110,7 +110,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/886e4b8a-67b9-4e2b-afd2-2db763ca34ad
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/4c6e1f5c-d8a6-43d1-a8d6-ebae694fdf95
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -122,14 +122,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:25 GMT
+                - Tue, 07 Jul 2026 07:46:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - e3d532ca-9326-4311-9fe4-b3372c0c6ca6
+                - 0f79236d-cb7c-40e2-b6bd-9b27aa379ba2
         status: 204 No Content
         code: 204
-        duration: 68.450469ms
+        duration: 117.507945ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -140,25 +140,25 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/886e4b8a-67b9-4e2b-afd2-2db763ca34ad
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/4c6e1f5c-d8a6-43d1-a8d6-ebae694fdf95
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 609
-        body: '{"id":"886e4b8a-67b9-4e2b-afd2-2db763ca34ad","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rsa4096","usage":{"asymmetric_encryption":"rsa_oaep_4096_sha256"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-03T15:28:23.867332Z","updated_at":"2026-07-03T15:28:25.444364Z","protected":false,"locked":false,"description":"Test key with RSA-4096 algorithm","tags":[],"rotated_at":"2026-07-03T15:28:24.075023Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-03T15:28:25.444364Z","protection_level":"software","region":"fr-par"}'
+        body: '{"id":"4c6e1f5c-d8a6-43d1-a8d6-ebae694fdf95","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rsa4096","usage":{"asymmetric_encryption":"rsa_oaep_4096_sha256"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-07T07:46:02.404700Z","updated_at":"2026-07-07T07:46:05.634304Z","protected":false,"locked":false,"description":"Test key with RSA-4096 algorithm","tags":[],"rotated_at":"2026-07-07T07:46:04.558426Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-07T07:46:05.634304Z","protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "609"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:25 GMT
+                - Tue, 07 Jul 2026 07:46:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 20b9ba12-7331-4ce4-a640-a36e30b527cb
+                - 12d1b9de-840a-4ab8-a72e-a4d872e8eeb5
         status: 200 OK
         code: 200
-        duration: 47.731042ms
+        duration: 44.648958ms

--- a/internal/services/keymanager/testdata/key-manager-key-with-rotation-policy.cassette.yaml
+++ b/internal/services/keymanager/testdata/key-manager-key-with-rotation-policy.cassette.yaml
@@ -6,9 +6,9 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 387
+        content_length: 341
         host: api.scaleway.com
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation","usage":{"symmetric_encryption":"aes_256_gcm"},"description":"Test key with rotation policy","tags":null,"rotation_policy":{"rotation_period":"3153600000.000000000s","next_rotation_at":"2027-01-01T00:00:00Z"},"unprotected":true,"origin":"unknown_origin","protection_level":"unknown_protection_level"}'
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation","usage":{"symmetric_encryption":"aes_256_gcm"},"description":"Test key with rotation policy","tags":null,"rotation_policy":{"rotation_period":"3153600000.000000000s","next_rotation_at":"2027-01-01T00:00:00Z"},"unprotected":true,"origin":"unknown_origin"}'
         headers:
             Content-Type:
                 - application/json
@@ -21,21 +21,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 628
-        body: '{"id":"d2371ecf-fbac-4d74-9be4-43f6c89a764f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:24.096639Z","updated_at":"2026-07-03T15:28:24.099582Z","protected":false,"locked":false,"description":"Test key with rotation policy","tags":[],"rotated_at":"2026-07-03T15:28:24.099582Z","rotation_policy":{"rotation_period":"3153600000s","next_rotation_at":"2027-01-01T00:00:00Z"},"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"8005ec5a-9322-4fa3-a132-33413536914a","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:05.216567Z","updated_at":"2026-07-07T07:46:05.224532Z","protected":false,"locked":false,"description":"Test key with rotation policy","tags":[],"rotated_at":"2026-07-07T07:46:05.224532Z","rotation_policy":{"rotation_period":"3153600000s","next_rotation_at":"2027-01-01T00:00:00Z"},"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "628"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:24 GMT
+                - Tue, 07 Jul 2026 07:46:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - b35da050-beb2-45ef-8f46-d730dd284b4a
+                - 093ae4ca-8af9-40c4-9288-44e4b76e52b2
         status: 200 OK
         code: 200
-        duration: 281.881111ms
+        duration: 3.159584788s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -46,28 +46,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/d2371ecf-fbac-4d74-9be4-43f6c89a764f
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/8005ec5a-9322-4fa3-a132-33413536914a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 628
-        body: '{"id":"d2371ecf-fbac-4d74-9be4-43f6c89a764f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:24.096639Z","updated_at":"2026-07-03T15:28:24.099582Z","protected":false,"locked":false,"description":"Test key with rotation policy","tags":[],"rotated_at":"2026-07-03T15:28:24.099582Z","rotation_policy":{"rotation_period":"3153600000s","next_rotation_at":"2027-01-01T00:00:00Z"},"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"8005ec5a-9322-4fa3-a132-33413536914a","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:05.216567Z","updated_at":"2026-07-07T07:46:05.224532Z","protected":false,"locked":false,"description":"Test key with rotation policy","tags":[],"rotated_at":"2026-07-07T07:46:05.224532Z","rotation_policy":{"rotation_period":"3153600000s","next_rotation_at":"2027-01-01T00:00:00Z"},"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "628"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:24 GMT
+                - Tue, 07 Jul 2026 07:46:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 07bb7804-c420-48fc-9392-7299d6147f25
+                - 04aa2808-3927-419b-9aa0-f464ac87aa04
         status: 200 OK
         code: 200
-        duration: 44.872383ms
+        duration: 73.967795ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -78,28 +78,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/d2371ecf-fbac-4d74-9be4-43f6c89a764f
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/8005ec5a-9322-4fa3-a132-33413536914a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 628
-        body: '{"id":"d2371ecf-fbac-4d74-9be4-43f6c89a764f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:24.096639Z","updated_at":"2026-07-03T15:28:24.099582Z","protected":false,"locked":false,"description":"Test key with rotation policy","tags":[],"rotated_at":"2026-07-03T15:28:24.099582Z","rotation_policy":{"rotation_period":"3153600000s","next_rotation_at":"2027-01-01T00:00:00Z"},"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"8005ec5a-9322-4fa3-a132-33413536914a","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:05.216567Z","updated_at":"2026-07-07T07:46:05.224532Z","protected":false,"locked":false,"description":"Test key with rotation policy","tags":[],"rotated_at":"2026-07-07T07:46:05.224532Z","rotation_policy":{"rotation_period":"3153600000s","next_rotation_at":"2027-01-01T00:00:00Z"},"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "628"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:24 GMT
+                - Tue, 07 Jul 2026 07:46:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 31216260-89b9-46ba-b923-d8171158376f
+                - 936f463e-2695-4c8b-89d5-4c97982ce38e
         status: 200 OK
         code: 200
-        duration: 34.824159ms
+        duration: 48.761186ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -110,7 +110,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/d2371ecf-fbac-4d74-9be4-43f6c89a764f
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/8005ec5a-9322-4fa3-a132-33413536914a
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -122,14 +122,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:25 GMT
+                - Tue, 07 Jul 2026 07:46:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 769dbb0e-fffd-4ad4-be08-76fe96280d11
+                - d7e6b5ba-7e3c-4219-97d5-f20d6b73c54e
         status: 204 No Content
         code: 204
-        duration: 59.856617ms
+        duration: 114.445844ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -140,25 +140,25 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/d2371ecf-fbac-4d74-9be4-43f6c89a764f
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/8005ec5a-9322-4fa3-a132-33413536914a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 668
-        body: '{"id":"d2371ecf-fbac-4d74-9be4-43f6c89a764f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-03T15:28:24.096639Z","updated_at":"2026-07-03T15:28:25.466926Z","protected":false,"locked":false,"description":"Test key with rotation policy","tags":[],"rotated_at":"2026-07-03T15:28:24.099582Z","rotation_policy":{"rotation_period":"3153600000s","next_rotation_at":"2027-01-01T00:00:00Z"},"origin":"scaleway_kms","deletion_requested_at":"2026-07-03T15:28:25.466926Z","protection_level":"software","region":"fr-par"}'
+        body: '{"id":"8005ec5a-9322-4fa3-a132-33413536914a","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-07T07:46:05.216567Z","updated_at":"2026-07-07T07:46:06.290771Z","protected":false,"locked":false,"description":"Test key with rotation policy","tags":[],"rotated_at":"2026-07-07T07:46:05.224532Z","rotation_policy":{"rotation_period":"3153600000s","next_rotation_at":"2027-01-01T00:00:00Z"},"origin":"scaleway_kms","deletion_requested_at":"2026-07-07T07:46:06.290771Z","protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "668"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:25 GMT
+                - Tue, 07 Jul 2026 07:46:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - daf5fe5e-3a80-4b23-8ffa-02d37698e092
+                - 8ab20b8a-6169-4ecb-a98a-eb6541b675e3
         status: 200 OK
         code: 200
-        duration: 42.940635ms
+        duration: 33.372221ms

--- a/internal/services/keymanager/testdata/list-key-manager-keys-by-name.cassette.yaml
+++ b/internal/services/keymanager/testdata/list-key-manager-keys-by-name.cassette.yaml
@@ -6,9 +6,9 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 233
+        content_length: 187
         host: api.scaleway.com
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-name-1","usage":{"symmetric_encryption":"aes_256_gcm"},"tags":null,"unprotected":true,"origin":"unknown_origin","protection_level":"unknown_protection_level"}'
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-name-1","usage":{"symmetric_encryption":"aes_256_gcm"},"tags":null,"unprotected":true,"origin":"unknown_origin"}'
         headers:
             Content-Type:
                 - application/json
@@ -21,21 +21,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 526
-        body: '{"id":"ed5bf6af-a425-41a4-a24b-5523d83431fd","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-name-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.254887Z","updated_at":"2026-07-03T15:28:19.259815Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.259815Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"9fe6b496-4efd-45bb-9c3f-1e8d940b365b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-name-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:09.371116Z","updated_at":"2026-07-07T07:46:09.375257Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:09.375257Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "526"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:19 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 8caa34fb-ebfe-44e2-8963-256c440593d7
+                - 676fff7e-a8ad-4c84-9060-9e1bc4840061
         status: 200 OK
         code: 200
-        duration: 653.421864ms
+        duration: 108.135219ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -46,28 +46,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/ed5bf6af-a425-41a4-a24b-5523d83431fd
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/9fe6b496-4efd-45bb-9c3f-1e8d940b365b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 526
-        body: '{"id":"ed5bf6af-a425-41a4-a24b-5523d83431fd","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-name-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.254887Z","updated_at":"2026-07-03T15:28:19.259815Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.259815Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"9fe6b496-4efd-45bb-9c3f-1e8d940b365b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-name-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:09.371116Z","updated_at":"2026-07-07T07:46:09.375257Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:09.375257Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "526"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:19 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 0c7901b7-64b6-4b17-9986-354e2a644d43
+                - 1386b816-1606-42ee-baf2-b19913ee0e1c
         status: 200 OK
         code: 200
-        duration: 80.727097ms
+        duration: 50.544993ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -78,28 +78,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/ed5bf6af-a425-41a4-a24b-5523d83431fd
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/9fe6b496-4efd-45bb-9c3f-1e8d940b365b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 526
-        body: '{"id":"ed5bf6af-a425-41a4-a24b-5523d83431fd","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-name-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.254887Z","updated_at":"2026-07-03T15:28:19.259815Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.259815Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"9fe6b496-4efd-45bb-9c3f-1e8d940b365b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-name-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:09.371116Z","updated_at":"2026-07-07T07:46:09.375257Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:09.375257Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "526"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:19 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 65b87e78-f935-4d42-82aa-a4d6445d78f5
+                - e154d558-5514-4760-bfd5-9d8fa72bda6c
         status: 200 OK
         code: 200
-        duration: 48.64589ms
+        duration: 53.704756ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -110,36 +110,36 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/ed5bf6af-a425-41a4-a24b-5523d83431fd
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/9fe6b496-4efd-45bb-9c3f-1e8d940b365b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 526
-        body: '{"id":"ed5bf6af-a425-41a4-a24b-5523d83431fd","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-name-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.254887Z","updated_at":"2026-07-03T15:28:19.259815Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.259815Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"9fe6b496-4efd-45bb-9c3f-1e8d940b365b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-name-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:09.371116Z","updated_at":"2026-07-07T07:46:09.375257Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:09.375257Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "526"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:20 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 070e4f6c-6974-4299-a3a9-6692cef7b70e
+                - ac542c4d-2706-42fa-be6e-034288d3ca40
         status: 200 OK
         code: 200
-        duration: 45.369997ms
+        duration: 135.612473ms
     - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 233
+        content_length: 187
         host: api.scaleway.com
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-name-2","usage":{"symmetric_encryption":"aes_256_gcm"},"tags":null,"unprotected":true,"origin":"unknown_origin","protection_level":"unknown_protection_level"}'
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-name-2","usage":{"symmetric_encryption":"aes_256_gcm"},"tags":null,"unprotected":true,"origin":"unknown_origin"}'
         headers:
             Content-Type:
                 - application/json
@@ -152,21 +152,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 526
-        body: '{"id":"cf1aa736-f399-45e7-a58b-d9247b130fd0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-name-2","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:20.438308Z","updated_at":"2026-07-03T15:28:20.443489Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:20.443489Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"e9373d17-3300-47a3-9bce-5812bf2999b1","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-name-2","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:11.483565Z","updated_at":"2026-07-07T07:46:11.487267Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:11.487267Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "526"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:20 GMT
+                - Tue, 07 Jul 2026 07:46:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 0750a503-4ce0-4121-8e13-f665cca98d4e
+                - cbfd44a6-8fcb-43ec-b85f-72ff95edfb5b
         status: 200 OK
         code: 200
-        duration: 95.91296ms
+        duration: 1.115393697s
     - id: 5
       request:
         proto: HTTP/1.1
@@ -177,28 +177,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/cf1aa736-f399-45e7-a58b-d9247b130fd0
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/e9373d17-3300-47a3-9bce-5812bf2999b1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 526
-        body: '{"id":"cf1aa736-f399-45e7-a58b-d9247b130fd0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-name-2","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:20.438308Z","updated_at":"2026-07-03T15:28:20.443489Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:20.443489Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"e9373d17-3300-47a3-9bce-5812bf2999b1","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-name-2","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:11.483565Z","updated_at":"2026-07-07T07:46:11.487267Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:11.487267Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "526"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:20 GMT
+                - Tue, 07 Jul 2026 07:46:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - b2e65495-2d9d-4ee7-bc39-6f3c8cda6610
+                - 41cfd987-e705-443a-9f61-a577a2dc76fe
         status: 200 OK
         code: 200
-        duration: 46.570952ms
+        duration: 48.823402ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -209,28 +209,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/ed5bf6af-a425-41a4-a24b-5523d83431fd
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/9fe6b496-4efd-45bb-9c3f-1e8d940b365b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 526
-        body: '{"id":"ed5bf6af-a425-41a4-a24b-5523d83431fd","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-name-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.254887Z","updated_at":"2026-07-03T15:28:19.259815Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.259815Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"9fe6b496-4efd-45bb-9c3f-1e8d940b365b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-name-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:09.371116Z","updated_at":"2026-07-07T07:46:09.375257Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:09.375257Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "526"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:20 GMT
+                - Tue, 07 Jul 2026 07:46:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - e74cae61-9aa2-4eeb-a954-f1697b89edf3
+                - cc90a645-b94f-44e8-8686-48ed19a35346
         status: 200 OK
         code: 200
-        duration: 48.948979ms
+        duration: 45.977578ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -241,28 +241,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/cf1aa736-f399-45e7-a58b-d9247b130fd0
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/e9373d17-3300-47a3-9bce-5812bf2999b1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 526
-        body: '{"id":"cf1aa736-f399-45e7-a58b-d9247b130fd0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-name-2","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:20.438308Z","updated_at":"2026-07-03T15:28:20.443489Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:20.443489Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"e9373d17-3300-47a3-9bce-5812bf2999b1","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-name-2","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:11.483565Z","updated_at":"2026-07-07T07:46:11.487267Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:11.487267Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "526"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
+                - Tue, 07 Jul 2026 07:46:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 125eaf27-ad4e-4380-a71a-c1c19f7b570a
+                - a8faf814-16cb-4f6b-91a4-ab0c9302a250
         status: 200 OK
         code: 200
-        duration: 153.978103ms
+        duration: 46.196223ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -279,8 +279,6 @@ interactions:
                 - "1"
             project_id:
                 - 105bdce1-64c0-48ab-899d-868455867ecf
-            protection_level:
-                - unknown_protection_level
             scheduled_for_deletion:
                 - "false"
             usage:
@@ -288,28 +286,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys?name=tf-test-km-by-name-1&order_by=name_asc&page=1&project_id=105bdce1-64c0-48ab-899d-868455867ecf&protection_level=unknown_protection_level&scheduled_for_deletion=false&usage=unknown_usage
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys?name=tf-test-km-by-name-1&order_by=name_asc&page=1&project_id=105bdce1-64c0-48ab-899d-868455867ecf&scheduled_for_deletion=false&usage=unknown_usage
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 553
-        body: '{"keys":[{"id":"ed5bf6af-a425-41a4-a24b-5523d83431fd","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-name-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.254887Z","updated_at":"2026-07-03T15:28:19.259815Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.259815Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}],"total_count":1}'
+        body: '{"keys":[{"id":"9fe6b496-4efd-45bb-9c3f-1e8d940b365b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-name-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:09.371116Z","updated_at":"2026-07-07T07:46:09.375257Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:09.375257Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "553"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
+                - Tue, 07 Jul 2026 07:46:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 9350cb49-40fa-49f9-b4dc-9eedcd12ba06
+                - 6b0638ee-db6f-49f7-a112-0a7b01257767
         status: 200 OK
         code: 200
-        duration: 99.416902ms
+        duration: 68.67452ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -320,7 +318,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/cf1aa736-f399-45e7-a58b-d9247b130fd0
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/e9373d17-3300-47a3-9bce-5812bf2999b1
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -332,14 +330,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
+                - Tue, 07 Jul 2026 07:46:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 9b7638c6-146e-44ed-bd71-0828793862d6
+                - c6453791-37f7-444a-82a0-62c530c039bc
         status: 204 No Content
         code: 204
-        duration: 117.539221ms
+        duration: 58.486186ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -350,7 +348,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/ed5bf6af-a425-41a4-a24b-5523d83431fd
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/9fe6b496-4efd-45bb-9c3f-1e8d940b365b
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -362,14 +360,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
+                - Tue, 07 Jul 2026 07:46:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 8432ba63-115d-44f1-acdf-64b159f4a8ed
+                - 8a848dbf-ccee-40bd-bb50-fff785be85e3
         status: 204 No Content
         code: 204
-        duration: 117.881704ms
+        duration: 72.126243ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -380,28 +378,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/ed5bf6af-a425-41a4-a24b-5523d83431fd
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/9fe6b496-4efd-45bb-9c3f-1e8d940b365b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 566
-        body: '{"id":"ed5bf6af-a425-41a4-a24b-5523d83431fd","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-name-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-03T15:28:19.254887Z","updated_at":"2026-07-03T15:28:21.815663Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.259815Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-03T15:28:21.815662Z","protection_level":"software","region":"fr-par"}'
+        body: '{"id":"9fe6b496-4efd-45bb-9c3f-1e8d940b365b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-name-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-07T07:46:09.371116Z","updated_at":"2026-07-07T07:46:12.403648Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:09.375257Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-07T07:46:12.403648Z","protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "566"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
+                - Tue, 07 Jul 2026 07:46:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 57dcf78f-7312-47c1-977b-c2b9f229fb84
+                - 697bf0ac-65a0-47a4-935e-4d9985db31b5
         status: 200 OK
         code: 200
-        duration: 44.935671ms
+        duration: 44.083984ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -412,25 +410,25 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/cf1aa736-f399-45e7-a58b-d9247b130fd0
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/e9373d17-3300-47a3-9bce-5812bf2999b1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 566
-        body: '{"id":"cf1aa736-f399-45e7-a58b-d9247b130fd0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-name-2","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-03T15:28:20.438308Z","updated_at":"2026-07-03T15:28:21.815405Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:20.443489Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-03T15:28:21.815405Z","protection_level":"software","region":"fr-par"}'
+        body: '{"id":"e9373d17-3300-47a3-9bce-5812bf2999b1","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-name-2","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-07T07:46:11.483565Z","updated_at":"2026-07-07T07:46:12.391665Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:11.487267Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-07T07:46:12.391665Z","protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "566"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
+                - Tue, 07 Jul 2026 07:46:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 08a74dc7-1483-4206-a9d7-18f518b2c525
+                - e7523c70-06b4-4043-809d-5d641daa6112
         status: 200 OK
         code: 200
-        duration: 45.920501ms
+        duration: 48.637017ms

--- a/internal/services/keymanager/testdata/list-key-manager-keys-by-project-ids.cassette.yaml
+++ b/internal/services/keymanager/testdata/list-key-manager-keys-by-project-ids.cassette.yaml
@@ -6,9 +6,9 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 236
+        content_length: 190
         host: api.scaleway.com
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-proj-id-1","usage":{"symmetric_encryption":"aes_256_gcm"},"tags":null,"unprotected":true,"origin":"unknown_origin","protection_level":"unknown_protection_level"}'
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-proj-id-1","usage":{"symmetric_encryption":"aes_256_gcm"},"tags":null,"unprotected":true,"origin":"unknown_origin"}'
         headers:
             Content-Type:
                 - application/json
@@ -21,21 +21,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 529
-        body: '{"id":"50757a9f-ef9d-4621-b926-7793034d5f23","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-proj-id-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.178853Z","updated_at":"2026-07-03T15:28:19.183840Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.183840Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"32f05ade-728c-4f76-bd12-19dabe740d47","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-proj-id-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:07.107841Z","updated_at":"2026-07-07T07:46:07.111533Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:07.111533Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "529"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:19 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 0f0937e7-9efc-4f94-ae10-cbc419d9fc3e
+                - bc24c8b6-da23-4307-8a43-45ace88910c0
         status: 200 OK
         code: 200
-        duration: 596.838595ms
+        duration: 121.883931ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -46,28 +46,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/50757a9f-ef9d-4621-b926-7793034d5f23
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/32f05ade-728c-4f76-bd12-19dabe740d47
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 529
-        body: '{"id":"50757a9f-ef9d-4621-b926-7793034d5f23","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-proj-id-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.178853Z","updated_at":"2026-07-03T15:28:19.183840Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.183840Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"32f05ade-728c-4f76-bd12-19dabe740d47","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-proj-id-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:07.107841Z","updated_at":"2026-07-07T07:46:07.111533Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:07.111533Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "529"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:19 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - ebb31e2a-7a6a-43f4-96fe-4ffefb667604
+                - 68c8ad92-a229-4ebe-affc-79934c075987
         status: 200 OK
         code: 200
-        duration: 89.810168ms
+        duration: 55.333536ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -78,28 +78,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/50757a9f-ef9d-4621-b926-7793034d5f23
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/32f05ade-728c-4f76-bd12-19dabe740d47
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 529
-        body: '{"id":"50757a9f-ef9d-4621-b926-7793034d5f23","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-proj-id-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.178853Z","updated_at":"2026-07-03T15:28:19.183840Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.183840Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"32f05ade-728c-4f76-bd12-19dabe740d47","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-proj-id-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:07.107841Z","updated_at":"2026-07-07T07:46:07.111533Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:07.111533Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "529"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:19 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 09183d54-e332-4f1f-bf7d-c21fe2ea237e
+                - 0d39a046-5376-4d55-8139-74a8fc3c2a29
         status: 200 OK
         code: 200
-        duration: 134.710734ms
+        duration: 52.762561ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -114,8 +114,6 @@ interactions:
                 - "1"
             project_id:
                 - 105bdce1-64c0-48ab-899d-868455867ecf
-            protection_level:
-                - unknown_protection_level
             scheduled_for_deletion:
                 - "false"
             usage:
@@ -123,28 +121,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys?order_by=name_asc&page=1&project_id=105bdce1-64c0-48ab-899d-868455867ecf&protection_level=unknown_protection_level&scheduled_for_deletion=false&usage=unknown_usage
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys?order_by=name_asc&page=1&project_id=105bdce1-64c0-48ab-899d-868455867ecf&scheduled_for_deletion=false&usage=unknown_usage
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 5392
-        body: '{"keys":[{"id":"f8880c35-46bf-4ecd-8185-c816231f0d78","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-decrypt-key","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.387100Z","updated_at":"2026-07-03T15:28:19.391480Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.391480Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"ed5bf6af-a425-41a4-a24b-5523d83431fd","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-name-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.254887Z","updated_at":"2026-07-03T15:28:19.259815Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.259815Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"50757a9f-ef9d-4621-b926-7793034d5f23","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-proj-id-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.178853Z","updated_at":"2026-07-03T15:28:19.183840Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.183840Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"04814e7e-4300-4b22-984e-eff1eec32557","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-scheduled-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.210917Z","updated_at":"2026-07-03T15:28:19.215546Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.215546Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"62a30059-9199-4f5b-b16d-7fc491b85dd0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-tags-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.878293Z","updated_at":"2026-07-03T15:28:19.882699Z","protected":false,"locked":false,"description":null,"tags":["env:test","team:test"],"rotated_at":"2026-07-03T15:28:19.882699Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"5180620d-12d4-4ff6-8d8e-fae5a52e6219","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-usage-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.233790Z","updated_at":"2026-07-03T15:28:19.237469Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.237469Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"c8c5298c-7ee8-4e8f-a430-5b5c3d8144c8","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-default-alg","usage":{"asymmetric_encryption":"rsa_oaep_3072_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:18.735474Z","updated_at":"2026-07-03T15:28:19.161311Z","protected":false,"locked":false,"description":"Test key with RSA-3072 algorithm","tags":[],"rotated_at":"2026-07-03T15:28:19.161311Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"1157fe98-a66f-4fbc-803c-30a07685869e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-sign-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.410788Z","updated_at":"2026-07-03T15:28:19.523205Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.523205Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"7e6da60c-5bfa-475c-851d-c7cf98923041","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.283852Z","updated_at":"2026-07-03T15:28:19.368507Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.368507Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"969b2333-caec-45d2-99b0-aef0b1d49d12","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-key-invalid","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.543164Z","updated_at":"2026-07-03T15:28:19.841001Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.841001Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}],"total_count":10}'
+        content_length: 3773
+        body: '{"keys":[{"id":"4e278f73-dff7-462f-98da-60f527e9cc1b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-decrypt-key","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:05.258556Z","updated_at":"2026-07-07T07:46:05.274407Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:05.274407Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"fc7cad12-56ed-4334-8120-6855db657a0b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-encrypt-key","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:07.859941Z","updated_at":"2026-07-07T07:46:07.863185Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:07.863185Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"32f05ade-728c-4f76-bd12-19dabe740d47","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-proj-id-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:07.107841Z","updated_at":"2026-07-07T07:46:07.111533Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:07.111533Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"3283da5a-09a0-4296-9d55-4af129b6f36d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-updated","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:05.823624Z","updated_at":"2026-07-07T07:46:07.448560Z","protected":false,"locked":false,"description":"Test key updated","tags":["tf","updated"],"rotated_at":"2026-07-07T07:46:05.832730Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"8a83f62f-2b00-4e17-9bef-bc10faef3098","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:04.804893Z","updated_at":"2026-07-07T07:46:05.170115Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:05.170115Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"5d6d4534-252a-419d-a05c-c8c46ca78bc8","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-key-invalid","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:04.605646Z","updated_at":"2026-07-07T07:46:04.766080Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:04.766080Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"f688d12f-fd78-4d61-b983-28316cef6d5f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-other-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:05.931361Z","updated_at":"2026-07-07T07:46:06.055912Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:06.055912Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}],"total_count":7}'
         headers:
             Content-Length:
-                - "5392"
+                - "3773"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:20 GMT
+                - Tue, 07 Jul 2026 07:46:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 1adfbbe4-6a74-4890-b9ab-6b32c389286d
+                - e9c31fc8-b448-40da-83d4-3501ab609a33
         status: 200 OK
         code: 200
-        duration: 92.6439ms
+        duration: 103.724764ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -155,7 +153,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/50757a9f-ef9d-4621-b926-7793034d5f23
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/32f05ade-728c-4f76-bd12-19dabe740d47
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -167,14 +165,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:20 GMT
+                - Tue, 07 Jul 2026 07:46:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 14ab0aa9-c7b4-4184-8c79-14859be93842
+                - c9322480-d770-4ecb-ab09-a52883129fa3
         status: 204 No Content
         code: 204
-        duration: 127.754949ms
+        duration: 77.622787ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -185,25 +183,25 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/50757a9f-ef9d-4621-b926-7793034d5f23
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/32f05ade-728c-4f76-bd12-19dabe740d47
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 569
-        body: '{"id":"50757a9f-ef9d-4621-b926-7793034d5f23","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-proj-id-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-03T15:28:19.178853Z","updated_at":"2026-07-03T15:28:20.568559Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.183840Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-03T15:28:20.568559Z","protection_level":"software","region":"fr-par"}'
+        body: '{"id":"32f05ade-728c-4f76-bd12-19dabe740d47","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-proj-id-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-07T07:46:07.107841Z","updated_at":"2026-07-07T07:46:08.509917Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:07.111533Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-07T07:46:08.509917Z","protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "569"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:20 GMT
+                - Tue, 07 Jul 2026 07:46:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - c7bc3d98-ab58-4f4c-b82e-289d9ad6bae3
+                - 1461d945-01bb-4990-9396-e35d7726331e
         status: 200 OK
         code: 200
-        duration: 54.612297ms
+        duration: 44.194156ms

--- a/internal/services/keymanager/testdata/list-key-manager-keys-by-regions.cassette.yaml
+++ b/internal/services/keymanager/testdata/list-key-manager-keys-by-regions.cassette.yaml
@@ -6,9 +6,9 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 234
+        content_length: 188
         host: api.scaleway.com
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-key-by-region","usage":{"symmetric_encryption":"aes_256_gcm"},"tags":null,"unprotected":true,"origin":"unknown_origin","protection_level":"unknown_protection_level"}'
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-key-by-region","usage":{"symmetric_encryption":"aes_256_gcm"},"tags":null,"unprotected":true,"origin":"unknown_origin"}'
         headers:
             Content-Type:
                 - application/json
@@ -21,21 +21,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 527
-        body: '{"id":"2b4fe63f-f7b7-4973-8ae1-39ae8546eab4","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-key-by-region","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:24.409873Z","updated_at":"2026-07-03T15:28:24.414509Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:24.414509Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"0020b937-8e07-4fff-bb9c-953dddee518d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-key-by-region","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:09.168638Z","updated_at":"2026-07-07T07:46:09.173329Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:09.173329Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "527"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:24 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 1d149c8a-3f2c-4410-b608-46a2952eb264
+                - 0feb5169-1430-44c5-8ca2-77780037685e
         status: 200 OK
         code: 200
-        duration: 70.447059ms
+        duration: 131.219064ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -46,28 +46,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/2b4fe63f-f7b7-4973-8ae1-39ae8546eab4
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/0020b937-8e07-4fff-bb9c-953dddee518d
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 527
-        body: '{"id":"2b4fe63f-f7b7-4973-8ae1-39ae8546eab4","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-key-by-region","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:24.409873Z","updated_at":"2026-07-03T15:28:24.414509Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:24.414509Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"0020b937-8e07-4fff-bb9c-953dddee518d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-key-by-region","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:09.168638Z","updated_at":"2026-07-07T07:46:09.173329Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:09.173329Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "527"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:24 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 355f9b31-8dc9-4233-b3db-83cd63e750d5
+                - cd854cc2-e236-4f41-a14f-63366ef6ff69
         status: 200 OK
         code: 200
-        duration: 42.358401ms
+        duration: 47.297524ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -78,28 +78,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/2b4fe63f-f7b7-4973-8ae1-39ae8546eab4
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/0020b937-8e07-4fff-bb9c-953dddee518d
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 527
-        body: '{"id":"2b4fe63f-f7b7-4973-8ae1-39ae8546eab4","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-key-by-region","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:24.409873Z","updated_at":"2026-07-03T15:28:24.414509Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:24.414509Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"0020b937-8e07-4fff-bb9c-953dddee518d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-key-by-region","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:09.168638Z","updated_at":"2026-07-07T07:46:09.173329Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:09.173329Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "527"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:25 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - f0d8d026-182b-4aa2-84b3-6fb17c936710
+                - 2395e1f9-dc3b-48bf-8f44-5aac613bc353
         status: 200 OK
         code: 200
-        duration: 48.116015ms
+        duration: 46.371975ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -114,8 +114,6 @@ interactions:
                 - "1"
             project_id:
                 - 105bdce1-64c0-48ab-899d-868455867ecf
-            protection_level:
-                - unknown_protection_level
             scheduled_for_deletion:
                 - "false"
             usage:
@@ -123,28 +121,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys?order_by=name_asc&page=1&project_id=105bdce1-64c0-48ab-899d-868455867ecf&protection_level=unknown_protection_level&scheduled_for_deletion=false&usage=unknown_usage
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys?order_by=name_asc&page=1&project_id=105bdce1-64c0-48ab-899d-868455867ecf&scheduled_for_deletion=false&usage=unknown_usage
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 2732
-        body: '{"keys":[{"id":"2c3026cf-38d3-4155-a38a-09fbd05249d0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-decrypt-key-ad","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:23.280724Z","updated_at":"2026-07-03T15:28:23.284017Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:23.284017Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"23871059-a682-4a9d-9cc7-f9e5588a7555","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-generate-no-plaintext","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:22.769593Z","updated_at":"2026-07-03T15:28:22.772636Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:22.772636Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"2b4fe63f-f7b7-4973-8ae1-39ae8546eab4","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-key-by-region","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:24.409873Z","updated_at":"2026-07-03T15:28:24.414509Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:24.414509Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"866337c1-b045-426a-91c8-6d3ab6194e9e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation-action","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":2,"created_at":"2026-07-03T15:28:23.813688Z","updated_at":"2026-07-03T15:28:24.080715Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:24.080715Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"727f3036-5b41-4ff2-ba78-b622b07430ab","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-updated","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:23.841284Z","updated_at":"2026-07-03T15:28:25.302477Z","protected":false,"locked":false,"description":"Test key updated","tags":["tf","updated"],"rotated_at":"2026-07-03T15:28:23.844354Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}],"total_count":5}'
+        content_length: 4816
+        body: '{"keys":[{"id":"278f8b55-19be-4193-bc44-ae05d00ee8eb","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-decrypt-key-ad","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:09.338590Z","updated_at":"2026-07-07T07:46:09.342697Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:09.342697Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"fc7cad12-56ed-4334-8120-6855db657a0b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-encrypt-key","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:07.859941Z","updated_at":"2026-07-07T07:46:07.863185Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:07.863185Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"ae023895-cd70-4bc6-808e-e135d21d469a","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-generate-data-key","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:08.427013Z","updated_at":"2026-07-07T07:46:08.432841Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:08.432841Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"d4f12236-7e6e-4042-8693-751f819f2095","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-generate-no-plaintext","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:08.340831Z","updated_at":"2026-07-07T07:46:08.344193Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:08.344193Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"0020b937-8e07-4fff-bb9c-953dddee518d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-key-by-region","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:09.168638Z","updated_at":"2026-07-07T07:46:09.173329Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:09.173329Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"9fe6b496-4efd-45bb-9c3f-1e8d940b365b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-name-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:09.371116Z","updated_at":"2026-07-07T07:46:09.375257Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:09.375257Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"ca7c5496-d4ab-47c7-81c2-659459b85696","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-usage-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:08.578898Z","updated_at":"2026-07-07T07:46:08.583520Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:08.583520Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"c6345a8f-86a4-429d-8bb0-338f4320e065","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation-action","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":2,"created_at":"2026-07-07T07:46:09.306386Z","updated_at":"2026-07-07T07:46:09.492477Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-07T07:46:09.492477Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"50ed0b96-d717-4deb-a9e7-f57d7b563903","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-sign-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:08.258877Z","updated_at":"2026-07-07T07:46:08.309258Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:08.309258Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}],"total_count":9}'
         headers:
             Content-Length:
-                - "2732"
+                - "4816"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:25 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - aaac2c91-e81f-4cbd-8333-eeeaeba3405e
+                - 71194cfc-bf42-4296-89a4-5e1eb4c0f3e2
         status: 200 OK
         code: 200
-        duration: 52.421432ms
+        duration: 65.910087ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -155,7 +153,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/2b4fe63f-f7b7-4973-8ae1-39ae8546eab4
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/0020b937-8e07-4fff-bb9c-953dddee518d
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -167,14 +165,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:25 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 6a96471b-41df-4dc6-9575-27b898dd6e3e
+                - 90a3e55d-3b2b-4fe0-b688-e3ea09b48a05
         status: 204 No Content
         code: 204
-        duration: 73.654454ms
+        duration: 64.920145ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -185,25 +183,25 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/2b4fe63f-f7b7-4973-8ae1-39ae8546eab4
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/0020b937-8e07-4fff-bb9c-953dddee518d
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 567
-        body: '{"id":"2b4fe63f-f7b7-4973-8ae1-39ae8546eab4","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-key-by-region","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-03T15:28:24.409873Z","updated_at":"2026-07-03T15:28:25.750478Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:24.414509Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-03T15:28:25.750478Z","protection_level":"software","region":"fr-par"}'
+        body: '{"id":"0020b937-8e07-4fff-bb9c-953dddee518d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-key-by-region","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-07T07:46:09.168638Z","updated_at":"2026-07-07T07:46:10.260489Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:09.173329Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-07T07:46:10.260489Z","protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "567"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:25 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 2cba899a-b5c3-4aef-95f5-fe493380ce27
+                - 0a0a130b-77a9-476d-ac81-8c6ae03574b0
         status: 200 OK
         code: 200
-        duration: 56.92451ms
+        duration: 138.913053ms

--- a/internal/services/keymanager/testdata/list-key-manager-keys-by-scheduled-for-deletion.cassette.yaml
+++ b/internal/services/keymanager/testdata/list-key-manager-keys-by-scheduled-for-deletion.cassette.yaml
@@ -6,9 +6,9 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 238
+        content_length: 192
         host: api.scaleway.com
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-scheduled-1","usage":{"symmetric_encryption":"aes_256_gcm"},"tags":null,"unprotected":true,"origin":"unknown_origin","protection_level":"unknown_protection_level"}'
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-scheduled-1","usage":{"symmetric_encryption":"aes_256_gcm"},"tags":null,"unprotected":true,"origin":"unknown_origin"}'
         headers:
             Content-Type:
                 - application/json
@@ -21,21 +21,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 531
-        body: '{"id":"04814e7e-4300-4b22-984e-eff1eec32557","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-scheduled-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.210917Z","updated_at":"2026-07-03T15:28:19.215546Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.215546Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"8f6c8663-9f49-4589-a085-a24a0af15bd8","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-scheduled-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:02.355008Z","updated_at":"2026-07-07T07:46:02.363203Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:02.363203Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "531"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:19 GMT
+                - Tue, 07 Jul 2026 07:46:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 3160f904-1b45-4b3f-9274-351c98142fa2
+                - a6f8bfa5-b5ff-4f84-902c-26770d28b757
         status: 200 OK
         code: 200
-        duration: 615.494897ms
+        duration: 281.862252ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -46,28 +46,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/04814e7e-4300-4b22-984e-eff1eec32557
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/8f6c8663-9f49-4589-a085-a24a0af15bd8
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 531
-        body: '{"id":"04814e7e-4300-4b22-984e-eff1eec32557","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-scheduled-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.210917Z","updated_at":"2026-07-03T15:28:19.215546Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.215546Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"8f6c8663-9f49-4589-a085-a24a0af15bd8","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-scheduled-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:02.355008Z","updated_at":"2026-07-07T07:46:02.363203Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:02.363203Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "531"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:19 GMT
+                - Tue, 07 Jul 2026 07:46:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 4436acb7-0bc4-4d79-b05f-1d58a6b2d612
+                - 4fe3e20a-0d46-4cc1-87e9-c0c2af3a5239
         status: 200 OK
         code: 200
-        duration: 82.571111ms
+        duration: 177.820468ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -78,28 +78,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/04814e7e-4300-4b22-984e-eff1eec32557
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/8f6c8663-9f49-4589-a085-a24a0af15bd8
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 531
-        body: '{"id":"04814e7e-4300-4b22-984e-eff1eec32557","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-scheduled-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.210917Z","updated_at":"2026-07-03T15:28:19.215546Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.215546Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"8f6c8663-9f49-4589-a085-a24a0af15bd8","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-scheduled-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:02.355008Z","updated_at":"2026-07-07T07:46:02.363203Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:02.363203Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "531"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:19 GMT
+                - Tue, 07 Jul 2026 07:46:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 3a727abd-f382-4cb0-b69b-7eb8bf54e9a5
+                - 000a17cf-5d0d-4ec8-a344-a860b252e507
         status: 200 OK
         code: 200
-        duration: 121.85633ms
+        duration: 190.59273ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -110,36 +110,36 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/04814e7e-4300-4b22-984e-eff1eec32557
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/8f6c8663-9f49-4589-a085-a24a0af15bd8
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 531
-        body: '{"id":"04814e7e-4300-4b22-984e-eff1eec32557","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-scheduled-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.210917Z","updated_at":"2026-07-03T15:28:19.215546Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.215546Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"8f6c8663-9f49-4589-a085-a24a0af15bd8","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-scheduled-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:02.355008Z","updated_at":"2026-07-07T07:46:02.363203Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:02.363203Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "531"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:20 GMT
+                - Tue, 07 Jul 2026 07:46:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 5ee3b748-eb76-4026-b6e4-f19886aa3720
+                - 9c30d7e7-7e84-4c5c-a1ed-fccaa2ad023b
         status: 200 OK
         code: 200
-        duration: 135.570318ms
+        duration: 58.756263ms
     - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 238
+        content_length: 192
         host: api.scaleway.com
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-scheduled-2","usage":{"symmetric_encryption":"aes_256_gcm"},"tags":null,"unprotected":true,"origin":"unknown_origin","protection_level":"unknown_protection_level"}'
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-scheduled-2","usage":{"symmetric_encryption":"aes_256_gcm"},"tags":null,"unprotected":true,"origin":"unknown_origin"}'
         headers:
             Content-Type:
                 - application/json
@@ -152,21 +152,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 531
-        body: '{"id":"09ba6785-9f2f-40e4-9aa5-caa8d05b42c3","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-scheduled-2","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:21.428537Z","updated_at":"2026-07-03T15:28:21.431824Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:21.431824Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"1cc27b72-c941-4504-9735-41b16b9964ea","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-scheduled-2","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:05.899837Z","updated_at":"2026-07-07T07:46:05.902492Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:05.902492Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "531"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
+                - Tue, 07 Jul 2026 07:46:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - a7f997a6-1158-460e-a904-0dc6e31fef56
+                - 45d27354-645a-442f-8c93-e82786f733e8
         status: 200 OK
         code: 200
-        duration: 900.609813ms
+        duration: 2.573843314s
     - id: 5
       request:
         proto: HTTP/1.1
@@ -177,28 +177,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/09ba6785-9f2f-40e4-9aa5-caa8d05b42c3
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/1cc27b72-c941-4504-9735-41b16b9964ea
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 531
-        body: '{"id":"09ba6785-9f2f-40e4-9aa5-caa8d05b42c3","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-scheduled-2","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:21.428537Z","updated_at":"2026-07-03T15:28:21.431824Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:21.431824Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"1cc27b72-c941-4504-9735-41b16b9964ea","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-scheduled-2","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:05.899837Z","updated_at":"2026-07-07T07:46:05.902492Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:05.902492Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "531"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
+                - Tue, 07 Jul 2026 07:46:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 9c45f854-e5ed-4f77-a2d5-318172c2a1b3
+                - 4d0c600d-d708-4106-b30f-a48e35c90d78
         status: 200 OK
         code: 200
-        duration: 54.399117ms
+        duration: 40.222521ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -209,28 +209,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/09ba6785-9f2f-40e4-9aa5-caa8d05b42c3
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/8f6c8663-9f49-4589-a085-a24a0af15bd8
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 531
-        body: '{"id":"09ba6785-9f2f-40e4-9aa5-caa8d05b42c3","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-scheduled-2","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:21.428537Z","updated_at":"2026-07-03T15:28:21.431824Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:21.431824Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"8f6c8663-9f49-4589-a085-a24a0af15bd8","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-scheduled-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:02.355008Z","updated_at":"2026-07-07T07:46:02.363203Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:02.363203Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "531"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:22 GMT
+                - Tue, 07 Jul 2026 07:46:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - f283c9bf-f88f-4960-b327-591b135f8bf5
+                - 63121992-902f-4c18-9fd0-12e133ef5da6
         status: 200 OK
         code: 200
-        duration: 46.000963ms
+        duration: 43.469076ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -241,28 +241,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/04814e7e-4300-4b22-984e-eff1eec32557
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/1cc27b72-c941-4504-9735-41b16b9964ea
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 531
-        body: '{"id":"04814e7e-4300-4b22-984e-eff1eec32557","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-scheduled-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.210917Z","updated_at":"2026-07-03T15:28:19.215546Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.215546Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"1cc27b72-c941-4504-9735-41b16b9964ea","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-scheduled-2","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:05.899837Z","updated_at":"2026-07-07T07:46:05.902492Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:05.902492Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "531"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:22 GMT
+                - Tue, 07 Jul 2026 07:46:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 715d190d-92a2-478a-9f2b-5464eee1e34f
+                - 5a8351ae-428a-4706-87ff-64403a7c761b
         status: 200 OK
         code: 200
-        duration: 50.353578ms
+        duration: 84.643097ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -277,8 +277,6 @@ interactions:
                 - "1"
             project_id:
                 - 105bdce1-64c0-48ab-899d-868455867ecf
-            protection_level:
-                - unknown_protection_level
             scheduled_for_deletion:
                 - "false"
             usage:
@@ -286,28 +284,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys?order_by=name_asc&page=1&project_id=105bdce1-64c0-48ab-899d-868455867ecf&protection_level=unknown_protection_level&scheduled_for_deletion=false&usage=unknown_usage
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys?order_by=name_asc&page=1&project_id=105bdce1-64c0-48ab-899d-868455867ecf&scheduled_for_deletion=false&usage=unknown_usage
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 5383
-        body: '{"keys":[{"id":"eb04b054-d2ff-4deb-9d9e-c3b297c9a814","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-generate-data-key","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:21.457910Z","updated_at":"2026-07-03T15:28:21.463281Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:21.463281Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"04814e7e-4300-4b22-984e-eff1eec32557","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-scheduled-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.210917Z","updated_at":"2026-07-03T15:28:19.215546Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.215546Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"09ba6785-9f2f-40e4-9aa5-caa8d05b42c3","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-scheduled-2","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:21.428537Z","updated_at":"2026-07-03T15:28:21.431824Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:21.431824Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"62a30059-9199-4f5b-b16d-7fc491b85dd0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-tags-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.878293Z","updated_at":"2026-07-03T15:28:19.882699Z","protected":false,"locked":false,"description":null,"tags":["env:test","team:test"],"rotated_at":"2026-07-03T15:28:19.882699Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"b5d0e5ed-511f-4084-9ae1-5c4238ddd21b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-tags-2","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:21.485131Z","updated_at":"2026-07-03T15:28:21.488381Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:21.488381Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"5180620d-12d4-4ff6-8d8e-fae5a52e6219","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-usage-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.233790Z","updated_at":"2026-07-03T15:28:19.237469Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.237469Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"a6bcfe1d-58dc-4ff7-8cd8-641dd5374f13","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-usage-2","usage":{"asymmetric_encryption":"rsa_oaep_4096_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:20.545511Z","updated_at":"2026-07-03T15:28:21.411434Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:21.411434Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"3ce11279-c8b9-4f12-aaaf-e26766a2967c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-ds","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:21.508255Z","updated_at":"2026-07-03T15:28:21.511698Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-03T15:28:21.511698Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"969b2333-caec-45d2-99b0-aef0b1d49d12","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-key-invalid","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.543164Z","updated_at":"2026-07-03T15:28:19.841001Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.841001Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"b1132c2b-01d9-4c6c-950c-b4b15d787780","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-other-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.995464Z","updated_at":"2026-07-03T15:28:20.337904Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:20.337904Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}],"total_count":10}'
+        content_length: 6513
+        body: '{"keys":[{"id":"4e278f73-dff7-462f-98da-60f527e9cc1b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-decrypt-key","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:05.258556Z","updated_at":"2026-07-07T07:46:05.274407Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:05.274407Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"8f6c8663-9f49-4589-a085-a24a0af15bd8","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-scheduled-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:02.355008Z","updated_at":"2026-07-07T07:46:02.363203Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:02.363203Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"1cc27b72-c941-4504-9735-41b16b9964ea","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-scheduled-2","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:05.899837Z","updated_at":"2026-07-07T07:46:05.902492Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:05.902492Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"6798c2c6-d52e-48ac-b16d-19ad9451bcf7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-tags-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:05.189978Z","updated_at":"2026-07-07T07:46:05.193334Z","protected":false,"locked":false,"description":null,"tags":["env:test","team:test"],"rotated_at":"2026-07-07T07:46:05.193334Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"95de20ee-ec29-4841-88e2-a5367a5841ce","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-tags-2","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:06.313266Z","updated_at":"2026-07-07T07:46:06.319284Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:06.319284Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"c5d9acd5-7ee7-45f4-a4e0-b8cafa8fbbed","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-default-alg","usage":{"asymmetric_encryption":"rsa_oaep_3072_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:05.298737Z","updated_at":"2026-07-07T07:46:05.801108Z","protected":false,"locked":false,"description":"Test key with RSA-3072 algorithm","tags":[],"rotated_at":"2026-07-07T07:46:05.801108Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"69f533d2-2b1c-4943-be59-0ec66be8f088","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-ds","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:05.866222Z","updated_at":"2026-07-07T07:46:05.874934Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-07T07:46:05.874934Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"9d0ae4f2-276f-44d0-b7f5-7631bdf9680f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-unprotected","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:06.350936Z","updated_at":"2026-07-07T07:46:06.355484Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-07T07:46:06.355484Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"3283da5a-09a0-4296-9d55-4af129b6f36d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-update","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:05.823624Z","updated_at":"2026-07-07T07:46:05.832730Z","protected":false,"locked":false,"description":"Test key","tags":["tf","test"],"rotated_at":"2026-07-07T07:46:05.832730Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"8a83f62f-2b00-4e17-9bef-bc10faef3098","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:04.804893Z","updated_at":"2026-07-07T07:46:05.170115Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:05.170115Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"5d6d4534-252a-419d-a05c-c8c46ca78bc8","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-key-invalid","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:04.605646Z","updated_at":"2026-07-07T07:46:04.766080Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:04.766080Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"},{"id":"f688d12f-fd78-4d61-b983-28316cef6d5f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-verify-other-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:05.931361Z","updated_at":"2026-07-07T07:46:06.055912Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:06.055912Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}],"total_count":12}'
         headers:
             Content-Length:
-                - "5383"
+                - "6513"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:22 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 0c0eec0c-cc6c-48c1-9732-47af59d9e0fc
+                - aeca2bef-d684-4ebf-a4ad-b53dad0a6059
         status: 200 OK
         code: 200
-        duration: 96.516705ms
+        duration: 91.129523ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -318,7 +316,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/09ba6785-9f2f-40e4-9aa5-caa8d05b42c3
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/1cc27b72-c941-4504-9735-41b16b9964ea
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -330,14 +328,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 1bfefaba-020f-45bc-a13f-47ee7b660392
+                - 53d54615-b714-42f4-95d8-8dacda0fa47f
         status: 204 No Content
         code: 204
-        duration: 78.553575ms
+        duration: 104.885004ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -348,7 +346,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/04814e7e-4300-4b22-984e-eff1eec32557
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/8f6c8663-9f49-4589-a085-a24a0af15bd8
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -360,14 +358,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - b420e2f3-09d5-401d-8fe3-4f81b0a0c357
+                - ed3f1290-1b2d-4b24-a6fa-bd88f1af5406
         status: 204 No Content
         code: 204
-        duration: 94.538299ms
+        duration: 127.725364ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -378,28 +376,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/04814e7e-4300-4b22-984e-eff1eec32557
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/8f6c8663-9f49-4589-a085-a24a0af15bd8
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 571
-        body: '{"id":"04814e7e-4300-4b22-984e-eff1eec32557","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-scheduled-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-03T15:28:19.210917Z","updated_at":"2026-07-03T15:28:23.054282Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.215546Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-03T15:28:23.054282Z","protection_level":"software","region":"fr-par"}'
+        body: '{"id":"8f6c8663-9f49-4589-a085-a24a0af15bd8","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-scheduled-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-07T07:46:02.355008Z","updated_at":"2026-07-07T07:46:07.415224Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:02.363203Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-07T07:46:07.415224Z","protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "571"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - aa252546-5980-40fc-83fa-15cdd3a4fb6f
+                - 90d4da3d-43c0-4306-84ab-1f4103dbeee2
         status: 200 OK
         code: 200
-        duration: 49.577761ms
+        duration: 60.484526ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -410,25 +408,25 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/09ba6785-9f2f-40e4-9aa5-caa8d05b42c3
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/1cc27b72-c941-4504-9735-41b16b9964ea
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 571
-        body: '{"id":"09ba6785-9f2f-40e4-9aa5-caa8d05b42c3","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-scheduled-2","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-03T15:28:21.428537Z","updated_at":"2026-07-03T15:28:23.046695Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:21.431824Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-03T15:28:23.046695Z","protection_level":"software","region":"fr-par"}'
+        body: '{"id":"1cc27b72-c941-4504-9735-41b16b9964ea","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-scheduled-2","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-07T07:46:05.899837Z","updated_at":"2026-07-07T07:46:07.406075Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:05.902492Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-07T07:46:07.406075Z","protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "571"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - c0105273-6faf-438e-8614-f6aa3d05500b
+                - 565254e4-071f-44bd-b0e1-d3a9739f45b9
         status: 200 OK
         code: 200
-        duration: 47.706406ms
+        duration: 37.401875ms

--- a/internal/services/keymanager/testdata/list-key-manager-keys-by-tags.cassette.yaml
+++ b/internal/services/keymanager/testdata/list-key-manager-keys-by-tags.cassette.yaml
@@ -6,9 +6,9 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 253
+        content_length: 207
         host: api.scaleway.com
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-tags-1","usage":{"symmetric_encryption":"aes_256_gcm"},"tags":["env:test","team:test"],"unprotected":true,"origin":"unknown_origin","protection_level":"unknown_protection_level"}'
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-tags-1","usage":{"symmetric_encryption":"aes_256_gcm"},"tags":["env:test","team:test"],"unprotected":true,"origin":"unknown_origin"}'
         headers:
             Content-Type:
                 - application/json
@@ -21,21 +21,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 548
-        body: '{"id":"62a30059-9199-4f5b-b16d-7fc491b85dd0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-tags-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.878293Z","updated_at":"2026-07-03T15:28:19.882699Z","protected":false,"locked":false,"description":null,"tags":["env:test","team:test"],"rotated_at":"2026-07-03T15:28:19.882699Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"6798c2c6-d52e-48ac-b16d-19ad9451bcf7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-tags-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:05.189978Z","updated_at":"2026-07-07T07:46:05.193334Z","protected":false,"locked":false,"description":null,"tags":["env:test","team:test"],"rotated_at":"2026-07-07T07:46:05.193334Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "548"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:19 GMT
+                - Tue, 07 Jul 2026 07:46:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 9e225c65-4eb3-4120-94b3-12c11a3f66d0
+                - 9930721b-0e50-4fa8-8040-191a4b60893d
         status: 200 OK
         code: 200
-        duration: 1.269782838s
+        duration: 3.103874486s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -46,28 +46,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/62a30059-9199-4f5b-b16d-7fc491b85dd0
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/6798c2c6-d52e-48ac-b16d-19ad9451bcf7
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 548
-        body: '{"id":"62a30059-9199-4f5b-b16d-7fc491b85dd0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-tags-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.878293Z","updated_at":"2026-07-03T15:28:19.882699Z","protected":false,"locked":false,"description":null,"tags":["env:test","team:test"],"rotated_at":"2026-07-03T15:28:19.882699Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"6798c2c6-d52e-48ac-b16d-19ad9451bcf7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-tags-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:05.189978Z","updated_at":"2026-07-07T07:46:05.193334Z","protected":false,"locked":false,"description":null,"tags":["env:test","team:test"],"rotated_at":"2026-07-07T07:46:05.193334Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "548"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:19 GMT
+                - Tue, 07 Jul 2026 07:46:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 39bb7934-9bac-4d2e-9b98-1397df853862
+                - 82bfc0dc-3513-47f4-8536-54c257922428
         status: 200 OK
         code: 200
-        duration: 55.028258ms
+        duration: 76.259453ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -78,28 +78,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/62a30059-9199-4f5b-b16d-7fc491b85dd0
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/6798c2c6-d52e-48ac-b16d-19ad9451bcf7
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 548
-        body: '{"id":"62a30059-9199-4f5b-b16d-7fc491b85dd0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-tags-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.878293Z","updated_at":"2026-07-03T15:28:19.882699Z","protected":false,"locked":false,"description":null,"tags":["env:test","team:test"],"rotated_at":"2026-07-03T15:28:19.882699Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"6798c2c6-d52e-48ac-b16d-19ad9451bcf7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-tags-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:05.189978Z","updated_at":"2026-07-07T07:46:05.193334Z","protected":false,"locked":false,"description":null,"tags":["env:test","team:test"],"rotated_at":"2026-07-07T07:46:05.193334Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "548"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:20 GMT
+                - Tue, 07 Jul 2026 07:46:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 12c0d6cf-cde9-41c2-88db-d468fad57c2b
+                - 4ce7c7ee-8f16-462e-8b8f-fd2c27124953
         status: 200 OK
         code: 200
-        duration: 47.07536ms
+        duration: 56.224398ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -110,36 +110,36 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/62a30059-9199-4f5b-b16d-7fc491b85dd0
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/6798c2c6-d52e-48ac-b16d-19ad9451bcf7
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 548
-        body: '{"id":"62a30059-9199-4f5b-b16d-7fc491b85dd0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-tags-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.878293Z","updated_at":"2026-07-03T15:28:19.882699Z","protected":false,"locked":false,"description":null,"tags":["env:test","team:test"],"rotated_at":"2026-07-03T15:28:19.882699Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"6798c2c6-d52e-48ac-b16d-19ad9451bcf7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-tags-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:05.189978Z","updated_at":"2026-07-07T07:46:05.193334Z","protected":false,"locked":false,"description":null,"tags":["env:test","team:test"],"rotated_at":"2026-07-07T07:46:05.193334Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "548"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:20 GMT
+                - Tue, 07 Jul 2026 07:46:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 48c3e693-7f99-4f83-8b3d-e0ea45d950ae
+                - be6796d4-5556-481a-9fff-0458b7189fd7
         status: 200 OK
         code: 200
-        duration: 133.933544ms
+        duration: 41.608796ms
     - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 233
+        content_length: 187
         host: api.scaleway.com
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-tags-2","usage":{"symmetric_encryption":"aes_256_gcm"},"tags":null,"unprotected":true,"origin":"unknown_origin","protection_level":"unknown_protection_level"}'
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-tags-2","usage":{"symmetric_encryption":"aes_256_gcm"},"tags":null,"unprotected":true,"origin":"unknown_origin"}'
         headers:
             Content-Type:
                 - application/json
@@ -152,21 +152,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 526
-        body: '{"id":"b5d0e5ed-511f-4084-9ae1-5c4238ddd21b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-tags-2","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:21.485131Z","updated_at":"2026-07-03T15:28:21.488381Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:21.488381Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"95de20ee-ec29-4841-88e2-a5367a5841ce","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-tags-2","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:06.313266Z","updated_at":"2026-07-07T07:46:06.319284Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:06.319284Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "526"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
+                - Tue, 07 Jul 2026 07:46:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - f93bc5f0-f26c-4874-bcaf-94b245297ecf
+                - 2e4f43c8-d0c3-4700-a3ab-0272e97ac4c0
         status: 200 OK
         code: 200
-        duration: 351.560727ms
+        duration: 103.346564ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -177,28 +177,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/b5d0e5ed-511f-4084-9ae1-5c4238ddd21b
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/95de20ee-ec29-4841-88e2-a5367a5841ce
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 526
-        body: '{"id":"b5d0e5ed-511f-4084-9ae1-5c4238ddd21b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-tags-2","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:21.485131Z","updated_at":"2026-07-03T15:28:21.488381Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:21.488381Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"95de20ee-ec29-4841-88e2-a5367a5841ce","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-tags-2","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:06.313266Z","updated_at":"2026-07-07T07:46:06.319284Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:06.319284Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "526"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
+                - Tue, 07 Jul 2026 07:46:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 77d4358d-e4db-47cd-b92b-d0a6802d669f
+                - af81623d-273e-4ce0-aa31-50cd31482411
         status: 200 OK
         code: 200
-        duration: 43.519892ms
+        duration: 53.599353ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -209,28 +209,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/62a30059-9199-4f5b-b16d-7fc491b85dd0
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/95de20ee-ec29-4841-88e2-a5367a5841ce
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 548
-        body: '{"id":"62a30059-9199-4f5b-b16d-7fc491b85dd0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-tags-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.878293Z","updated_at":"2026-07-03T15:28:19.882699Z","protected":false,"locked":false,"description":null,"tags":["env:test","team:test"],"rotated_at":"2026-07-03T15:28:19.882699Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        content_length: 526
+        body: '{"id":"95de20ee-ec29-4841-88e2-a5367a5841ce","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-tags-2","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:06.313266Z","updated_at":"2026-07-07T07:46:06.319284Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:06.319284Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "548"
+                - "526"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:22 GMT
+                - Tue, 07 Jul 2026 07:46:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 028daa46-1e5f-418c-88f5-a1cb3bbd6413
+                - d7cd60a3-572b-4585-88bb-4e58e95f555b
         status: 200 OK
         code: 200
-        duration: 44.683478ms
+        duration: 42.829018ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -241,28 +241,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/b5d0e5ed-511f-4084-9ae1-5c4238ddd21b
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/6798c2c6-d52e-48ac-b16d-19ad9451bcf7
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 526
-        body: '{"id":"b5d0e5ed-511f-4084-9ae1-5c4238ddd21b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-tags-2","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:21.485131Z","updated_at":"2026-07-03T15:28:21.488381Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:21.488381Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        content_length: 548
+        body: '{"id":"6798c2c6-d52e-48ac-b16d-19ad9451bcf7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-tags-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:05.189978Z","updated_at":"2026-07-07T07:46:05.193334Z","protected":false,"locked":false,"description":null,"tags":["env:test","team:test"],"rotated_at":"2026-07-07T07:46:05.193334Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "526"
+                - "548"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:22 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 3f7060df-7f4b-41ce-af16-5f67126c2fbe
+                - 7577fb94-d617-4000-9c88-ac132ab126d6
         status: 200 OK
         code: 200
-        duration: 48.01752ms
+        duration: 53.392378ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -277,8 +277,6 @@ interactions:
                 - "1"
             project_id:
                 - 105bdce1-64c0-48ab-899d-868455867ecf
-            protection_level:
-                - unknown_protection_level
             scheduled_for_deletion:
                 - "false"
             tags:
@@ -288,28 +286,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys?order_by=name_asc&page=1&project_id=105bdce1-64c0-48ab-899d-868455867ecf&protection_level=unknown_protection_level&scheduled_for_deletion=false&tags=env%3Atest&usage=unknown_usage
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys?order_by=name_asc&page=1&project_id=105bdce1-64c0-48ab-899d-868455867ecf&scheduled_for_deletion=false&tags=env%3Atest&usage=unknown_usage
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 575
-        body: '{"keys":[{"id":"62a30059-9199-4f5b-b16d-7fc491b85dd0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-tags-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.878293Z","updated_at":"2026-07-03T15:28:19.882699Z","protected":false,"locked":false,"description":null,"tags":["env:test","team:test"],"rotated_at":"2026-07-03T15:28:19.882699Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}],"total_count":1}'
+        body: '{"keys":[{"id":"6798c2c6-d52e-48ac-b16d-19ad9451bcf7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-tags-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:05.189978Z","updated_at":"2026-07-07T07:46:05.193334Z","protected":false,"locked":false,"description":null,"tags":["env:test","team:test"],"rotated_at":"2026-07-07T07:46:05.193334Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "575"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:22 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 07a194f5-9148-4726-9844-fa7bc1ade1cb
+                - 748100e9-4d38-48df-a459-6b1052437356
         status: 200 OK
         code: 200
-        duration: 42.021117ms
+        duration: 94.117899ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -320,7 +318,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/b5d0e5ed-511f-4084-9ae1-5c4238ddd21b
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/95de20ee-ec29-4841-88e2-a5367a5841ce
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -332,14 +330,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 9491f53f-94d4-480d-945a-ce5d2c311f0d
+                - 60edd35e-3183-40a0-aed9-433a9f13866b
         status: 204 No Content
         code: 204
-        duration: 95.767739ms
+        duration: 72.64565ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -350,7 +348,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/62a30059-9199-4f5b-b16d-7fc491b85dd0
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/6798c2c6-d52e-48ac-b16d-19ad9451bcf7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -362,14 +360,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 78fdf19b-6860-4a63-9663-2c5fe6f47bca
+                - c0c6c37c-19fc-40fc-bfbe-f1eceb85c1cf
         status: 204 No Content
         code: 204
-        duration: 149.346905ms
+        duration: 117.94244ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -380,28 +378,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/62a30059-9199-4f5b-b16d-7fc491b85dd0
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/6798c2c6-d52e-48ac-b16d-19ad9451bcf7
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 588
-        body: '{"id":"62a30059-9199-4f5b-b16d-7fc491b85dd0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-tags-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-03T15:28:19.878293Z","updated_at":"2026-07-03T15:28:23.098681Z","protected":false,"locked":false,"description":null,"tags":["env:test","team:test"],"rotated_at":"2026-07-03T15:28:19.882699Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-03T15:28:23.098681Z","protection_level":"software","region":"fr-par"}'
+        body: '{"id":"6798c2c6-d52e-48ac-b16d-19ad9451bcf7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-tags-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-07T07:46:05.189978Z","updated_at":"2026-07-07T07:46:07.817163Z","protected":false,"locked":false,"description":null,"tags":["env:test","team:test"],"rotated_at":"2026-07-07T07:46:05.193334Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-07T07:46:07.817162Z","protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "588"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - c7f6de34-1081-44fa-bb77-f4c35da9b510
+                - 7a79a929-a4dc-4153-91d7-354205039068
         status: 200 OK
         code: 200
-        duration: 47.635694ms
+        duration: 41.275719ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -412,25 +410,25 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/b5d0e5ed-511f-4084-9ae1-5c4238ddd21b
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/95de20ee-ec29-4841-88e2-a5367a5841ce
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 566
-        body: '{"id":"b5d0e5ed-511f-4084-9ae1-5c4238ddd21b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-tags-2","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-03T15:28:21.485131Z","updated_at":"2026-07-03T15:28:23.074937Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:21.488381Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-03T15:28:23.074937Z","protection_level":"software","region":"fr-par"}'
+        body: '{"id":"95de20ee-ec29-4841-88e2-a5367a5841ce","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-tags-2","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-07T07:46:06.313266Z","updated_at":"2026-07-07T07:46:07.776455Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:06.319284Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-07T07:46:07.776455Z","protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "566"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 32db6817-402f-49e5-b3e2-004359567248
+                - ed2750a4-0376-4daf-90cb-01e7dce1f2fa
         status: 200 OK
         code: 200
-        duration: 47.029294ms
+        duration: 42.371852ms

--- a/internal/services/keymanager/testdata/list-key-manager-keys-by-usage.cassette.yaml
+++ b/internal/services/keymanager/testdata/list-key-manager-keys-by-usage.cassette.yaml
@@ -6,9 +6,9 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 234
+        content_length: 188
         host: api.scaleway.com
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-usage-1","usage":{"symmetric_encryption":"aes_256_gcm"},"tags":null,"unprotected":true,"origin":"unknown_origin","protection_level":"unknown_protection_level"}'
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-usage-1","usage":{"symmetric_encryption":"aes_256_gcm"},"tags":null,"unprotected":true,"origin":"unknown_origin"}'
         headers:
             Content-Type:
                 - application/json
@@ -21,21 +21,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 527
-        body: '{"id":"5180620d-12d4-4ff6-8d8e-fae5a52e6219","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-usage-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.233790Z","updated_at":"2026-07-03T15:28:19.237469Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.237469Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"ca7c5496-d4ab-47c7-81c2-659459b85696","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-usage-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:08.578898Z","updated_at":"2026-07-07T07:46:08.583520Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:08.583520Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "527"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:19 GMT
+                - Tue, 07 Jul 2026 07:46:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 1ebe49e5-c092-4fac-a20f-6207ce2b7635
+                - 5fd86589-6133-4f45-8a05-f6e74df3323f
         status: 200 OK
         code: 200
-        duration: 616.743943ms
+        duration: 86.524872ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -46,28 +46,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/5180620d-12d4-4ff6-8d8e-fae5a52e6219
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/ca7c5496-d4ab-47c7-81c2-659459b85696
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 527
-        body: '{"id":"5180620d-12d4-4ff6-8d8e-fae5a52e6219","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-usage-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.233790Z","updated_at":"2026-07-03T15:28:19.237469Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.237469Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"ca7c5496-d4ab-47c7-81c2-659459b85696","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-usage-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:08.578898Z","updated_at":"2026-07-07T07:46:08.583520Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:08.583520Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "527"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:19 GMT
+                - Tue, 07 Jul 2026 07:46:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 5069fcec-822d-454f-9276-68ba999a7ec1
+                - 5b340554-b48e-4330-ae07-66586c469776
         status: 200 OK
         code: 200
-        duration: 82.550823ms
+        duration: 46.835345ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -78,28 +78,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/5180620d-12d4-4ff6-8d8e-fae5a52e6219
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/ca7c5496-d4ab-47c7-81c2-659459b85696
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 527
-        body: '{"id":"5180620d-12d4-4ff6-8d8e-fae5a52e6219","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-usage-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.233790Z","updated_at":"2026-07-03T15:28:19.237469Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.237469Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"ca7c5496-d4ab-47c7-81c2-659459b85696","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-usage-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:08.578898Z","updated_at":"2026-07-07T07:46:08.583520Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:08.583520Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "527"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:19 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - dc1da4bf-73b3-4880-bb66-0a98fdde8b82
+                - 880d7ac7-fd3d-4982-9661-aa505ef84950
         status: 200 OK
         code: 200
-        duration: 49.654945ms
+        duration: 42.790592ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -110,36 +110,36 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/5180620d-12d4-4ff6-8d8e-fae5a52e6219
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/ca7c5496-d4ab-47c7-81c2-659459b85696
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 527
-        body: '{"id":"5180620d-12d4-4ff6-8d8e-fae5a52e6219","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-usage-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.233790Z","updated_at":"2026-07-03T15:28:19.237469Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.237469Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"ca7c5496-d4ab-47c7-81c2-659459b85696","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-usage-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:08.578898Z","updated_at":"2026-07-07T07:46:08.583520Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:08.583520Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "527"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:20 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 64311b7d-604e-4539-b572-55af28393fa5
+                - 39466ed1-1d09-42b6-975e-03c4a8c95bcb
         status: 200 OK
         code: 200
-        duration: 154.717381ms
+        duration: 50.006019ms
     - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 244
+        content_length: 198
         host: api.scaleway.com
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-usage-2","usage":{"asymmetric_encryption":"rsa_oaep_4096_sha256"},"tags":null,"unprotected":true,"origin":"unknown_origin","protection_level":"unknown_protection_level"}'
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-usage-2","usage":{"asymmetric_encryption":"rsa_oaep_4096_sha256"},"tags":null,"unprotected":true,"origin":"unknown_origin"}'
         headers:
             Content-Type:
                 - application/json
@@ -152,21 +152,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 537
-        body: '{"id":"a6bcfe1d-58dc-4ff7-8cd8-641dd5374f13","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-usage-2","usage":{"asymmetric_encryption":"rsa_oaep_4096_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:20.545511Z","updated_at":"2026-07-03T15:28:21.411434Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:21.411434Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"c6baa102-9da6-4e83-839c-797a5b64b6e4","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-usage-2","usage":{"asymmetric_encryption":"rsa_oaep_4096_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:09.677898Z","updated_at":"2026-07-07T07:46:11.437321Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:11.437321Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "537"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
+                - Tue, 07 Jul 2026 07:46:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 218cebf8-b67b-4b54-a6dc-7c66413b97e9
+                - 4ceccc39-e3df-4bcc-8029-32c5e02f4384
         status: 200 OK
         code: 200
-        duration: 949.366811ms
+        duration: 1.881838992s
     - id: 5
       request:
         proto: HTTP/1.1
@@ -177,28 +177,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/a6bcfe1d-58dc-4ff7-8cd8-641dd5374f13
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/c6baa102-9da6-4e83-839c-797a5b64b6e4
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 537
-        body: '{"id":"a6bcfe1d-58dc-4ff7-8cd8-641dd5374f13","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-usage-2","usage":{"asymmetric_encryption":"rsa_oaep_4096_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:20.545511Z","updated_at":"2026-07-03T15:28:21.411434Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:21.411434Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"c6baa102-9da6-4e83-839c-797a5b64b6e4","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-usage-2","usage":{"asymmetric_encryption":"rsa_oaep_4096_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:09.677898Z","updated_at":"2026-07-07T07:46:11.437321Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:11.437321Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "537"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
+                - Tue, 07 Jul 2026 07:46:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - e7ce2bfc-a8ab-4f23-b8ce-e6386e0412b1
+                - 79c4ceb4-9973-456a-b01d-c89f5360402a
         status: 200 OK
         code: 200
-        duration: 47.920718ms
+        duration: 37.108416ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -209,28 +209,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/a6bcfe1d-58dc-4ff7-8cd8-641dd5374f13
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/ca7c5496-d4ab-47c7-81c2-659459b85696
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 537
-        body: '{"id":"a6bcfe1d-58dc-4ff7-8cd8-641dd5374f13","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-usage-2","usage":{"asymmetric_encryption":"rsa_oaep_4096_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:20.545511Z","updated_at":"2026-07-03T15:28:21.411434Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:21.411434Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        content_length: 527
+        body: '{"id":"ca7c5496-d4ab-47c7-81c2-659459b85696","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-usage-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:08.578898Z","updated_at":"2026-07-07T07:46:08.583520Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:08.583520Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "537"
+                - "527"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
+                - Tue, 07 Jul 2026 07:46:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 409febf2-05c8-401b-9936-d1693b9748f5
+                - 5e688c8c-47e5-4720-afe2-f824f72de4f3
         status: 200 OK
         code: 200
-        duration: 43.301683ms
+        duration: 52.720352ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -241,28 +241,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/5180620d-12d4-4ff6-8d8e-fae5a52e6219
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/c6baa102-9da6-4e83-839c-797a5b64b6e4
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 527
-        body: '{"id":"5180620d-12d4-4ff6-8d8e-fae5a52e6219","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-usage-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.233790Z","updated_at":"2026-07-03T15:28:19.237469Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.237469Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        content_length: 537
+        body: '{"id":"c6baa102-9da6-4e83-839c-797a5b64b6e4","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-usage-2","usage":{"asymmetric_encryption":"rsa_oaep_4096_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:09.677898Z","updated_at":"2026-07-07T07:46:11.437321Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:11.437321Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
-                - "527"
+                - "537"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
+                - Tue, 07 Jul 2026 07:46:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 6751dd8d-7a0c-4001-8fab-a98336482dcb
+                - 0016e209-b72f-48ba-a1b8-60385f660b29
         status: 200 OK
         code: 200
-        duration: 43.678811ms
+        duration: 51.884104ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -277,8 +277,6 @@ interactions:
                 - "1"
             project_id:
                 - 105bdce1-64c0-48ab-899d-868455867ecf
-            protection_level:
-                - unknown_protection_level
             scheduled_for_deletion:
                 - "false"
             usage:
@@ -286,28 +284,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys?order_by=name_asc&page=1&project_id=105bdce1-64c0-48ab-899d-868455867ecf&protection_level=unknown_protection_level&scheduled_for_deletion=false&usage=asymmetric_encryption
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys?order_by=name_asc&page=1&project_id=105bdce1-64c0-48ab-899d-868455867ecf&scheduled_for_deletion=false&usage=asymmetric_encryption
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 564
-        body: '{"keys":[{"id":"a6bcfe1d-58dc-4ff7-8cd8-641dd5374f13","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-usage-2","usage":{"asymmetric_encryption":"rsa_oaep_4096_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:20.545511Z","updated_at":"2026-07-03T15:28:21.411434Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:21.411434Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}],"total_count":1}'
+        body: '{"keys":[{"id":"c6baa102-9da6-4e83-839c-797a5b64b6e4","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-usage-2","usage":{"asymmetric_encryption":"rsa_oaep_4096_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:09.677898Z","updated_at":"2026-07-07T07:46:11.437321Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:11.437321Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "564"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:22 GMT
+                - Tue, 07 Jul 2026 07:46:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 5e89ab59-3c8a-44f0-9452-68e3caabb631
+                - 0fe442d7-109d-45cd-a0d2-bc110f248651
         status: 200 OK
         code: 200
-        duration: 128.083225ms
+        duration: 105.838035ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -318,7 +316,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/5180620d-12d4-4ff6-8d8e-fae5a52e6219
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/c6baa102-9da6-4e83-839c-797a5b64b6e4
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -330,14 +328,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 8bb586b3-1079-4a57-83f8-2bd4235ef9e9
+                - 86a8215a-1d8d-49fb-aec8-286ee95e88a3
         status: 204 No Content
         code: 204
-        duration: 102.32789ms
+        duration: 73.990833ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -348,7 +346,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/a6bcfe1d-58dc-4ff7-8cd8-641dd5374f13
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/ca7c5496-d4ab-47c7-81c2-659459b85696
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -360,14 +358,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 42523fd0-8bd0-433a-933a-fb7da826ce60
+                - 0334e801-025d-4738-ac27-c817c71d9206
         status: 204 No Content
         code: 204
-        duration: 103.633342ms
+        duration: 81.043903ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -378,28 +376,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/a6bcfe1d-58dc-4ff7-8cd8-641dd5374f13
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/c6baa102-9da6-4e83-839c-797a5b64b6e4
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 577
-        body: '{"id":"a6bcfe1d-58dc-4ff7-8cd8-641dd5374f13","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-usage-2","usage":{"asymmetric_encryption":"rsa_oaep_4096_sha256"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-03T15:28:20.545511Z","updated_at":"2026-07-03T15:28:23.037779Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:21.411434Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-03T15:28:23.037778Z","protection_level":"software","region":"fr-par"}'
+        body: '{"id":"c6baa102-9da6-4e83-839c-797a5b64b6e4","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-usage-2","usage":{"asymmetric_encryption":"rsa_oaep_4096_sha256"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-07T07:46:09.677898Z","updated_at":"2026-07-07T07:46:12.419363Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:11.437321Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-07T07:46:12.419363Z","protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "577"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 5f8cbb49-6428-4702-9d48-69d87655c1a3
+                - 921aa05d-5346-44b4-90c9-ac012ce1784d
         status: 200 OK
         code: 200
-        duration: 45.937964ms
+        duration: 52.084323ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -410,25 +408,25 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/5180620d-12d4-4ff6-8d8e-fae5a52e6219
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/ca7c5496-d4ab-47c7-81c2-659459b85696
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 567
-        body: '{"id":"5180620d-12d4-4ff6-8d8e-fae5a52e6219","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-usage-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-03T15:28:19.233790Z","updated_at":"2026-07-03T15:28:23.029298Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.237469Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-03T15:28:23.029298Z","protection_level":"software","region":"fr-par"}'
+        body: '{"id":"ca7c5496-d4ab-47c7-81c2-659459b85696","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-km-by-usage-1","usage":{"symmetric_encryption":"aes_256_gcm"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-07T07:46:08.578898Z","updated_at":"2026-07-07T07:46:12.425534Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:08.583520Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-07T07:46:12.425534Z","protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "567"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:23 GMT
+                - Tue, 07 Jul 2026 07:46:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - afdeffe2-ae4e-4ced-ae8c-efd515ea5df8
+                - 86ca4bab-881e-4c56-b250-9416d62a5c28
         status: 200 OK
         code: 200
-        duration: 44.712533ms
+        duration: 65.09844ms

--- a/internal/services/keymanager/testdata/sign-ephemeral-resource-basic.cassette.yaml
+++ b/internal/services/keymanager/testdata/sign-ephemeral-resource-basic.cassette.yaml
@@ -21,22 +21,57 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 430
-        body: '{"id":"8353536d-27ba-4e9d-bcf7-4d29355a1a29","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-sign-secret","status":"ready","created_at":"2026-07-03T15:28:18.835051Z","updated_at":"2026-07-03T15:28:18.835051Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"ff937fa7-da7f-4f59-813b-e81210767820","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-sign-secret","status":"ready","created_at":"2026-07-07T07:46:08.278576Z","updated_at":"2026-07-07T07:46:08.278576Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "430"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:18 GMT
+                - Tue, 07 Jul 2026 07:46:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 62179fa0-b4a9-49bb-807d-aa2b4d6be6ff
+                - 8669b1fc-2f34-45a3-bfaa-648d2690a0e3
         status: 200 OK
         code: 200
-        duration: 207.725565ms
+        duration: 89.538639ms
     - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 189
+        host: api.scaleway.com
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-sign-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"tags":null,"unprotected":true,"origin":"unknown_origin"}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 528
+        body: '{"id":"50ed0b96-d717-4deb-a9e7-f57d7b563903","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-sign-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:08.258877Z","updated_at":"2026-07-07T07:46:08.309258Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:08.309258Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "528"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 07 Jul 2026 07:46:08 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 3344ac69-9769-4ba6-9a23-c1ca079926ff
+        status: 200 OK
+        code: 200
+        duration: 142.690937ms
+    - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -46,29 +81,61 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8353536d-27ba-4e9d-bcf7-4d29355a1a29
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ff937fa7-da7f-4f59-813b-e81210767820
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 430
-        body: '{"id":"8353536d-27ba-4e9d-bcf7-4d29355a1a29","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-sign-secret","status":"ready","created_at":"2026-07-03T15:28:18.835051Z","updated_at":"2026-07-03T15:28:18.835051Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"ff937fa7-da7f-4f59-813b-e81210767820","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-sign-secret","status":"ready","created_at":"2026-07-07T07:46:08.278576Z","updated_at":"2026-07-07T07:46:08.278576Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "430"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:18 GMT
+                - Tue, 07 Jul 2026 07:46:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 517e1c3c-dd5b-4174-a5e4-0bcc2529d19a
+                - 0af6f561-4ff4-4fda-b785-b7c188e7acfa
         status: 200 OK
         code: 200
-        duration: 50.340443ms
-    - id: 2
+        duration: 55.222492ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/50ed0b96-d717-4deb-a9e7-f57d7b563903
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 528
+        body: '{"id":"50ed0b96-d717-4deb-a9e7-f57d7b563903","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-sign-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:08.258877Z","updated_at":"2026-07-07T07:46:08.309258Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:08.309258Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "528"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 07 Jul 2026 07:46:08 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 0904d613-397c-45ba-80fc-4791641b820f
+        status: 200 OK
+        code: 200
+        duration: 47.558679ms
+    - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -81,7 +148,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8353536d-27ba-4e9d-bcf7-4d29355a1a29/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ff937fa7-da7f-4f59-813b-e81210767820/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -95,81 +162,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:18 GMT
+                - Tue, 07 Jul 2026 07:46:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 0a9438b5-3fae-4a62-8f0b-eb7905d839c8
+                - 72a79ee8-1a8f-4d1e-86bb-c481a29194e3
         status: 200 OK
         code: 200
-        duration: 36.665187ms
-    - id: 3
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 235
-        host: api.scaleway.com
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-sign-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"tags":null,"unprotected":true,"origin":"unknown_origin","protection_level":"unknown_protection_level"}'
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 528
-        body: '{"id":"1157fe98-a66f-4fbc-803c-30a07685869e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-sign-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.410788Z","updated_at":"2026-07-03T15:28:19.523205Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.523205Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "528"
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 03 Jul 2026 15:28:19 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            X-Request-Id:
-                - c340a495-a43b-4730-83a8-c7df8ffedb4e
-        status: 200 OK
-        code: 200
-        duration: 900.942565ms
-    - id: 4
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/1157fe98-a66f-4fbc-803c-30a07685869e
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 528
-        body: '{"id":"1157fe98-a66f-4fbc-803c-30a07685869e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-sign-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.410788Z","updated_at":"2026-07-03T15:28:19.523205Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.523205Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "528"
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 03 Jul 2026 15:28:19 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            X-Request-Id:
-                - ea34bdf2-fbaa-485f-9acc-7a65781296f2
-        status: 200 OK
-        code: 200
-        duration: 39.855389ms
+        duration: 78.434669ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -183,28 +183,28 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/1157fe98-a66f-4fbc-803c-30a07685869e/sign
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/50ed0b96-d717-4deb-a9e7-f57d7b563903/sign
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 408
-        body: '{"key_id":"1157fe98-a66f-4fbc-803c-30a07685869e","signature":"FzrsLiGj7FkF3IcLwnCaLKbYrgSp/Gw4zMa9uTSvU9s3Tqfosg8ASbTzz7YnB/XIvwwEshNcZCeLt55JTz7JTFQBPhlfDfBRo9cVGiGGCuLqO2pl+v65nLq2eGGUxroJ5hEARHq2gzysWvRKDtpTsjQFVmN2tD9tf4fl33nIEMuFMbNH67STOdyHRDoWCZFx6urwk7X4WdiABdzKxr/1Dwrzq44k+t5Au+Gb5lCmvF7aBGLnJ9IsBXyR9c2xoYirY6//1ehdT00y2o6TFNMjZZvU39/Ip717cmgpvzrFMNeCZ7NOcMgLX4UwsQoXQvA6EeNs4+3PIWh0wztYAx/eQg=="}'
+        body: '{"key_id":"50ed0b96-d717-4deb-a9e7-f57d7b563903","signature":"G3jeEoVOTWQas9kWm6mVnYWAqoZIGI7aDIhhND2wtnta5X4GK9jU5t6EIpA4LH+fp5LQr36eZiRuxZcmogMeIe/ZYkqgSBNstbmwMcF8pYDzo0rXqtuQUX/H4dOIphJTVT1Brzdx+NAEmQr7PGa/fDsRuk7iDKId5VMleYC8l2TeKM6vsknCeumqka6670liQxaUSbgt5ltMDCAyTkXPgX2TLBceP6lJYONUePQLTgO2f8Pb/NxJDYhu+cDe1qtxBeRx3anBT/RjooN4IOWjeHgebkh7FO8g8HbRN3sp8Vc9lI+6gu5XbllcaaM2hcg6RqqVMeQjw/MT53TcghCMDQ=="}'
         headers:
             Content-Length:
                 - "408"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:19 GMT
+                - Tue, 07 Jul 2026 07:46:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 53e2a72b-3f4f-4046-bddf-f8a1f9686b4c
+                - 466c7fb7-b440-4fe7-924c-fc5ee356819d
         status: 200 OK
         code: 200
-        duration: 246.666266ms
+        duration: 112.977787ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -212,34 +212,34 @@ interactions:
         proto_minor: 1
         content_length: 496
         host: api.scaleway.com
-        body: '{"data":"Rnpyc0xpR2o3RmtGM0ljTHduQ2FMS2JZcmdTcC9HdzR6TWE5dVRTdlU5czNUcWZvc2c4QVNiVHp6N1luQi9YSXZ3d0VzaE5jWkNlTHQ1NUpUejdKVEZRQlBobGZEZkJSbzljVkdpR0dDdUxxTzJwbCt2NjVuTHEyZUdHVXhyb0o1aEVBUkhxMmd6eXNXdlJLRHRwVHNqUUZWbU4ydEQ5dGY0ZmwzM25JRU11Rk1iTkg2N1NUT2R5SFJEb1dDWkZ4NnVyd2s3WDRXZGlBQmR6S3hyLzFEd3J6cTQ0ayt0NUF1K0diNWxDbXZGN2FCR0xuSjlJc0JYeVI5YzJ4b1lpclk2Ly8xZWhkVDAweTJvNlRGTk1qWlp2VTM5L0lwNzE3Y21ncHZ6ckZNTmVDWjdOT2NNZ0xYNFV3c1FvWFF2QTZFZU5zNCszUElXaDB3enRZQXgvZVFnPT0=","description":"version1"}'
+        body: '{"data":"RzNqZUVvVk9UV1FhczlrV202bVZuWVdBcW9aSUdJN2FESWhoTkQyd3RudGE1WDRHSzlqVTV0NkVJcEE0TEgrZnA1TFFyMzZlWmlSdXhaY21vZ01lSWUvWllrcWdTQk5zdGJtd01jRjhwWUR6bzByWHF0dVFVWC9INGRPSXBoSlRWVDFCcnpkeCtOQUVtUXI3UEdhL2ZEc1J1azdpREtJZDVWTWxlWUM4bDJUZUtNNnZza25DZXVtcWthNjY3MGxpUXhhVVNiZ3Q1bHRNRENBeVRrWFBnWDJUTEJjZVA2bEpZT05VZVBRTFRnTzJmOFBiL054SkRZaHUrY0RlMXF0eEJlUngzYW5CVC9Sam9vTjRJT1dqZUhnZWJraDdGTzhnOEhiUk4zc3A4VmM5bEkrNmd1NVhibGxjYWFNMmhjZzZScXFWTWVRancvTVQ1M1RjZ2hDTURRPT0=","description":"version1"}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8353536d-27ba-4e9d-bcf7-4d29355a1a29/versions
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ff937fa7-da7f-4f59-813b-e81210767820/versions
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"8353536d-27ba-4e9d-bcf7-4d29355a1a29","status":"enabled","created_at":"2026-07-03T15:28:20.211273Z","updated_at":"2026-07-03T15:28:20.211273Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"ff937fa7-da7f-4f59-813b-e81210767820","status":"enabled","created_at":"2026-07-07T07:46:08.897132Z","updated_at":"2026-07-07T07:46:08.897132Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:20 GMT
+                - Tue, 07 Jul 2026 07:46:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - e227b879-ae52-4e25-852f-e88cf99e547d
+                - 22b833ac-7532-4d6d-ba90-aacf92d4d59f
         status: 200 OK
         code: 200
-        duration: 384.075358ms
+        duration: 414.696964ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -250,28 +250,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8353536d-27ba-4e9d-bcf7-4d29355a1a29/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ff937fa7-da7f-4f59-813b-e81210767820/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"8353536d-27ba-4e9d-bcf7-4d29355a1a29","status":"enabled","created_at":"2026-07-03T15:28:20.211273Z","updated_at":"2026-07-03T15:28:20.211273Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"ff937fa7-da7f-4f59-813b-e81210767820","status":"enabled","created_at":"2026-07-07T07:46:08.897132Z","updated_at":"2026-07-07T07:46:08.897132Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:20 GMT
+                - Tue, 07 Jul 2026 07:46:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 86bea314-f6be-4cab-bf95-2c77fd2a6b1f
+                - e1c0fe9a-fadf-49bd-b7c1-a07c1f758416
         status: 200 OK
         code: 200
-        duration: 48.525273ms
+        duration: 48.444984ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -282,28 +282,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8353536d-27ba-4e9d-bcf7-4d29355a1a29/versions/1/access
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ff937fa7-da7f-4f59-813b-e81210767820/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 569
-        body: '{"secret_id":"8353536d-27ba-4e9d-bcf7-4d29355a1a29","revision":1,"data":"Rnpyc0xpR2o3RmtGM0ljTHduQ2FMS2JZcmdTcC9HdzR6TWE5dVRTdlU5czNUcWZvc2c4QVNiVHp6N1luQi9YSXZ3d0VzaE5jWkNlTHQ1NUpUejdKVEZRQlBobGZEZkJSbzljVkdpR0dDdUxxTzJwbCt2NjVuTHEyZUdHVXhyb0o1aEVBUkhxMmd6eXNXdlJLRHRwVHNqUUZWbU4ydEQ5dGY0ZmwzM25JRU11Rk1iTkg2N1NUT2R5SFJEb1dDWkZ4NnVyd2s3WDRXZGlBQmR6S3hyLzFEd3J6cTQ0ayt0NUF1K0diNWxDbXZGN2FCR0xuSjlJc0JYeVI5YzJ4b1lpclk2Ly8xZWhkVDAweTJvNlRGTk1qWlp2VTM5L0lwNzE3Y21ncHZ6ckZNTmVDWjdOT2NNZ0xYNFV3c1FvWFF2QTZFZU5zNCszUElXaDB3enRZQXgvZVFnPT0=","data_crc32":null,"type":"opaque"}'
+        body: '{"secret_id":"ff937fa7-da7f-4f59-813b-e81210767820","revision":1,"data":"RzNqZUVvVk9UV1FhczlrV202bVZuWVdBcW9aSUdJN2FESWhoTkQyd3RudGE1WDRHSzlqVTV0NkVJcEE0TEgrZnA1TFFyMzZlWmlSdXhaY21vZ01lSWUvWllrcWdTQk5zdGJtd01jRjhwWUR6bzByWHF0dVFVWC9INGRPSXBoSlRWVDFCcnpkeCtOQUVtUXI3UEdhL2ZEc1J1azdpREtJZDVWTWxlWUM4bDJUZUtNNnZza25DZXVtcWthNjY3MGxpUXhhVVNiZ3Q1bHRNRENBeVRrWFBnWDJUTEJjZVA2bEpZT05VZVBRTFRnTzJmOFBiL054SkRZaHUrY0RlMXF0eEJlUngzYW5CVC9Sam9vTjRJT1dqZUhnZWJraDdGTzhnOEhiUk4zc3A4VmM5bEkrNmd1NVhibGxjYWFNMmhjZzZScXFWTWVRancvTVQ1M1RjZ2hDTURRPT0=","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
                 - "569"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:20 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - fafa41bb-0b3e-4663-bca5-b801ab38b214
+                - d0de06a3-abcb-4d3d-9f9a-0743afc4ffe1
         status: 200 OK
         code: 200
-        duration: 71.373148ms
+        duration: 96.083049ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -314,28 +314,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8353536d-27ba-4e9d-bcf7-4d29355a1a29/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ff937fa7-da7f-4f59-813b-e81210767820/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"8353536d-27ba-4e9d-bcf7-4d29355a1a29","status":"enabled","created_at":"2026-07-03T15:28:20.211273Z","updated_at":"2026-07-03T15:28:20.211273Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"ff937fa7-da7f-4f59-813b-e81210767820","status":"enabled","created_at":"2026-07-07T07:46:08.897132Z","updated_at":"2026-07-07T07:46:08.897132Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:20 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 7d579a2f-87b1-40fc-b65e-10999d323f2f
+                - ecf725d3-ae46-4977-a9fc-a223829920b6
         status: 200 OK
         code: 200
-        duration: 37.237332ms
+        duration: 40.053873ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -349,28 +349,28 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/1157fe98-a66f-4fbc-803c-30a07685869e/sign
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/50ed0b96-d717-4deb-a9e7-f57d7b563903/sign
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 408
-        body: '{"key_id":"1157fe98-a66f-4fbc-803c-30a07685869e","signature":"kywbmZtY1X0MWRRup8DvYdHAetUHFWewRkameYz561DH6hIx981ErqzlqlnbNCVnc0sEug2IM9YE3ZAui/WpQt6E3XgT8pqPOAQOvF0KePa/W64ahVlm+KfX907C09k0O/NrNEIXxuyvfhYtJYQX1i0DMRn6OF2qv3tmMHx9onxH19QYcuYZZDPFpaRsa/sLZfjcRhgrn+tGamMwtrcwweW3vI+vLHMgs4NNLUH0nudf496rTAhxZRg1IJbvsm6FQuKkHcRNRzqwCRl9nkM0f4TQT2b3cebuoUDcOZYl1uKzFBtcxPYWLl7+/8u0rg/MzuV+0V9xK70ocMhuo6w3fA=="}'
+        body: '{"key_id":"50ed0b96-d717-4deb-a9e7-f57d7b563903","signature":"D7a5+96ziNzqjFQj8y10vPOvzkZ3MNAqgjY2JCEdWFCdZRWsrqXLAYxViUBMPoxzOvtdTvKxZhNKCrF6TmMaauqIe0WbNfbWBF5MelCVFcp/gLHnOD5D6btLPVwp432nkFBQ9qLouT+8oNYEoeN8cKRgmj/hTflx3K07ZeN/+BCruwBggSD5aTDfO0F62NI9eDCoy9N4lZ28jv0Y7mFWd+0jxFRhuBbVYFpTJC28DRpcBrHji7EX0oG6RTX0/R2CX1llwYXRcT+5YpqsGmZnSEAa/H8LZbI64lv/XcyC+MsX2EXen3PS8MoRHpPyg/vehNup86gusq4H5BF7waoRpw=="}'
         headers:
             Content-Length:
                 - "408"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:20 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - d65c9be6-4b07-493d-815c-4efb008e76f3
+                - 6b0a621f-c29e-4d44-b170-cef3b0ca8e7d
         status: 200 OK
         code: 200
-        duration: 98.808359ms
+        duration: 100.659909ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -381,28 +381,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8353536d-27ba-4e9d-bcf7-4d29355a1a29/versions/1/access
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ff937fa7-da7f-4f59-813b-e81210767820/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 569
-        body: '{"secret_id":"8353536d-27ba-4e9d-bcf7-4d29355a1a29","revision":1,"data":"Rnpyc0xpR2o3RmtGM0ljTHduQ2FMS2JZcmdTcC9HdzR6TWE5dVRTdlU5czNUcWZvc2c4QVNiVHp6N1luQi9YSXZ3d0VzaE5jWkNlTHQ1NUpUejdKVEZRQlBobGZEZkJSbzljVkdpR0dDdUxxTzJwbCt2NjVuTHEyZUdHVXhyb0o1aEVBUkhxMmd6eXNXdlJLRHRwVHNqUUZWbU4ydEQ5dGY0ZmwzM25JRU11Rk1iTkg2N1NUT2R5SFJEb1dDWkZ4NnVyd2s3WDRXZGlBQmR6S3hyLzFEd3J6cTQ0ayt0NUF1K0diNWxDbXZGN2FCR0xuSjlJc0JYeVI5YzJ4b1lpclk2Ly8xZWhkVDAweTJvNlRGTk1qWlp2VTM5L0lwNzE3Y21ncHZ6ckZNTmVDWjdOT2NNZ0xYNFV3c1FvWFF2QTZFZU5zNCszUElXaDB3enRZQXgvZVFnPT0=","data_crc32":null,"type":"opaque"}'
+        body: '{"secret_id":"ff937fa7-da7f-4f59-813b-e81210767820","revision":1,"data":"RzNqZUVvVk9UV1FhczlrV202bVZuWVdBcW9aSUdJN2FESWhoTkQyd3RudGE1WDRHSzlqVTV0NkVJcEE0TEgrZnA1TFFyMzZlWmlSdXhaY21vZ01lSWUvWllrcWdTQk5zdGJtd01jRjhwWUR6bzByWHF0dVFVWC9INGRPSXBoSlRWVDFCcnpkeCtOQUVtUXI3UEdhL2ZEc1J1azdpREtJZDVWTWxlWUM4bDJUZUtNNnZza25DZXVtcWthNjY3MGxpUXhhVVNiZ3Q1bHRNRENBeVRrWFBnWDJUTEJjZVA2bEpZT05VZVBRTFRnTzJmOFBiL054SkRZaHUrY0RlMXF0eEJlUngzYW5CVC9Sam9vTjRJT1dqZUhnZWJraDdGTzhnOEhiUk4zc3A4VmM5bEkrNmd1NVhibGxjYWFNMmhjZzZScXFWTWVRancvTVQ1M1RjZ2hDTURRPT0=","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
                 - "569"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:20 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 3ae7bf10-d99d-448c-8dca-d2d8e40ca6be
+                - 05ef30c3-bcec-48e0-9d72-18ded7c52f16
         status: 200 OK
         code: 200
-        duration: 45.094781ms
+        duration: 122.482526ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -413,28 +413,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8353536d-27ba-4e9d-bcf7-4d29355a1a29/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ff937fa7-da7f-4f59-813b-e81210767820/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"8353536d-27ba-4e9d-bcf7-4d29355a1a29","status":"enabled","created_at":"2026-07-03T15:28:20.211273Z","updated_at":"2026-07-03T15:28:20.211273Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"ff937fa7-da7f-4f59-813b-e81210767820","status":"enabled","created_at":"2026-07-07T07:46:08.897132Z","updated_at":"2026-07-07T07:46:08.897132Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:20 GMT
+                - Tue, 07 Jul 2026 07:46:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 40e604bf-c592-4cb3-beb2-bebe8c6fa785
+                - 19ad7b7c-a37f-4632-9cd6-a11e8d173b99
         status: 200 OK
         code: 200
-        duration: 39.225667ms
+        duration: 46.129444ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -445,28 +445,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/1157fe98-a66f-4fbc-803c-30a07685869e
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/50ed0b96-d717-4deb-a9e7-f57d7b563903
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 528
-        body: '{"id":"1157fe98-a66f-4fbc-803c-30a07685869e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-sign-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-03T15:28:19.410788Z","updated_at":"2026-07-03T15:28:19.523205Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.523205Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
+        body: '{"id":"50ed0b96-d717-4deb-a9e7-f57d7b563903","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-sign-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-07-07T07:46:08.258877Z","updated_at":"2026-07-07T07:46:08.309258Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:08.309258Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "528"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - a8957b08-903b-4f83-91ec-c5a6cf9f7e4c
+                - b1c5c2f1-0a6c-46c0-bbe9-18f420232c3a
         status: 200 OK
         code: 200
-        duration: 59.663024ms
+        duration: 53.464428ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -477,28 +477,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8353536d-27ba-4e9d-bcf7-4d29355a1a29
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ff937fa7-da7f-4f59-813b-e81210767820
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 430
-        body: '{"id":"8353536d-27ba-4e9d-bcf7-4d29355a1a29","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-sign-secret","status":"ready","created_at":"2026-07-03T15:28:18.835051Z","updated_at":"2026-07-03T15:28:18.835051Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"ff937fa7-da7f-4f59-813b-e81210767820","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-sign-secret","status":"ready","created_at":"2026-07-07T07:46:08.278576Z","updated_at":"2026-07-07T07:46:08.278576Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "430"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 8d4a001f-4f8c-4305-9e43-9eef8283627a
+                - 38bc4fdc-7875-48ec-bc75-ca09f9d3e593
         status: 200 OK
         code: 200
-        duration: 59.609173ms
+        duration: 53.579517ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -512,28 +512,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8353536d-27ba-4e9d-bcf7-4d29355a1a29/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ff937fa7-da7f-4f59-813b-e81210767820/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 333
-        body: '{"versions":[{"revision":1,"secret_id":"8353536d-27ba-4e9d-bcf7-4d29355a1a29","status":"enabled","created_at":"2026-07-03T15:28:20.211273Z","updated_at":"2026-07-03T15:28:20.211273Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
+        body: '{"versions":[{"revision":1,"secret_id":"ff937fa7-da7f-4f59-813b-e81210767820","status":"enabled","created_at":"2026-07-07T07:46:08.897132Z","updated_at":"2026-07-07T07:46:08.897132Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "333"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 6a59041c-2198-4314-8ab5-04c0b82322bd
+                - c0423655-5025-4d76-87cf-2260a4bee47c
         status: 200 OK
         code: 200
-        duration: 52.599276ms
+        duration: 50.985959ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -547,28 +547,28 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/1157fe98-a66f-4fbc-803c-30a07685869e/sign
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/50ed0b96-d717-4deb-a9e7-f57d7b563903/sign
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 408
-        body: '{"key_id":"1157fe98-a66f-4fbc-803c-30a07685869e","signature":"gA4u3RlMXo2GDO4bVdDgLhLSNxy6HVxVprdnBXYOAxPK4wLQ83LFI4ritnzZJj00KkEycJ8iVyozMLvS3f8n5BUd0Yl5JOubmTAHiQWBDjN/9rTrT4RmkdFEM6dSQXdF7gRZ5Y3p2KHRFjXDM4MscmoWsl6VWFr37Pp6Hea92eUzwd/0ZuADMGtuVAEdKB6yro0a9fKghHksBqK8hrsb741RzmjvctTftVWxa3v0bxoszLTvXPReDNb10VXw7X7YNFgIJDh4t3f/Pcdx6zfC83f1HG0/Xx+dwfuaaM124jwfX/27IMsRU6i9gB7P0UeZ7rCcQAMrcRtFTiyjXDhbMg=="}'
+        body: '{"key_id":"50ed0b96-d717-4deb-a9e7-f57d7b563903","signature":"VVB6d66ITVpMoa4eBPZgqdiASNoQzLM/DHpz6doHaSL4BfR7jUxNbwiuUR7DYQhUFp5nV+ZTu7WaKFcGr4zp3nCmytmm/VvPeys9J8ucGY3SA2Xz3YgoFHvbyc4NgEGeh1F1hL+4uyHsf5lTOS1RXNEnXYxqrrdBty1HtRBFrTZz7CpkAD51Z/1kr8J2D8t3Hstv9V+0ALrcAfNFBTbVpksqMxtzFwBCaW7YXwznFt9gTt9j1AqZoEQpExgSB9en4kXnhaZxseP4Af447C+aNg9RofFW1Dj/N5KUZQeTG3iB2Ml4iKQjGdPQOf///W3oKWtTI2549ppgVaytr6BuRQ=="}'
         headers:
             Content-Length:
                 - "408"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - ffe949fd-109e-4752-a387-b7cb22db4f85
+                - a7164aab-6e5e-47ef-af50-2cf8186395cd
         status: 200 OK
         code: 200
-        duration: 49.880118ms
+        duration: 212.940546ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -579,28 +579,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8353536d-27ba-4e9d-bcf7-4d29355a1a29/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ff937fa7-da7f-4f59-813b-e81210767820/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"8353536d-27ba-4e9d-bcf7-4d29355a1a29","status":"enabled","created_at":"2026-07-03T15:28:20.211273Z","updated_at":"2026-07-03T15:28:20.211273Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"ff937fa7-da7f-4f59-813b-e81210767820","status":"enabled","created_at":"2026-07-07T07:46:08.897132Z","updated_at":"2026-07-07T07:46:08.897132Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 113392c7-9d5b-413b-9794-b0b06fe2b95b
+                - 4321b534-be99-4786-a0e1-f1a021b48884
         status: 200 OK
         code: 200
-        duration: 43.380321ms
+        duration: 44.690442ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -611,28 +611,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8353536d-27ba-4e9d-bcf7-4d29355a1a29/versions/1/access
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ff937fa7-da7f-4f59-813b-e81210767820/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 569
-        body: '{"secret_id":"8353536d-27ba-4e9d-bcf7-4d29355a1a29","revision":1,"data":"Rnpyc0xpR2o3RmtGM0ljTHduQ2FMS2JZcmdTcC9HdzR6TWE5dVRTdlU5czNUcWZvc2c4QVNiVHp6N1luQi9YSXZ3d0VzaE5jWkNlTHQ1NUpUejdKVEZRQlBobGZEZkJSbzljVkdpR0dDdUxxTzJwbCt2NjVuTHEyZUdHVXhyb0o1aEVBUkhxMmd6eXNXdlJLRHRwVHNqUUZWbU4ydEQ5dGY0ZmwzM25JRU11Rk1iTkg2N1NUT2R5SFJEb1dDWkZ4NnVyd2s3WDRXZGlBQmR6S3hyLzFEd3J6cTQ0ayt0NUF1K0diNWxDbXZGN2FCR0xuSjlJc0JYeVI5YzJ4b1lpclk2Ly8xZWhkVDAweTJvNlRGTk1qWlp2VTM5L0lwNzE3Y21ncHZ6ckZNTmVDWjdOT2NNZ0xYNFV3c1FvWFF2QTZFZU5zNCszUElXaDB3enRZQXgvZVFnPT0=","data_crc32":null,"type":"opaque"}'
+        body: '{"secret_id":"ff937fa7-da7f-4f59-813b-e81210767820","revision":1,"data":"RzNqZUVvVk9UV1FhczlrV202bVZuWVdBcW9aSUdJN2FESWhoTkQyd3RudGE1WDRHSzlqVTV0NkVJcEE0TEgrZnA1TFFyMzZlWmlSdXhaY21vZ01lSWUvWllrcWdTQk5zdGJtd01jRjhwWUR6bzByWHF0dVFVWC9INGRPSXBoSlRWVDFCcnpkeCtOQUVtUXI3UEdhL2ZEc1J1azdpREtJZDVWTWxlWUM4bDJUZUtNNnZza25DZXVtcWthNjY3MGxpUXhhVVNiZ3Q1bHRNRENBeVRrWFBnWDJUTEJjZVA2bEpZT05VZVBRTFRnTzJmOFBiL054SkRZaHUrY0RlMXF0eEJlUngzYW5CVC9Sam9vTjRJT1dqZUhnZWJraDdGTzhnOEhiUk4zc3A4VmM5bEkrNmd1NVhibGxjYWFNMmhjZzZScXFWTWVRancvTVQ1M1RjZ2hDTURRPT0=","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
                 - "569"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 81804942-7409-4fdc-94cd-ad11b1678714
+                - 1d26241e-e204-458a-afde-4d4421fc94f3
         status: 200 OK
         code: 200
-        duration: 135.940654ms
+        duration: 53.244639ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -643,28 +643,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8353536d-27ba-4e9d-bcf7-4d29355a1a29/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ff937fa7-da7f-4f59-813b-e81210767820/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 302
-        body: '{"revision":1,"secret_id":"8353536d-27ba-4e9d-bcf7-4d29355a1a29","status":"enabled","created_at":"2026-07-03T15:28:20.211273Z","updated_at":"2026-07-03T15:28:20.211273Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        body: '{"revision":1,"secret_id":"ff937fa7-da7f-4f59-813b-e81210767820","status":"enabled","created_at":"2026-07-07T07:46:08.897132Z","updated_at":"2026-07-07T07:46:08.897132Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "302"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:21 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 615fbfc5-7630-4c83-b18c-93e68acbaeb7
+                - b7a168bf-b6db-4589-b4a9-41400fa0cb23
         status: 200 OK
         code: 200
-        duration: 54.559307ms
+        duration: 43.430269ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -675,7 +675,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8353536d-27ba-4e9d-bcf7-4d29355a1a29/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ff937fa7-da7f-4f59-813b-e81210767820/versions/1
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -687,14 +687,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:22 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 5e715a05-d947-4fe9-9d54-8387db9b467d
+                - 70b9ef23-0d92-44dc-9ba8-ccd8bc64ec03
         status: 204 No Content
         code: 204
-        duration: 63.390114ms
+        duration: 114.827877ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -705,7 +705,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8353536d-27ba-4e9d-bcf7-4d29355a1a29
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ff937fa7-da7f-4f59-813b-e81210767820
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -717,14 +717,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:22 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - bab2bb39-80d8-435f-aad5-9f314c78c932
+                - 2f8414dc-4a03-4c98-8631-c9776c0dab34
         status: 204 No Content
         code: 204
-        duration: 64.633539ms
+        duration: 61.391052ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -735,7 +735,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/1157fe98-a66f-4fbc-803c-30a07685869e
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/50ed0b96-d717-4deb-a9e7-f57d7b563903
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -747,14 +747,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:22 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - c763d436-de39-4a81-9459-5412aff63967
+                - 616aea67-c45f-44f7-ba81-8bad0696f5de
         status: 204 No Content
         code: 204
-        duration: 69.855719ms
+        duration: 108.851165ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -765,28 +765,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/1157fe98-a66f-4fbc-803c-30a07685869e
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/50ed0b96-d717-4deb-a9e7-f57d7b563903
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 568
-        body: '{"id":"1157fe98-a66f-4fbc-803c-30a07685869e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-sign-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-03T15:28:19.410788Z","updated_at":"2026-07-03T15:28:22.228189Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-03T15:28:19.523205Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-03T15:28:22.228188Z","protection_level":"software","region":"fr-par"}'
+        body: '{"id":"50ed0b96-d717-4deb-a9e7-f57d7b563903","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-sign-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-07-07T07:46:08.258877Z","updated_at":"2026-07-07T07:46:10.836700Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-07-07T07:46:08.309258Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-07-07T07:46:10.836700Z","protection_level":"software","region":"fr-par"}'
         headers:
             Content-Length:
                 - "568"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:22 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - d6e0d42b-eb83-48e4-83d2-848273969167
+                - 9e31c5bd-5955-453e-96aa-c78fd6adcd56
         status: 200 OK
         code: 200
-        duration: 47.090089ms
+        duration: 52.88194ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -797,25 +797,25 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/8353536d-27ba-4e9d-bcf7-4d29355a1a29
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/ff937fa7-da7f-4f59-813b-e81210767820
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 455
-        body: '{"id":"8353536d-27ba-4e9d-bcf7-4d29355a1a29","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-sign-secret","status":"ready","created_at":"2026-07-03T15:28:18.835051Z","updated_at":"2026-07-03T15:28:22.227522Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-07-03T15:28:22.227522Z","key_id":null,"region":"fr-par"}'
+        body: '{"id":"ff937fa7-da7f-4f59-813b-e81210767820","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-sign-secret","status":"ready","created_at":"2026-07-07T07:46:08.278576Z","updated_at":"2026-07-07T07:46:10.788945Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-07-07T07:46:10.788945Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "455"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Jul 2026 15:28:22 GMT
+                - Tue, 07 Jul 2026 07:46:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 7b3eec99-49dc-46e7-9c89-b9d218476df2
+                - d8cc0248-63f7-482c-914f-9abe5a38fbc0
         status: 200 OK
         code: 200
-        duration: 35.594056ms
+        duration: 46.969741ms

--- a/internal/services/object/testdata/s3-bucket-server-side-encryption-configuration-kms-with-key.cassette.yaml
+++ b/internal/services/object/testdata/s3-bucket-server-side-encryption-configuration-kms-with-key.cassette.yaml
@@ -6,19 +6,19 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 300
+        content_length: 254
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"project_id":"4d333544-41be-4b0b-8907-0b9036859747","name":"my-kms-key-tf-test","usage":{"asymmetric_encryption":"rsa_oaep_4096_sha256"},"description":"This key is used to encrypt bucket objects","tags":null,"unprotected":true,"origin":"unknown_origin","protection_level":"unknown_protection_level"}'
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"my-kms-key-tf-test","usage":{"asymmetric_encryption":"rsa_oaep_4096_sha256"},"description":"This key is used to encrypt bucket objects","tags":null,"unprotected":true,"origin":"unknown_origin"}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys
         method: POST
       response:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 590
+        content_length: 574
         uncompressed: false
-        body: '{"created_at":"2026-06-19T15:55:45.380971Z","deletion_requested_at":null,"description":"This key is used to encrypt bucket objects","id":"10f50f38-da6e-49b4-bdc9-026a48c01c2c","locked":false,"name":"my-kms-key-tf-test","origin":"scaleway_kms","project_id":"4d333544-41be-4b0b-8907-0b9036859747","protected":false,"protection_level":"unknown_protection_level","region":"fr-par","rotated_at":"2026-06-19T15:55:46.154902Z","rotation_count":1,"rotation_policy":null,"state":"enabled","tags":[],"updated_at":"2026-06-19T15:55:46.154902Z","usage":{"asymmetric_encryption":"rsa_oaep_4096_sha256"}}'
+        body: '{"created_at":"2026-07-07T07:47:23.355753Z","deletion_requested_at":null,"description":"This key is used to encrypt bucket objects","id":"ec82cc34-b95a-4460-9982-6bcdc2f6e62d","locked":false,"name":"my-kms-key-tf-test","origin":"scaleway_kms","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"protection_level":"software","region":"fr-par","rotated_at":"2026-07-07T07:47:23.791485Z","rotation_count":1,"rotation_policy":null,"state":"enabled","tags":[],"updated_at":"2026-07-07T07:47:23.791485Z","usage":{"asymmetric_encryption":"rsa_oaep_4096_sha256"}}'
         headers:
             Content-Length:
-                - "590"
+                - "574"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 19 Jun 2026 15:55:46 GMT
+                - Tue, 07 Jul 2026 07:47:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7925d5fd-d50b-45c4-9784-4dc73f0bcbef
+                - 57280f7e-b6e0-487f-82b0-b059792dfa7d
         status: 200 OK
         code: 200
-        duration: 1.041166625s
+        duration: 770.219369ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,8 +67,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/10f50f38-da6e-49b4-bdc9-026a48c01c2c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/ec82cc34-b95a-4460-9982-6bcdc2f6e62d
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 590
+        content_length: 574
         uncompressed: false
-        body: '{"created_at":"2026-06-19T15:55:45.380971Z","deletion_requested_at":null,"description":"This key is used to encrypt bucket objects","id":"10f50f38-da6e-49b4-bdc9-026a48c01c2c","locked":false,"name":"my-kms-key-tf-test","origin":"scaleway_kms","project_id":"4d333544-41be-4b0b-8907-0b9036859747","protected":false,"protection_level":"unknown_protection_level","region":"fr-par","rotated_at":"2026-06-19T15:55:46.154902Z","rotation_count":1,"rotation_policy":null,"state":"enabled","tags":[],"updated_at":"2026-06-19T15:55:46.154902Z","usage":{"asymmetric_encryption":"rsa_oaep_4096_sha256"}}'
+        body: '{"created_at":"2026-07-07T07:47:23.355753Z","deletion_requested_at":null,"description":"This key is used to encrypt bucket objects","id":"ec82cc34-b95a-4460-9982-6bcdc2f6e62d","locked":false,"name":"my-kms-key-tf-test","origin":"scaleway_kms","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"protection_level":"software","region":"fr-par","rotated_at":"2026-07-07T07:47:23.791485Z","rotation_count":1,"rotation_policy":null,"state":"enabled","tags":[],"updated_at":"2026-07-07T07:47:23.791485Z","usage":{"asymmetric_encryption":"rsa_oaep_4096_sha256"}}'
         headers:
             Content-Length:
-                - "590"
+                - "574"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 19 Jun 2026 15:55:46 GMT
+                - Tue, 07 Jul 2026 07:47:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 605dc962-c746-4e23-aa33-f692179277ac
+                - d0e995c5-810f-41c2-a839-96483ff4283b
         status: 200 OK
         code: 200
-        duration: 43.719ms
+        duration: 102.606472ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -109,7 +109,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: sse-config-basic-7847572103153094311.s3.nl-ams.scw.cloud
+        host: sse-config-basic-6692275151688570271.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -118,16 +118,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e28aea1e-3e6a-4905-88f2-70af18fdf002
+                - 7158b7ef-6c00-407f-b506-8e916adbab86
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.101.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.42.1 ua/2.1 os/linux lang/go#1.26.0 md/GOOS#linux md/GOARCH#amd64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260619T155545Z
-        url: https://sse-config-basic-7847572103153094311.s3.nl-ams.scw.cloud/
+                - 20260707T074723Z
+        url: https://sse-config-basic-6692275151688570271.s3.nl-ams.scw.cloud/
         method: PUT
       response:
         proto: HTTP/2.0
@@ -142,16 +142,16 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Fri, 19 Jun 2026 15:55:45 GMT
+                - Tue, 07 Jul 2026 07:47:23 GMT
             Location:
-                - /sse-config-basic-7847572103153094311
+                - /sse-config-basic-6692275151688570271
             X-Amz-Id-2:
-                - txg9b2444bc6e144db5b48e-006a356681
+                - txg5ec10de35ab447328996-006a4caf0b
             X-Amz-Request-Id:
-                - txg9b2444bc6e144db5b48e-006a356681
+                - txg5ec10de35ab447328996-006a4caf0b
         status: 200 OK
         code: 200
-        duration: 4.824327541s
+        duration: 4.701466437s
     - id: 3
       request:
         proto: HTTP/1.1
@@ -160,7 +160,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: sse-config-basic-7847572103153094311.s3.nl-ams.scw.cloud
+        host: sse-config-basic-6692275151688570271.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -169,11 +169,11 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e6453ca0-438c-462c-9510-6f62e825dd15
+                - 547b1ee4-9e0a-4d05-8323-749540438f59
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.101.0 terraform-provider-scaleway/develop m/E,Z,e
+                - aws-sdk-go-v2/1.42.1 ua/2.1 os/linux lang/go#1.26.0 md/GOOS#linux md/GOARCH#amd64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,Z,e
             X-Amz-Acl:
                 - private
             X-Amz-Checksum-Crc32:
@@ -181,8 +181,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260619T155549Z
-        url: https://sse-config-basic-7847572103153094311.s3.nl-ams.scw.cloud/?acl=
+                - 20260707T074727Z
+        url: https://sse-config-basic-6692275151688570271.s3.nl-ams.scw.cloud/?acl=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -197,14 +197,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Fri, 19 Jun 2026 15:55:50 GMT
+                - Tue, 07 Jul 2026 07:47:27 GMT
             X-Amz-Id-2:
-                - txg7515682762964947a027-006a356686
+                - txgf2481863c4d8443c8991-006a4caf0f
             X-Amz-Request-Id:
-                - txg7515682762964947a027-006a356686
+                - txgf2481863c4d8443c8991-006a4caf0f
         status: 200 OK
         code: 200
-        duration: 115.201625ms
+        duration: 285.889034ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -213,7 +213,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: sse-config-basic-7847572103153094311.s3.nl-ams.scw.cloud
+        host: sse-config-basic-6692275151688570271.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -222,16 +222,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 86db3979-05a1-47df-b013-7ae7e63e135b
+                - b74a9d31-2fc0-480d-b24a-2ee94da6272c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.101.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.42.1 ua/2.1 os/linux lang/go#1.26.0 md/GOOS#linux md/GOARCH#amd64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260619T155550Z
-        url: https://sse-config-basic-7847572103153094311.s3.nl-ams.scw.cloud/?acl=
+                - 20260707T074728Z
+        url: https://sse-config-basic-6692275151688570271.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -243,21 +243,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Fri, 19 Jun 2026 15:55:50 GMT
+                - Tue, 07 Jul 2026 07:47:28 GMT
             X-Amz-Id-2:
-                - txg4d5c278771e64d85927f-006a356686
+                - txgfffbc6a8dad040629a01-006a4caf10
             X-Amz-Request-Id:
-                - txg4d5c278771e64d85927f-006a356686
+                - txgfffbc6a8dad040629a01-006a4caf10
         status: 200 OK
         code: 200
-        duration: 56.047375ms
+        duration: 106.323166ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -266,7 +266,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: sse-config-basic-7847572103153094311.s3.nl-ams.scw.cloud
+        host: sse-config-basic-6692275151688570271.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -275,16 +275,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 54ada26e-8dcd-4f75-8a61-6ce49119e1a0
+                - ab43d1ce-5c62-4b10-a8df-c6d83c81e638
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.101.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.42.1 ua/2.1 os/linux lang/go#1.26.0 md/GOOS#linux md/GOARCH#amd64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260619T155550Z
-        url: https://sse-config-basic-7847572103153094311.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260707T074728Z
+        url: https://sse-config-basic-6692275151688570271.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -294,21 +294,21 @@ interactions:
         trailer: {}
         content_length: 305
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgbe9e6ddafe2b4830b4a9-006a356686</RequestId><HostId>txgbe9e6ddafe2b4830b4a9-006a356686</HostId><Resource>/sse-config-basic-7847572103153094311</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txge2454593823f49bab809-006a4caf10</RequestId><HostId>txge2454593823f49bab809-006a4caf10</HostId><Resource>/sse-config-basic-6692275151688570271</Resource></Error>
         headers:
             Content-Length:
                 - "305"
             Content-Type:
                 - application/xml
             Date:
-                - Fri, 19 Jun 2026 15:55:50 GMT
+                - Tue, 07 Jul 2026 07:47:28 GMT
             X-Amz-Id-2:
-                - txgbe9e6ddafe2b4830b4a9-006a356686
+                - txge2454593823f49bab809-006a4caf10
             X-Amz-Request-Id:
-                - txgbe9e6ddafe2b4830b4a9-006a356686
+                - txge2454593823f49bab809-006a4caf10
         status: 404 Not Found
         code: 404
-        duration: 39.179125ms
+        duration: 135.065444ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -317,7 +317,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: sse-config-basic-7847572103153094311.s3.nl-ams.scw.cloud
+        host: sse-config-basic-6692275151688570271.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -326,16 +326,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 093cf4f3-03a2-4355-8e7f-f286c6399625
+                - c5da6835-c99c-4f4e-8249-aa87e5a5ade4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.101.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.42.1 ua/2.1 os/linux lang/go#1.26.0 md/GOOS#linux md/GOARCH#amd64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260619T155550Z
-        url: https://sse-config-basic-7847572103153094311.s3.nl-ams.scw.cloud/
+                - 20260707T074728Z
+        url: https://sse-config-basic-6692275151688570271.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -347,21 +347,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>sse-config-basic-7847572103153094311</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>sse-config-basic-6692275151688570271</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "262"
             Content-Type:
                 - application/xml
             Date:
-                - Fri, 19 Jun 2026 15:55:50 GMT
+                - Tue, 07 Jul 2026 07:47:28 GMT
             X-Amz-Id-2:
-                - txg25c0e8f5ca0b425bbbe5-006a356686
+                - txg5506832151c046efbf69-006a4caf10
             X-Amz-Request-Id:
-                - txg25c0e8f5ca0b425bbbe5-006a356686
+                - txg5506832151c046efbf69-006a4caf10
         status: 200 OK
         code: 200
-        duration: 119.988167ms
+        duration: 449.334023ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -370,7 +370,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: sse-config-basic-7847572103153094311.s3.nl-ams.scw.cloud
+        host: sse-config-basic-6692275151688570271.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -379,16 +379,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 2d271245-171b-4fec-9660-a4b89e381eb3
+                - a44a4e94-d8fb-44d3-a830-5668ff718263
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.101.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.42.1 ua/2.1 os/linux lang/go#1.26.0 md/GOOS#linux md/GOARCH#amd64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260619T155550Z
-        url: https://sse-config-basic-7847572103153094311.s3.nl-ams.scw.cloud/?tagging=
+                - 20260707T074728Z
+        url: https://sse-config-basic-6692275151688570271.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -398,21 +398,21 @@ interactions:
         trailer: {}
         content_length: 311
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgb4ad55e236a7425bb266-006a356686</RequestId><HostId>txgb4ad55e236a7425bb266-006a356686</HostId><Resource>/sse-config-basic-7847572103153094311</Resource><BucketName>sse-config-basic-7847572103153094311</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgb3b2a8f78ecb4a6b9aed-006a4caf10</RequestId><HostId>txgb3b2a8f78ecb4a6b9aed-006a4caf10</HostId><Resource>/sse-config-basic-6692275151688570271</Resource><BucketName>sse-config-basic-6692275151688570271</BucketName></Error>
         headers:
             Content-Length:
                 - "311"
             Content-Type:
                 - application/xml
             Date:
-                - Fri, 19 Jun 2026 15:55:50 GMT
+                - Tue, 07 Jul 2026 07:47:28 GMT
             X-Amz-Id-2:
-                - txgb4ad55e236a7425bb266-006a356686
+                - txgb3b2a8f78ecb4a6b9aed-006a4caf10
             X-Amz-Request-Id:
-                - txgb4ad55e236a7425bb266-006a356686
+                - txgb3b2a8f78ecb4a6b9aed-006a4caf10
         status: 404 Not Found
         code: 404
-        duration: 63.271375ms
+        duration: 171.381197ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -421,7 +421,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: sse-config-basic-7847572103153094311.s3.nl-ams.scw.cloud
+        host: sse-config-basic-6692275151688570271.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -430,16 +430,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 39cef66f-bc89-4ddd-95a9-dda4f5993149
+                - ee65d75e-abfb-4e86-ad95-2a9473d27c1c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.101.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.42.1 ua/2.1 os/linux lang/go#1.26.0 md/GOOS#linux md/GOARCH#amd64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260619T155550Z
-        url: https://sse-config-basic-7847572103153094311.s3.nl-ams.scw.cloud/?cors=
+                - 20260707T074728Z
+        url: https://sse-config-basic-6692275151688570271.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -449,21 +449,21 @@ interactions:
         trailer: {}
         content_length: 273
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg9a284567c8e44c95b07c-006a356686</RequestId><HostId>txg9a284567c8e44c95b07c-006a356686</HostId><Resource>/sse-config-basic-7847572103153094311</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgf441782e0ca34fb58999-006a4caf11</RequestId><HostId>txgf441782e0ca34fb58999-006a4caf11</HostId><Resource>/sse-config-basic-6692275151688570271</Resource></Error>
         headers:
             Content-Length:
                 - "273"
             Content-Type:
                 - application/xml
             Date:
-                - Fri, 19 Jun 2026 15:55:50 GMT
+                - Tue, 07 Jul 2026 07:47:29 GMT
             X-Amz-Id-2:
-                - txg9a284567c8e44c95b07c-006a356686
+                - txgf441782e0ca34fb58999-006a4caf11
             X-Amz-Request-Id:
-                - txg9a284567c8e44c95b07c-006a356686
+                - txgf441782e0ca34fb58999-006a4caf11
         status: 404 Not Found
         code: 404
-        duration: 72.231875ms
+        duration: 188.672558ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -472,7 +472,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: sse-config-basic-7847572103153094311.s3.nl-ams.scw.cloud
+        host: sse-config-basic-6692275151688570271.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -481,16 +481,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - bd5ea16f-47d0-452e-8194-9892c4548ed3
+                - 303deb58-304c-402a-a1b1-3e351e000710
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.101.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.42.1 ua/2.1 os/linux lang/go#1.26.0 md/GOOS#linux md/GOARCH#amd64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260619T155550Z
-        url: https://sse-config-basic-7847572103153094311.s3.nl-ams.scw.cloud/?versioning=
+                - 20260707T074729Z
+        url: https://sse-config-basic-6692275151688570271.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -509,14 +509,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Fri, 19 Jun 2026 15:55:50 GMT
+                - Tue, 07 Jul 2026 07:47:29 GMT
             X-Amz-Id-2:
-                - txg89e8235dc75f431fb7a8-006a356686
+                - txg51cfa0e06e2b40d091d9-006a4caf11
             X-Amz-Request-Id:
-                - txg89e8235dc75f431fb7a8-006a356686
+                - txg51cfa0e06e2b40d091d9-006a4caf11
         status: 200 OK
         code: 200
-        duration: 52.165084ms
+        duration: 172.418043ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -525,7 +525,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: sse-config-basic-7847572103153094311.s3.nl-ams.scw.cloud
+        host: sse-config-basic-6692275151688570271.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -534,16 +534,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - df1f5156-221b-4cc1-9655-2c3e24fd68e1
+                - 744824d8-8fc8-496c-b310-469cf0660aa3
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.101.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.42.1 ua/2.1 os/linux lang/go#1.26.0 md/GOOS#linux md/GOARCH#amd64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260619T155550Z
-        url: https://sse-config-basic-7847572103153094311.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260707T074729Z
+        url: https://sse-config-basic-6692275151688570271.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -553,21 +553,21 @@ interactions:
         trailer: {}
         content_length: 344
         uncompressed: false
-        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txgb2a8f49eb9c44c809db7-006a356686</RequestId><HostId>txgb2a8f49eb9c44c809db7-006a356686</HostId><Resource>/sse-config-basic-7847572103153094311</Resource><BucketName>sse-config-basic-7847572103153094311</BucketName></Error>
+        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txg65fbbbcb63df42099202-006a4caf11</RequestId><HostId>txg65fbbbcb63df42099202-006a4caf11</HostId><Resource>/sse-config-basic-6692275151688570271</Resource><BucketName>sse-config-basic-6692275151688570271</BucketName></Error>
         headers:
             Content-Length:
                 - "344"
             Content-Type:
                 - application/xml
             Date:
-                - Fri, 19 Jun 2026 15:55:50 GMT
+                - Tue, 07 Jul 2026 07:47:29 GMT
             X-Amz-Id-2:
-                - txgb2a8f49eb9c44c809db7-006a356686
+                - txg65fbbbcb63df42099202-006a4caf11
             X-Amz-Request-Id:
-                - txgb2a8f49eb9c44c809db7-006a356686
+                - txg65fbbbcb63df42099202-006a4caf11
         status: 404 Not Found
         code: 404
-        duration: 20.611833ms
+        duration: 118.019824ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -576,7 +576,7 @@ interactions:
         content_length: 333
         transfer_encoding: []
         trailer: {}
-        host: sse-config-basic-7847572103153094311.s3.nl-ams.scw.cloud
+        host: sse-config-basic-6692275151688570271.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: <ServerSideEncryptionConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><ApplyServerSideEncryptionByDefault><KMSMasterKeyID>my-kms-key-tf-test</KMSMasterKeyID><SSEAlgorithm>aws:kms</SSEAlgorithm></ApplyServerSideEncryptionByDefault><BucketKeyEnabled>true</BucketKeyEnabled></Rule></ServerSideEncryptionConfiguration>
@@ -585,20 +585,20 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d757e80f-de13-4828-b732-6bd9597df94b
+                - 5c8e338d-d7ee-4e87-acb8-db7e6d90754f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
                 - application/xml
             User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.101.0 terraform-provider-scaleway/develop m/E,Z,e
+                - aws-sdk-go-v2/1.42.1 ua/2.1 os/linux lang/go#1.26.0 md/GOOS#linux md/GOARCH#amd64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,Z,e
             X-Amz-Checksum-Crc32:
                 - Dsnpvg==
             X-Amz-Content-Sha256:
                 - c8601d21d2f7d1343a002c48d359ee52d679b61b1e3517b16acc4a4a9f206ab3
             X-Amz-Date:
-                - 20260619T155550Z
-        url: https://sse-config-basic-7847572103153094311.s3.nl-ams.scw.cloud/?encryption=
+                - 20260707T074729Z
+        url: https://sse-config-basic-6692275151688570271.s3.nl-ams.scw.cloud/?encryption=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -613,14 +613,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Fri, 19 Jun 2026 15:55:50 GMT
+                - Tue, 07 Jul 2026 07:47:29 GMT
             X-Amz-Id-2:
-                - txge1a4f9740da8426d812b-006a356686
+                - txg530d556b1c58417fa110-006a4caf11
             X-Amz-Request-Id:
-                - txge1a4f9740da8426d812b-006a356686
+                - txg530d556b1c58417fa110-006a4caf11
         status: 200 OK
         code: 200
-        duration: 97.003042ms
+        duration: 200.22094ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -629,7 +629,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: sse-config-basic-7847572103153094311.s3.nl-ams.scw.cloud
+        host: sse-config-basic-6692275151688570271.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -638,16 +638,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 20d28892-e6e0-47aa-949f-5dcd7d71a886
+                - f4bd6c5e-f3b1-4db9-a472-989124a2b196
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.101.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.42.1 ua/2.1 os/linux lang/go#1.26.0 md/GOOS#linux md/GOARCH#amd64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260619T155550Z
-        url: https://sse-config-basic-7847572103153094311.s3.nl-ams.scw.cloud/?encryption=
+                - 20260707T074729Z
+        url: https://sse-config-basic-6692275151688570271.s3.nl-ams.scw.cloud/?encryption=
         method: GET
       response:
         proto: HTTP/2.0
@@ -666,14 +666,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Fri, 19 Jun 2026 15:55:50 GMT
+                - Tue, 07 Jul 2026 07:47:29 GMT
             X-Amz-Id-2:
-                - txgc1eb733faf504de9bc9c-006a356686
+                - txge1ea03632b264b688a89-006a4caf11
             X-Amz-Request-Id:
-                - txgc1eb733faf504de9bc9c-006a356686
+                - txge1ea03632b264b688a89-006a4caf11
         status: 200 OK
         code: 200
-        duration: 106.521083ms
+        duration: 97.698322ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -682,7 +682,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: sse-config-basic-7847572103153094311.s3.nl-ams.scw.cloud
+        host: sse-config-basic-6692275151688570271.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -691,16 +691,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 8dd2574d-f076-4c6f-83d8-c0295988d54c
+                - 825eca51-980a-46be-ac19-ec090b221f6e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.101.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.42.1 ua/2.1 os/linux lang/go#1.26.0 md/GOOS#linux md/GOARCH#amd64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260619T155550Z
-        url: https://sse-config-basic-7847572103153094311.s3.nl-ams.scw.cloud/?encryption=
+                - 20260707T074729Z
+        url: https://sse-config-basic-6692275151688570271.s3.nl-ams.scw.cloud/?encryption=
         method: GET
       response:
         proto: HTTP/2.0
@@ -719,14 +719,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Fri, 19 Jun 2026 15:55:50 GMT
+                - Tue, 07 Jul 2026 07:47:29 GMT
             X-Amz-Id-2:
-                - txg1e81202b7a694ea39565-006a356686
+                - txg73e3478c1e0e4c03848d-006a4caf11
             X-Amz-Request-Id:
-                - txg1e81202b7a694ea39565-006a356686
+                - txg73e3478c1e0e4c03848d-006a4caf11
         status: 200 OK
         code: 200
-        duration: 53.111833ms
+        duration: 31.399534ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -735,7 +735,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: sse-config-basic-7847572103153094311.s3.nl-ams.scw.cloud
+        host: sse-config-basic-6692275151688570271.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -744,16 +744,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 8610e05a-c905-459a-81fb-85f36bdfbe56
+                - b2aaed7f-039f-49cd-b8d9-7b5e76bb83ea
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.101.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.42.1 ua/2.1 os/linux lang/go#1.26.0 md/GOOS#linux md/GOARCH#amd64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260619T155550Z
-        url: https://sse-config-basic-7847572103153094311.s3.nl-ams.scw.cloud/?acl=
+                - 20260707T074729Z
+        url: https://sse-config-basic-6692275151688570271.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -765,21 +765,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Fri, 19 Jun 2026 15:55:50 GMT
+                - Tue, 07 Jul 2026 07:47:29 GMT
             X-Amz-Id-2:
-                - txg3bf7bd0e59a3443c8d05-006a356686
+                - txg77ea032febbb45619ae0-006a4caf11
             X-Amz-Request-Id:
-                - txg3bf7bd0e59a3443c8d05-006a356686
+                - txg77ea032febbb45619ae0-006a4caf11
         status: 200 OK
         code: 200
-        duration: 65.724959ms
+        duration: 208.494614ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -788,7 +788,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: sse-config-basic-7847572103153094311.s3.nl-ams.scw.cloud
+        host: sse-config-basic-6692275151688570271.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -797,16 +797,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d52e0459-4244-4591-a06a-a10358981a05
+                - 847f5533-896d-42ca-b30e-0256a667aa46
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.101.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.42.1 ua/2.1 os/linux lang/go#1.26.0 md/GOOS#linux md/GOARCH#amd64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260619T155550Z
-        url: https://sse-config-basic-7847572103153094311.s3.nl-ams.scw.cloud/?encryption=
+                - 20260707T074730Z
+        url: https://sse-config-basic-6692275151688570271.s3.nl-ams.scw.cloud/?encryption=
         method: GET
       response:
         proto: HTTP/2.0
@@ -825,14 +825,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Fri, 19 Jun 2026 15:55:51 GMT
+                - Tue, 07 Jul 2026 07:47:30 GMT
             X-Amz-Id-2:
-                - txg43faf40eb4ca4c569429-006a356687
+                - txgef691dcaa3c34bd2ac32-006a4caf12
             X-Amz-Request-Id:
-                - txg43faf40eb4ca4c569429-006a356687
+                - txgef691dcaa3c34bd2ac32-006a4caf12
         status: 200 OK
         code: 200
-        duration: 123.916709ms
+        duration: 209.30679ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -848,8 +848,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/10f50f38-da6e-49b4-bdc9-026a48c01c2c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/ec82cc34-b95a-4460-9982-6bcdc2f6e62d
         method: GET
       response:
         proto: HTTP/2.0
@@ -857,20 +857,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 590
+        content_length: 574
         uncompressed: false
-        body: '{"created_at":"2026-06-19T15:55:45.380971Z","deletion_requested_at":null,"description":"This key is used to encrypt bucket objects","id":"10f50f38-da6e-49b4-bdc9-026a48c01c2c","locked":false,"name":"my-kms-key-tf-test","origin":"scaleway_kms","project_id":"4d333544-41be-4b0b-8907-0b9036859747","protected":false,"protection_level":"unknown_protection_level","region":"fr-par","rotated_at":"2026-06-19T15:55:46.154902Z","rotation_count":1,"rotation_policy":null,"state":"enabled","tags":[],"updated_at":"2026-06-19T15:55:46.154902Z","usage":{"asymmetric_encryption":"rsa_oaep_4096_sha256"}}'
+        body: '{"created_at":"2026-07-07T07:47:23.355753Z","deletion_requested_at":null,"description":"This key is used to encrypt bucket objects","id":"ec82cc34-b95a-4460-9982-6bcdc2f6e62d","locked":false,"name":"my-kms-key-tf-test","origin":"scaleway_kms","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"protection_level":"software","region":"fr-par","rotated_at":"2026-07-07T07:47:23.791485Z","rotation_count":1,"rotation_policy":null,"state":"enabled","tags":[],"updated_at":"2026-07-07T07:47:23.791485Z","usage":{"asymmetric_encryption":"rsa_oaep_4096_sha256"}}'
         headers:
             Content-Length:
-                - "590"
+                - "574"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 19 Jun 2026 15:55:51 GMT
+                - Tue, 07 Jul 2026 07:47:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -878,10 +878,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f7d5f1d5-7637-4457-a34c-7995eefd8125
+                - a1944681-9008-4826-a28c-5b6c5ac985cd
         status: 200 OK
         code: 200
-        duration: 102.268042ms
+        duration: 111.205607ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -890,7 +890,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: sse-config-basic-7847572103153094311.s3.nl-ams.scw.cloud
+        host: sse-config-basic-6692275151688570271.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -899,16 +899,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - bd55cc3c-08fb-4b4e-9a6d-76b25e6042ed
+                - c014fd2e-3b99-4197-890b-6ef204629ac4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.101.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.42.1 ua/2.1 os/linux lang/go#1.26.0 md/GOOS#linux md/GOARCH#amd64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260619T155551Z
-        url: https://sse-config-basic-7847572103153094311.s3.nl-ams.scw.cloud/?acl=
+                - 20260707T074730Z
+        url: https://sse-config-basic-6692275151688570271.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -920,21 +920,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Fri, 19 Jun 2026 15:55:51 GMT
+                - Tue, 07 Jul 2026 07:47:30 GMT
             X-Amz-Id-2:
-                - txg63cc55bcb5dd4fffbbde-006a356687
+                - txg10bb4d90517a46bd936a-006a4caf12
             X-Amz-Request-Id:
-                - txg63cc55bcb5dd4fffbbde-006a356687
+                - txg10bb4d90517a46bd936a-006a4caf12
         status: 200 OK
         code: 200
-        duration: 108.456041ms
+        duration: 283.406609ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -943,7 +943,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: sse-config-basic-7847572103153094311.s3.nl-ams.scw.cloud
+        host: sse-config-basic-6692275151688570271.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -952,16 +952,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6df1bf36-fcb9-4852-858c-50b442655808
+                - e0014d03-7203-4410-908c-090c7de387d2
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.101.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.42.1 ua/2.1 os/linux lang/go#1.26.0 md/GOOS#linux md/GOARCH#amd64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260619T155551Z
-        url: https://sse-config-basic-7847572103153094311.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260707T074730Z
+        url: https://sse-config-basic-6692275151688570271.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -971,21 +971,21 @@ interactions:
         trailer: {}
         content_length: 305
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg437bec2925704455892d-006a356687</RequestId><HostId>txg437bec2925704455892d-006a356687</HostId><Resource>/sse-config-basic-7847572103153094311</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgf6d6bdefd90343aca718-006a4caf12</RequestId><HostId>txgf6d6bdefd90343aca718-006a4caf12</HostId><Resource>/sse-config-basic-6692275151688570271</Resource></Error>
         headers:
             Content-Length:
                 - "305"
             Content-Type:
                 - application/xml
             Date:
-                - Fri, 19 Jun 2026 15:55:51 GMT
+                - Tue, 07 Jul 2026 07:47:30 GMT
             X-Amz-Id-2:
-                - txg437bec2925704455892d-006a356687
+                - txgf6d6bdefd90343aca718-006a4caf12
             X-Amz-Request-Id:
-                - txg437bec2925704455892d-006a356687
+                - txgf6d6bdefd90343aca718-006a4caf12
         status: 404 Not Found
         code: 404
-        duration: 37.950292ms
+        duration: 293.24803ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -994,7 +994,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: sse-config-basic-7847572103153094311.s3.nl-ams.scw.cloud
+        host: sse-config-basic-6692275151688570271.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1003,16 +1003,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 1c348cc7-ac5b-4027-9b5c-018395612981
+                - 4c5405cc-b89f-448a-bd1a-a89db6ec0a86
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.101.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.42.1 ua/2.1 os/linux lang/go#1.26.0 md/GOOS#linux md/GOARCH#amd64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260619T155551Z
-        url: https://sse-config-basic-7847572103153094311.s3.nl-ams.scw.cloud/
+                - 20260707T074730Z
+        url: https://sse-config-basic-6692275151688570271.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -1024,21 +1024,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>sse-config-basic-7847572103153094311</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>sse-config-basic-6692275151688570271</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "262"
             Content-Type:
                 - application/xml
             Date:
-                - Fri, 19 Jun 2026 15:55:51 GMT
+                - Tue, 07 Jul 2026 07:47:31 GMT
             X-Amz-Id-2:
-                - txga03d71bf4eb44d7d9131-006a356687
+                - txgdeb9a15499de4820acd6-006a4caf13
             X-Amz-Request-Id:
-                - txga03d71bf4eb44d7d9131-006a356687
+                - txgdeb9a15499de4820acd6-006a4caf13
         status: 200 OK
         code: 200
-        duration: 74.938125ms
+        duration: 256.499017ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1047,7 +1047,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: sse-config-basic-7847572103153094311.s3.nl-ams.scw.cloud
+        host: sse-config-basic-6692275151688570271.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1056,16 +1056,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - cf2f5565-1431-4576-a638-cc390fac1c87
+                - 7b3cf3ec-3078-4004-ac73-0857b988a827
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.101.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.42.1 ua/2.1 os/linux lang/go#1.26.0 md/GOOS#linux md/GOARCH#amd64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260619T155551Z
-        url: https://sse-config-basic-7847572103153094311.s3.nl-ams.scw.cloud/?tagging=
+                - 20260707T074731Z
+        url: https://sse-config-basic-6692275151688570271.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1075,21 +1075,21 @@ interactions:
         trailer: {}
         content_length: 311
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgc6b179c8caf94571b21c-006a356687</RequestId><HostId>txgc6b179c8caf94571b21c-006a356687</HostId><Resource>/sse-config-basic-7847572103153094311</Resource><BucketName>sse-config-basic-7847572103153094311</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgb1cfe468855b4cb299b4-006a4caf13</RequestId><HostId>txgb1cfe468855b4cb299b4-006a4caf13</HostId><Resource>/sse-config-basic-6692275151688570271</Resource><BucketName>sse-config-basic-6692275151688570271</BucketName></Error>
         headers:
             Content-Length:
                 - "311"
             Content-Type:
                 - application/xml
             Date:
-                - Fri, 19 Jun 2026 15:55:51 GMT
+                - Tue, 07 Jul 2026 07:47:31 GMT
             X-Amz-Id-2:
-                - txgc6b179c8caf94571b21c-006a356687
+                - txgb1cfe468855b4cb299b4-006a4caf13
             X-Amz-Request-Id:
-                - txgc6b179c8caf94571b21c-006a356687
+                - txgb1cfe468855b4cb299b4-006a4caf13
         status: 404 Not Found
         code: 404
-        duration: 88.943041ms
+        duration: 88.971351ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1098,7 +1098,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: sse-config-basic-7847572103153094311.s3.nl-ams.scw.cloud
+        host: sse-config-basic-6692275151688570271.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1107,16 +1107,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b8c9d201-55b6-48ad-b648-bb528555ac35
+                - cabf2970-a8ad-4bd7-a050-b4611116385d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.101.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.42.1 ua/2.1 os/linux lang/go#1.26.0 md/GOOS#linux md/GOARCH#amd64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260619T155551Z
-        url: https://sse-config-basic-7847572103153094311.s3.nl-ams.scw.cloud/?cors=
+                - 20260707T074731Z
+        url: https://sse-config-basic-6692275151688570271.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1126,21 +1126,21 @@ interactions:
         trailer: {}
         content_length: 273
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg1dcdf1dcc7ea4f8a9562-006a356687</RequestId><HostId>txg1dcdf1dcc7ea4f8a9562-006a356687</HostId><Resource>/sse-config-basic-7847572103153094311</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg76430750fb7a4537a28e-006a4caf13</RequestId><HostId>txg76430750fb7a4537a28e-006a4caf13</HostId><Resource>/sse-config-basic-6692275151688570271</Resource></Error>
         headers:
             Content-Length:
                 - "273"
             Content-Type:
                 - application/xml
             Date:
-                - Fri, 19 Jun 2026 15:55:51 GMT
+                - Tue, 07 Jul 2026 07:47:31 GMT
             X-Amz-Id-2:
-                - txg1dcdf1dcc7ea4f8a9562-006a356687
+                - txg76430750fb7a4537a28e-006a4caf13
             X-Amz-Request-Id:
-                - txg1dcdf1dcc7ea4f8a9562-006a356687
+                - txg76430750fb7a4537a28e-006a4caf13
         status: 404 Not Found
         code: 404
-        duration: 50.352875ms
+        duration: 78.322819ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1149,7 +1149,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: sse-config-basic-7847572103153094311.s3.nl-ams.scw.cloud
+        host: sse-config-basic-6692275151688570271.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1158,16 +1158,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 766598e6-c5e1-4b72-96d0-bd35e7b78a32
+                - 99d09dc9-9ea8-41ef-8041-a7e25958b802
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.101.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.42.1 ua/2.1 os/linux lang/go#1.26.0 md/GOOS#linux md/GOARCH#amd64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260619T155551Z
-        url: https://sse-config-basic-7847572103153094311.s3.nl-ams.scw.cloud/?versioning=
+                - 20260707T074731Z
+        url: https://sse-config-basic-6692275151688570271.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1186,14 +1186,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Fri, 19 Jun 2026 15:55:51 GMT
+                - Tue, 07 Jul 2026 07:47:31 GMT
             X-Amz-Id-2:
-                - txgab0f42c022264f4bb084-006a356687
+                - txg973f8b43f04e45958d50-006a4caf13
             X-Amz-Request-Id:
-                - txgab0f42c022264f4bb084-006a356687
+                - txg973f8b43f04e45958d50-006a4caf13
         status: 200 OK
         code: 200
-        duration: 53.710708ms
+        duration: 130.009088ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1202,7 +1202,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: sse-config-basic-7847572103153094311.s3.nl-ams.scw.cloud
+        host: sse-config-basic-6692275151688570271.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1211,16 +1211,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - dfa3b6bf-d334-4512-a9f6-82f88650f866
+                - 5b11cc4f-26f0-472c-9e5b-6451cff78431
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.101.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.42.1 ua/2.1 os/linux lang/go#1.26.0 md/GOOS#linux md/GOARCH#amd64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260619T155551Z
-        url: https://sse-config-basic-7847572103153094311.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260707T074731Z
+        url: https://sse-config-basic-6692275151688570271.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1230,21 +1230,21 @@ interactions:
         trailer: {}
         content_length: 344
         uncompressed: false
-        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txgeca3755aa3f94a7e9ac2-006a356687</RequestId><HostId>txgeca3755aa3f94a7e9ac2-006a356687</HostId><Resource>/sse-config-basic-7847572103153094311</Resource><BucketName>sse-config-basic-7847572103153094311</BucketName></Error>
+        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txg5f47b82c1ca14c158e62-006a4caf13</RequestId><HostId>txg5f47b82c1ca14c158e62-006a4caf13</HostId><Resource>/sse-config-basic-6692275151688570271</Resource><BucketName>sse-config-basic-6692275151688570271</BucketName></Error>
         headers:
             Content-Length:
                 - "344"
             Content-Type:
                 - application/xml
             Date:
-                - Fri, 19 Jun 2026 15:55:51 GMT
+                - Tue, 07 Jul 2026 07:47:31 GMT
             X-Amz-Id-2:
-                - txgeca3755aa3f94a7e9ac2-006a356687
+                - txg5f47b82c1ca14c158e62-006a4caf13
             X-Amz-Request-Id:
-                - txgeca3755aa3f94a7e9ac2-006a356687
+                - txg5f47b82c1ca14c158e62-006a4caf13
         status: 404 Not Found
         code: 404
-        duration: 69.041542ms
+        duration: 108.391615ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1253,7 +1253,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: sse-config-basic-7847572103153094311.s3.nl-ams.scw.cloud
+        host: sse-config-basic-6692275151688570271.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1262,16 +1262,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 31e41f0c-2b2d-402e-ae31-2e0355a2d96a
+                - 1732ee84-1c75-4daa-9b64-a0942f029e3e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.101.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.42.1 ua/2.1 os/linux lang/go#1.26.0 md/GOOS#linux md/GOARCH#amd64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260619T155551Z
-        url: https://sse-config-basic-7847572103153094311.s3.nl-ams.scw.cloud/?encryption=
+                - 20260707T074731Z
+        url: https://sse-config-basic-6692275151688570271.s3.nl-ams.scw.cloud/?encryption=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1290,14 +1290,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Fri, 19 Jun 2026 15:55:51 GMT
+                - Tue, 07 Jul 2026 07:47:31 GMT
             X-Amz-Id-2:
-                - txg1148b0a4107a4d58936a-006a356687
+                - txg8482d38598024190a56a-006a4caf13
             X-Amz-Request-Id:
-                - txg1148b0a4107a4d58936a-006a356687
+                - txg8482d38598024190a56a-006a4caf13
         status: 200 OK
         code: 200
-        duration: 33.424583ms
+        duration: 195.82128ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1306,7 +1306,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: sse-config-basic-7847572103153094311.s3.nl-ams.scw.cloud
+        host: sse-config-basic-6692275151688570271.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1315,16 +1315,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f8246a77-2d59-4085-9949-ea0d957f7e20
+                - 23ac3b24-da82-40fd-8862-f1b39a1b16ed
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.101.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.42.1 ua/2.1 os/linux lang/go#1.26.0 md/GOOS#linux md/GOARCH#amd64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260619T155551Z
-        url: https://sse-config-basic-7847572103153094311.s3.nl-ams.scw.cloud/?acl=
+                - 20260707T074731Z
+        url: https://sse-config-basic-6692275151688570271.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1336,21 +1336,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Fri, 19 Jun 2026 15:55:51 GMT
+                - Tue, 07 Jul 2026 07:47:32 GMT
             X-Amz-Id-2:
-                - txge477df8b95fe48bba3c7-006a356687
+                - txg1f424b58ae79499297cd-006a4caf14
             X-Amz-Request-Id:
-                - txge477df8b95fe48bba3c7-006a356687
+                - txg1f424b58ae79499297cd-006a4caf14
         status: 200 OK
         code: 200
-        duration: 54.920834ms
+        duration: 255.885993ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1359,7 +1359,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: sse-config-basic-7847572103153094311.s3.nl-ams.scw.cloud
+        host: sse-config-basic-6692275151688570271.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1368,16 +1368,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 97e40802-a0d1-439c-abda-4b40fe6a5640
+                - b7601904-5194-4ab0-a8c7-71be76ddc6c8
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.101.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.42.1 ua/2.1 os/linux lang/go#1.26.0 md/GOOS#linux md/GOARCH#amd64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260619T155552Z
-        url: https://sse-config-basic-7847572103153094311.s3.nl-ams.scw.cloud/?encryption=
+                - 20260707T074732Z
+        url: https://sse-config-basic-6692275151688570271.s3.nl-ams.scw.cloud/?encryption=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1396,14 +1396,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Fri, 19 Jun 2026 15:55:52 GMT
+                - Tue, 07 Jul 2026 07:47:32 GMT
             X-Amz-Id-2:
-                - txg09b6e94572d54e32b80f-006a356688
+                - txgfc626ade81b140f0b0b4-006a4caf14
             X-Amz-Request-Id:
-                - txg09b6e94572d54e32b80f-006a356688
+                - txgfc626ade81b140f0b0b4-006a4caf14
         status: 200 OK
         code: 200
-        duration: 112.132292ms
+        duration: 34.415816ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1412,7 +1412,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: sse-config-basic-7847572103153094311.s3.nl-ams.scw.cloud
+        host: sse-config-basic-6692275151688570271.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1421,16 +1421,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9543fcf5-27c2-44cd-b90a-a3764bdfa10a
+                - a72b70e4-a423-4de6-8f7d-6c812bce8d85
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.101.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.42.1 ua/2.1 os/linux lang/go#1.26.0 md/GOOS#linux md/GOARCH#amd64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260619T155552Z
-        url: https://sse-config-basic-7847572103153094311.s3.nl-ams.scw.cloud/?acl=
+                - 20260707T074732Z
+        url: https://sse-config-basic-6692275151688570271.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1442,21 +1442,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Fri, 19 Jun 2026 15:55:52 GMT
+                - Tue, 07 Jul 2026 07:47:32 GMT
             X-Amz-Id-2:
-                - txg857619e531ea4c698d13-006a356688
+                - txgd04e96c549674f58a16f-006a4caf14
             X-Amz-Request-Id:
-                - txg857619e531ea4c698d13-006a356688
+                - txgd04e96c549674f58a16f-006a4caf14
         status: 200 OK
         code: 200
-        duration: 67.338958ms
+        duration: 109.731772ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1465,7 +1465,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: sse-config-basic-7847572103153094311.s3.nl-ams.scw.cloud
+        host: sse-config-basic-6692275151688570271.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1474,16 +1474,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 8fe550df-4bfd-4522-971c-bdb502a69865
+                - 28b1f22d-0078-49fe-8c0d-5e65bf6c9e78
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.101.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.42.1 ua/2.1 os/linux lang/go#1.26.0 md/GOOS#linux md/GOARCH#amd64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260619T155552Z
-        url: https://sse-config-basic-7847572103153094311.s3.nl-ams.scw.cloud/?encryption=
+                - 20260707T074733Z
+        url: https://sse-config-basic-6692275151688570271.s3.nl-ams.scw.cloud/?encryption=
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1496,14 +1496,14 @@ interactions:
         body: ""
         headers:
             Date:
-                - Fri, 19 Jun 2026 15:55:52 GMT
+                - Tue, 07 Jul 2026 07:47:33 GMT
             X-Amz-Id-2:
-                - txga12fe209548741d5a5f3-006a356688
+                - txg43d7513545f94624a79d-006a4caf15
             X-Amz-Request-Id:
-                - txga12fe209548741d5a5f3-006a356688
+                - txg43d7513545f94624a79d-006a4caf15
         status: 204 No Content
         code: 204
-        duration: 99.479292ms
+        duration: 232.27134ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1519,8 +1519,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/10f50f38-da6e-49b4-bdc9-026a48c01c2c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/ec82cc34-b95a-4460-9982-6bcdc2f6e62d
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1537,9 +1537,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 19 Jun 2026 15:55:52 GMT
+                - Tue, 07 Jul 2026 07:47:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1547,10 +1547,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ef12bd64-e8ac-429b-8bd6-25b41b0f5816
+                - ede357c0-293b-4013-848c-1d32e6dd50ea
         status: 204 No Content
         code: 204
-        duration: 77.344917ms
+        duration: 156.307497ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1559,7 +1559,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: sse-config-basic-7847572103153094311.s3.nl-ams.scw.cloud
+        host: sse-config-basic-6692275151688570271.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1568,16 +1568,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 57994309-63a2-4ff5-b556-498e591a5a54
+                - c8e50361-394d-4d8f-b48b-695513a5d310
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.101.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.42.1 ua/2.1 os/linux lang/go#1.26.0 md/GOOS#linux md/GOARCH#amd64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260619T155552Z
-        url: https://sse-config-basic-7847572103153094311.s3.nl-ams.scw.cloud/
+                - 20260707T074733Z
+        url: https://sse-config-basic-6692275151688570271.s3.nl-ams.scw.cloud/
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1590,11 +1590,11 @@ interactions:
         body: ""
         headers:
             Date:
-                - Fri, 19 Jun 2026 15:55:52 GMT
+                - Tue, 07 Jul 2026 07:47:33 GMT
             X-Amz-Id-2:
-                - txgaa5978a521e54cdcbffa-006a356688
+                - txgf765fdba0f204a92b47f-006a4caf15
             X-Amz-Request-Id:
-                - txgaa5978a521e54cdcbffa-006a356688
+                - txgf765fdba0f204a92b47f-006a4caf15
         status: 204 No Content
         code: 204
-        duration: 236.052334ms
+        duration: 314.818965ms

--- a/internal/services/opensearch/deployment.go
+++ b/internal/services/opensearch/deployment.go
@@ -211,12 +211,14 @@ func resourceDeploymentCreate(ctx context.Context, d *schema.ResourceData, meta 
 		return diag.FromErr(err)
 	}
 
+	nodeCount := uint32(deploymentNodeCountFromConfig(d))
+
 	req := &searchdbapi.CreateDeploymentRequest{
 		Region:    region,
 		ProjectID: d.Get("project_id").(string),
 		Name:      types.ExpandOrGenerateString(d.Get("name"), "opensearch"),
 		Version:   d.Get("version").(string),
-		NodeCount: uint32(deploymentNodeCountFromConfig(d)),
+		NodeCount: &nodeCount,
 		NodeType:  d.Get("node_type").(string),
 	}
 


### PR DESCRIPTION
Bumping sdk go in https://github.com/scaleway/terraform-provider-scaleway/pull/4168/changes introduced a break in opensearch namespace.
This PR bumps the SDK and fixes the opensearch namespace changes, as well as the adding of kms `protection_level`.