### PR TITLE
fix(registry): datasource lookups were only using the first page

### DIFF
--- a/internal/services/registry/image_data_source.go
+++ b/internal/services/registry/image_data_source.go
@@ -96,7 +96,7 @@ func DataSourceRegistryImageRead(ctx context.Context, d *schema.ResourceData, m 
 			Name:        types.ExpandStringPtr(imageName),
 			NamespaceID: namespaceID,
 			ProjectID:   types.ExpandStringPtr(d.Get("project_id")),
-		}, scw.WithContext(ctx))
+		}, scw.WithContext(ctx), scw.WithAllPages())
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/internal/services/registry/namespace_data_source.go
+++ b/internal/services/registry/namespace_data_source.go
@@ -47,7 +47,7 @@ func DataSourceNamespaceRead(ctx context.Context, d *schema.ResourceData, m any)
 			Region:    region,
 			Name:      types.ExpandStringPtr(namespaceName),
 			ProjectID: types.ExpandStringPtr(d.Get("project_id")),
-		}, scw.WithContext(ctx))
+		}, scw.WithContext(ctx), scw.WithAllPages())
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/internal/services/registry/tag_data_source.go
+++ b/internal/services/registry/tag_data_source.go
@@ -99,7 +99,7 @@ func DataSourceImageTagRead(ctx context.Context, d *schema.ResourceData, m any) 
 		res, err := api.ListTags(&registry.ListTagsRequest{
 			Region:  region,
 			ImageID: locality.ExpandID(imageID),
-		}, scw.WithContext(ctx))
+		}, scw.WithContext(ctx), scw.WithAllPages())
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/internal/services/registry/testdata/data-source-image-tag-basic.cassette.yaml
+++ b/internal/services/registry/testdata/data-source-image-tag-basic.cassette.yaml
@@ -18,7 +18,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces
         method: POST
       response:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 468
+        content_length: 481
         uncompressed: false
-        body: '{"created_at":"2025-09-05T15:09:08.030212671Z","description":"Test namespace for Docker image","endpoint":"rg.fr-par.scw.cloud/test-namespace-2","id":"5ac57b0d-e658-4cff-935c-a4f99176d116","image_count":0,"is_public":false,"name":"test-namespace-2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":0,"status":"ready","status_message":"","updated_at":"2025-09-05T15:09:08.030212671Z"}'
+        body: '{"created_at":"2026-07-17T09:50:00.553562212Z","description":"Test namespace for Docker image","endpoint":"rg.fr-par.scw.cloud/test-namespace-2","id":"42a09a31-9f99-43aa-931b-6257a16afb1d","image_count":0,"is_public":false,"name":"test-namespace-2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":0,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:00.553562212Z"}'
         headers:
             Content-Length:
-                - "468"
+                - "481"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:08 GMT
+                - Fri, 17 Jul 2026 09:50:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 21ed9ca6-f131-4d33-8dbb-c91587726894
+                - abf24fe7-dd92-486b-aae4-f4cb2df9e92f
         status: 200 OK
         code: 200
-        duration: 666.582959ms
+        duration: 334.168625ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,8 +67,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/5ac57b0d-e658-4cff-935c-a4f99176d116
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/42a09a31-9f99-43aa-931b-6257a16afb1d
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 462
+        content_length: 475
         uncompressed: false
-        body: '{"created_at":"2025-09-05T15:09:08.030213Z","description":"Test namespace for Docker image","endpoint":"rg.fr-par.scw.cloud/test-namespace-2","id":"5ac57b0d-e658-4cff-935c-a4f99176d116","image_count":0,"is_public":false,"name":"test-namespace-2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":0,"status":"ready","status_message":"","updated_at":"2025-09-05T15:09:08.030213Z"}'
+        body: '{"created_at":"2026-07-17T09:50:00.553562Z","description":"Test namespace for Docker image","endpoint":"rg.fr-par.scw.cloud/test-namespace-2","id":"42a09a31-9f99-43aa-931b-6257a16afb1d","image_count":0,"is_public":false,"name":"test-namespace-2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":0,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:00.553562Z"}'
         headers:
             Content-Length:
-                - "462"
+                - "475"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:08 GMT
+                - Fri, 17 Jul 2026 09:50:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 078e5e28-3d0e-4b34-8e3b-e001b582612c
+                - 45e081b2-c78a-4620-b918-e4f5844a20e2
         status: 200 OK
         code: 200
-        duration: 157.66825ms
+        duration: 1.039404429s
     - id: 2
       request:
         proto: HTTP/1.1
@@ -116,8 +116,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/5ac57b0d-e658-4cff-935c-a4f99176d116
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/42a09a31-9f99-43aa-931b-6257a16afb1d
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,20 +125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 462
+        content_length: 475
         uncompressed: false
-        body: '{"created_at":"2025-09-05T15:09:08.030213Z","description":"Test namespace for Docker image","endpoint":"rg.fr-par.scw.cloud/test-namespace-2","id":"5ac57b0d-e658-4cff-935c-a4f99176d116","image_count":0,"is_public":false,"name":"test-namespace-2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":0,"status":"ready","status_message":"","updated_at":"2025-09-05T15:09:08.030213Z"}'
+        body: '{"created_at":"2026-07-17T09:50:00.553562Z","description":"Test namespace for Docker image","endpoint":"rg.fr-par.scw.cloud/test-namespace-2","id":"42a09a31-9f99-43aa-931b-6257a16afb1d","image_count":0,"is_public":false,"name":"test-namespace-2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":0,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:00.553562Z"}'
         headers:
             Content-Length:
-                - "462"
+                - "475"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:08 GMT
+                - Fri, 17 Jul 2026 09:50:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 144ee139-c3de-40e1-be0f-59592cd4cd68
+                - f06509b2-495b-468d-8e90-e18fc91a450b
         status: 200 OK
         code: 200
-        duration: 164.020834ms
+        duration: 292.092379ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -165,8 +165,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/5ac57b0d-e658-4cff-935c-a4f99176d116
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/42a09a31-9f99-43aa-931b-6257a16afb1d
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,20 +174,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 468
+        content_length: 481
         uncompressed: false
-        body: '{"created_at":"2025-09-05T15:09:08.030213Z","description":"Test namespace for Docker image","endpoint":"rg.fr-par.scw.cloud/test-namespace-2","id":"5ac57b0d-e658-4cff-935c-a4f99176d116","image_count":1,"is_public":false,"name":"test-namespace-2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":4131347,"status":"ready","status_message":"","updated_at":"2025-09-05T15:09:23.022873Z"}'
+        body: '{"created_at":"2026-07-17T09:50:00.553562Z","description":"Test namespace for Docker image","endpoint":"rg.fr-par.scw.cloud/test-namespace-2","id":"42a09a31-9f99-43aa-931b-6257a16afb1d","image_count":1,"is_public":false,"name":"test-namespace-2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":3847002,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:08.335288Z"}'
         headers:
             Content-Length:
-                - "468"
+                - "481"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:23 GMT
+                - Fri, 17 Jul 2026 09:50:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,10 +195,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 02cdb0ce-b392-4281-82ac-af988b27981a
+                - 6e0ce43a-0aa6-44b3-a32e-482146e79c89
         status: 200 OK
         code: 200
-        duration: 140.4465ms
+        duration: 235.835218ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -214,8 +214,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces?name=test-namespace-2&order_by=created_at_asc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/fr-par/images?name=alpine&order_by=created_at_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -223,20 +223,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 501
+        content_length: 331
         uncompressed: false
-        body: '{"namespaces":[{"created_at":"2025-09-05T15:09:08.030213Z","description":"Test namespace for Docker image","endpoint":"rg.fr-par.scw.cloud/test-namespace-2","id":"5ac57b0d-e658-4cff-935c-a4f99176d116","image_count":1,"is_public":false,"name":"test-namespace-2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":4131347,"status":"ready","status_message":"","updated_at":"2025-09-05T15:09:23.022873Z"}],"total_count":1}'
+        body: '{"images":[{"created_at":"2026-07-17T09:50:07.430796Z","id":"97acc09a-89cb-4c45-8b75-207be248b202","name":"alpine","namespace_id":"42a09a31-9f99-43aa-931b-6257a16afb1d","size":3847002,"status":"ready","status_message":"","tags":["test"],"updated_at":"2026-07-17T09:50:08.319162Z","visibility":"inherit"}],"total_count":1}'
         headers:
             Content-Length:
-                - "501"
+                - "331"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:23 GMT
+                - Fri, 17 Jul 2026 09:50:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -244,10 +244,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e0d55457-97e5-490e-b6f7-59318d6fb1e3
+                - 714b2b5f-08bc-42a8-8b49-93ab036bace4
         status: 200 OK
         code: 200
-        duration: 144.110667ms
+        duration: 161.773825ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -263,8 +263,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/5ac57b0d-e658-4cff-935c-a4f99176d116
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces?name=test-namespace-2&order_by=created_at_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -272,20 +272,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 468
+        content_length: 515
         uncompressed: false
-        body: '{"created_at":"2025-09-05T15:09:08.030213Z","description":"Test namespace for Docker image","endpoint":"rg.fr-par.scw.cloud/test-namespace-2","id":"5ac57b0d-e658-4cff-935c-a4f99176d116","image_count":1,"is_public":false,"name":"test-namespace-2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":4131347,"status":"ready","status_message":"","updated_at":"2025-09-05T15:09:23.022873Z"}'
+        body: '{"namespaces":[{"created_at":"2026-07-17T09:50:00.553562Z","description":"Test namespace for Docker image","endpoint":"rg.fr-par.scw.cloud/test-namespace-2","id":"42a09a31-9f99-43aa-931b-6257a16afb1d","image_count":1,"is_public":false,"name":"test-namespace-2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":3847002,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:08.335288Z"}],"total_count":1}'
         headers:
             Content-Length:
-                - "468"
+                - "515"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:23 GMT
+                - Fri, 17 Jul 2026 09:50:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -293,10 +293,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 05d2b4b9-31d9-4a90-9d67-e9ca00d38ac6
+                - 6c1b2b3f-044f-4746-9ac2-41bd32ad752c
         status: 200 OK
         code: 200
-        duration: 151.689542ms
+        duration: 163.659343ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -312,8 +312,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/fr-par/images?name=alpine&order_by=created_at_asc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/42a09a31-9f99-43aa-931b-6257a16afb1d
         method: GET
       response:
         proto: HTTP/2.0
@@ -321,20 +321,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 321
+        content_length: 481
         uncompressed: false
-        body: '{"images":[{"created_at":"2025-09-05T15:09:21.831814Z","id":"b8409493-d83f-4cd1-98a7-9983a4db2291","name":"alpine","namespace_id":"5ac57b0d-e658-4cff-935c-a4f99176d116","size":4131347,"status":"ready","status_message":"","tags":["test"],"updated_at":"2025-09-05T15:09:23.016584Z","visibility":"inherit"}],"total_count":1}'
+        body: '{"created_at":"2026-07-17T09:50:00.553562Z","description":"Test namespace for Docker image","endpoint":"rg.fr-par.scw.cloud/test-namespace-2","id":"42a09a31-9f99-43aa-931b-6257a16afb1d","image_count":1,"is_public":false,"name":"test-namespace-2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":3847002,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:08.335288Z"}'
         headers:
             Content-Length:
-                - "321"
+                - "481"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:23 GMT
+                - Fri, 17 Jul 2026 09:50:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -342,10 +342,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5d18482d-b661-4b4f-bd24-c4cda72007ed
+                - 2ababfb0-e2ec-41e2-b36c-f4bb6ac5655c
         status: 200 OK
         code: 200
-        duration: 168.777292ms
+        duration: 205.143394ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -361,8 +361,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/5ac57b0d-e658-4cff-935c-a4f99176d116
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/42a09a31-9f99-43aa-931b-6257a16afb1d
         method: GET
       response:
         proto: HTTP/2.0
@@ -370,20 +370,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 468
+        content_length: 481
         uncompressed: false
-        body: '{"created_at":"2025-09-05T15:09:08.030213Z","description":"Test namespace for Docker image","endpoint":"rg.fr-par.scw.cloud/test-namespace-2","id":"5ac57b0d-e658-4cff-935c-a4f99176d116","image_count":1,"is_public":false,"name":"test-namespace-2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":4131347,"status":"ready","status_message":"","updated_at":"2025-09-05T15:09:23.022873Z"}'
+        body: '{"created_at":"2026-07-17T09:50:00.553562Z","description":"Test namespace for Docker image","endpoint":"rg.fr-par.scw.cloud/test-namespace-2","id":"42a09a31-9f99-43aa-931b-6257a16afb1d","image_count":1,"is_public":false,"name":"test-namespace-2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":3847002,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:08.335288Z"}'
         headers:
             Content-Length:
-                - "468"
+                - "481"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:24 GMT
+                - Fri, 17 Jul 2026 09:50:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -391,10 +391,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d5372873-cd5a-4305-ab8e-c590d8efdbd7
+                - 072abf9b-124a-4710-8a9e-b7286e5c9e1e
         status: 200 OK
         code: 200
-        duration: 154.584917ms
+        duration: 215.096323ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -410,8 +410,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/fr-par/images/b8409493-d83f-4cd1-98a7-9983a4db2291/tags?order_by=created_at_asc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/fr-par/images/97acc09a-89cb-4c45-8b75-207be248b202/tags?order_by=created_at_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -419,20 +419,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 322
+        content_length: 329
         uncompressed: false
-        body: '{"tags":[{"created_at":"2025-09-05T15:09:21.847469Z","digest":"sha256:a19367999603840546b8612572e338ec076c6d1f2fec61760a9e11410f546733","id":"60b86b56-11d1-448a-8912-fba8d3a96195","image_id":"b8409493-d83f-4cd1-98a7-9983a4db2291","name":"test","status":"ready","updated_at":"2025-09-05T15:09:23.028907Z"}],"total_count":1}'
+        body: '{"tags":[{"created_at":"2026-07-17T09:50:07.445813Z","digest":"sha256:96e9340afe8cd4ab5ee2989f5a544c3405ff2fc2450dd1a6f9eee2a63e6cda56","id":"325e15bf-bd80-4c38-8c78-d169a20e031c","image_id":"97acc09a-89cb-4c45-8b75-207be248b202","name":"test","status":"ready","updated_at":"2026-07-17T09:50:08.351151Z"}],"total_count":1}'
         headers:
             Content-Length:
