### PR TITLE
fix(keymanager): mark next_rotation_at as computed to stop rotation schedule drift

### DIFF
--- a/docs/resources/key_manager_key.md
+++ b/docs/resources/key_manager_key.md
@@ -91,7 +91,8 @@ The following arguments are supported:
     - `scaleway_kms` (default)
     - `external`
 - `rotation_policy` (Block, Optional) – Rotation policy for the key:
-    - `rotation_period` (String, Optional) – The period between key rotations (e.g., `"720h"` for 30 days).
+    - `rotation_period` (String, Required) – The period between key rotations (e.g., `"720h"` for 30 days).
+    - `next_rotation_at` (String, Optional) – The date and time of the next scheduled rotation, in RFC 3339 format. If not set, it is computed by the Key Manager API from `rotation_period`.
 
 ## Attributes Reference
 
@@ -122,6 +123,8 @@ terraform import scaleway_key_manager_key.main fr-par/11111111-2222-3333-4444-55
 
 - **Protection**: By default, keys are protected and cannot be deleted. To allow deletion, set `unprotected = true` when creating the key.
 - **Rotation Policy**: The `rotation_policy` block allows you to set automatic rotation for your key.
+  If `next_rotation_at` is not set, the Key Manager API schedules the next rotation at `rotation_period` from the key's creation, and reschedules it after each rotation.
+  If you set `next_rotation_at` explicitly, it must be in the future (the API rejects past dates). Once the scheduled rotation occurs, the API computes a new `next_rotation_at`, so the configured value becomes stale: update or remove it from the configuration (or use `ignore_changes`) to avoid a permanent diff.
 - **Origin**: The `origin` argument is optional and defaults to `scaleway_kms`. Use `external` if you want to import an external key (see Scaleway documentation for details).
 - **Project and Region**: If not specified, `project_id` and `region` will default to the provider configuration.
 - **Algorithm Validation**: The provider validates that the specified `algorithm` is compatible with the `usage` type at plan time, providing early feedback on configuration errors.

--- a/internal/services/keymanager/key_resource.go
+++ b/internal/services/keymanager/key_resource.go
@@ -13,6 +13,7 @@ import (
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/dsf"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/identity"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/locality/regional"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/meta"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/services/account"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/transport"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/types"
@@ -97,8 +98,14 @@ func keySchema() map[string]*schema.Schema {
 			Description: "Key rotation policy.",
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
-					"rotation_period":  {Type: schema.TypeString, Required: true, DiffSuppressFunc: dsf.Duration, Description: "Time interval between two key rotations. The minimum duration is 24 hours and the maximum duration is 1 year (876000 hours)."},
-					"next_rotation_at": {Type: schema.TypeString, Optional: true, Description: "Timestamp indicating the next scheduled rotation."},
+					"rotation_period": {Type: schema.TypeString, Required: true, DiffSuppressFunc: dsf.Duration, Description: "Time interval between two key rotations. The minimum duration is 24 hours and the maximum duration is 1 year (876000 hours)."},
+					"next_rotation_at": {
+						Type:             schema.TypeString,
+						Optional:         true,
+						Computed:         true,
+						ValidateDiagFunc: verify.IsDate(),
+						Description:      "Timestamp indicating the next scheduled rotation. Computed from rotation_period if not set.",
+					},
 				},
 			},
 		},
@@ -250,6 +257,16 @@ func resourceKeyManagerKeyUpdate(ctx context.Context, d *schema.ResourceData, m 
 			rp, err := ExpandKeyRotationPolicy(v)
 			if err != nil {
 				return diag.Errorf("invalid rotation_period: %v", err)
+			}
+
+			// next_rotation_at is Optional+Computed: when it is absent from the
+			// configuration, d.Get returns the value carried over from state.
+			// Sending it back would pin the previous schedule, so only forward
+			// it when the user explicitly set it.
+			if rp != nil {
+				if _, set := meta.GetRawConfigForKey(d, "rotation_policy.0.next_rotation_at", cty.String); !set {
+					rp.NextRotationAt = nil
+				}
 			}
 
 			updateReq.RotationPolicy = rp

--- a/internal/services/keymanager/key_resource_test.go
+++ b/internal/services/keymanager/key_resource_test.go
@@ -164,6 +164,98 @@ func TestAccKeyManagerKey_WithRotationPolicy(t *testing.T) {
 	})
 }
 
