### PR TITLE
docs(file): remove private beta notice and fix size_in_gb unit

### DIFF
--- a/docs/resources/file_filesystem.md
+++ b/docs/resources/file_filesystem.md
@@ -5,8 +5,6 @@ page_title: "Scaleway: scaleway_file_filesystem"
 
 # Resource: scaleway_file_filesystem
 
--> **This product is currently in private beta. To request access, please contact your Technical Account Manager.**
-
 Creates and manages a Scaleway File Storage filesystem in a specific region. A filesystem is a scalable storage resource that can be mounted on Compute instances and is typically used for share persistent storage between multiple instances (RWX).
 
 This resource allows you to define and manage the size, tags, and region of a filesystem, and track its creation and update timestamps, current status, and number of active attachments.
@@ -17,7 +15,7 @@ This resource allows you to define and manage the size, tags, and region of a fi
 
 ```terraform
 resource scaleway_file_filesystem file {
-  name = "my-nfs-filesystem"
+  name = "my-filesystem"
   size_in_gb = 100
 }
 ```

--- a/docs/resources/file_filesystem.md
+++ b/docs/resources/file_filesystem.md
@@ -5,7 +5,7 @@ page_title: "Scaleway: scaleway_file_filesystem"
 
 # Resource: scaleway_file_filesystem
 
-Creates and manages a Scaleway File Storage filesystem in a specific region. A filesystem is a scalable storage resource that can be mounted on Compute instances and is typically used for share persistent storage between multiple instances (RWX).
+Creates and manages a Scaleway File Storage filesystem in a specific region. A filesystem is a scalable storage resource that can be mounted on Compute instances and is typically used to share persistent storage between multiple instances (RWX).
 
 This resource allows you to define and manage the size, tags, and region of a filesystem, and track its creation and update timestamps, current status, and number of active attachments.
 
@@ -23,9 +23,9 @@ resource scaleway_file_filesystem file {
 ## Argument Reference
 
 - `name` - (Optional) The name of the filesystem. If not provided, a random name will be generated.
-- `size_in_gb` - (Required) The size of the filesystem in bytes, with a granularity of 1 GB (10⁹ bytes).
-      - Minimum: 25 GB (25000000000 bytes)
-      - Maximum: 50 TB (50000000000000 bytes)
+- `size_in_gb` - (Required) The size of the filesystem in gigabytes (10⁹ bytes), with a granularity of 1 GB.
+      - Minimum: 25 GB
+      - Maximum: 50 TB (50000 GB)
 - `tags` - (Optional) A list of tags associated with the filesystem.
 - `region` - (Defaults to [provider](../index.md#arguments-reference) `region`) The region where the filesystem will be created (e.g., fr-par, nl-ams).
 - `project_id` - (Defaults to [provider](../index.md#arguments-reference) `project_id`) The ID of the project the server is

--- a/templates/resources/file_filesystem.md.tmpl
+++ b/templates/resources/file_filesystem.md.tmpl
@@ -6,8 +6,6 @@ page_title: "Scaleway: scaleway_file_filesystem"
 
 # Resource: scaleway_file_filesystem
 
--> **This product is currently in private beta. To request access, please contact your Technical Account Manager.**
-
 Creates and manages a Scaleway File Storage filesystem in a specific region. A filesystem is a scalable storage resource that can be mounted on Compute instances and is typically used for share persistent storage between multiple instances (RWX).
 
 This resource allows you to define and manage the size, tags, and region of a filesystem, and track its creation and update timestamps, current status, and number of active attachments.
@@ -18,7 +16,7 @@ This resource allows you to define and manage the size, tags, and region of a fi
 
 ```terraform
 resource scaleway_file_filesystem file {
-  name = "my-nfs-filesystem"
+  name = "my-filesystem"
   size_in_gb = 100
 }
 ```

--- a/templates/resources/file_filesystem.md.tmpl
+++ b/templates/resources/file_filesystem.md.tmpl
@@ -6,7 +6,7 @@ page_title: "Scaleway: scaleway_file_filesystem"
 
 # Resource: scaleway_file_filesystem
 
-Creates and manages a Scaleway File Storage filesystem in a specific region. A filesystem is a scalable storage resource that can be mounted on Compute instances and is typically used for share persistent storage between multiple instances (RWX).
+Creates and manages a Scaleway File Storage filesystem in a specific region. A filesystem is a scalable storage resource that can be mounted on Compute instances and is typically used to share persistent storage between multiple instances (RWX).
 
 This resource allows you to define and manage the size, tags, and region of a filesystem, and track its creation and update timestamps, current status, and number of active attachments.
 
@@ -24,9 +24,9 @@ resource scaleway_file_filesystem file {
 ## Argument Reference
 
 - `name` - (Optional) The name of the filesystem. If not provided, a random name will be generated.
-- `size_in_gb` - (Required) The size of the filesystem in bytes, with a granularity of 1 GB (10⁹ bytes).
-      - Minimum: 25 GB (25000000000 bytes)
-      - Maximum: 50 TB (50000000000000 bytes)
+- `size_in_gb` - (Required) The size of the filesystem in gigabytes (10⁹ bytes), with a granularity of 1 GB.
+      - Minimum: 25 GB
+      - Maximum: 50 TB (50000 GB)
 - `tags` - (Optional) A list of tags associated with the filesystem.
 - `region` - (Defaults to [provider](../index.md#arguments-reference) `region`) The region where the filesystem will be created (e.g., fr-par, nl-ams).
 - `project_id` - (Defaults to [provider](../index.md#arguments-reference) `project_id`) The ID of the project the server is


### PR DESCRIPTION
File Storage is now generally available. This PR cleans up the `file_filesystem` resource documentation:

- Remove the outdated private beta notice
- Rename the example filesystem `my-nfs-filesystem` to `my-filesystem`
- Fix the `size_in_gb` description: the argument is in gigabytes (converted to bytes by the provider), not in bytes
- Minor grammar fix in the resource description

Both `docs/` and `templates/` are updated.

Signed-off-by: Noé Larrieu-Lacoste <noelarrieulacoste@yahoo.fr>