-                - "322"
+                - "329"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:24 GMT
+                - Fri, 17 Jul 2026 09:50:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -440,10 +440,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 935a1b57-2510-4ee1-8134-524c91d295b5
+                - 452425cb-74f7-4449-9662-da0b15adcaad
         status: 200 OK
         code: 200
-        duration: 211.519959ms
+        duration: 230.018503ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -459,8 +459,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/fr-par/tags/60b86b56-11d1-448a-8912-fba8d3a96195
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/fr-par/tags/325e15bf-bd80-4c38-8c78-d169a20e031c
         method: GET
       response:
         proto: HTTP/2.0
@@ -468,20 +468,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 295
+        content_length: 301
         uncompressed: false
-        body: '{"created_at":"2025-09-05T15:09:21.847469Z","digest":"sha256:a19367999603840546b8612572e338ec076c6d1f2fec61760a9e11410f546733","id":"60b86b56-11d1-448a-8912-fba8d3a96195","image_id":"b8409493-d83f-4cd1-98a7-9983a4db2291","name":"test","status":"ready","updated_at":"2025-09-05T15:09:23.028907Z"}'
+        body: '{"created_at":"2026-07-17T09:50:07.445813Z","digest":"sha256:96e9340afe8cd4ab5ee2989f5a544c3405ff2fc2450dd1a6f9eee2a63e6cda56","id":"325e15bf-bd80-4c38-8c78-d169a20e031c","image_id":"97acc09a-89cb-4c45-8b75-207be248b202","name":"test","status":"ready","updated_at":"2026-07-17T09:50:08.351151Z"}'
         headers:
             Content-Length:
-                - "295"
+                - "301"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:24 GMT
+                - Fri, 17 Jul 2026 09:50:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -489,10 +489,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9bad8dd1-37e2-4e0a-b2ed-9891012add53
+                - 23b83e96-20d0-4721-8864-44e60e0fb6dc
         status: 200 OK
         code: 200
-        duration: 162.262792ms
+        duration: 48.424592ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -508,8 +508,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/5ac57b0d-e658-4cff-935c-a4f99176d116
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/42a09a31-9f99-43aa-931b-6257a16afb1d
         method: GET
       response:
         proto: HTTP/2.0
@@ -517,20 +517,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 468
+        content_length: 481
         uncompressed: false
-        body: '{"created_at":"2025-09-05T15:09:08.030213Z","description":"Test namespace for Docker image","endpoint":"rg.fr-par.scw.cloud/test-namespace-2","id":"5ac57b0d-e658-4cff-935c-a4f99176d116","image_count":1,"is_public":false,"name":"test-namespace-2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":4131347,"status":"ready","status_message":"","updated_at":"2025-09-05T15:09:23.022873Z"}'
+        body: '{"created_at":"2026-07-17T09:50:00.553562Z","description":"Test namespace for Docker image","endpoint":"rg.fr-par.scw.cloud/test-namespace-2","id":"42a09a31-9f99-43aa-931b-6257a16afb1d","image_count":1,"is_public":false,"name":"test-namespace-2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":3847002,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:08.335288Z"}'
         headers:
             Content-Length:
-                - "468"
+                - "481"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:24 GMT
+                - Fri, 17 Jul 2026 09:50:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -538,10 +538,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ff2bb725-5391-4019-a50e-882e25b02ad8
+                - 26e57b85-46c3-4a6b-bf43-c468235b8739
         status: 200 OK
         code: 200
-        duration: 159.537917ms
+        duration: 36.072719ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -557,8 +557,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces?name=test-namespace-2&order_by=created_at_asc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/fr-par/images?name=alpine&order_by=created_at_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -566,20 +566,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 501
+        content_length: 331
         uncompressed: false
-        body: '{"namespaces":[{"created_at":"2025-09-05T15:09:08.030213Z","description":"Test namespace for Docker image","endpoint":"rg.fr-par.scw.cloud/test-namespace-2","id":"5ac57b0d-e658-4cff-935c-a4f99176d116","image_count":1,"is_public":false,"name":"test-namespace-2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":4131347,"status":"ready","status_message":"","updated_at":"2025-09-05T15:09:23.022873Z"}],"total_count":1}'
+        body: '{"images":[{"created_at":"2026-07-17T09:50:07.430796Z","id":"97acc09a-89cb-4c45-8b75-207be248b202","name":"alpine","namespace_id":"42a09a31-9f99-43aa-931b-6257a16afb1d","size":3847002,"status":"ready","status_message":"","tags":["test"],"updated_at":"2026-07-17T09:50:08.319162Z","visibility":"inherit"}],"total_count":1}'
         headers:
             Content-Length:
-                - "501"
+                - "331"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:24 GMT
+                - Fri, 17 Jul 2026 09:50:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -587,10 +587,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4bd091a8-b29e-46c6-890c-8168c049d3ae
+                - 2ef25d4b-75fa-46d4-84e6-8de4064cb43f
         status: 200 OK
         code: 200
-        duration: 136.725792ms
+        duration: 130.539741ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -606,8 +606,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/fr-par/images?name=alpine&order_by=created_at_asc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces?name=test-namespace-2&order_by=created_at_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -615,20 +615,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 321
+        content_length: 515
         uncompressed: false
-        body: '{"images":[{"created_at":"2025-09-05T15:09:21.831814Z","id":"b8409493-d83f-4cd1-98a7-9983a4db2291","name":"alpine","namespace_id":"5ac57b0d-e658-4cff-935c-a4f99176d116","size":4131347,"status":"ready","status_message":"","tags":["test"],"updated_at":"2025-09-05T15:09:23.016584Z","visibility":"inherit"}],"total_count":1}'
+        body: '{"namespaces":[{"created_at":"2026-07-17T09:50:00.553562Z","description":"Test namespace for Docker image","endpoint":"rg.fr-par.scw.cloud/test-namespace-2","id":"42a09a31-9f99-43aa-931b-6257a16afb1d","image_count":1,"is_public":false,"name":"test-namespace-2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":3847002,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:08.335288Z"}],"total_count":1}'
         headers:
             Content-Length:
-                - "321"
+                - "515"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:24 GMT
+                - Fri, 17 Jul 2026 09:50:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -636,10 +636,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1d03cdf5-25b7-4910-8c81-726a7c9b6247
+                - 38025866-6bab-44bb-84b9-72092439975d
         status: 200 OK
         code: 200
-        duration: 153.134833ms
+        duration: 148.580919ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -655,8 +655,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/5ac57b0d-e658-4cff-935c-a4f99176d116
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/fr-par/images/97acc09a-89cb-4c45-8b75-207be248b202/tags?order_by=created_at_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -664,20 +664,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 468
+        content_length: 329
         uncompressed: false
-        body: '{"created_at":"2025-09-05T15:09:08.030213Z","description":"Test namespace for Docker image","endpoint":"rg.fr-par.scw.cloud/test-namespace-2","id":"5ac57b0d-e658-4cff-935c-a4f99176d116","image_count":1,"is_public":false,"name":"test-namespace-2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":4131347,"status":"ready","status_message":"","updated_at":"2025-09-05T15:09:23.022873Z"}'
+        body: '{"tags":[{"created_at":"2026-07-17T09:50:07.445813Z","digest":"sha256:96e9340afe8cd4ab5ee2989f5a544c3405ff2fc2450dd1a6f9eee2a63e6cda56","id":"325e15bf-bd80-4c38-8c78-d169a20e031c","image_id":"97acc09a-89cb-4c45-8b75-207be248b202","name":"test","status":"ready","updated_at":"2026-07-17T09:50:08.351151Z"}],"total_count":1}'
         headers:
             Content-Length:
-                - "468"
+                - "329"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:24 GMT
+                - Fri, 17 Jul 2026 09:50:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -685,10 +685,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bf2f070f-08b0-4637-a84e-709811f54a06
+                - 3990caf0-addc-4125-8b92-46ae4365b8e0
         status: 200 OK
         code: 200
-        duration: 153.0425ms
+        duration: 62.499408ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -704,8 +704,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/fr-par/images/b8409493-d83f-4cd1-98a7-9983a4db2291/tags?order_by=created_at_asc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/42a09a31-9f99-43aa-931b-6257a16afb1d
         method: GET
       response:
         proto: HTTP/2.0
@@ -713,20 +713,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 322
+        content_length: 481
         uncompressed: false
-        body: '{"tags":[{"created_at":"2025-09-05T15:09:21.847469Z","digest":"sha256:a19367999603840546b8612572e338ec076c6d1f2fec61760a9e11410f546733","id":"60b86b56-11d1-448a-8912-fba8d3a96195","image_id":"b8409493-d83f-4cd1-98a7-9983a4db2291","name":"test","status":"ready","updated_at":"2025-09-05T15:09:23.028907Z"}],"total_count":1}'
+        body: '{"created_at":"2026-07-17T09:50:00.553562Z","description":"Test namespace for Docker image","endpoint":"rg.fr-par.scw.cloud/test-namespace-2","id":"42a09a31-9f99-43aa-931b-6257a16afb1d","image_count":1,"is_public":false,"name":"test-namespace-2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":3847002,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:08.335288Z"}'
         headers:
             Content-Length:
-                - "322"
+                - "481"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:24 GMT
+                - Fri, 17 Jul 2026 09:50:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -734,10 +734,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 42ea4631-d23d-4e23-a395-59f14be92b32
+                - f03883f3-7df6-4463-ba85-8b45c204efa6
         status: 200 OK
         code: 200
-        duration: 154.5945ms
+        duration: 51.552277ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -753,8 +753,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces?name=test-namespace-2&order_by=created_at_asc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/42a09a31-9f99-43aa-931b-6257a16afb1d
         method: GET
       response:
         proto: HTTP/2.0
@@ -762,20 +762,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 501
+        content_length: 481
         uncompressed: false
-        body: '{"namespaces":[{"created_at":"2025-09-05T15:09:08.030213Z","description":"Test namespace for Docker image","endpoint":"rg.fr-par.scw.cloud/test-namespace-2","id":"5ac57b0d-e658-4cff-935c-a4f99176d116","image_count":1,"is_public":false,"name":"test-namespace-2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":4131347,"status":"ready","status_message":"","updated_at":"2025-09-05T15:09:23.022873Z"}],"total_count":1}'
+        body: '{"created_at":"2026-07-17T09:50:00.553562Z","description":"Test namespace for Docker image","endpoint":"rg.fr-par.scw.cloud/test-namespace-2","id":"42a09a31-9f99-43aa-931b-6257a16afb1d","image_count":1,"is_public":false,"name":"test-namespace-2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":3847002,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:08.335288Z"}'
         headers:
             Content-Length:
-                - "501"
+                - "481"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:25 GMT
+                - Fri, 17 Jul 2026 09:50:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -783,10 +783,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 646962d2-09f7-4ee7-9aef-d6ddbf7d1694
+                - 6467fc59-0150-4dfc-93b9-1e8b140dcc8d
         status: 200 OK
         code: 200
-        duration: 155.040792ms
+        duration: 40.20762ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -802,8 +802,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/fr-par/images?name=alpine&order_by=created_at_asc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces?name=test-namespace-2&order_by=created_at_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -811,20 +811,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 321
+        content_length: 515
         uncompressed: false
-        body: '{"images":[{"created_at":"2025-09-05T15:09:21.831814Z","id":"b8409493-d83f-4cd1-98a7-9983a4db2291","name":"alpine","namespace_id":"5ac57b0d-e658-4cff-935c-a4f99176d116","size":4131347,"status":"ready","status_message":"","tags":["test"],"updated_at":"2025-09-05T15:09:23.016584Z","visibility":"inherit"}],"total_count":1}'
+        body: '{"namespaces":[{"created_at":"2026-07-17T09:50:00.553562Z","description":"Test namespace for Docker image","endpoint":"rg.fr-par.scw.cloud/test-namespace-2","id":"42a09a31-9f99-43aa-931b-6257a16afb1d","image_count":1,"is_public":false,"name":"test-namespace-2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":3847002,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:08.335288Z"}],"total_count":1}'
         headers:
             Content-Length:
-                - "321"
+                - "515"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:25 GMT
+                - Fri, 17 Jul 2026 09:50:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -832,10 +832,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c05dafa2-4b4d-4017-824e-ee87813bbf0d
+                - 9985dc19-9685-46ad-bd56-0e8efca9738c
         status: 200 OK
         code: 200
-        duration: 157.847708ms
+        duration: 49.915718ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -851,8 +851,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/5ac57b0d-e658-4cff-935c-a4f99176d116
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/42a09a31-9f99-43aa-931b-6257a16afb1d
         method: GET
       response:
         proto: HTTP/2.0
@@ -860,20 +860,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 468
+        content_length: 481
         uncompressed: false
-        body: '{"created_at":"2025-09-05T15:09:08.030213Z","description":"Test namespace for Docker image","endpoint":"rg.fr-par.scw.cloud/test-namespace-2","id":"5ac57b0d-e658-4cff-935c-a4f99176d116","image_count":1,"is_public":false,"name":"test-namespace-2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":4131347,"status":"ready","status_message":"","updated_at":"2025-09-05T15:09:23.022873Z"}'
+        body: '{"created_at":"2026-07-17T09:50:00.553562Z","description":"Test namespace for Docker image","endpoint":"rg.fr-par.scw.cloud/test-namespace-2","id":"42a09a31-9f99-43aa-931b-6257a16afb1d","image_count":1,"is_public":false,"name":"test-namespace-2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":3847002,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:08.335288Z"}'
         headers:
             Content-Length:
