### PR TITLE
fix(file): increase max filesystem size from 10TB to 50TB

### DIFF
--- a/docs/resources/file_filesystem.md
+++ b/docs/resources/file_filesystem.md
@@ -25,9 +25,9 @@ resource scaleway_file_filesystem file {
 ## Argument Reference
 
 - `name` - (Optional) The name of the filesystem. If not provided, a random name will be generated.
-- `size_in_gb` - (Required) The size of the filesystem in bytes, with a granularity of 100 GB (10¹¹ bytes).
-      - Minimum: 100 GB (100000000000 bytes)
-      - Maximum: 10 TB (10000000000000 bytes)
+- `size_in_gb` - (Required) The size of the filesystem in bytes, with a granularity of 1 GB (10⁹ bytes).
+      - Minimum: 25 GB (25000000000 bytes)
+      - Maximum: 50 TB (50000000000000 bytes)
 - `tags` - (Optional) A list of tags associated with the filesystem.
 - `region` - (Defaults to [provider](../index.md#arguments-reference) `region`) The region where the filesystem will be created (e.g., fr-par, nl-ams).
 - `project_id` - (Defaults to [provider](../index.md#arguments-reference) `project_id`) The ID of the project the server is

--- a/internal/services/file/filesystem.go
+++ b/internal/services/file/filesystem.go
@@ -48,8 +48,8 @@ func fileSystemSchema() map[string]*schema.Schema {
 		"size_in_gb": {
 			Type:         schema.TypeInt,
 			Required:     true,
-			ValidateFunc: validation.IntBetween(25, 10000),
-			Description:  "The filesystem size in GB. Minimum 25GB, maximum 10TB",
+			ValidateFunc: validation.IntBetween(25, 50000),
+			Description:  "The filesystem size in GB. Minimum 25GB, maximum 50TB",
 		},
 		"tags": {
 			Type: schema.TypeList,

--- a/internal/services/file/filesystem_test.go
+++ b/internal/services/file/filesystem_test.go
@@ -78,7 +78,7 @@ func TestAccFileSystem_SizeTooSmallFails(t *testing.T) {
 						size_in_gb = %d
 					}
 				`, fileSystemName, sizeInGB),
-				ExpectError: regexp.MustCompile(`expected size_in_gb to be in the range \(25 - 10000\)`),
+				ExpectError: regexp.MustCompile(`expected size_in_gb to be in the range \(25 - 50000\)`),
 			},
 		},
 	})
@@ -117,7 +117,7 @@ func TestAccFileSystem_SizeTooLargeFails(t *testing.T) {
 	defer tt.Cleanup()
 
 	fileSystemName := "TestAccFileSystem_SizeTooLargeFails"
-	sizeInGB := 10100 // Above 10 TB limit
+	sizeInGB := 50100 // Above 50 TB limit
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: tt.ProviderFactories,
@@ -130,7 +130,7 @@ func TestAccFileSystem_SizeTooLargeFails(t *testing.T) {
 						size_in_gb = %d
 					}
 				`, fileSystemName, sizeInGB),
-				ExpectError: regexp.MustCompile(`expected size_in_gb to be in the range \(25 - 10000\)`),
+				ExpectError: regexp.MustCompile(`expected size_in_gb to be in the range \(25 - 50000\)`),
 			},
 		},
 	})

--- a/templates/resources/file_filesystem.md.tmpl
+++ b/templates/resources/file_filesystem.md.tmpl
@@ -26,9 +26,9 @@ resource scaleway_file_filesystem file {
 ## Argument Reference
 
 - `name` - (Optional) The name of the filesystem. If not provided, a random name will be generated.
-- `size_in_gb` - (Required) The size of the filesystem in bytes, with a granularity of 100 GB (10¹¹ bytes).
-      - Minimum: 100 GB (100000000000 bytes)
-      - Maximum: 10 TB (10000000000000 bytes)
+- `size_in_gb` - (Required) The size of the filesystem in bytes, with a granularity of 1 GB (10⁹ bytes).
+      - Minimum: 25 GB (25000000000 bytes)
+      - Maximum: 50 TB (50000000000000 bytes)
 - `tags` - (Optional) A list of tags associated with the filesystem.
 - `region` - (Defaults to [provider](../index.md#arguments-reference) `region`) The region where the filesystem will be created (e.g., fr-par, nl-ams).
 - `project_id` - (Defaults to [provider](../index.md#arguments-reference) `project_id`) The ID of the project the server is


### PR DESCRIPTION
Increase the maximum allowed `size_in_gb` for `scaleway_file_filesystem` from 10TB to 50TB (allowed range is now 25GB–50TB).                                                                           
                                                                                                     
- Update `size_in_gb` validation to `IntBetween(25, 50000)`                                        
- Update size limit tests accordingly                                                              
- Update `docs/resources/file_filesystem.md` (min 25GB, max 50TB, 1GB granularity)