### PR TITLE
fix(transport): jittered backoff for API rate limits

### DIFF
--- a/internal/transport/backoff_internal_test.go
+++ b/internal/transport/backoff_internal_test.go
@@ -1,0 +1,132 @@
+package transport
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestParseRetryAfter(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		header  string
+		wantOK  bool
+		want    time.Duration
+		wantMin time.Duration // for date-based values, a lower bound
+	}{
+		{name: "empty", header: "", wantOK: false},
+		{name: "seconds", header: "30", wantOK: true, want: 30 * time.Second},
+		{name: "zero seconds", header: "0", wantOK: true, want: 0},
+		{name: "negative rejected", header: "-5", wantOK: false},
+		{name: "malformed", header: "soon", wantOK: false},
+		{
+			name:    "http date in the future",
+			header:  time.Now().Add(2 * time.Minute).UTC().Format(http.TimeFormat),
+			wantOK:  true,
+			wantMin: time.Minute, // roughly two minutes, allow slack
+		},
+		{
+			name:   "http date in the past",
+			header: time.Now().Add(-2 * time.Minute).UTC().Format(http.TimeFormat),
+			wantOK: true,
+			want:   0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := parseRetryAfter(tt.header)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+
+			if !ok {
+				return
+			}
+
+			if tt.wantMin > 0 {
+				if got < tt.wantMin {
+					t.Fatalf("got %v, want >= %v", got, tt.wantMin)
+				}
+
+				return
+			}
+
+			if got != tt.want {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRateLimitBackoff(t *testing.T) {
+	t.Parallel()
+
+	minWait := 2 * time.Second
+	maxWait := 2 * time.Minute
+
+	t.Run("honors Retry-After over computed backoff", func(t *testing.T) {
+		t.Parallel()
+
+		resp := &http.Response{Header: http.Header{"Retry-After": {"30"}}}
+
+		got := rateLimitBackoff(minWait, maxWait, 0, resp)
+		if got != 30*time.Second {
+			t.Fatalf("got %v, want 30s", got)
+		}
+	})
+
+	t.Run("jittered exponential when no timing header present", func(t *testing.T) {
+		t.Parallel()
+
+		// Scaleway's gateway 429 carries no Retry-After: must fall back to backoff.
+		resp := &http.Response{Header: http.Header{"X-Envoy-Ratelimited": {"true"}}}
+
+		got := rateLimitBackoff(minWait, maxWait, 0, resp)
+		if got < minWait || got > 2*minWait {
+			t.Fatalf("got %v, want within [%v, %v]", got, minWait, 2*minWait)
+		}
+	})
+
+	t.Run("jittered exponential stays within bounds and varies", func(t *testing.T) {
+		t.Parallel()
+
+		seen := map[time.Duration]struct{}{}
+
+		for range 50 {
+			got := rateLimitBackoff(minWait, maxWait, 4, nil)
+			// attempt 4: exponential ceiling is min*2^4 = 32s, capped at maxWait.
+			if got < minWait || got > 32*time.Second {
+				t.Fatalf("got %v, want within [%v, 32s]", got, minWait)
+			}
+
+			seen[got] = struct{}{}
+		}
+
+		if len(seen) < 2 {
+			t.Fatalf("expected jitter to produce varied delays, got %d distinct values", len(seen))
+		}
+	})
+
+	t.Run("caps at maxWait", func(t *testing.T) {
+		t.Parallel()
+
+		got := rateLimitBackoff(minWait, maxWait, 20, nil)
+		if got > maxWait {
+			t.Fatalf("got %v, want <= %v", got, maxWait)
+		}
+	})
+
+	t.Run("zero min does not panic", func(t *testing.T) {
+		t.Parallel()
+
+		got := rateLimitBackoff(0, 0, 3, nil)
+		if got != 0 {
+			t.Fatalf("got %v, want 0", got)
+		}
+	})
+}

--- a/internal/transport/retry.go
+++ b/internal/transport/retry.go
@@ -5,7 +5,10 @@ import (
 	"context"
 	"errors"
 	"io"
+	"math"
+	"math/rand"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
@@ -45,7 +48,7 @@ func NewRetryableTransportWithOptions(defaultTransport http.RoundTripper, option
 	c.HTTPClient = &http.Client{Transport: defaultTransport}
 
 	// Defaults
-	c.RetryMax = 3
+	c.RetryMax = 5
 	c.RetryWaitMax = 2 * time.Minute
 	c.Logger = logging.L
 	c.RetryWaitMin = time.Second * 2
@@ -56,6 +59,7 @@ func NewRetryableTransportWithOptions(defaultTransport http.RoundTripper, option
 
 		return retryablehttp.DefaultRetryPolicy(ctx, resp, err)
 	}
+	c.Backoff = rateLimitBackoff
 
 	// If ErrorHandler is not set, retryablehttp will wrap http errors
 	c.ErrorHandler = func(resp *http.Response, err error, _ int) (*http.Response, error) {
@@ -88,6 +92,66 @@ func NewRetryableTransportWithOptions(defaultTransport http.RoundTripper, option
 // TODO Retry logic should be moved in the SDK
 func NewRetryableTransport(defaultTransport http.RoundTripper) http.RoundTripper {
 	return NewRetryableTransportWithOptions(defaultTransport, RetryableTransportOptions{})
+}
+
+// rateLimitBackoff computes how long to wait before the next retry.
+//
+// Scaleway's API Gateway (Envoy) returns 429 responses carrying no timing
+// guidance whatsoever — only "x-envoy-ratelimited: true", with no Retry-After
+// or X-RateLimit-* headers. So client-side backoff is the only lever we have.
+// The jitter is the important part: Terraform issues many requests concurrently,
+// so without it every throttled request would retry in lock-step and immediately
+// re-trigger the limit (a thundering herd). Retry-After is still honored if
+// present, since some individual product APIs may set it and it is the standard.
+func rateLimitBackoff(minWait, maxWait time.Duration, attemptNum int, resp *http.Response) time.Duration {
+	if resp != nil {
+		// Retry-After (RFC 7231): honored if present, though Scaleway's gateway
+		// does not currently send it on rate-limited responses.
+		if wait, ok := parseRetryAfter(resp.Header.Get("Retry-After")); ok {
+			return wait
+		}
+	}
+
+	// Exponential backoff (minWait * 2^attemptNum), capped at maxWait.
+	backoff := float64(minWait) * math.Pow(2, float64(attemptNum))
+	if backoff > float64(maxWait) || math.IsInf(backoff, 0) {
+		backoff = float64(maxWait)
+	}
+
+	// Full jitter across [minWait, backoff].
+	span := int64(backoff) - int64(minWait)
+	if span <= 0 {
+		return minWait
+	}
+
+	return minWait + time.Duration(rand.Int63n(span))
+}
+
+// parseRetryAfter parses an RFC 7231 Retry-After value: either a number of
+// seconds or an HTTP-date. It returns ok=false when the header is absent or
+// malformed so the caller can fall back to computed backoff.
+func parseRetryAfter(v string) (time.Duration, bool) {
+	if v == "" {
+		return 0, false
+	}
+
+	if secs, err := strconv.ParseInt(v, 10, 64); err == nil {
+		if secs < 0 {
+			return 0, false
+		}
+
+		return time.Duration(secs) * time.Second, true
+	}
+
+	if t, err := http.ParseTime(v); err == nil {
+		if until := time.Until(t); until > 0 {
+			return until, true
+		}
+
+		return 0, true // date already passed: retry immediately
+	}
+
+	return 0, false
 }
 
 // RetryableTransport client is a bridge between scw.httpClient interface and retryablehttp.Client


### PR DESCRIPTION
## Background

We hit sustained HTTP 429 rate limiting from the Scaleway API when applying with Terraform's default concurrency.

While diagnosing, I captured a **real** 429 from the Scaleway API by bursting concurrent read-only requests:

```
HTTP/2 429
x-envoy-ratelimited: true
server: Scaleway API Gateway (fr-par-3;edge03)
```

Scaleway's API Gateway is Envoy-based, and its rate-limit filter returns a bare 429 with **no timing guidance at all** — no `Retry-After`, no `X-RateLimit-*` headers. So header-driven backoff cannot help here; client-side backoff is the only lever.

## Problem

The retry transport left `go-retryablehttp`'s `DefaultBackoff` in place. Its fallback exponential backoff has **no jitter**. Under Terraform's concurrent execution (default `-parallelism=10`), every throttled request backs off in lock-step (2s → 4s → 8s …) and retries at the same instant — a thundering herd that immediately re-triggers the limit.

## Change

- Replace the backoff with a jittered exponential strategy (full jitter across `[min, min*2^n]`, capped at `RetryWaitMax`), wired via `Client.Backoff`. This spreads concurrent retries out and breaks the herd.
- Raise `RetryMax` from 3 to 5 so sustained throttling gets more attempts.
- `Retry-After` is still honored when present (standard, zero cost) in case an individual product API sets it — though the gateway does not.
- Add unit tests covering `Retry-After` parsing, jitter bounds/variance, the `x-envoy-ratelimited` fallback path, the `RetryWaitMax` cap, and zero-min safety.

`go build`, `go vet`, `gofmt`, and the transport tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)