-                - "468"
+                - "481"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:25 GMT
+                - Fri, 17 Jul 2026 09:50:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -881,10 +881,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 32b408a1-9704-4f0b-8d2f-391e4a69bf56
+                - 139e03a1-83fa-4da9-8a67-ea5b6a3f2968
         status: 200 OK
         code: 200
-        duration: 169.760625ms
+        duration: 36.919463ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -900,8 +900,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/5ac57b0d-e658-4cff-935c-a4f99176d116
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/fr-par/images?name=alpine&order_by=created_at_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -909,20 +909,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 468
+        content_length: 331
         uncompressed: false
-        body: '{"created_at":"2025-09-05T15:09:08.030213Z","description":"Test namespace for Docker image","endpoint":"rg.fr-par.scw.cloud/test-namespace-2","id":"5ac57b0d-e658-4cff-935c-a4f99176d116","image_count":1,"is_public":false,"name":"test-namespace-2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":4131347,"status":"ready","status_message":"","updated_at":"2025-09-05T15:09:23.022873Z"}'
+        body: '{"images":[{"created_at":"2026-07-17T09:50:07.430796Z","id":"97acc09a-89cb-4c45-8b75-207be248b202","name":"alpine","namespace_id":"42a09a31-9f99-43aa-931b-6257a16afb1d","size":3847002,"status":"ready","status_message":"","tags":["test"],"updated_at":"2026-07-17T09:50:08.319162Z","visibility":"inherit"}],"total_count":1}'
         headers:
             Content-Length:
-                - "468"
+                - "331"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:25 GMT
+                - Fri, 17 Jul 2026 09:50:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -930,10 +930,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dc751817-9a99-489e-9799-1c56bdea3cd0
+                - 7778857d-a724-48d7-8219-05fe05f66b1c
         status: 200 OK
         code: 200
-        duration: 172.366208ms
+        duration: 134.459266ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -949,8 +949,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/fr-par/images/b8409493-d83f-4cd1-98a7-9983a4db2291/tags?order_by=created_at_asc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/fr-par/images/97acc09a-89cb-4c45-8b75-207be248b202/tags?order_by=created_at_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -958,20 +958,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 322
+        content_length: 329
         uncompressed: false
-        body: '{"tags":[{"created_at":"2025-09-05T15:09:21.847469Z","digest":"sha256:a19367999603840546b8612572e338ec076c6d1f2fec61760a9e11410f546733","id":"60b86b56-11d1-448a-8912-fba8d3a96195","image_id":"b8409493-d83f-4cd1-98a7-9983a4db2291","name":"test","status":"ready","updated_at":"2025-09-05T15:09:23.028907Z"}],"total_count":1}'
+        body: '{"tags":[{"created_at":"2026-07-17T09:50:07.445813Z","digest":"sha256:96e9340afe8cd4ab5ee2989f5a544c3405ff2fc2450dd1a6f9eee2a63e6cda56","id":"325e15bf-bd80-4c38-8c78-d169a20e031c","image_id":"97acc09a-89cb-4c45-8b75-207be248b202","name":"test","status":"ready","updated_at":"2026-07-17T09:50:08.351151Z"}],"total_count":1}'
         headers:
             Content-Length:
-                - "322"
+                - "329"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:25 GMT
+                - Fri, 17 Jul 2026 09:50:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -979,10 +979,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 335329e0-65cd-41aa-9fbf-7afac4040154
+                - a7877be8-ba2e-4ccf-aeab-4e248a6b1ac1
         status: 200 OK
         code: 200
-        duration: 168.713625ms
+        duration: 57.00612ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -998,8 +998,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/5ac57b0d-e658-4cff-935c-a4f99176d116
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/fr-par/images?name=alpine&order_by=created_at_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -1007,20 +1007,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 468
+        content_length: 331
         uncompressed: false
-        body: '{"created_at":"2025-09-05T15:09:08.030213Z","description":"Test namespace for Docker image","endpoint":"rg.fr-par.scw.cloud/test-namespace-2","id":"5ac57b0d-e658-4cff-935c-a4f99176d116","image_count":1,"is_public":false,"name":"test-namespace-2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":4131347,"status":"ready","status_message":"","updated_at":"2025-09-05T15:09:23.022873Z"}'
+        body: '{"images":[{"created_at":"2026-07-17T09:50:07.430796Z","id":"97acc09a-89cb-4c45-8b75-207be248b202","name":"alpine","namespace_id":"42a09a31-9f99-43aa-931b-6257a16afb1d","size":3847002,"status":"ready","status_message":"","tags":["test"],"updated_at":"2026-07-17T09:50:08.319162Z","visibility":"inherit"}],"total_count":1}'
         headers:
             Content-Length:
-                - "468"
+                - "331"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:25 GMT
+                - Fri, 17 Jul 2026 09:50:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1028,10 +1028,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d94a3291-45d3-44c4-80a9-ea9608c8803f
+                - 9dac3053-b799-40a7-9f56-5dffb0e13e44
         status: 200 OK
         code: 200
-        duration: 144.652292ms
+        duration: 56.864504ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1047,8 +1047,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces?name=test-namespace-2&order_by=created_at_asc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces?name=test-namespace-2&order_by=created_at_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -1056,20 +1056,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 501
+        content_length: 515
         uncompressed: false
-        body: '{"namespaces":[{"created_at":"2025-09-05T15:09:08.030213Z","description":"Test namespace for Docker image","endpoint":"rg.fr-par.scw.cloud/test-namespace-2","id":"5ac57b0d-e658-4cff-935c-a4f99176d116","image_count":1,"is_public":false,"name":"test-namespace-2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":4131347,"status":"ready","status_message":"","updated_at":"2025-09-05T15:09:23.022873Z"}],"total_count":1}'
+        body: '{"namespaces":[{"created_at":"2026-07-17T09:50:00.553562Z","description":"Test namespace for Docker image","endpoint":"rg.fr-par.scw.cloud/test-namespace-2","id":"42a09a31-9f99-43aa-931b-6257a16afb1d","image_count":1,"is_public":false,"name":"test-namespace-2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":3847002,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:08.335288Z"}],"total_count":1}'
         headers:
             Content-Length:
-                - "501"
+                - "515"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:25 GMT
+                - Fri, 17 Jul 2026 09:50:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1077,10 +1077,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a8e48382-1f86-4aee-9f21-d42e75750954
+                - 1e0b5033-5b5f-43cd-85ca-2d36853dc29e
         status: 200 OK
         code: 200
-        duration: 170.518416ms
+        duration: 150.697252ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1096,8 +1096,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/fr-par/images?name=alpine&order_by=created_at_asc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/42a09a31-9f99-43aa-931b-6257a16afb1d
         method: GET
       response:
         proto: HTTP/2.0
@@ -1105,20 +1105,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 321
+        content_length: 481
         uncompressed: false
-        body: '{"images":[{"created_at":"2025-09-05T15:09:21.831814Z","id":"b8409493-d83f-4cd1-98a7-9983a4db2291","name":"alpine","namespace_id":"5ac57b0d-e658-4cff-935c-a4f99176d116","size":4131347,"status":"ready","status_message":"","tags":["test"],"updated_at":"2025-09-05T15:09:23.016584Z","visibility":"inherit"}],"total_count":1}'
+        body: '{"created_at":"2026-07-17T09:50:00.553562Z","description":"Test namespace for Docker image","endpoint":"rg.fr-par.scw.cloud/test-namespace-2","id":"42a09a31-9f99-43aa-931b-6257a16afb1d","image_count":1,"is_public":false,"name":"test-namespace-2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":3847002,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:08.335288Z"}'
         headers:
             Content-Length:
-                - "321"
+                - "481"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:25 GMT
+                - Fri, 17 Jul 2026 09:50:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1126,10 +1126,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f02f9ec2-25a1-429d-8551-cc533073d2a9
+                - 311103be-6a1f-4a43-af65-22a5c9e79302
         status: 200 OK
         code: 200
-        duration: 192.953625ms
+        duration: 265.64367ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1145,8 +1145,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/5ac57b0d-e658-4cff-935c-a4f99176d116
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/42a09a31-9f99-43aa-931b-6257a16afb1d
         method: GET
       response:
         proto: HTTP/2.0
@@ -1154,20 +1154,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 468
+        content_length: 481
         uncompressed: false
-        body: '{"created_at":"2025-09-05T15:09:08.030213Z","description":"Test namespace for Docker image","endpoint":"rg.fr-par.scw.cloud/test-namespace-2","id":"5ac57b0d-e658-4cff-935c-a4f99176d116","image_count":1,"is_public":false,"name":"test-namespace-2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":4131347,"status":"ready","status_message":"","updated_at":"2025-09-05T15:09:23.022873Z"}'
+        body: '{"created_at":"2026-07-17T09:50:00.553562Z","description":"Test namespace for Docker image","endpoint":"rg.fr-par.scw.cloud/test-namespace-2","id":"42a09a31-9f99-43aa-931b-6257a16afb1d","image_count":1,"is_public":false,"name":"test-namespace-2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":3847002,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:08.335288Z"}'
         headers:
             Content-Length:
-                - "468"
+                - "481"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:25 GMT
+                - Fri, 17 Jul 2026 09:50:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1175,10 +1175,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 11652c10-07ff-4a05-9e8a-068f3d1b5d76
+                - 97419725-91ce-4dbd-aa9d-54ceed093fb9
         status: 200 OK
         code: 200
-        duration: 135.386625ms
+        duration: 229.005587ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1194,8 +1194,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/fr-par/images/b8409493-d83f-4cd1-98a7-9983a4db2291
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/fr-par/images/97acc09a-89cb-4c45-8b75-207be248b202
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1203,20 +1203,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 298
+        content_length: 307
         uncompressed: false
-        body: '{"created_at":"2025-09-05T15:09:21.831814Z","id":"b8409493-d83f-4cd1-98a7-9983a4db2291","name":"alpine","namespace_id":"5ac57b0d-e658-4cff-935c-a4f99176d116","size":4131347,"status":"deleting","status_message":"","tags":["test"],"updated_at":"2025-09-05T15:09:26.197117229Z","visibility":"inherit"}'
+        body: '{"created_at":"2026-07-17T09:50:07.430796Z","id":"97acc09a-89cb-4c45-8b75-207be248b202","name":"alpine","namespace_id":"42a09a31-9f99-43aa-931b-6257a16afb1d","size":3847002,"status":"deleting","status_message":"","tags":["test"],"updated_at":"2026-07-17T09:50:11.181781482Z","visibility":"inherit"}'
         headers:
             Content-Length:
-                - "298"
+                - "307"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:26 GMT
+                - Fri, 17 Jul 2026 09:50:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1224,10 +1224,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fe2bc2bf-de07-43a8-9175-75d3cefe658c
+                - 87b7ffff-3917-4a3a-9609-d90cd8696446
         status: 200 OK
         code: 200
-        duration: 174.065542ms
+        duration: 209.266934ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1243,8 +1243,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/fr-par/images?name=alpine&order_by=created_at_asc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces?name=test-namespace-2&order_by=created_at_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -1252,20 +1252,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 324
+        content_length: 515
         uncompressed: false
-        body: '{"images":[{"created_at":"2025-09-05T15:09:21.831814Z","id":"b8409493-d83f-4cd1-98a7-9983a4db2291","name":"alpine","namespace_id":"5ac57b0d-e658-4cff-935c-a4f99176d116","size":4131347,"status":"deleting","status_message":"","tags":["test"],"updated_at":"2025-09-05T15:09:26.197117Z","visibility":"inherit"}],"total_count":1}'
+        body: '{"namespaces":[{"created_at":"2026-07-17T09:50:00.553562Z","description":"Test namespace for Docker image","endpoint":"rg.fr-par.scw.cloud/test-namespace-2","id":"42a09a31-9f99-43aa-931b-6257a16afb1d","image_count":1,"is_public":false,"name":"test-namespace-2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":3847002,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:08.335288Z"}],"total_count":1}'
         headers:
             Content-Length:
-                - "324"
+                - "515"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:26 GMT
+                - Fri, 17 Jul 2026 09:50:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1273,10 +1273,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 55407025-8f3c-4b28-9c72-18863888c766
+                - 2739f0b6-0769-447c-94eb-385b115a1f33
         status: 200 OK
         code: 200
-        duration: 140.968583ms
+        duration: 38.967305ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1292,8 +1292,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces?name=test-namespace-2&order_by=created_at_asc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/fr-par/images?name=alpine&order_by=created_at_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -1301,20 +1301,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 501
+        content_length: 334
         uncompressed: false
-        body: '{"namespaces":[{"created_at":"2025-09-05T15:09:08.030213Z","description":"Test namespace for Docker image","endpoint":"rg.fr-par.scw.cloud/test-namespace-2","id":"5ac57b0d-e658-4cff-935c-a4f99176d116","image_count":1,"is_public":false,"name":"test-namespace-2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":4131347,"status":"ready","status_message":"","updated_at":"2025-09-05T15:09:23.022873Z"}],"total_count":1}'
+        body: '{"images":[{"created_at":"2026-07-17T09:50:07.430796Z","id":"97acc09a-89cb-4c45-8b75-207be248b202","name":"alpine","namespace_id":"42a09a31-9f99-43aa-931b-6257a16afb1d","size":3847002,"status":"deleting","status_message":"","tags":["test"],"updated_at":"2026-07-17T09:50:11.181781Z","visibility":"inherit"}],"total_count":1}'
         headers:
             Content-Length:
-                - "501"
+                - "334"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:26 GMT
+                - Fri, 17 Jul 2026 09:50:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1322,10 +1322,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c2e43dc0-be6c-4ae5-a2f2-3c9b4bc6a369
+                - f3c086f0-51dd-4cf6-a01e-bdb3b68add21
         status: 200 OK
         code: 200
-        duration: 170.721125ms
+        duration: 48.798505ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1341,8 +1341,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/5ac57b0d-e658-4cff-935c-a4f99176d116
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/42a09a31-9f99-43aa-931b-6257a16afb1d
         method: GET
       response:
         proto: HTTP/2.0