+func TestAccKeyManagerKey_RotationPolicyDrift(t *testing.T) {
+	tt := acctest.NewTestTools(t)
+	defer tt.Cleanup()
+
+	config := `
+	resource "scaleway_key_manager_key" "main" {
+	  name        = "tf-test-kms-key-rotation-drift"
+	  region      = "fr-par"
+	  usage       = "symmetric_encryption"
+	  algorithm   = "aes_256_gcm"
+	  unprotected = true
+
+	  rotation_policy {
+	    rotation_period = "720h"
+	  }
+	}
+	`
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: tt.ProviderFactories,
+		CheckDestroy:             IsKeyManagerKeyDestroyed(tt),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("scaleway_key_manager_key.main", "rotation_policy.0.rotation_period", "720h0m0s"),
+					resource.TestCheckResourceAttrSet("scaleway_key_manager_key.main", "rotation_policy.0.next_rotation_at"),
+				),
+			},
+			{
+				// next_rotation_at is not set in the config: re-planning must
+				// not produce a diff, otherwise every apply postpones the
+				// scheduled rotation.
+				Config:   config,
+				PlanOnly: true,
+			},
+			{
+				ResourceName:      "scaleway_key_manager_key.main",
+				ImportState:       true,
+				ImportStateVerify: true,
+				// unprotected is not returned by the API (only the computed
+				// protected attribute is), so it cannot survive an import.
+				ImportStateVerifyIgnore: []string{"unprotected"},
+			},
+			{
+				// Changing only rotation_period must let the API recompute the
+				// schedule instead of re-sending the value carried over from
+				// state (the cassette body matcher fails on replay otherwise).
+				Config: `
+				resource "scaleway_key_manager_key" "main" {
+				  name        = "tf-test-kms-key-rotation-drift"
+				  region      = "fr-par"
+				  usage       = "symmetric_encryption"
+				  algorithm   = "aes_256_gcm"
+				  unprotected = true
+
+				  rotation_policy {
+				    rotation_period = "8760h"
+				  }
+				}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("scaleway_key_manager_key.main", "rotation_policy.0.rotation_period", "8760h0m0s"),
+					resource.TestCheckResourceAttrSet("scaleway_key_manager_key.main", "rotation_policy.0.next_rotation_at"),
+				),
+			},
+			{
+				// An explicitly configured next_rotation_at must be sent to
+				// the API and round-trip unchanged.
+				Config: `
+				resource "scaleway_key_manager_key" "main" {
+				  name        = "tf-test-kms-key-rotation-drift"
+				  region      = "fr-par"
+				  usage       = "symmetric_encryption"
+				  algorithm   = "aes_256_gcm"
+				  unprotected = true
+
+				  rotation_policy {
+				    rotation_period  = "8760h"
+				    next_rotation_at = "2027-03-01T00:00:00Z"
+				  }
+				}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("scaleway_key_manager_key.main", "rotation_policy.0.rotation_period", "8760h0m0s"),
+					resource.TestCheckResourceAttr("scaleway_key_manager_key.main", "rotation_policy.0.next_rotation_at", "2027-03-01T00:00:00Z"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccKeyManagerKey_WithCustomAlgorithm(t *testing.T) {
 	tt := acctest.NewTestTools(t)
 	defer tt.Cleanup()

--- a/internal/services/keymanager/testdata/key-manager-key-rotation-policy-drift.cassette.yaml
+++ b/internal/services/keymanager/testdata/key-manager-key-rotation-policy-drift.cassette.yaml
@@ -1,0 +1,490 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 280
+        host: api.scaleway.com
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-kms-key-rotation-drift","usage":{"symmetric_encryption":"aes_256_gcm"},"tags":null,"rotation_policy":{"rotation_period":"2592000.000000000s","next_rotation_at":null},"unprotected":true,"origin":"unknown_origin"}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 629
+        body: '{"id":"64bd5bfa-f432-4a1e-8cdd-e1e91d2797bc", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-kms-key-rotation-drift", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-07-22T10:26:52.981683Z", "updated_at":"2026-07-22T10:26:52.984851Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-07-22T10:26:52.984851Z", "rotation_policy":{"rotation_period":"2592000s", "next_rotation_at":"2026-08-21T10:26:52.942709Z"}, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"software", "region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "629"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 22 Jul 2026 10:26:53 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            X-Request-Id:
+                - c5a5853b-1c19-49d5-84be-b972227c98ea
+        status: 200 OK
+        code: 200
+        duration: 273.227959ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/64bd5bfa-f432-4a1e-8cdd-e1e91d2797bc
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 629
+        body: '{"id":"64bd5bfa-f432-4a1e-8cdd-e1e91d2797bc", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-kms-key-rotation-drift", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-07-22T10:26:52.981683Z", "updated_at":"2026-07-22T10:26:52.984851Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-07-22T10:26:52.984851Z", "rotation_policy":{"rotation_period":"2592000s", "next_rotation_at":"2026-08-21T10:26:52.942709Z"}, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"software", "region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "629"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 22 Jul 2026 10:26:53 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            X-Request-Id:
+                - af72bf9e-43eb-4ffe-9d90-4fabfe6af884
+        status: 200 OK
+        code: 200
+        duration: 79.0035ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/64bd5bfa-f432-4a1e-8cdd-e1e91d2797bc
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 629
+        body: '{"id":"64bd5bfa-f432-4a1e-8cdd-e1e91d2797bc", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-kms-key-rotation-drift", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-07-22T10:26:52.981683Z", "updated_at":"2026-07-22T10:26:52.984851Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-07-22T10:26:52.984851Z", "rotation_policy":{"rotation_period":"2592000s", "next_rotation_at":"2026-08-21T10:26:52.942709Z"}, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"software", "region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "629"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 22 Jul 2026 10:26:53 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            X-Request-Id:
+                - 28825421-12fa-41d9-9a63-03b926cbe3b4
+        status: 200 OK
+        code: 200
+        duration: 70.062708ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/64bd5bfa-f432-4a1e-8cdd-e1e91d2797bc
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 629
+        body: '{"id":"64bd5bfa-f432-4a1e-8cdd-e1e91d2797bc", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-kms-key-rotation-drift", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-07-22T10:26:52.981683Z", "updated_at":"2026-07-22T10:26:52.984851Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-07-22T10:26:52.984851Z", "rotation_policy":{"rotation_period":"2592000s", "next_rotation_at":"2026-08-21T10:26:52.942709Z"}, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"software", "region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "629"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 22 Jul 2026 10:26:53 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            X-Request-Id:
+                - d86001a8-8b78-49bd-8a5c-5c9b27430cc1
+        status: 200 OK
+        code: 200
+        duration: 66.156375ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/64bd5bfa-f432-4a1e-8cdd-e1e91d2797bc
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 629
+        body: '{"id":"64bd5bfa-f432-4a1e-8cdd-e1e91d2797bc", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-kms-key-rotation-drift", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-07-22T10:26:52.981683Z", "updated_at":"2026-07-22T10:26:52.984851Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-07-22T10:26:52.984851Z", "rotation_policy":{"rotation_period":"2592000s", "next_rotation_at":"2026-08-21T10:26:52.942709Z"}, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"software", "region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "629"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 22 Jul 2026 10:26:53 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            X-Request-Id:
+                - 8c687021-4af2-4f5c-83d6-8d8e174a9aae
+        status: 200 OK
+        code: 200
+        duration: 60.405583ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/64bd5bfa-f432-4a1e-8cdd-e1e91d2797bc
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 629
+        body: '{"id":"64bd5bfa-f432-4a1e-8cdd-e1e91d2797bc", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-kms-key-rotation-drift", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-07-22T10:26:52.981683Z", "updated_at":"2026-07-22T10:26:52.984851Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-07-22T10:26:52.984851Z", "rotation_policy":{"rotation_period":"2592000s", "next_rotation_at":"2026-08-21T10:26:52.942709Z"}, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"software", "region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "629"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 22 Jul 2026 10:26:53 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            X-Request-Id:
+                - ffb59cdf-7e04-4892-94f3-c0a231cb997e
+        status: 200 OK
+        code: 200
+        duration: 67.138458ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 85
+        host: api.scaleway.com
+        body: '{"rotation_policy":{"rotation_period":"31536000.000000000s","next_rotation_at":null}}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/64bd5bfa-f432-4a1e-8cdd-e1e91d2797bc
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 630
+        body: '{"id":"64bd5bfa-f432-4a1e-8cdd-e1e91d2797bc", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-kms-key-rotation-drift", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-07-22T10:26:52.981683Z", "updated_at":"2026-07-22T10:26:54.135017Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-07-22T10:26:52.984851Z", "rotation_policy":{"rotation_period":"31536000s", "next_rotation_at":"2027-07-22T10:26:54.114113Z"}, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"software", "region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "630"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 22 Jul 2026 10:26:54 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            X-Request-Id:
+                - 4d2b6cc1-1d9c-4f24-b94a-0face8ee8a94
+        status: 200 OK
+        code: 200
+        duration: 83.417667ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/64bd5bfa-f432-4a1e-8cdd-e1e91d2797bc
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 630
+        body: '{"id":"64bd5bfa-f432-4a1e-8cdd-e1e91d2797bc", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-kms-key-rotation-drift", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-07-22T10:26:52.981683Z", "updated_at":"2026-07-22T10:26:54.135017Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-07-22T10:26:52.984851Z", "rotation_policy":{"rotation_period":"31536000s", "next_rotation_at":"2027-07-22T10:26:54.114113Z"}, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"software", "region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "630"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 22 Jul 2026 10:26:54 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            X-Request-Id:
+                - 7d80449b-61c3-4c97-9c90-a2ef0fab7d58
+        status: 200 OK
+        code: 200
+        duration: 81.626083ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/64bd5bfa-f432-4a1e-8cdd-e1e91d2797bc
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 630
+        body: '{"id":"64bd5bfa-f432-4a1e-8cdd-e1e91d2797bc", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-kms-key-rotation-drift", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-07-22T10:26:52.981683Z", "updated_at":"2026-07-22T10:26:54.135017Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-07-22T10:26:52.984851Z", "rotation_policy":{"rotation_period":"31536000s", "next_rotation_at":"2027-07-22T10:26:54.114113Z"}, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"software", "region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "630"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 22 Jul 2026 10:26:54 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            X-Request-Id:
+                - 03ffca61-018a-45bc-999c-8c750224542c
+        status: 200 OK
+        code: 200
+        duration: 64.816875ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/64bd5bfa-f432-4a1e-8cdd-e1e91d2797bc
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 630
+        body: '{"id":"64bd5bfa-f432-4a1e-8cdd-e1e91d2797bc", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-kms-key-rotation-drift", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-07-22T10:26:52.981683Z", "updated_at":"2026-07-22T10:26:54.135017Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-07-22T10:26:52.984851Z", "rotation_policy":{"rotation_period":"31536000s", "next_rotation_at":"2027-07-22T10:26:54.114113Z"}, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"software", "region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "630"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 22 Jul 2026 10:26:54 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            X-Request-Id:
+                - 9a54e440-56dd-4b94-b1f0-b28979eb8312
+        status: 200 OK
+        code: 200
+        duration: 53.010208ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 103
+        host: api.scaleway.com
+        body: '{"rotation_policy":{"rotation_period":"31536000.000000000s","next_rotation_at":"2027-03-01T00:00:00Z"}}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/64bd5bfa-f432-4a1e-8cdd-e1e91d2797bc
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 623
+        body: '{"id":"64bd5bfa-f432-4a1e-8cdd-e1e91d2797bc", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-kms-key-rotation-drift", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-07-22T10:26:52.981683Z", "updated_at":"2026-07-22T10:26:54.786315Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-07-22T10:26:52.984851Z", "rotation_policy":{"rotation_period":"31536000s", "next_rotation_at":"2027-03-01T00:00:00Z"}, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"software", "region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "623"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 22 Jul 2026 10:26:54 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            X-Request-Id:
+                - cac92d74-4a44-4d1f-bbca-f73b864080b7
+        status: 200 OK
+        code: 200
+        duration: 80.475417ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/64bd5bfa-f432-4a1e-8cdd-e1e91d2797bc
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 623
+        body: '{"id":"64bd5bfa-f432-4a1e-8cdd-e1e91d2797bc", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-kms-key-rotation-drift", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-07-22T10:26:52.981683Z", "updated_at":"2026-07-22T10:26:54.786315Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-07-22T10:26:52.984851Z", "rotation_policy":{"rotation_period":"31536000s", "next_rotation_at":"2027-03-01T00:00:00Z"}, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"software", "region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "623"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 22 Jul 2026 10:26:54 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            X-Request-Id:
+                - 29d8d33b-5604-4443-996e-ae850d198c64
+        status: 200 OK
+        code: 200
+        duration: 64.198667ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/64bd5bfa-f432-4a1e-8cdd-e1e91d2797bc
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 623
+        body: '{"id":"64bd5bfa-f432-4a1e-8cdd-e1e91d2797bc", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-kms-key-rotation-drift", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"enabled", "rotation_count":1, "created_at":"2026-07-22T10:26:52.981683Z", "updated_at":"2026-07-22T10:26:54.786315Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-07-22T10:26:52.984851Z", "rotation_policy":{"rotation_period":"31536000s", "next_rotation_at":"2027-03-01T00:00:00Z"}, "origin":"scaleway_kms", "deletion_requested_at":null, "protection_level":"software", "region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "623"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 22 Jul 2026 10:26:55 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            X-Request-Id:
+                - 368c9aab-9bdf-41dd-881f-9ba3a0d631a6
+        status: 200 OK
+        code: 200
+        duration: 60.723459ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/64bd5bfa-f432-4a1e-8cdd-e1e91d2797bc
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 22 Jul 2026 10:26:55 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            X-Request-Id:
+                - de40850d-0dbb-4b46-be07-e67c7e785fc6
+        status: 204 No Content
+        code: 204
+        duration: 83.722125ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/64bd5bfa-f432-4a1e-8cdd-e1e91d2797bc
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 663
+        body: '{"id":"64bd5bfa-f432-4a1e-8cdd-e1e91d2797bc", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-kms-key-rotation-drift", "usage":{"symmetric_encryption":"aes_256_gcm"}, "state":"scheduled_for_deletion", "rotation_count":1, "created_at":"2026-07-22T10:26:52.981683Z", "updated_at":"2026-07-22T10:26:55.303458Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-07-22T10:26:52.984851Z", "rotation_policy":{"rotation_period":"31536000s", "next_rotation_at":"2027-03-01T00:00:00Z"}, "origin":"scaleway_kms", "deletion_requested_at":"2026-07-22T10:26:55.303458Z", "protection_level":"software", "region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "663"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 22 Jul 2026 10:26:55 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            X-Request-Id:
+                - 9715c098-59f7-4fad-adf6-44b1129adf0c
+        status: 200 OK
+        code: 200
+        duration: 76.362333ms

--- a/templates/resources/key_manager_key.md.tmpl
+++ b/templates/resources/key_manager_key.md.tmpl
@@ -92,7 +92,8 @@ The following arguments are supported:
     - `scaleway_kms` (default)
     - `external`
 - `rotation_policy` (Block, Optional) – Rotation policy for the key:
-    - `rotation_period` (String, Optional) – The period between key rotations (e.g., `"720h"` for 30 days).
+    - `rotation_period` (String, Required) – The period between key rotations (e.g., `"720h"` for 30 days).
+    - `next_rotation_at` (String, Optional) – The date and time of the next scheduled rotation, in RFC 3339 format. If not set, it is computed by the Key Manager API from `rotation_period`.
 
 ## Attributes Reference
 
@@ -123,6 +124,8 @@ terraform import scaleway_key_manager_key.main fr-par/11111111-2222-3333-4444-55
 
 - **Protection**: By default, keys are protected and cannot be deleted. To allow deletion, set `unprotected = true` when creating the key.
 - **Rotation Policy**: The `rotation_policy` block allows you to set automatic rotation for your key.
+  If `next_rotation_at` is not set, the Key Manager API schedules the next rotation at `rotation_period` from the key's creation, and reschedules it after each rotation.
+  If you set `next_rotation_at` explicitly, it must be in the future (the API rejects past dates). Once the scheduled rotation occurs, the API computes a new `next_rotation_at`, so the configured value becomes stale: update or remove it from the configuration (or use `ignore_changes`) to avoid a permanent diff.
 - **Origin**: The `origin` argument is optional and defaults to `scaleway_kms`. Use `external` if you want to import an external key (see Scaleway documentation for details).
 - **Project and Region**: If not specified, `project_id` and `region` will default to the provider configuration.
 - **Algorithm Validation**: The provider validates that the specified `algorithm` is compatible with the `usage` type at plan time, providing early feedback on configuration errors.


### PR DESCRIPTION
Author of this PR is @eschmar from https://github.com/scaleway/terraform-provider-scaleway/pull/4214.
Commit was picked to this branch to add commit signature.

## What

- Mark `rotation_policy.next_rotation_at` on `scaleway_key_manager_key` as `Computed` (in addition to `Optional`) and validate it as an RFC 3339 date.
- On update, only send `next_rotation_at` to the API when it is explicitly set in the configuration, so changing `rotation_period` lets Key Manager recompute the schedule instead of re-sending the value carried over from state.
- Add an acceptance test covering: no diff on re-plan, `ImportStateVerify`, a `rotation_period`-only update, and an explicitly configured `next_rotation_at` round-tripping unchanged.
- Document `next_rotation_at` and its future-date constraint. Also correct the docs to list `rotation_period` as Required inside the block: the schema has always had `Required: true` there — no schema change — the docs just wrongly said Optional, and the API confirms a `rotation_policy` without `rotation_period` is rejected.

## Why

When a key has a `rotation_policy` without an explicit `next_rotation_at`, every plan showed `next_rotation_at -> null` because the attribute was `Optional` but not `Computed`. Each apply then called `UpdateKey` with `NextRotationAt = nil`, which the API interprets as "reschedule to now + rotation_period" — so every apply silently postponed the next rotation, and a regularly-applied key would effectively never rotate.

With this change the API-computed timestamp is retained in state when not configured, producing an empty plan and leaving the rotation schedule untouched.

Co-authored with Claude Code, feel free to discard silently if that is an issue. Hope this fits into the greater picture.