### PR TITLE
docs(contaner): fix probe timeout parameter name

### DIFF
--- a/docs/resources/container.md
+++ b/docs/resources/container.md
@@ -234,7 +234,7 @@ The following arguments are supported:
         - `path` - Path to use for the HTTP health check.
     - `failure_threshold` - Number of consecutive failures before considering the container has to be restarted.
     - `interval`- Time interval between checks (in duration notation, e.g. "30s").
-    - `duration` - Duration before the check times out (in duration notation, e.g. "30s").
+    - `timeout` - Duration before the check times out (in duration notation, e.g. "30s").
 
 - `health_check` - (Deprecated) Health check configuration block of the container.
     - `tcp` - When set to `true`, performs TCP checks on the container.
@@ -251,7 +251,7 @@ The following arguments are supported:
         - `path` - Path to use for the HTTP health check.
     - `failure_threshold` - Number of consecutive failures before considering the container has to be restarted.
     - `interval`- Time interval between checks (in duration notation, e.g. "30s").
-    - `duration` - Duration before the check times out (in duration notation, e.g. "30s").
+    - `timeout` - Duration before the check times out (in duration notation, e.g. "30s").
 
 - `scaling_option` - (Optional) Configuration block used to decide when to scale up or down. Possible values:
     - `concurrent_requests_threshold` - Scale depending on the number of concurrent requests being processed per container instance.

--- a/templates/resources/container.md.tmpl
+++ b/templates/resources/container.md.tmpl
@@ -92,7 +92,7 @@ The following arguments are supported:
         - `path` - Path to use for the HTTP health check.
     - `failure_threshold` - Number of consecutive failures before considering the container has to be restarted.
     - `interval`- Time interval between checks (in duration notation, e.g. "30s").
-    - `duration` - Duration before the check times out (in duration notation, e.g. "30s").
+    - `timeout` - Duration before the check times out (in duration notation, e.g. "30s").
 
 - `health_check` - (Deprecated) Health check configuration block of the container.
     - `tcp` - When set to `true`, performs TCP checks on the container.
@@ -109,7 +109,7 @@ The following arguments are supported:
         - `path` - Path to use for the HTTP health check.
     - `failure_threshold` - Number of consecutive failures before considering the container has to be restarted.
     - `interval`- Time interval between checks (in duration notation, e.g. "30s").
-    - `duration` - Duration before the check times out (in duration notation, e.g. "30s").
+    - `timeout` - Duration before the check times out (in duration notation, e.g. "30s").
 
 - `scaling_option` - (Optional) Configuration block used to decide when to scale up or down. Possible values:
     - `concurrent_requests_threshold` - Scale depending on the number of concurrent requests being processed per container instance.


### PR DESCRIPTION
attribute `duration` results in error.
api docs also mention `timeout`, not `duration`.
https://www.scaleway.com/en/developers/api/serverless-containers/containers#create-a-new-container-in-a-namespace

(i will not followup here, feel free to change things in this PR.)