@@ -1350,20 +1350,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 468
+        content_length: 481
         uncompressed: false
-        body: '{"created_at":"2025-09-05T15:09:08.030213Z","description":"Test namespace for Docker image","endpoint":"rg.fr-par.scw.cloud/test-namespace-2","id":"5ac57b0d-e658-4cff-935c-a4f99176d116","image_count":1,"is_public":false,"name":"test-namespace-2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":4131347,"status":"ready","status_message":"","updated_at":"2025-09-05T15:09:23.022873Z"}'
+        body: '{"created_at":"2026-07-17T09:50:00.553562Z","description":"Test namespace for Docker image","endpoint":"rg.fr-par.scw.cloud/test-namespace-2","id":"42a09a31-9f99-43aa-931b-6257a16afb1d","image_count":1,"is_public":false,"name":"test-namespace-2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":3847002,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:08.335288Z"}'
         headers:
             Content-Length:
-                - "468"
+                - "481"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:26 GMT
+                - Fri, 17 Jul 2026 09:50:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1371,10 +1371,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c20363e2-2329-4e6e-a948-74f545ed02c0
+                - c0da2623-36ac-4fb4-862a-7ddfb829f479
         status: 200 OK
         code: 200
-        duration: 147.277834ms
+        duration: 63.627048ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1390,8 +1390,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/fr-par/images?name=alpine&order_by=created_at_asc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces?name=test-namespace-2&order_by=created_at_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -1399,20 +1399,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 324
+        content_length: 515
         uncompressed: false
-        body: '{"images":[{"created_at":"2025-09-05T15:09:21.831814Z","id":"b8409493-d83f-4cd1-98a7-9983a4db2291","name":"alpine","namespace_id":"5ac57b0d-e658-4cff-935c-a4f99176d116","size":4131347,"status":"deleting","status_message":"","tags":["test"],"updated_at":"2025-09-05T15:09:26.197117Z","visibility":"inherit"}],"total_count":1}'
+        body: '{"namespaces":[{"created_at":"2026-07-17T09:50:00.553562Z","description":"Test namespace for Docker image","endpoint":"rg.fr-par.scw.cloud/test-namespace-2","id":"42a09a31-9f99-43aa-931b-6257a16afb1d","image_count":1,"is_public":false,"name":"test-namespace-2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":3847002,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:08.335288Z"}],"total_count":1}'
         headers:
             Content-Length:
-                - "324"
+                - "515"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:26 GMT
+                - Fri, 17 Jul 2026 09:50:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1420,10 +1420,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9305cac5-702c-4b0b-a794-674362144c29
+                - 92fc0def-c469-4de2-9e98-39750c3fcc1c
         status: 200 OK
         code: 200
-        duration: 141.661791ms
+        duration: 145.762035ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1439,8 +1439,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces?name=test-namespace-2&order_by=created_at_asc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/fr-par/images?name=alpine&order_by=created_at_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -1448,20 +1448,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 501
+        content_length: 334
         uncompressed: false
-        body: '{"namespaces":[{"created_at":"2025-09-05T15:09:08.030213Z","description":"Test namespace for Docker image","endpoint":"rg.fr-par.scw.cloud/test-namespace-2","id":"5ac57b0d-e658-4cff-935c-a4f99176d116","image_count":1,"is_public":false,"name":"test-namespace-2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":4131347,"status":"ready","status_message":"","updated_at":"2025-09-05T15:09:23.022873Z"}],"total_count":1}'
+        body: '{"images":[{"created_at":"2026-07-17T09:50:07.430796Z","id":"97acc09a-89cb-4c45-8b75-207be248b202","name":"alpine","namespace_id":"42a09a31-9f99-43aa-931b-6257a16afb1d","size":3847002,"status":"deleting","status_message":"","tags":["test"],"updated_at":"2026-07-17T09:50:11.181781Z","visibility":"inherit"}],"total_count":1}'
         headers:
             Content-Length:
-                - "501"
+                - "334"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:26 GMT
+                - Fri, 17 Jul 2026 09:50:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1469,10 +1469,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9c7cf7cc-14ca-4b6d-a4a4-59df271ebc17
+                - c218b52f-9ca5-4add-8fb8-0ba4ab157cd8
         status: 200 OK
         code: 200
-        duration: 158.076833ms
+        duration: 146.35995ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1488,8 +1488,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/5ac57b0d-e658-4cff-935c-a4f99176d116
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/42a09a31-9f99-43aa-931b-6257a16afb1d
         method: GET
       response:
         proto: HTTP/2.0
@@ -1497,20 +1497,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 468
+        content_length: 481
         uncompressed: false
-        body: '{"created_at":"2025-09-05T15:09:08.030213Z","description":"Test namespace for Docker image","endpoint":"rg.fr-par.scw.cloud/test-namespace-2","id":"5ac57b0d-e658-4cff-935c-a4f99176d116","image_count":1,"is_public":false,"name":"test-namespace-2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":4131347,"status":"ready","status_message":"","updated_at":"2025-09-05T15:09:23.022873Z"}'
+        body: '{"created_at":"2026-07-17T09:50:00.553562Z","description":"Test namespace for Docker image","endpoint":"rg.fr-par.scw.cloud/test-namespace-2","id":"42a09a31-9f99-43aa-931b-6257a16afb1d","image_count":1,"is_public":false,"name":"test-namespace-2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":3847002,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:08.335288Z"}'
         headers:
             Content-Length:
-                - "468"
+                - "481"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:26 GMT
+                - Fri, 17 Jul 2026 09:50:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1518,10 +1518,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b2bf5c6f-0801-4640-9cc8-ff1803ac8389
+                - 6eadcc6d-9d66-4428-8c6d-2d8c468ed7b1
         status: 200 OK
         code: 200
-        duration: 166.097542ms
+        duration: 35.654682ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1537,8 +1537,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/5ac57b0d-e658-4cff-935c-a4f99176d116
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/42a09a31-9f99-43aa-931b-6257a16afb1d
         method: GET
       response:
         proto: HTTP/2.0
@@ -1546,20 +1546,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 468
+        content_length: 481
         uncompressed: false
-        body: '{"created_at":"2025-09-05T15:09:08.030213Z","description":"Test namespace for Docker image","endpoint":"rg.fr-par.scw.cloud/test-namespace-2","id":"5ac57b0d-e658-4cff-935c-a4f99176d116","image_count":1,"is_public":false,"name":"test-namespace-2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":4131347,"status":"ready","status_message":"","updated_at":"2025-09-05T15:09:23.022873Z"}'
+        body: '{"created_at":"2026-07-17T09:50:00.553562Z","description":"Test namespace for Docker image","endpoint":"rg.fr-par.scw.cloud/test-namespace-2","id":"42a09a31-9f99-43aa-931b-6257a16afb1d","image_count":1,"is_public":false,"name":"test-namespace-2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":3847002,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:08.335288Z"}'
         headers:
             Content-Length:
-                - "468"
+                - "481"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:27 GMT
+                - Fri, 17 Jul 2026 09:50:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1567,10 +1567,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 582382f1-d507-459a-8e8c-1e3035a81151
+                - be6d6403-aa9a-4bd6-98e9-6f95b9c188b1
         status: 200 OK
         code: 200
-        duration: 161.799167ms
+        duration: 225.460074ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1586,8 +1586,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/5ac57b0d-e658-4cff-935c-a4f99176d116
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/42a09a31-9f99-43aa-931b-6257a16afb1d
         method: GET
       response:
         proto: HTTP/2.0
@@ -1595,20 +1595,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 468
+        content_length: 481
         uncompressed: false
-        body: '{"created_at":"2025-09-05T15:09:08.030213Z","description":"Test namespace for Docker image","endpoint":"rg.fr-par.scw.cloud/test-namespace-2","id":"5ac57b0d-e658-4cff-935c-a4f99176d116","image_count":1,"is_public":false,"name":"test-namespace-2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":4131347,"status":"ready","status_message":"","updated_at":"2025-09-05T15:09:23.022873Z"}'
+        body: '{"created_at":"2026-07-17T09:50:00.553562Z","description":"Test namespace for Docker image","endpoint":"rg.fr-par.scw.cloud/test-namespace-2","id":"42a09a31-9f99-43aa-931b-6257a16afb1d","image_count":1,"is_public":false,"name":"test-namespace-2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":3847002,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:08.335288Z"}'
         headers:
             Content-Length:
-                - "468"
+                - "481"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:27 GMT
+                - Fri, 17 Jul 2026 09:50:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1616,10 +1616,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8cad49c7-6eb0-491b-be2c-f4000db92756
+                - 55e0632f-4c6d-4e0a-bade-7cfca2802869
         status: 200 OK
         code: 200
-        duration: 167.724083ms
+        duration: 46.231746ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1635,8 +1635,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/5ac57b0d-e658-4cff-935c-a4f99176d116
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/42a09a31-9f99-43aa-931b-6257a16afb1d
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1644,20 +1644,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 474
+        content_length: 487
         uncompressed: false
-        body: '{"created_at":"2025-09-05T15:09:08.030213Z","description":"Test namespace for Docker image","endpoint":"rg.fr-par.scw.cloud/test-namespace-2","id":"5ac57b0d-e658-4cff-935c-a4f99176d116","image_count":1,"is_public":false,"name":"test-namespace-2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":4131347,"status":"deleting","status_message":"","updated_at":"2025-09-05T15:09:27.622754383Z"}'
+        body: '{"created_at":"2026-07-17T09:50:00.553562Z","description":"Test namespace for Docker image","endpoint":"rg.fr-par.scw.cloud/test-namespace-2","id":"42a09a31-9f99-43aa-931b-6257a16afb1d","image_count":1,"is_public":false,"name":"test-namespace-2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":3847002,"status":"deleting","status_message":"","updated_at":"2026-07-17T09:50:12.261744560Z"}'
         headers:
             Content-Length:
-                - "474"
+                - "487"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:27 GMT
+                - Fri, 17 Jul 2026 09:50:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1665,10 +1665,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2a204739-499f-4b58-8ee1-67184082a5fc
+                - ab5fe7e7-f5dd-45f9-ac48-00d3bf534b77
         status: 200 OK
         code: 200
-        duration: 188.160792ms
+        duration: 243.96142ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1684,8 +1684,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/5ac57b0d-e658-4cff-935c-a4f99176d116
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/42a09a31-9f99-43aa-931b-6257a16afb1d
         method: GET
       response:
         proto: HTTP/2.0
@@ -1693,20 +1693,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 471
+        content_length: 484
         uncompressed: false
-        body: '{"created_at":"2025-09-05T15:09:08.030213Z","description":"Test namespace for Docker image","endpoint":"rg.fr-par.scw.cloud/test-namespace-2","id":"5ac57b0d-e658-4cff-935c-a4f99176d116","image_count":1,"is_public":false,"name":"test-namespace-2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":4131347,"status":"deleting","status_message":"","updated_at":"2025-09-05T15:09:27.622754Z"}'
+        body: '{"created_at":"2026-07-17T09:50:00.553562Z","description":"Test namespace for Docker image","endpoint":"rg.fr-par.scw.cloud/test-namespace-2","id":"42a09a31-9f99-43aa-931b-6257a16afb1d","image_count":1,"is_public":false,"name":"test-namespace-2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":3847002,"status":"deleting","status_message":"","updated_at":"2026-07-17T09:50:12.261745Z"}'
         headers:
             Content-Length:
-                - "471"
+                - "484"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:27 GMT
+                - Fri, 17 Jul 2026 09:50:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1714,10 +1714,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 90a7eaca-a8b6-419d-ab10-647fe4379514
+                - 29b01d93-09da-4890-bd47-16f3323b029c
         status: 200 OK
         code: 200
-        duration: 153.69675ms
+        duration: 225.872511ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1733,8 +1733,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/5ac57b0d-e658-4cff-935c-a4f99176d116
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/42a09a31-9f99-43aa-931b-6257a16afb1d
         method: GET
       response:
         proto: HTTP/2.0
@@ -1753,9 +1753,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:35 GMT
+                - Fri, 17 Jul 2026 09:50:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1763,10 +1763,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 352f6358-9a76-4c61-8d21-ee53c2cd5614
+                - acc578ec-f082-45ca-8fa7-ef5ee76816de
         status: 404 Not Found
         code: 404
-        duration: 59.688167ms
+        duration: 26.764423ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1782,8 +1782,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/5ac57b0d-e658-4cff-935c-a4f99176d116
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/42a09a31-9f99-43aa-931b-6257a16afb1d
         method: GET
       response:
         proto: HTTP/2.0
@@ -1802,9 +1802,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:36 GMT
+                - Fri, 17 Jul 2026 09:50:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1812,7 +1812,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8afa9574-8e16-4c1c-8c1c-2f030405904b
+                - 77c809d7-abb1-472c-a313-50f2fddf9eb9
         status: 404 Not Found
         code: 404
-        duration: 63.971375ms
+        duration: 22.239809ms

--- a/internal/services/registry/testdata/data-source-namespace-basic.cassette.yaml
+++ b/internal/services/registry/testdata/data-source-namespace-basic.cassette.yaml
@@ -18,7 +18,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces
         method: POST
       response:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 429
+        content_length: 442
         uncompressed: false
-        body: '{"created_at":"2025-09-05T15:09:50.758553876Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"5742e64f-5b7c-4d58-98c7-7114176de0ef","image_count":0,"is_public":false,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2025-09-05T15:09:50.758553876Z"}'
+        body: '{"created_at":"2026-07-17T09:50:00.636593861Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"dc55a9a7-a43c-4fb8-96ca-325f9d3fa062","image_count":0,"is_public":false,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:00.636593861Z"}'
         headers:
             Content-Length:
-                - "429"
+                - "442"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:50 GMT
+                - Fri, 17 Jul 2026 09:50:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ea92de55-2d8e-4724-af77-7d1724bcf9af
+                - bf73450d-b0d1-415e-9aa4-3ee839d626df
         status: 200 OK
         code: 200
