### PR TITLE
fix(types): boolean attributes wrongly set to nil when "false" in GetBool

### DIFF
--- a/internal/types/bool.go
+++ b/internal/types/bool.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -20,11 +21,30 @@ func ExpandBoolPtr(data any) *bool {
 	return new(data.(bool))
 }
 
-func GetBool(d *schema.ResourceData, key string) any {
-	val, ok := d.GetOk(key)
-	if !ok {
+// rawConfigReader abstracts ResourceData and ResourceDiff for GetBool.
+type rawConfigReader interface {
+	GetRawConfig() cty.Value
+}
+
+var (
+	_ rawConfigReader = (*schema.ResourceData)(nil)
+	_ rawConfigReader = (*schema.ResourceDiff)(nil)
+)
+
+// GetBool returns the configured boolean value, or nil when the attribute is absent.
+//
+// It reads the raw configuration because GetOk treats false as unset, which would
+// prevent callers from distinguishing an explicit false from an omitted value.
+func GetBool(d rawConfigReader, key string) any {
+	rawConfig := d.GetRawConfig()
+	if rawConfig.IsNull() || !rawConfig.IsKnown() {
 		return nil
 	}
 
-	return val
+	value, exists := rawConfig.AsValueMap()[key]
+	if !exists || value.IsNull() || !value.IsKnown() {
+		return nil
+	}
+
+	return value.True()
 }

--- a/internal/types/bool_test.go
+++ b/internal/types/bool_test.go
@@ -1,0 +1,93 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/types"
+	"github.com/stretchr/testify/assert"
+)
+
+type rawConfigStub struct {
+	rawConfig cty.Value
+}
+
+func (s rawConfigStub) GetRawConfig() cty.Value {
+	return s.rawConfig
+}
+
+func objectConfig(attributes map[string]cty.Value) cty.Value {
+	if len(attributes) == 0 {
+		return cty.EmptyObjectVal
+	}
+
+	return cty.ObjectVal(attributes)
+}
+
+func TestGetBool(t *testing.T) {
+	tests := []struct {
+		rawConfig cty.Value
+		expected  any
+		name      string
+		key       string
+	}{
+		{
+			name:      "explicit true is reported",
+			rawConfig: objectConfig(map[string]cty.Value{"assign_flexible_ip": cty.True}),
+			key:       "assign_flexible_ip",
+			expected:  true,
+		},
+		{
+			name:      "explicit false is reported and not mistaken for an absent attribute",
+			rawConfig: objectConfig(map[string]cty.Value{"assign_flexible_ip": cty.False}),
+			key:       "assign_flexible_ip",
+			expected:  false,
+		},
+		{
+			name:      "attribute left null is absent",
+			rawConfig: objectConfig(map[string]cty.Value{"assign_flexible_ip": cty.NullVal(cty.Bool)}),
+			key:       "assign_flexible_ip",
+			expected:  nil,
+		},
+		{
+			name:      "attribute unknown at plan time is absent",
+			rawConfig: objectConfig(map[string]cty.Value{"assign_flexible_ip": cty.UnknownVal(cty.Bool)}),
+			key:       "assign_flexible_ip",
+			expected:  nil,
+		},
+		{
+			name:      "attribute missing from the configuration is absent",
+			rawConfig: objectConfig(map[string]cty.Value{"name": cty.StringVal("lb")}),
+			key:       "assign_flexible_ip",
+			expected:  nil,
+		},
+		{
+			name:      "null configuration is absent",
+			rawConfig: cty.NullVal(cty.EmptyObject),
+			key:       "assign_flexible_ip",
+			expected:  nil,
+		},
+		{
+			name:      "absent configuration is absent",
+			rawConfig: cty.NilVal,
+			key:       "assign_flexible_ip",
+			expected:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, types.GetBool(rawConfigStub{rawConfig: tt.rawConfig}, tt.key))
+		})
+	}
+}
+
+// Explicit false must be preserved so the API does not fall back to its default.
+func TestGetBoolExpandsExplicitFalseToPointer(t *testing.T) {
+	rawConfig := objectConfig(map[string]cty.Value{"assign_flexible_ip": cty.False})
+
+	assigned := types.ExpandBoolPtr(types.GetBool(rawConfigStub{rawConfig: rawConfig}, "assign_flexible_ip"))
+
+	assert.NotNil(t, assigned)
+	assert.False(t, *assigned)
+}


### PR DESCRIPTION
Fixes #4258

### Problem

`types.GetBool` uses `d.GetOk`, which treats zero values as absent. For `schema.TypeBool`, that means an explicit `false` is returned as unset.

The current path is:

```text
false -> GetOk(...)=(_, false) -> GetBool=nil -> ExpandBoolPtr=nil -> field omitted from API request
```

The API then applies its own default.

This only becomes visible when the API default is `true`. For example, the documented private Load Balancer configuration:

```terraform
resource "scaleway_lb" "base" {
  name               = "private-lb"
  type               = "LB-S"
  assign_flexible_ip = false
}
```

currently creates an LB with a public IPv4.

We hit this in production with an internal LB fronting OpenSearch on port 9200. Terraform planned `assign_flexible_ip = false`, but the resulting LB still had a public IP and was reachable outside the VPC.

### Scope

The helper is currently used by these attributes:

| Resource | Attributes |
|---|---|
| `scaleway_lb` | `assign_flexible_ip`, `assign_flexible_ipv6` |
| `scaleway_lb_backend` | `ssl_bridging`, `ignore_ssl_server_verify`, `send_proxy_v2` |
| `scaleway_iam_policy` | `no_principal` |
| `scaleway_iam_ssh_key` | `disabled` |
| `scaleway_instance_image` | `public` |
| `scaleway_vpc_public_gateway_dhcp` data source | `enable_masquerade` |

For all of them, an explicit `false` is currently equivalent to leaving the attribute unset.

### Fix

`GetBool` now reads `d.GetRawConfig()` so it can distinguish an explicit `false` from a null or missing attribute.

This follows the same approach already used in `internal/meta/extractors.go`.

The helper now accepts a small `rawConfigReader` interface instead of `*schema.ResourceData`. Both `*schema.ResourceData` and `*schema.ResourceDiff` implement it, so existing call sites do not need to change and the helper can be unit tested directly.

Behavior stays the same for:

* unset attributes
* attributes set to `true`

An explicit `false` is now returned as `false` and passed to the API.

### Tests

With the previous implementation, the regression is caught by:

```text
--- FAIL: TestGetBool/explicit_false_is_reported_and_not_mistaken_for_an_absent_attribute
    expected: bool(false)
    actual  : <nil>(<nil>)

--- FAIL: TestGetBoolExpandsExplicitFalseToPointer
```

I did not add an acceptance test for `scaleway_lb`. Verifying that the LB has no public IP requires a recorded VCR cassette. I can add one if there is a preferred workflow for recording and committing cassettes.