-        duration: 1.121723292s
+        duration: 434.737939ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,8 +67,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/5742e64f-5b7c-4d58-98c7-7114176de0ef
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/dc55a9a7-a43c-4fb8-96ca-325f9d3fa062
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 423
+        content_length: 436
         uncompressed: false
-        body: '{"created_at":"2025-09-05T15:09:50.758554Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"5742e64f-5b7c-4d58-98c7-7114176de0ef","image_count":0,"is_public":false,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2025-09-05T15:09:50.758554Z"}'
+        body: '{"created_at":"2026-07-17T09:50:00.636594Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"dc55a9a7-a43c-4fb8-96ca-325f9d3fa062","image_count":0,"is_public":false,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:00.636594Z"}'
         headers:
             Content-Length:
-                - "423"
+                - "436"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:51 GMT
+                - Fri, 17 Jul 2026 09:50:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 01b49788-0e41-46d2-87b8-a2bcde7dfc64
+                - f7472e62-9fcb-4d76-8e28-9ab0c52ec4a7
         status: 200 OK
         code: 200
-        duration: 806.771291ms
+        duration: 362.324978ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -116,8 +116,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/5742e64f-5b7c-4d58-98c7-7114176de0ef
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/dc55a9a7-a43c-4fb8-96ca-325f9d3fa062
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,20 +125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 423
+        content_length: 436
         uncompressed: false
-        body: '{"created_at":"2025-09-05T15:09:50.758554Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"5742e64f-5b7c-4d58-98c7-7114176de0ef","image_count":0,"is_public":false,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2025-09-05T15:09:50.758554Z"}'
+        body: '{"created_at":"2026-07-17T09:50:00.636594Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"dc55a9a7-a43c-4fb8-96ca-325f9d3fa062","image_count":0,"is_public":false,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:00.636594Z"}'
         headers:
             Content-Length:
-                - "423"
+                - "436"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:51 GMT
+                - Fri, 17 Jul 2026 09:50:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 533bb8b8-6411-40a7-a8e4-5845dae702eb
+                - 376acf41-05b1-4863-9fc4-febdc697e0d3
         status: 200 OK
         code: 200
-        duration: 195.058708ms
+        duration: 86.116207ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -165,8 +165,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces?name=test-cr-data&order_by=created_at_asc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/dc55a9a7-a43c-4fb8-96ca-325f9d3fa062
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,20 +174,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 456
+        content_length: 436
         uncompressed: false
-        body: '{"namespaces":[{"created_at":"2025-09-05T15:09:50.758554Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"5742e64f-5b7c-4d58-98c7-7114176de0ef","image_count":0,"is_public":false,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2025-09-05T15:09:50.758554Z"}],"total_count":1}'
+        body: '{"created_at":"2026-07-17T09:50:00.636594Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"dc55a9a7-a43c-4fb8-96ca-325f9d3fa062","image_count":0,"is_public":false,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:00.636594Z"}'
         headers:
             Content-Length:
-                - "456"
+                - "436"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:52 GMT
+                - Fri, 17 Jul 2026 09:50:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,10 +195,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 204dd0df-6d82-44e9-a690-efadc72cc033
+                - 30cde4dc-dba1-46e0-a118-e54630396ccd
         status: 200 OK
         code: 200
-        duration: 197.230708ms
+        duration: 83.100062ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -214,8 +214,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/5742e64f-5b7c-4d58-98c7-7114176de0ef
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces?name=test-cr-data&order_by=created_at_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -223,20 +223,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 423
+        content_length: 470
         uncompressed: false
-        body: '{"created_at":"2025-09-05T15:09:50.758554Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"5742e64f-5b7c-4d58-98c7-7114176de0ef","image_count":0,"is_public":false,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2025-09-05T15:09:50.758554Z"}'
+        body: '{"namespaces":[{"created_at":"2026-07-17T09:50:00.636594Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"dc55a9a7-a43c-4fb8-96ca-325f9d3fa062","image_count":0,"is_public":false,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:00.636594Z"}],"total_count":1}'
         headers:
             Content-Length:
-                - "423"
+                - "470"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:52 GMT
+                - Fri, 17 Jul 2026 09:50:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -244,10 +244,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9151c901-03d0-44c4-a84f-9c367825e4ba
+                - 7c9c6db3-19a2-4401-8224-dec7931932bf
         status: 200 OK
         code: 200
-        duration: 213.689083ms
+        duration: 237.364275ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -263,8 +263,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/5742e64f-5b7c-4d58-98c7-7114176de0ef
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/dc55a9a7-a43c-4fb8-96ca-325f9d3fa062
         method: GET
       response:
         proto: HTTP/2.0
@@ -272,20 +272,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 423
+        content_length: 436
         uncompressed: false
-        body: '{"created_at":"2025-09-05T15:09:50.758554Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"5742e64f-5b7c-4d58-98c7-7114176de0ef","image_count":0,"is_public":false,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2025-09-05T15:09:50.758554Z"}'
+        body: '{"created_at":"2026-07-17T09:50:00.636594Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"dc55a9a7-a43c-4fb8-96ca-325f9d3fa062","image_count":0,"is_public":false,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:00.636594Z"}'
         headers:
             Content-Length:
-                - "423"
+                - "436"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:52 GMT
+                - Fri, 17 Jul 2026 09:50:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -293,10 +293,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - af6b34ae-e441-4854-9e55-7e41ba21613c
+                - efbae16e-62b5-415b-890e-061882e1a82c
         status: 200 OK
         code: 200
-        duration: 192.392709ms
+        duration: 207.586542ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -312,8 +312,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/5742e64f-5b7c-4d58-98c7-7114176de0ef
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/dc55a9a7-a43c-4fb8-96ca-325f9d3fa062
         method: GET
       response:
         proto: HTTP/2.0
@@ -321,20 +321,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 423
+        content_length: 436
         uncompressed: false
-        body: '{"created_at":"2025-09-05T15:09:50.758554Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"5742e64f-5b7c-4d58-98c7-7114176de0ef","image_count":0,"is_public":false,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2025-09-05T15:09:50.758554Z"}'
+        body: '{"created_at":"2026-07-17T09:50:00.636594Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"dc55a9a7-a43c-4fb8-96ca-325f9d3fa062","image_count":0,"is_public":false,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:00.636594Z"}'
         headers:
             Content-Length:
-                - "423"
+                - "436"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:53 GMT
+                - Fri, 17 Jul 2026 09:50:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -342,10 +342,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 81a810c1-c19d-4bac-b1fd-a7b4244737dc
+                - 3d68d372-9306-4b90-bd10-08ad3073620c
         status: 200 OK
         code: 200
-        duration: 994.885292ms
+        duration: 221.8013ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -361,8 +361,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/5742e64f-5b7c-4d58-98c7-7114176de0ef
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/dc55a9a7-a43c-4fb8-96ca-325f9d3fa062
         method: GET
       response:
         proto: HTTP/2.0
@@ -370,20 +370,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 423
+        content_length: 436
         uncompressed: false
-        body: '{"created_at":"2025-09-05T15:09:50.758554Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"5742e64f-5b7c-4d58-98c7-7114176de0ef","image_count":0,"is_public":false,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2025-09-05T15:09:50.758554Z"}'
+        body: '{"created_at":"2026-07-17T09:50:00.636594Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"dc55a9a7-a43c-4fb8-96ca-325f9d3fa062","image_count":0,"is_public":false,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:00.636594Z"}'
         headers:
             Content-Length:
-                - "423"
+                - "436"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:53 GMT
+                - Fri, 17 Jul 2026 09:50:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -391,10 +391,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 24462d05-6f9f-4d88-b146-58294f845b54
+                - c7213c36-4689-477a-8e4c-597146f27303
         status: 200 OK
         code: 200
-        duration: 234.693ms
+        duration: 77.423149ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -410,8 +410,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces?name=test-cr-data&order_by=created_at_asc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces?name=test-cr-data&order_by=created_at_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -419,20 +419,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 456
+        content_length: 470
         uncompressed: false
-        body: '{"namespaces":[{"created_at":"2025-09-05T15:09:50.758554Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"5742e64f-5b7c-4d58-98c7-7114176de0ef","image_count":0,"is_public":false,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2025-09-05T15:09:50.758554Z"}],"total_count":1}'
+        body: '{"namespaces":[{"created_at":"2026-07-17T09:50:00.636594Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"dc55a9a7-a43c-4fb8-96ca-325f9d3fa062","image_count":0,"is_public":false,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:00.636594Z"}],"total_count":1}'
         headers:
             Content-Length:
-                - "456"
+                - "470"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:53 GMT
+                - Fri, 17 Jul 2026 09:50:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -440,10 +440,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 717af125-bb0e-4a6c-99ad-378ea8bff6ff
+                - 8315d4ab-c391-4d4a-8138-426326f5f804
         status: 200 OK
         code: 200
-        duration: 235.486042ms
+        duration: 187.147391ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -459,8 +459,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/5742e64f-5b7c-4d58-98c7-7114176de0ef
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/dc55a9a7-a43c-4fb8-96ca-325f9d3fa062
         method: GET
       response:
         proto: HTTP/2.0
@@ -468,20 +468,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 423
+        content_length: 436
         uncompressed: false
-        body: '{"created_at":"2025-09-05T15:09:50.758554Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"5742e64f-5b7c-4d58-98c7-7114176de0ef","image_count":0,"is_public":false,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2025-09-05T15:09:50.758554Z"}'
+        body: '{"created_at":"2026-07-17T09:50:00.636594Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"dc55a9a7-a43c-4fb8-96ca-325f9d3fa062","image_count":0,"is_public":false,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:00.636594Z"}'
         headers:
             Content-Length:
-                - "423"
+                - "436"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:53 GMT
+                - Fri, 17 Jul 2026 09:50:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -489,10 +489,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7b08c21e-659e-488a-ad23-fb3b37166a56
+                - c60cabd7-3e0b-4238-a334-530054f72ae8
         status: 200 OK
         code: 200
-        duration: 203.299958ms
+        duration: 87.40323ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -508,8 +508,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/5742e64f-5b7c-4d58-98c7-7114176de0ef
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/dc55a9a7-a43c-4fb8-96ca-325f9d3fa062
         method: GET
       response:
         proto: HTTP/2.0
@@ -517,20 +517,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 423
+        content_length: 436
         uncompressed: false
-        body: '{"created_at":"2025-09-05T15:09:50.758554Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"5742e64f-5b7c-4d58-98c7-7114176de0ef","image_count":0,"is_public":false,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2025-09-05T15:09:50.758554Z"}'
+        body: '{"created_at":"2026-07-17T09:50:00.636594Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"dc55a9a7-a43c-4fb8-96ca-325f9d3fa062","image_count":0,"is_public":false,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:00.636594Z"}'
         headers:
             Content-Length:
-                - "423"
+                - "436"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:54 GMT
+                - Fri, 17 Jul 2026 09:50:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -538,10 +538,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 668ee9ad-6958-456b-8571-216b6ad0ad1e
+                - 8970ed06-9938-4912-aeec-4e7f1b3bc228
         status: 200 OK
         code: 200
-        duration: 220.857125ms
+        duration: 212.31475ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -557,8 +557,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/5742e64f-5b7c-4d58-98c7-7114176de0ef
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/dc55a9a7-a43c-4fb8-96ca-325f9d3fa062
         method: GET
       response:
         proto: HTTP/2.0
@@ -566,20 +566,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 423
+        content_length: 436
         uncompressed: false
-        body: '{"created_at":"2025-09-05T15:09:50.758554Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"5742e64f-5b7c-4d58-98c7-7114176de0ef","image_count":0,"is_public":false,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2025-09-05T15:09:50.758554Z"}'
+        body: '{"created_at":"2026-07-17T09:50:00.636594Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"dc55a9a7-a43c-4fb8-96ca-325f9d3fa062","image_count":0,"is_public":false,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:00.636594Z"}'
         headers:
             Content-Length:
-                - "423"
+                - "436"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:54 GMT
+                - Fri, 17 Jul 2026 09:50:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -587,10 +587,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3e4a95a3-1a91-491f-9f82-9588ed314b30
+                - 8a0d5f57-771d-4b92-acd9-3a6b7a989045
         status: 200 OK
         code: 200
-        duration: 217.032333ms
+        duration: 75.022352ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -606,8 +606,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces?name=test-cr-data&order_by=created_at_asc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces?name=test-cr-data&order_by=created_at_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -615,20 +615,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 456
+        content_length: 470
         uncompressed: false
-        body: '{"namespaces":[{"created_at":"2025-09-05T15:09:50.758554Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"5742e64f-5b7c-4d58-98c7-7114176de0ef","image_count":0,"is_public":false,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2025-09-05T15:09:50.758554Z"}],"total_count":1}'
+        body: '{"namespaces":[{"created_at":"2026-07-17T09:50:00.636594Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"dc55a9a7-a43c-4fb8-96ca-325f9d3fa062","image_count":0,"is_public":false,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:00.636594Z"}],"total_count":1}'
         headers:
             Content-Length:
-                - "456"
+                - "470"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:54 GMT
+                - Fri, 17 Jul 2026 09:50:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -636,10 +636,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c6078ad3-d3d3-4265-b507-c22ab71bd9f2
+                - 65e1f10a-88eb-4dfa-9c0c-91563f1f965f
         status: 200 OK
         code: 200
-        duration: 831.909ms
+        duration: 186.898703ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -655,8 +655,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/5742e64f-5b7c-4d58-98c7-7114176de0ef
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/dc55a9a7-a43c-4fb8-96ca-325f9d3fa062
         method: GET
       response:
         proto: HTTP/2.0
@@ -664,20 +664,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 423
+        content_length: 436
         uncompressed: false
-        body: '{"created_at":"2025-09-05T15:09:50.758554Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"5742e64f-5b7c-4d58-98c7-7114176de0ef","image_count":0,"is_public":false,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2025-09-05T15:09:50.758554Z"}'
+        body: '{"created_at":"2026-07-17T09:50:00.636594Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"dc55a9a7-a43c-4fb8-96ca-325f9d3fa062","image_count":0,"is_public":false,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:00.636594Z"}'
         headers:
             Content-Length:
-                - "423"
+                - "436"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:55 GMT
+                - Fri, 17 Jul 2026 09:50:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -685,10 +685,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ea74acdb-345e-43d1-8f2b-7e2090b91726
+                - ba838307-3f2b-498c-b77a-be08f4752ff6
         status: 200 OK
         code: 200
-        duration: 214.091459ms
+        duration: 89.862867ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -704,8 +704,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/5742e64f-5b7c-4d58-98c7-7114176de0ef
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/dc55a9a7-a43c-4fb8-96ca-325f9d3fa062
         method: GET
       response:
         proto: HTTP/2.0
@@ -713,20 +713,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 423
+        content_length: 436
         uncompressed: false
-        body: '{"created_at":"2025-09-05T15:09:50.758554Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"5742e64f-5b7c-4d58-98c7-7114176de0ef","image_count":0,"is_public":false,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2025-09-05T15:09:50.758554Z"}'
+        body: '{"created_at":"2026-07-17T09:50:00.636594Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"dc55a9a7-a43c-4fb8-96ca-325f9d3fa062","image_count":0,"is_public":false,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:00.636594Z"}'
         headers:
             Content-Length:
-                - "423"
+                - "436"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:55 GMT
+                - Fri, 17 Jul 2026 09:50:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -734,10 +734,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bfbc5ddf-7d50-4eb1-b5f1-de8b187764a3
+                - b62b4c40-3a46-4e02-afda-eeaf100bdddc
         status: 200 OK
         code: 200
-        duration: 213.251666ms
+        duration: 94.773829ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -753,8 +753,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/5742e64f-5b7c-4d58-98c7-7114176de0ef
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/dc55a9a7-a43c-4fb8-96ca-325f9d3fa062
         method: GET
       response:
         proto: HTTP/2.0
@@ -762,20 +762,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 423
+        content_length: 436
         uncompressed: false
-        body: '{"created_at":"2025-09-05T15:09:50.758554Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"5742e64f-5b7c-4d58-98c7-7114176de0ef","image_count":0,"is_public":false,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2025-09-05T15:09:50.758554Z"}'
+        body: '{"created_at":"2026-07-17T09:50:00.636594Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"dc55a9a7-a43c-4fb8-96ca-325f9d3fa062","image_count":0,"is_public":false,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:00.636594Z"}'
         headers:
             Content-Length:
-                - "423"
+                - "436"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:55 GMT
+                - Fri, 17 Jul 2026 09:50:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -783,10 +783,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - faf6cb36-ff61-4dd8-86a4-0344d2dea3ea
+                - c6568c51-5874-4c15-b5a1-00924b43f1dc
         status: 200 OK
         code: 200
-        duration: 199.161917ms
+        duration: 71.810948ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -804,8 +804,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/5742e64f-5b7c-4d58-98c7-7114176de0ef
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/dc55a9a7-a43c-4fb8-96ca-325f9d3fa062
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -813,20 +813,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 425
+        content_length: 438
         uncompressed: false
-        body: '{"created_at":"2025-09-05T15:09:50.758554Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"5742e64f-5b7c-4d58-98c7-7114176de0ef","image_count":0,"is_public":true,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2025-09-05T15:09:56.041259438Z"}'
+        body: '{"created_at":"2026-07-17T09:50:00.636594Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"dc55a9a7-a43c-4fb8-96ca-325f9d3fa062","image_count":0,"is_public":true,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:03.631205155Z"}'
         headers:
             Content-Length:
-                - "425"
+                - "438"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:56 GMT
+                - Fri, 17 Jul 2026 09:50:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -834,10 +834,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bb4b4ac6-f682-4497-b0dc-e2c742b96b39
+                - 67342207-9ee6-48e7-a99f-a0e6c4a59f1e
         status: 200 OK
         code: 200
-        duration: 204.75525ms
+        duration: 290.350452ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -853,8 +853,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/5742e64f-5b7c-4d58-98c7-7114176de0ef
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/dc55a9a7-a43c-4fb8-96ca-325f9d3fa062
         method: GET
       response:
         proto: HTTP/2.0
@@ -862,20 +862,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 422
+        content_length: 435
         uncompressed: false
-        body: '{"created_at":"2025-09-05T15:09:50.758554Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"5742e64f-5b7c-4d58-98c7-7114176de0ef","image_count":0,"is_public":true,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2025-09-05T15:09:56.041259Z"}'
+        body: '{"created_at":"2026-07-17T09:50:00.636594Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"dc55a9a7-a43c-4fb8-96ca-325f9d3fa062","image_count":0,"is_public":true,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:03.631205Z"}'
         headers:
             Content-Length:
-                - "422"
+                - "435"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:56 GMT
+                - Fri, 17 Jul 2026 09:50:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -883,10 +883,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - acc849b0-4b96-414c-8c4f-47992dcc2a93
+                - 0c755cef-35c2-442b-9e08-ede6dac3c1d0
         status: 200 OK
         code: 200
-        duration: 177.458042ms
+        duration: 80.288772ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -902,8 +902,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces?name=test-cr-data&order_by=created_at_asc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/dc55a9a7-a43c-4fb8-96ca-325f9d3fa062
         method: GET
       response:
         proto: HTTP/2.0
@@ -911,20 +911,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 455
+        content_length: 435
         uncompressed: false
-        body: '{"namespaces":[{"created_at":"2025-09-05T15:09:50.758554Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"5742e64f-5b7c-4d58-98c7-7114176de0ef","image_count":0,"is_public":true,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2025-09-05T15:09:56.041259Z"}],"total_count":1}'
+        body: '{"created_at":"2026-07-17T09:50:00.636594Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"dc55a9a7-a43c-4fb8-96ca-325f9d3fa062","image_count":0,"is_public":true,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:03.631205Z"}'
         headers:
             Content-Length:
-                - "455"
+                - "435"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:56 GMT
+                - Fri, 17 Jul 2026 09:50:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -932,10 +932,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 22071f7f-1dec-47f8-a7e0-81d9a3fc24bc
+                - 0a9ce541-f854-4ce4-bca3-ba1564a6be5c
         status: 200 OK
         code: 200
-        duration: 238.056834ms
+        duration: 78.811161ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -951,8 +951,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/5742e64f-5b7c-4d58-98c7-7114176de0ef
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces?name=test-cr-data&order_by=created_at_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -960,20 +960,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 422
+        content_length: 469
         uncompressed: false
-        body: '{"created_at":"2025-09-05T15:09:50.758554Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"5742e64f-5b7c-4d58-98c7-7114176de0ef","image_count":0,"is_public":true,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2025-09-05T15:09:56.041259Z"}'
+        body: '{"namespaces":[{"created_at":"2026-07-17T09:50:00.636594Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"dc55a9a7-a43c-4fb8-96ca-325f9d3fa062","image_count":0,"is_public":true,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:03.631205Z"}],"total_count":1}'
         headers:
             Content-Length:
-                - "422"
+                - "469"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:56 GMT
+                - Fri, 17 Jul 2026 09:50:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -981,10 +981,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 84ff4452-e161-4b0d-bbae-e4640e1db451
+                - 42b61103-9303-4589-a594-a55bbce74b87
         status: 200 OK
         code: 200
-        duration: 250.77675ms
+        duration: 217.150438ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1000,8 +1000,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/5742e64f-5b7c-4d58-98c7-7114176de0ef
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/dc55a9a7-a43c-4fb8-96ca-325f9d3fa062
         method: GET
       response:
         proto: HTTP/2.0
@@ -1009,20 +1009,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 422
+        content_length: 435
         uncompressed: false
-        body: '{"created_at":"2025-09-05T15:09:50.758554Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"5742e64f-5b7c-4d58-98c7-7114176de0ef","image_count":0,"is_public":true,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2025-09-05T15:09:56.041259Z"}'
+        body: '{"created_at":"2026-07-17T09:50:00.636594Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"dc55a9a7-a43c-4fb8-96ca-325f9d3fa062","image_count":0,"is_public":true,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:03.631205Z"}'
         headers:
             Content-Length:
-                - "422"
+                - "435"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:56 GMT
+                - Fri, 17 Jul 2026 09:50:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1030,10 +1030,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 92a8e61c-a7bf-4d79-b517-c446cf83724c
+                - ee2c0e51-0b42-4898-847b-8e9f32875893
         status: 200 OK
         code: 200
-        duration: 235.736167ms
+        duration: 77.773428ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1049,8 +1049,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/5742e64f-5b7c-4d58-98c7-7114176de0ef
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/dc55a9a7-a43c-4fb8-96ca-325f9d3fa062
         method: GET
       response:
         proto: HTTP/2.0
@@ -1058,20 +1058,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 422
+        content_length: 435
         uncompressed: false
-        body: '{"created_at":"2025-09-05T15:09:50.758554Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"5742e64f-5b7c-4d58-98c7-7114176de0ef","image_count":0,"is_public":true,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2025-09-05T15:09:56.041259Z"}'
+        body: '{"created_at":"2026-07-17T09:50:00.636594Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"dc55a9a7-a43c-4fb8-96ca-325f9d3fa062","image_count":0,"is_public":true,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:03.631205Z"}'
         headers:
             Content-Length:
-                - "422"
+                - "435"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:57 GMT
+                - Fri, 17 Jul 2026 09:50:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1079,10 +1079,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bf4533f1-12ce-49cf-9ef7-ee46839278cc
+                - 3dfce349-12bc-4a2b-8729-2505491fb3da
         status: 200 OK
         code: 200
-        duration: 206.006583ms
+        duration: 84.702467ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1098,8 +1098,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces?name=test-cr-data&order_by=created_at_asc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/dc55a9a7-a43c-4fb8-96ca-325f9d3fa062
         method: GET
       response:
         proto: HTTP/2.0
@@ -1107,20 +1107,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 455
+        content_length: 435
         uncompressed: false
-        body: '{"namespaces":[{"created_at":"2025-09-05T15:09:50.758554Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"5742e64f-5b7c-4d58-98c7-7114176de0ef","image_count":0,"is_public":true,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2025-09-05T15:09:56.041259Z"}],"total_count":1}'
+        body: '{"created_at":"2026-07-17T09:50:00.636594Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"dc55a9a7-a43c-4fb8-96ca-325f9d3fa062","image_count":0,"is_public":true,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:03.631205Z"}'
         headers:
             Content-Length:
-                - "455"
+                - "435"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:57 GMT
+                - Fri, 17 Jul 2026 09:50:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1128,10 +1128,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f15a490d-9533-4ca0-8efa-5e88087f2ca2
+                - aa273401-1588-4bb8-a5ca-ff32242c658f
         status: 200 OK
         code: 200
-        duration: 205.442458ms
+        duration: 83.246598ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1147,8 +1147,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/5742e64f-5b7c-4d58-98c7-7114176de0ef
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces?name=test-cr-data&order_by=created_at_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -1156,20 +1156,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 422
+        content_length: 469
         uncompressed: false
-        body: '{"created_at":"2025-09-05T15:09:50.758554Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"5742e64f-5b7c-4d58-98c7-7114176de0ef","image_count":0,"is_public":true,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2025-09-05T15:09:56.041259Z"}'
+        body: '{"namespaces":[{"created_at":"2026-07-17T09:50:00.636594Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"dc55a9a7-a43c-4fb8-96ca-325f9d3fa062","image_count":0,"is_public":true,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:03.631205Z"}],"total_count":1}'
         headers:
             Content-Length:
-                - "422"
+                - "469"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:57 GMT
+                - Fri, 17 Jul 2026 09:50:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1177,10 +1177,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 163c4628-f0af-475c-975a-4137bdb929ae
+                - 11179dce-625e-443f-8fe2-80f00a7ace37
         status: 200 OK
         code: 200
-        duration: 229.527792ms
+        duration: 83.288908ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1196,8 +1196,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/5742e64f-5b7c-4d58-98c7-7114176de0ef
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/dc55a9a7-a43c-4fb8-96ca-325f9d3fa062
         method: GET
       response:
         proto: HTTP/2.0
@@ -1205,20 +1205,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 422
+        content_length: 435
         uncompressed: false
-        body: '{"created_at":"2025-09-05T15:09:50.758554Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"5742e64f-5b7c-4d58-98c7-7114176de0ef","image_count":0,"is_public":true,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2025-09-05T15:09:56.041259Z"}'
+        body: '{"created_at":"2026-07-17T09:50:00.636594Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"dc55a9a7-a43c-4fb8-96ca-325f9d3fa062","image_count":0,"is_public":true,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:03.631205Z"}'
         headers:
             Content-Length:
-                - "422"
+                - "435"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:57 GMT
+                - Fri, 17 Jul 2026 09:50:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1226,10 +1226,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 77352537-ff14-47f6-83c5-0b27ed749336
+                - 4cae2486-ea6d-4524-86c9-eddbdecef60a
         status: 200 OK
         code: 200
-        duration: 180.547959ms
+        duration: 84.10863ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1245,8 +1245,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/5742e64f-5b7c-4d58-98c7-7114176de0ef
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/dc55a9a7-a43c-4fb8-96ca-325f9d3fa062
         method: GET
       response:
         proto: HTTP/2.0
@@ -1254,20 +1254,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 422
+        content_length: 435
         uncompressed: false
-        body: '{"created_at":"2025-09-05T15:09:50.758554Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"5742e64f-5b7c-4d58-98c7-7114176de0ef","image_count":0,"is_public":true,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2025-09-05T15:09:56.041259Z"}'
+        body: '{"created_at":"2026-07-17T09:50:00.636594Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"dc55a9a7-a43c-4fb8-96ca-325f9d3fa062","image_count":0,"is_public":true,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:03.631205Z"}'
         headers:
             Content-Length:
-                - "422"
+                - "435"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:57 GMT
+                - Fri, 17 Jul 2026 09:50:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1275,10 +1275,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7e2f5ef5-7964-41c1-b738-b245f51b223d
+                - b81e3cba-c912-48eb-8ba8-64c75679d6c8
         status: 200 OK
         code: 200
-        duration: 212.561292ms
+        duration: 84.781055ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1294,8 +1294,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces?name=test-cr-data&order_by=created_at_asc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/dc55a9a7-a43c-4fb8-96ca-325f9d3fa062
         method: GET
       response:
         proto: HTTP/2.0
@@ -1303,20 +1303,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 455
+        content_length: 435
         uncompressed: false
-        body: '{"namespaces":[{"created_at":"2025-09-05T15:09:50.758554Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"5742e64f-5b7c-4d58-98c7-7114176de0ef","image_count":0,"is_public":true,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2025-09-05T15:09:56.041259Z"}],"total_count":1}'
+        body: '{"created_at":"2026-07-17T09:50:00.636594Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"dc55a9a7-a43c-4fb8-96ca-325f9d3fa062","image_count":0,"is_public":true,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:03.631205Z"}'
         headers:
             Content-Length:
-                - "455"
+                - "435"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:57 GMT
+                - Fri, 17 Jul 2026 09:50:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1324,10 +1324,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cea1284b-bc42-4fd5-a361-5a47b13d4735
+                - aa2164c9-be95-4e64-ba13-898878999361
         status: 200 OK
         code: 200
-        duration: 184.255709ms
+        duration: 87.889554ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1343,8 +1343,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/5742e64f-5b7c-4d58-98c7-7114176de0ef
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces?name=test-cr-data&order_by=created_at_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -1352,20 +1352,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 422
+        content_length: 469
         uncompressed: false
-        body: '{"created_at":"2025-09-05T15:09:50.758554Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"5742e64f-5b7c-4d58-98c7-7114176de0ef","image_count":0,"is_public":true,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2025-09-05T15:09:56.041259Z"}'
+        body: '{"namespaces":[{"created_at":"2026-07-17T09:50:00.636594Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"dc55a9a7-a43c-4fb8-96ca-325f9d3fa062","image_count":0,"is_public":true,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:03.631205Z"}],"total_count":1}'
         headers:
             Content-Length:
-                - "422"
+                - "469"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:58 GMT
+                - Fri, 17 Jul 2026 09:50:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1373,10 +1373,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ac6a920f-6b0d-47ca-88bf-7261b776934e
+                - 24e133d4-aa3b-4eef-ab80-c210f4e9dacd
         status: 200 OK
         code: 200
-        duration: 202.240416ms
+        duration: 171.375993ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1392,8 +1392,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/5742e64f-5b7c-4d58-98c7-7114176de0ef
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/dc55a9a7-a43c-4fb8-96ca-325f9d3fa062
         method: GET
       response:
         proto: HTTP/2.0
@@ -1401,20 +1401,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 422
+        content_length: 435
         uncompressed: false
-        body: '{"created_at":"2025-09-05T15:09:50.758554Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"5742e64f-5b7c-4d58-98c7-7114176de0ef","image_count":0,"is_public":true,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2025-09-05T15:09:56.041259Z"}'
+        body: '{"created_at":"2026-07-17T09:50:00.636594Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"dc55a9a7-a43c-4fb8-96ca-325f9d3fa062","image_count":0,"is_public":true,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:03.631205Z"}'
         headers:
             Content-Length:
-                - "422"
+                - "435"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:58 GMT
+                - Fri, 17 Jul 2026 09:50:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1422,10 +1422,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dd08a11f-e46e-4037-8956-ec4923f68b82
+                - 26039c01-d972-4b0e-aecd-952f0cd4e2e9
         status: 200 OK
         code: 200
-        duration: 242.047791ms
+        duration: 79.845147ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1441,8 +1441,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/5742e64f-5b7c-4d58-98c7-7114176de0ef
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/dc55a9a7-a43c-4fb8-96ca-325f9d3fa062
         method: GET
       response:
         proto: HTTP/2.0
@@ -1450,20 +1450,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 422
+        content_length: 435
         uncompressed: false
-        body: '{"created_at":"2025-09-05T15:09:50.758554Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"5742e64f-5b7c-4d58-98c7-7114176de0ef","image_count":0,"is_public":true,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2025-09-05T15:09:56.041259Z"}'
+        body: '{"created_at":"2026-07-17T09:50:00.636594Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"dc55a9a7-a43c-4fb8-96ca-325f9d3fa062","image_count":0,"is_public":true,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:03.631205Z"}'
         headers:
             Content-Length:
-                - "422"
+                - "435"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:58 GMT
+                - Fri, 17 Jul 2026 09:50:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1471,10 +1471,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 374ac599-8d33-4084-acb9-ae31f4a3942c
+                - f56b8224-c9e7-4e55-aee9-bde95790a850
         status: 200 OK
         code: 200
-        duration: 180.6815ms
+        duration: 116.715888ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1490,8 +1490,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/5742e64f-5b7c-4d58-98c7-7114176de0ef
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/dc55a9a7-a43c-4fb8-96ca-325f9d3fa062
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1499,20 +1499,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 428
+        content_length: 441
         uncompressed: false
-        body: '{"created_at":"2025-09-05T15:09:50.758554Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"5742e64f-5b7c-4d58-98c7-7114176de0ef","image_count":0,"is_public":true,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"deleting","status_message":"","updated_at":"2025-09-05T15:09:58.794491170Z"}'
+        body: '{"created_at":"2026-07-17T09:50:00.636594Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"dc55a9a7-a43c-4fb8-96ca-325f9d3fa062","image_count":0,"is_public":true,"name":"test-cr-data","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"deleting","status_message":"","updated_at":"2026-07-17T09:50:05.581481325Z"}'
         headers:
             Content-Length:
-                - "428"
+                - "441"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:58 GMT
+                - Fri, 17 Jul 2026 09:50:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1520,10 +1520,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1485efe9-ccb0-4777-b816-a74d9d8c2d2d
+                - 889cedeb-e632-4146-a925-30a11bb9c8d3
         status: 200 OK
         code: 200
-        duration: 240.3495ms
+        duration: 262.73172ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1539,8 +1539,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/5742e64f-5b7c-4d58-98c7-7114176de0ef
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/dc55a9a7-a43c-4fb8-96ca-325f9d3fa062
         method: GET
       response:
         proto: HTTP/2.0
@@ -1559,9 +1559,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:58 GMT
+                - Fri, 17 Jul 2026 09:50:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1569,10 +1569,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5ae8c4a2-3129-4d2c-ba26-6066ea620e35
+                - b446a4a1-4157-4b28-bfb8-4896b6e05a8f
         status: 404 Not Found
         code: 404
-        duration: 95.166292ms
+        duration: 61.115232ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1588,8 +1588,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/5742e64f-5b7c-4d58-98c7-7114176de0ef
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/dc55a9a7-a43c-4fb8-96ca-325f9d3fa062
         method: GET
       response:
         proto: HTTP/2.0
@@ -1608,9 +1608,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:59 GMT
+                - Fri, 17 Jul 2026 09:50:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1618,10 +1618,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3fc7312a-13fd-456d-9621-562b8e3f4b39
+                - b61bc3d8-7ad5-47d0-9fce-8b751d5fc03c
         status: 404 Not Found
         code: 404
-        duration: 98.914458ms
+        duration: 63.017111ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1637,8 +1637,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/5742e64f-5b7c-4d58-98c7-7114176de0ef
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/dc55a9a7-a43c-4fb8-96ca-325f9d3fa062
         method: GET
       response:
         proto: HTTP/2.0
@@ -1657,9 +1657,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:59 GMT
+                - Fri, 17 Jul 2026 09:50:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1667,10 +1667,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8d442cd7-2d95-4ed8-a85b-da2679fa4bbb
+                - 249d9d3f-410e-455d-8f31-82beaa91a295
         status: 404 Not Found
         code: 404
-        duration: 96.99575ms
+        duration: 58.340461ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1686,8 +1686,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/5742e64f-5b7c-4d58-98c7-7114176de0ef
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/dc55a9a7-a43c-4fb8-96ca-325f9d3fa062
         method: GET
       response:
         proto: HTTP/2.0
@@ -1706,9 +1706,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 05 Sep 2025 15:09:59 GMT
+                - Fri, 17 Jul 2026 09:50:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1716,7 +1716,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b730db42-a53e-4e5f-aa2b-d9939ca51338
+                - 89fe2c33-982e-4b9a-a911-049d3eaf4e57
         status: 404 Not Found
         code: 404
-        duration: 101.260583ms
+        duration: 61.586679ms

--- a/internal/services/registry/testdata/namespace-basic.cassette.yaml
+++ b/internal/services/registry/testdata/namespace-basic.cassette.yaml
@@ -12,13 +12,13 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"test-cr-ns-01","description":"","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","is_public":false}'
+        body: '{"name":"test-cr-ns-01","description":"","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","is_public":false}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces
         method: POST
       response:
@@ -29,7 +29,7 @@ interactions:
         trailer: {}
         content_length: 444
         uncompressed: false
-        body: '{"created_at":"2024-12-26T10:25:20.463071602Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-ns-01","id":"d520dbb2-4002-4513-8947-fc39b0c9e849","image_count":0,"is_public":false,"name":"test-cr-ns-01","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2024-12-26T10:25:20.463071602Z"}'
+        body: '{"created_at":"2026-07-17T09:50:00.638933292Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-ns-01","id":"77e91a59-aa35-4d6d-ae0f-ccf15ac80639","image_count":0,"is_public":false,"name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:00.638933292Z"}'
         headers:
             Content-Length:
                 - "444"
@@ -38,7 +38,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Dec 2024 10:25:20 GMT
+                - Fri, 17 Jul 2026 09:50:00 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 244c0128-f06d-416f-b411-4cfb30947dd0
+                - 77d7bab7-63a2-4234-ba33-397fc6aae556
         status: 200 OK
         code: 200
-        duration: 563.69125ms
+        duration: 435.183357ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,8 +67,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/d520dbb2-4002-4513-8947-fc39b0c9e849
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/77e91a59-aa35-4d6d-ae0f-ccf15ac80639
         method: GET
       response:
         proto: HTTP/2.0
@@ -78,7 +78,7 @@ interactions:
         trailer: {}
         content_length: 438
         uncompressed: false
-        body: '{"created_at":"2024-12-26T10:25:20.463072Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-ns-01","id":"d520dbb2-4002-4513-8947-fc39b0c9e849","image_count":0,"is_public":false,"name":"test-cr-ns-01","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2024-12-26T10:25:20.463072Z"}'
+        body: '{"created_at":"2026-07-17T09:50:00.638933Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-ns-01","id":"77e91a59-aa35-4d6d-ae0f-ccf15ac80639","image_count":0,"is_public":false,"name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:00.638933Z"}'
         headers:
             Content-Length:
                 - "438"
@@ -87,7 +87,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Dec 2024 10:25:20 GMT
+                - Fri, 17 Jul 2026 09:50:01 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 90737e64-6345-43f5-9fc0-8d1632b6b8b4
+                - bf02d381-aa53-4075-94cb-0f791fb20810
         status: 200 OK
         code: 200
-        duration: 140.218917ms
+        duration: 361.362718ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -116,8 +116,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/d520dbb2-4002-4513-8947-fc39b0c9e849
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/77e91a59-aa35-4d6d-ae0f-ccf15ac80639
         method: GET
       response:
         proto: HTTP/2.0
@@ -127,7 +127,7 @@ interactions:
         trailer: {}
         content_length: 438
         uncompressed: false
-        body: '{"created_at":"2024-12-26T10:25:20.463072Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-ns-01","id":"d520dbb2-4002-4513-8947-fc39b0c9e849","image_count":0,"is_public":false,"name":"test-cr-ns-01","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2024-12-26T10:25:20.463072Z"}'
+        body: '{"created_at":"2026-07-17T09:50:00.638933Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-ns-01","id":"77e91a59-aa35-4d6d-ae0f-ccf15ac80639","image_count":0,"is_public":false,"name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:00.638933Z"}'
         headers:
             Content-Length:
                 - "438"
@@ -136,7 +136,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Dec 2024 10:25:20 GMT
+                - Fri, 17 Jul 2026 09:50:01 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 47d2feaa-321a-4a96-a324-7b9058539409
+                - 71bd40f6-e1a7-4afa-87e5-788a070a2d39
         status: 200 OK
         code: 200
-        duration: 128.299583ms
+        duration: 243.246785ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -165,8 +165,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/d520dbb2-4002-4513-8947-fc39b0c9e849
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/77e91a59-aa35-4d6d-ae0f-ccf15ac80639
         method: GET
       response:
         proto: HTTP/2.0
@@ -176,7 +176,7 @@ interactions:
         trailer: {}
         content_length: 438
         uncompressed: false
-        body: '{"created_at":"2024-12-26T10:25:20.463072Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-ns-01","id":"d520dbb2-4002-4513-8947-fc39b0c9e849","image_count":0,"is_public":false,"name":"test-cr-ns-01","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2024-12-26T10:25:20.463072Z"}'
+        body: '{"created_at":"2026-07-17T09:50:00.638933Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-ns-01","id":"77e91a59-aa35-4d6d-ae0f-ccf15ac80639","image_count":0,"is_public":false,"name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:00.638933Z"}'
         headers:
             Content-Length:
                 - "438"
@@ -185,7 +185,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Dec 2024 10:25:20 GMT
+                - Fri, 17 Jul 2026 09:50:01 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
@@ -195,10 +195,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 351b4964-3528-4541-a0c1-aa213f56358e
+                - d4fc0946-6d6b-4155-bc62-e7bc4c2940f4
         status: 200 OK
         code: 200
-        duration: 128.820666ms
+        duration: 216.923892ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -214,8 +214,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/d520dbb2-4002-4513-8947-fc39b0c9e849
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/77e91a59-aa35-4d6d-ae0f-ccf15ac80639
         method: GET
       response:
         proto: HTTP/2.0
@@ -225,7 +225,7 @@ interactions:
         trailer: {}
         content_length: 438
         uncompressed: false
-        body: '{"created_at":"2024-12-26T10:25:20.463072Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-ns-01","id":"d520dbb2-4002-4513-8947-fc39b0c9e849","image_count":0,"is_public":false,"name":"test-cr-ns-01","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2024-12-26T10:25:20.463072Z"}'
+        body: '{"created_at":"2026-07-17T09:50:00.638933Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-ns-01","id":"77e91a59-aa35-4d6d-ae0f-ccf15ac80639","image_count":0,"is_public":false,"name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:00.638933Z"}'
         headers:
             Content-Length:
                 - "438"
@@ -234,7 +234,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Dec 2024 10:25:21 GMT
+                - Fri, 17 Jul 2026 09:50:01 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
@@ -244,10 +244,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - be037106-d1fb-4582-b6c8-1e0ced365386
+                - be9d1e03-3cfd-46cd-bd97-ed38768c1576
         status: 200 OK
         code: 200
-        duration: 126.336292ms
+        duration: 85.493355ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -263,8 +263,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/d520dbb2-4002-4513-8947-fc39b0c9e849
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/77e91a59-aa35-4d6d-ae0f-ccf15ac80639
         method: GET
       response:
         proto: HTTP/2.0
@@ -274,7 +274,7 @@ interactions:
         trailer: {}
         content_length: 438
         uncompressed: false
-        body: '{"created_at":"2024-12-26T10:25:20.463072Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-ns-01","id":"d520dbb2-4002-4513-8947-fc39b0c9e849","image_count":0,"is_public":false,"name":"test-cr-ns-01","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2024-12-26T10:25:20.463072Z"}'
+        body: '{"created_at":"2026-07-17T09:50:00.638933Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-ns-01","id":"77e91a59-aa35-4d6d-ae0f-ccf15ac80639","image_count":0,"is_public":false,"name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:00.638933Z"}'
         headers:
             Content-Length:
                 - "438"
@@ -283,7 +283,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Dec 2024 10:25:21 GMT
+                - Fri, 17 Jul 2026 09:50:02 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
@@ -293,10 +293,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ce08d5c4-630b-46ec-a886-e72a842c5ca0
+                - a4f09953-c9b7-4ed6-a9a1-68977d7304ed
         status: 200 OK
         code: 200
-        duration: 122.877041ms
+        duration: 80.767362ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -312,8 +312,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/d520dbb2-4002-4513-8947-fc39b0c9e849
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/77e91a59-aa35-4d6d-ae0f-ccf15ac80639
         method: GET
       response:
         proto: HTTP/2.0
@@ -323,7 +323,7 @@ interactions:
         trailer: {}
         content_length: 438
         uncompressed: false
-        body: '{"created_at":"2024-12-26T10:25:20.463072Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-ns-01","id":"d520dbb2-4002-4513-8947-fc39b0c9e849","image_count":0,"is_public":false,"name":"test-cr-ns-01","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2024-12-26T10:25:20.463072Z"}'
+        body: '{"created_at":"2026-07-17T09:50:00.638933Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-ns-01","id":"77e91a59-aa35-4d6d-ae0f-ccf15ac80639","image_count":0,"is_public":false,"name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:00.638933Z"}'
         headers:
             Content-Length:
                 - "438"
@@ -332,7 +332,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Dec 2024 10:25:22 GMT
+                - Fri, 17 Jul 2026 09:50:02 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
@@ -342,10 +342,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9525a2e5-4801-4c82-ba80-84c81b1dae2d
+                - 1e3e535f-c4de-4429-97aa-e46d1fbc07b6
         status: 200 OK
         code: 200
-        duration: 88.854583ms
+        duration: 80.506321ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -363,8 +363,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/d520dbb2-4002-4513-8947-fc39b0c9e849
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/77e91a59-aa35-4d6d-ae0f-ccf15ac80639
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -374,7 +374,7 @@ interactions:
         trailer: {}
         content_length: 466
         uncompressed: false
-        body: '{"created_at":"2024-12-26T10:25:20.463072Z","description":"test registry namespace 01","endpoint":"rg.pl-waw.scw.cloud/test-cr-ns-01","id":"d520dbb2-4002-4513-8947-fc39b0c9e849","image_count":0,"is_public":true,"name":"test-cr-ns-01","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2024-12-26T10:25:22.176681203Z"}'
+        body: '{"created_at":"2026-07-17T09:50:00.638933Z","description":"test registry namespace 01","endpoint":"rg.pl-waw.scw.cloud/test-cr-ns-01","id":"77e91a59-aa35-4d6d-ae0f-ccf15ac80639","image_count":0,"is_public":true,"name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:02.583456136Z"}'
         headers:
             Content-Length:
                 - "466"
@@ -383,7 +383,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Dec 2024 10:25:22 GMT
+                - Fri, 17 Jul 2026 09:50:02 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
@@ -393,10 +393,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 993e772c-b89d-4f11-862a-299aeeee1360
+                - db49c774-d03b-42ec-b4ac-46b45c826b8e
         status: 200 OK
         code: 200
-        duration: 93.129334ms
+        duration: 241.482946ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -412,8 +412,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/d520dbb2-4002-4513-8947-fc39b0c9e849
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/77e91a59-aa35-4d6d-ae0f-ccf15ac80639
         method: GET
       response:
         proto: HTTP/2.0
@@ -423,7 +423,7 @@ interactions:
         trailer: {}
         content_length: 463
         uncompressed: false
-        body: '{"created_at":"2024-12-26T10:25:20.463072Z","description":"test registry namespace 01","endpoint":"rg.pl-waw.scw.cloud/test-cr-ns-01","id":"d520dbb2-4002-4513-8947-fc39b0c9e849","image_count":0,"is_public":true,"name":"test-cr-ns-01","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2024-12-26T10:25:22.176681Z"}'
+        body: '{"created_at":"2026-07-17T09:50:00.638933Z","description":"test registry namespace 01","endpoint":"rg.pl-waw.scw.cloud/test-cr-ns-01","id":"77e91a59-aa35-4d6d-ae0f-ccf15ac80639","image_count":0,"is_public":true,"name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:02.583456Z"}'
         headers:
             Content-Length:
                 - "463"
@@ -432,7 +432,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Dec 2024 10:25:22 GMT
+                - Fri, 17 Jul 2026 09:50:02 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
@@ -442,10 +442,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e7465c4b-08e5-40c9-bb35-efa62ca00743
+                - 3a0c9b6d-bd5a-408e-8788-157a992f6eb8
         status: 200 OK
         code: 200
-        duration: 79.477667ms
+        duration: 78.413513ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -461,8 +461,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/d520dbb2-4002-4513-8947-fc39b0c9e849
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/77e91a59-aa35-4d6d-ae0f-ccf15ac80639
         method: GET
       response:
         proto: HTTP/2.0
@@ -472,7 +472,7 @@ interactions:
         trailer: {}
         content_length: 463
         uncompressed: false
-        body: '{"created_at":"2024-12-26T10:25:20.463072Z","description":"test registry namespace 01","endpoint":"rg.pl-waw.scw.cloud/test-cr-ns-01","id":"d520dbb2-4002-4513-8947-fc39b0c9e849","image_count":0,"is_public":true,"name":"test-cr-ns-01","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2024-12-26T10:25:22.176681Z"}'
+        body: '{"created_at":"2026-07-17T09:50:00.638933Z","description":"test registry namespace 01","endpoint":"rg.pl-waw.scw.cloud/test-cr-ns-01","id":"77e91a59-aa35-4d6d-ae0f-ccf15ac80639","image_count":0,"is_public":true,"name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:02.583456Z"}'
         headers:
             Content-Length:
                 - "463"
@@ -481,7 +481,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Dec 2024 10:25:22 GMT
+                - Fri, 17 Jul 2026 09:50:02 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
@@ -491,10 +491,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 643f629b-e761-4029-a7c0-03fb7fbc7476
+                - d7edc960-7971-415d-9ee3-b0de6599dff0
         status: 200 OK
         code: 200
-        duration: 90.854458ms
+        duration: 71.41292ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -510,8 +510,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/d520dbb2-4002-4513-8947-fc39b0c9e849
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/77e91a59-aa35-4d6d-ae0f-ccf15ac80639
         method: GET
       response:
         proto: HTTP/2.0
@@ -521,7 +521,7 @@ interactions:
         trailer: {}
         content_length: 463
         uncompressed: false
-        body: '{"created_at":"2024-12-26T10:25:20.463072Z","description":"test registry namespace 01","endpoint":"rg.pl-waw.scw.cloud/test-cr-ns-01","id":"d520dbb2-4002-4513-8947-fc39b0c9e849","image_count":0,"is_public":true,"name":"test-cr-ns-01","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2024-12-26T10:25:22.176681Z"}'
+        body: '{"created_at":"2026-07-17T09:50:00.638933Z","description":"test registry namespace 01","endpoint":"rg.pl-waw.scw.cloud/test-cr-ns-01","id":"77e91a59-aa35-4d6d-ae0f-ccf15ac80639","image_count":0,"is_public":true,"name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:02.583456Z"}'
         headers:
             Content-Length:
                 - "463"
@@ -530,7 +530,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Dec 2024 10:25:22 GMT
+                - Fri, 17 Jul 2026 09:50:03 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
@@ -540,10 +540,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b5d971cd-7a87-41d7-b692-b35bc599a93f
+                - ee8ac115-64d7-4ebf-9a01-b7c01cbaf771
         status: 200 OK
         code: 200
-        duration: 84.522875ms
+        duration: 87.315635ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -559,8 +559,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/d520dbb2-4002-4513-8947-fc39b0c9e849
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/77e91a59-aa35-4d6d-ae0f-ccf15ac80639
         method: GET
       response:
         proto: HTTP/2.0
@@ -570,7 +570,7 @@ interactions:
         trailer: {}
         content_length: 463
         uncompressed: false
-        body: '{"created_at":"2024-12-26T10:25:20.463072Z","description":"test registry namespace 01","endpoint":"rg.pl-waw.scw.cloud/test-cr-ns-01","id":"d520dbb2-4002-4513-8947-fc39b0c9e849","image_count":0,"is_public":true,"name":"test-cr-ns-01","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2024-12-26T10:25:22.176681Z"}'
+        body: '{"created_at":"2026-07-17T09:50:00.638933Z","description":"test registry namespace 01","endpoint":"rg.pl-waw.scw.cloud/test-cr-ns-01","id":"77e91a59-aa35-4d6d-ae0f-ccf15ac80639","image_count":0,"is_public":true,"name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2026-07-17T09:50:02.583456Z"}'
         headers:
             Content-Length:
                 - "463"
@@ -579,7 +579,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Dec 2024 10:25:23 GMT
+                - Fri, 17 Jul 2026 09:50:03 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
@@ -589,10 +589,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 17755a42-0d76-4363-8046-97d4421d8965
+                - c2e54007-299a-4622-addd-cf62302a016b
         status: 200 OK
         code: 200
-        duration: 79.427625ms
+        duration: 81.352503ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -608,8 +608,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/d520dbb2-4002-4513-8947-fc39b0c9e849
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/77e91a59-aa35-4d6d-ae0f-ccf15ac80639
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -619,7 +619,7 @@ interactions:
         trailer: {}
         content_length: 469
         uncompressed: false
-        body: '{"created_at":"2024-12-26T10:25:20.463072Z","description":"test registry namespace 01","endpoint":"rg.pl-waw.scw.cloud/test-cr-ns-01","id":"d520dbb2-4002-4513-8947-fc39b0c9e849","image_count":0,"is_public":true,"name":"test-cr-ns-01","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","region":"pl-waw","size":0,"status":"deleting","status_message":"","updated_at":"2024-12-26T10:25:23.178554209Z"}'
+        body: '{"created_at":"2026-07-17T09:50:00.638933Z","description":"test registry namespace 01","endpoint":"rg.pl-waw.scw.cloud/test-cr-ns-01","id":"77e91a59-aa35-4d6d-ae0f-ccf15ac80639","image_count":0,"is_public":true,"name":"test-cr-ns-01","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"pl-waw","size":0,"status":"deleting","status_message":"","updated_at":"2026-07-17T09:50:03.738499250Z"}'
         headers:
             Content-Length:
                 - "469"
@@ -628,7 +628,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Dec 2024 10:25:23 GMT
+                - Fri, 17 Jul 2026 09:50:03 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
@@ -638,10 +638,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b1bbf792-917d-4da1-8aa4-35c1bf12d993
+                - c7b5c9e5-6af0-4796-9648-c4480f40e633
         status: 200 OK
         code: 200
-        duration: 95.556792ms
+        duration: 276.834328ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -657,8 +657,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/d520dbb2-4002-4513-8947-fc39b0c9e849
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/77e91a59-aa35-4d6d-ae0f-ccf15ac80639
         method: GET
       response:
         proto: HTTP/2.0
@@ -677,7 +677,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Dec 2024 10:25:23 GMT
+                - Fri, 17 Jul 2026 09:50:03 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
@@ -687,10 +687,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 69309877-1051-4c66-a511-85545e7443bd
+                - e1e22576-e7bc-40b6-8d75-2a7d2f30de50
         status: 404 Not Found
         code: 404
-        duration: 55.481583ms
+        duration: 61.984057ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -706,8 +706,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/d520dbb2-4002-4513-8947-fc39b0c9e849
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/77e91a59-aa35-4d6d-ae0f-ccf15ac80639
         method: GET
       response:
         proto: HTTP/2.0
@@ -726,7 +726,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Dec 2024 10:25:23 GMT
+                - Fri, 17 Jul 2026 09:50:03 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
@@ -736,7 +736,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 882781a4-c9f9-4931-8b5d-1cbec38c0a85
+                - f1298523-cad9-4985-a9f4-38e8d2e0e7e2
         status: 404 Not Found
         code: 404
-        duration: 56.56125ms
+        duration: 59.739664ms


### PR DESCRIPTION
This caused tags to not be found when there's more than 50 for ex.