### PR TITLE
fix: #4266 k8s pool startup_taints overwrote taints on create

### DIFF
--- a/internal/services/k8s/pool.go
+++ b/internal/services/k8s/pool.go
@@ -435,7 +435,7 @@ func ResourceK8SPoolCreate(ctx context.Context, d *schema.ResourceData, m any) d
 	}
 
 	if startupTaints, ok := d.GetOk("startup_taints"); ok {
-		req.Taints = expandCoreV1Taints(startupTaints)
+		req.StartupTaints = expandCoreV1Taints(startupTaints)
 	}
 
 	// Validate pool configuration

--- a/internal/services/k8s/pool_test.go
+++ b/internal/services/k8s/pool_test.go
@@ -858,6 +858,12 @@ func TestAccPool_TaintsAndLabels(t *testing.T) {
 							value = "value2"
 							effect = "NoExecute"
 						}
+
+						startup_taints {
+							key = "startup-key1"
+							value = "startup-value1"
+							effect = "NoSchedule"
+						}
 					}`,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckK8SClusterExists(tt, "scaleway_k8s_cluster.main"),
@@ -877,7 +883,12 @@ func TestAccPool_TaintsAndLabels(t *testing.T) {
 						"value":  "value2",
 						"effect": "NoExecute",
 					}),
-					resource.TestCheckResourceAttr("scaleway_k8s_pool.main", "startup_taints.#", "0"),
+					resource.TestCheckResourceAttr("scaleway_k8s_pool.main", "startup_taints.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs("scaleway_k8s_pool.main", "startup_taints.*", map[string]string{
+						"key":    "startup-key1",
+						"value":  "startup-value1",
+						"effect": "NoSchedule",
+					}),
 				),
 			},
 			{

--- a/internal/services/k8s/testdata/pool-taints-and-labels.cassette.yaml
+++ b/internal/services/k8s/testdata/pool-taints-and-labels.cassette.yaml
@@ -10,64 +10,64 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/k8s/v1/regions/fr-par/versions
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 4355
-        body: '{"versions":[{"region":"fr-par","name":"1.35.3","label":"Kubernetes 1.35.3","available_cnis":["cilium","cilium_native","calico","kilo","none"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","CPUManagerPolicyAlphaOptions","ImageVolume","MutatingAdmissionPolicy"],"available_admission_plugins":["AlwaysPullImages","PodNodeSelector","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","cpuManagerPolicyOptions":"map[string]string","enableDebuggingHandlers":"bool","evictionHard":"map[string]string","evictionMinimumReclaim":"map[string]string","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxParallelImagePulls":"int32","maxPods":"uint16","registryBurst":"int32","registryPullQPS":"int32","serializeImagePulls":"bool"},"deprecated_at":"2027-01-19T00:00:00Z","end_of_life_at":"2027-03-19T00:00:00Z","released_at":"2026-01-19T00:00:00Z"},{"region":"fr-par","name":"1.34.6","label":"Kubernetes 1.34.6","available_cnis":["cilium","cilium_native","calico","kilo","none"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","CPUManagerPolicyAlphaOptions","ImageVolume","MutatingAdmissionPolicy"],"available_admission_plugins":["AlwaysPullImages","PodNodeSelector","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","cpuManagerPolicyOptions":"map[string]string","enableDebuggingHandlers":"bool","evictionHard":"map[string]string","evictionMinimumReclaim":"map[string]string","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxParallelImagePulls":"int32","maxPods":"uint16","registryBurst":"int32","registryPullQPS":"int32","serializeImagePulls":"bool"},"deprecated_at":"2026-09-29T00:00:00Z","end_of_life_at":"2026-11-29T00:00:00Z","released_at":"2025-09-29T00:00:00Z"},{"region":"fr-par","name":"1.33.10","label":"Kubernetes 1.33.10","available_cnis":["cilium","calico","kilo","none"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","DRAAdminAccess","DynamicResourceAllocation","PodLevelResources","CPUManagerPolicyAlphaOptions","ImageVolume"],"available_admission_plugins":["AlwaysPullImages","PodNodeSelector","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","cpuManagerPolicyOptions":"map[string]string","enableDebuggingHandlers":"bool","evictionHard":"map[string]string","evictionMinimumReclaim":"map[string]string","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxParallelImagePulls":"int32","maxPods":"uint16","registryBurst":"int32","registryPullQPS":"int32","serializeImagePulls":"bool"},"deprecated_at":"2026-09-04T00:00:00Z","end_of_life_at":"2026-11-04T00:00:00Z","released_at":"2025-09-04T00:00:00Z"},{"region":"fr-par","name":"1.32.13","label":"Kubernetes 1.32.13","available_cnis":["cilium","calico","kilo","none"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","InPlacePodVerticalScaling","SidecarContainers","DRAAdminAccess","DRAResourceClaimDeviceStatus","DynamicResourceAllocation","PodLevelResources","CPUManagerPolicyAlphaOptions","ImageVolume"],"available_admission_plugins":["AlwaysPullImages","PodNodeSelector","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","cpuManagerPolicyOptions":"map[string]string","enableDebuggingHandlers":"bool","evictionHard":"map[string]string","evictionMinimumReclaim":"map[string]string","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxParallelImagePulls":"int32","maxPods":"uint16","registryBurst":"int32","registryPullQPS":"int32","serializeImagePulls":"bool"},"deprecated_at":"2026-03-24T00:00:00Z","end_of_life_at":"2026-06-24T00:00:00Z","released_at":"2025-03-24T00:00:00Z"}]}'
+        content_length: 4251
+        body: '{"versions":[{"region":"fr-par","name":"1.36.1","label":"Kubernetes 1.36.1","available_cnis":["cilium","cilium_native","calico","kilo","none"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","CPUManagerPolicyAlphaOptions","ImageVolume","MutatingAdmissionPolicy"],"available_admission_plugins":["AlwaysPullImages","PodNodeSelector","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","cpuManagerPolicyOptions":"map[string]string","enableDebuggingHandlers":"bool","evictionHard":"map[string]string","evictionMinimumReclaim":"map[string]string","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxParallelImagePulls":"int32","maxPods":"uint16","registryBurst":"int32","registryPullQPS":"int32","serializeImagePulls":"bool"},"deprecated_at":"2027-07-07T00:00:00Z","end_of_life_at":"2027-09-07T00:00:00Z","released_at":"2026-07-07T00:00:00Z"},{"region":"fr-par","name":"1.35.3","label":"Kubernetes 1.35.3","available_cnis":["cilium","cilium_native","calico","kilo","none"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","CPUManagerPolicyAlphaOptions","ImageVolume","MutatingAdmissionPolicy"],"available_admission_plugins":["AlwaysPullImages","PodNodeSelector","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","cpuManagerPolicyOptions":"map[string]string","enableDebuggingHandlers":"bool","evictionHard":"map[string]string","evictionMinimumReclaim":"map[string]string","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxParallelImagePulls":"int32","maxPods":"uint16","registryBurst":"int32","registryPullQPS":"int32","serializeImagePulls":"bool"},"deprecated_at":"2027-01-19T00:00:00Z","end_of_life_at":"2027-03-19T00:00:00Z","released_at":"2026-01-19T00:00:00Z"},{"region":"fr-par","name":"1.34.6","label":"Kubernetes 1.34.6","available_cnis":["cilium","cilium_native","calico","kilo","none"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","CPUManagerPolicyAlphaOptions","ImageVolume","MutatingAdmissionPolicy"],"available_admission_plugins":["AlwaysPullImages","PodNodeSelector","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","cpuManagerPolicyOptions":"map[string]string","enableDebuggingHandlers":"bool","evictionHard":"map[string]string","evictionMinimumReclaim":"map[string]string","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxParallelImagePulls":"int32","maxPods":"uint16","registryBurst":"int32","registryPullQPS":"int32","serializeImagePulls":"bool"},"deprecated_at":"2026-09-29T00:00:00Z","end_of_life_at":"2026-11-29T00:00:00Z","released_at":"2025-09-29T00:00:00Z"},{"region":"fr-par","name":"1.33.10","label":"Kubernetes 1.33.10","available_cnis":["cilium","calico","kilo","none"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","DRAAdminAccess","DynamicResourceAllocation","PodLevelResources","CPUManagerPolicyAlphaOptions","ImageVolume"],"available_admission_plugins":["AlwaysPullImages","PodNodeSelector","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","cpuManagerPolicyOptions":"map[string]string","enableDebuggingHandlers":"bool","evictionHard":"map[string]string","evictionMinimumReclaim":"map[string]string","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxParallelImagePulls":"int32","maxPods":"uint16","registryBurst":"int32","registryPullQPS":"int32","serializeImagePulls":"bool"},"deprecated_at":"2026-09-04T00:00:00Z","end_of_life_at":"2026-11-04T00:00:00Z","released_at":"2025-09-04T00:00:00Z"}]}'
         headers:
             Content-Length:
-                - "4355"
+                - "4251"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:05:20 GMT
+                - Tue, 18 Aug 2026 09:38:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - d35c0eb9-1747-422c-8b3b-4b3ebf2c126f
+                - 68c84213-cc85-423e-910a-7cc201b42ed8
         status: 200 OK
         code: 200
-        duration: 57.567938ms
+        duration: 73.273068ms
     - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 122
+        content_length: 147
         host: api.scaleway.com
-        body: '{"name":"tf-vpc-interesting-ritchie","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"enable_routing":false}'
+        body: '{"name":"tf-vpc-hardcore-mestorf","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"enable_routing":false,"enable_transitivity":false}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 413
-        body: '{"id":"0f3756af-afff-43f7-b90c-e70492598b1b","name":"tf-vpc-interesting-ritchie","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-06-01T11:05:21.038572Z","updated_at":"2026-06-01T11:05:21.038572Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_default":false,"private_network_count":0,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        content_length: 470
+        body: '{"id":"621f79dd-9a8d-48fb-80eb-8b7db805149e","name":"tf-vpc-hardcore-mestorf","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-08-18T09:38:01.532361Z","updated_at":"2026-08-18T09:38:01.532361Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_default":false,"private_network_count":0,"routing_enabled":true,"custom_routes_propagation_enabled":true,"transitivity_enabled":false,"s3_integration_enabled":false,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "413"
+                - "470"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:05:21 GMT
+                - Tue, 18 Aug 2026 09:38:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 2b8c9b71-5879-43e3-bf39-58a495afefd5
+                - f0b5ad6f-8bff-471d-84c5-d8036b7b5992
         status: 200 OK
         code: 200
-        duration: 103.864411ms
+        duration: 122.187033ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -77,29 +77,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/0f3756af-afff-43f7-b90c-e70492598b1b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/621f79dd-9a8d-48fb-80eb-8b7db805149e
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 413
-        body: '{"id":"0f3756af-afff-43f7-b90c-e70492598b1b","name":"tf-vpc-interesting-ritchie","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-06-01T11:05:21.038572Z","updated_at":"2026-06-01T11:05:21.038572Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_default":false,"private_network_count":0,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        content_length: 470
+        body: '{"id":"621f79dd-9a8d-48fb-80eb-8b7db805149e","name":"tf-vpc-hardcore-mestorf","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-08-18T09:38:01.532361Z","updated_at":"2026-08-18T09:38:01.532361Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_default":false,"private_network_count":0,"routing_enabled":true,"custom_routes_propagation_enabled":true,"transitivity_enabled":false,"s3_integration_enabled":false,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "413"
+                - "470"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:05:21 GMT
+                - Tue, 18 Aug 2026 09:38:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 8eb7136e-d2eb-450a-8677-b0f5970f1e1d
+                - 66b103aa-599d-4243-999c-fbd973fe55ca
         status: 200 OK
         code: 200
-        duration: 68.632888ms
+        duration: 111.518954ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -107,34 +107,34 @@ interactions:
         proto_minor: 1
         content_length: 205
         host: api.scaleway.com
-        body: '{"name":"test-pool-taints-and-labels","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"subnets":null,"vpc_id":"0f3756af-afff-43f7-b90c-e70492598b1b","default_route_propagation_enabled":false}'
+        body: '{"name":"test-pool-taints-and-labels","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"subnets":null,"vpc_id":"621f79dd-9a8d-48fb-80eb-8b7db805149e","default_route_propagation_enabled":false}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 1072
-        body: '{"id":"03958c89-e8ad-4344-90e1-f1d02267e843","name":"test-pool-taints-and-labels","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-06-01T11:05:21.197514Z","updated_at":"2026-06-01T11:05:21.197514Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":[{"id":"d9bd5591-544c-4b08-9d13-efd5a4fa044b","created_at":"2026-06-01T11:05:21.197514Z","updated_at":"2026-06-01T11:05:21.197514Z","subnet":"172.16.24.0/22","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"03958c89-e8ad-4344-90e1-f1d02267e843","vpc_id":"0f3756af-afff-43f7-b90c-e70492598b1b"},{"id":"ed5bae7d-26b2-42b1-a42c-4cf74a572077","created_at":"2026-06-01T11:05:21.197514Z","updated_at":"2026-06-01T11:05:21.197514Z","subnet":"fd63:256c:45f7:f16::/64","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"03958c89-e8ad-4344-90e1-f1d02267e843","vpc_id":"0f3756af-afff-43f7-b90c-e70492598b1b"}],"vpc_id":"0f3756af-afff-43f7-b90c-e70492598b1b","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        content_length: 1136
+        body: '{"id":"e85f0802-5637-46d2-88c2-8ceb6767c532","name":"test-pool-taints-and-labels","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-08-18T09:38:01.802133Z","updated_at":"2026-08-18T09:38:01.802133Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":[{"id":"b07d02f2-cb17-4f4b-a7c8-128f3dd8562d","created_at":"2026-08-18T09:38:01.802133Z","updated_at":"2026-08-18T09:38:01.802133Z","subnet":"172.16.64.0/22","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e85f0802-5637-46d2-88c2-8ceb6767c532","vpc_id":"621f79dd-9a8d-48fb-80eb-8b7db805149e","region":"fr-par"},{"id":"2c1ea306-c6c0-4637-bfcd-a88c8d860ee1","created_at":"2026-08-18T09:38:01.802133Z","updated_at":"2026-08-18T09:38:01.802133Z","subnet":"fd63:256c:45f7:a125::/64","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e85f0802-5637-46d2-88c2-8ceb6767c532","vpc_id":"621f79dd-9a8d-48fb-80eb-8b7db805149e","region":"fr-par"}],"vpc_id":"621f79dd-9a8d-48fb-80eb-8b7db805149e","dhcp_enabled":true,"default_route_propagation_enabled":false,"has_s3_integration":false,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "1072"
+                - "1136"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:05:21 GMT
+                - Tue, 18 Aug 2026 09:38:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 1303b745-e356-4bc1-8bd4-a701affc083d
+                - 370199a2-f5b0-4289-83ec-b423f3c5f6cd
         status: 200 OK
         code: 200
-        duration: 586.62292ms
+        duration: 703.448941ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -144,29 +144,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/03958c89-e8ad-4344-90e1-f1d02267e843
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e85f0802-5637-46d2-88c2-8ceb6767c532
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 1072
-        body: '{"id":"03958c89-e8ad-4344-90e1-f1d02267e843","name":"test-pool-taints-and-labels","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-06-01T11:05:21.197514Z","updated_at":"2026-06-01T11:05:21.197514Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":[{"id":"d9bd5591-544c-4b08-9d13-efd5a4fa044b","created_at":"2026-06-01T11:05:21.197514Z","updated_at":"2026-06-01T11:05:21.197514Z","subnet":"172.16.24.0/22","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"03958c89-e8ad-4344-90e1-f1d02267e843","vpc_id":"0f3756af-afff-43f7-b90c-e70492598b1b"},{"id":"ed5bae7d-26b2-42b1-a42c-4cf74a572077","created_at":"2026-06-01T11:05:21.197514Z","updated_at":"2026-06-01T11:05:21.197514Z","subnet":"fd63:256c:45f7:f16::/64","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"03958c89-e8ad-4344-90e1-f1d02267e843","vpc_id":"0f3756af-afff-43f7-b90c-e70492598b1b"}],"vpc_id":"0f3756af-afff-43f7-b90c-e70492598b1b","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        content_length: 1136
+        body: '{"id":"e85f0802-5637-46d2-88c2-8ceb6767c532","name":"test-pool-taints-and-labels","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-08-18T09:38:01.802133Z","updated_at":"2026-08-18T09:38:01.802133Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":[{"id":"b07d02f2-cb17-4f4b-a7c8-128f3dd8562d","created_at":"2026-08-18T09:38:01.802133Z","updated_at":"2026-08-18T09:38:01.802133Z","subnet":"172.16.64.0/22","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e85f0802-5637-46d2-88c2-8ceb6767c532","vpc_id":"621f79dd-9a8d-48fb-80eb-8b7db805149e","region":"fr-par"},{"id":"2c1ea306-c6c0-4637-bfcd-a88c8d860ee1","created_at":"2026-08-18T09:38:01.802133Z","updated_at":"2026-08-18T09:38:01.802133Z","subnet":"fd63:256c:45f7:a125::/64","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e85f0802-5637-46d2-88c2-8ceb6767c532","vpc_id":"621f79dd-9a8d-48fb-80eb-8b7db805149e","region":"fr-par"}],"vpc_id":"621f79dd-9a8d-48fb-80eb-8b7db805149e","dhcp_enabled":true,"default_route_propagation_enabled":false,"has_s3_integration":false,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "1072"
+                - "1136"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:05:21 GMT
+                - Tue, 18 Aug 2026 09:38:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 129a9868-19cf-4562-a265-977fb3a75a5d
+                - cc58aae7-69c1-4dca-bc8b-463fe4999036
         status: 200 OK
         code: 200
-        duration: 49.633472ms
+        duration: 126.789846ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -174,12 +174,12 @@ interactions:
         proto_minor: 1
         content_length: 770
         host: api.scaleway.com
-        body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-pool-taints-and-labels","description":"","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"version":"1.35.3","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":null},"feature_gates":[],"admission_plugins":[],"apiserver_cert_sans":[],"private_network_id":"03958c89-e8ad-4344-90e1-f1d02267e843"}'
+        body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-pool-taints-and-labels","description":"","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"version":"1.36.1","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":null},"feature_gates":[],"admission_plugins":[],"apiserver_cert_sans":[],"private_network_id":"e85f0802-5637-46d2-88c2-8ceb6767c532"}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
         method: POST
       response:
@@ -187,21 +187,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 1595
-        body: '{"region":"fr-par","id":"90674a70-85ad-42bb-8877-9d4fe78940db","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-06-01T11:05:22.167457Z","updated_at":"2026-06-01T11:05:22.167457Z","type":"kapsule","name":"test-pool-taints-and-labels","description":"","status":"creating","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"cluster_url":"https://90674a70-85ad-42bb-8877-9d4fe78940db.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.90674a70-85ad-42bb-8877-9d4fe78940db.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":2},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"03958c89-e8ad-4344-90e1-f1d02267e843","commitment_ends_at":"2026-06-01T11:05:22.167465Z","acl_available":true,"iam_nodes_group_id":"","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        body: '{"region":"fr-par","id":"220ee062-8e89-47b8-96d9-ebe282662eb0","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-08-18T09:38:02.905614Z","updated_at":"2026-08-18T09:38:02.905614Z","type":"kapsule","name":"test-pool-taints-and-labels","description":"","status":"creating","version":"1.36.1","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"cluster_url":"https://220ee062-8e89-47b8-96d9-ebe282662eb0.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.220ee062-8e89-47b8-96d9-ebe282662eb0.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":2},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"e85f0802-5637-46d2-88c2-8ceb6767c532","commitment_ends_at":"2026-08-18T09:38:02.905622Z","acl_available":true,"iam_nodes_group_id":"","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
         headers:
             Content-Length:
                 - "1595"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:05:22 GMT
+                - Tue, 18 Aug 2026 09:38:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 05208cbb-55ad-4223-adc4-be6a90d4ceb3
+                - ef43faa2-d538-4058-8646-636b08ff0727
         status: 200 OK
         code: 200
-        duration: 415.017155ms
+        duration: 408.507863ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -211,29 +211,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/90674a70-85ad-42bb-8877-9d4fe78940db
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/220ee062-8e89-47b8-96d9-ebe282662eb0
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 1595
-        body: '{"region":"fr-par","id":"90674a70-85ad-42bb-8877-9d4fe78940db","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-06-01T11:05:22.167457Z","updated_at":"2026-06-01T11:05:22.167457Z","type":"kapsule","name":"test-pool-taints-and-labels","description":"","status":"creating","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"cluster_url":"https://90674a70-85ad-42bb-8877-9d4fe78940db.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.90674a70-85ad-42bb-8877-9d4fe78940db.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":2},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"03958c89-e8ad-4344-90e1-f1d02267e843","commitment_ends_at":"2026-06-01T11:05:22.167465Z","acl_available":true,"iam_nodes_group_id":"","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        body: '{"region":"fr-par","id":"220ee062-8e89-47b8-96d9-ebe282662eb0","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-08-18T09:38:02.905614Z","updated_at":"2026-08-18T09:38:02.905614Z","type":"kapsule","name":"test-pool-taints-and-labels","description":"","status":"creating","version":"1.36.1","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"cluster_url":"https://220ee062-8e89-47b8-96d9-ebe282662eb0.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.220ee062-8e89-47b8-96d9-ebe282662eb0.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":2},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"e85f0802-5637-46d2-88c2-8ceb6767c532","commitment_ends_at":"2026-08-18T09:38:02.905622Z","acl_available":true,"iam_nodes_group_id":"","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
         headers:
             Content-Length:
                 - "1595"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:05:22 GMT
+                - Tue, 18 Aug 2026 09:38:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - facb773a-e895-42aa-abbc-12606f198e80
+                - 295a075d-4153-4fe6-a5f2-c3c48c8d30b3
         status: 200 OK
         code: 200
-        duration: 44.559284ms
+        duration: 59.774495ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -243,29 +243,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/90674a70-85ad-42bb-8877-9d4fe78940db
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/220ee062-8e89-47b8-96d9-ebe282662eb0
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 1636
-        body: '{"region":"fr-par","id":"90674a70-85ad-42bb-8877-9d4fe78940db","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-06-01T11:05:22.167457Z","updated_at":"2026-06-01T11:05:22.669924Z","type":"kapsule","name":"test-pool-taints-and-labels","description":"","status":"pool_required","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"cluster_url":"https://90674a70-85ad-42bb-8877-9d4fe78940db.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.90674a70-85ad-42bb-8877-9d4fe78940db.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":2},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"03958c89-e8ad-4344-90e1-f1d02267e843","commitment_ends_at":"2026-06-01T11:05:22.167465Z","acl_available":true,"iam_nodes_group_id":"08fab0b3-c94e-4243-93c0-d8ff43e1d01d","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        body: '{"region":"fr-par","id":"220ee062-8e89-47b8-96d9-ebe282662eb0","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-08-18T09:38:02.905614Z","updated_at":"2026-08-18T09:38:03.328790Z","type":"kapsule","name":"test-pool-taints-and-labels","description":"","status":"pool_required","version":"1.36.1","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"cluster_url":"https://220ee062-8e89-47b8-96d9-ebe282662eb0.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.220ee062-8e89-47b8-96d9-ebe282662eb0.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":2},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"e85f0802-5637-46d2-88c2-8ceb6767c532","commitment_ends_at":"2026-08-18T09:38:02.905622Z","acl_available":true,"iam_nodes_group_id":"586830d7-c0e2-4bcd-a605-15e937921fc5","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
         headers:
             Content-Length:
                 - "1636"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:05:27 GMT
+                - Tue, 18 Aug 2026 09:38:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 602df8f2-7b98-461c-9fea-f3b3878e2891
+                - 452c8617-6439-4962-a416-1ae301168822
         status: 200 OK
         code: 200
-        duration: 43.370418ms
+        duration: 50.636919ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -282,8 +282,8 @@ interactions:
                 - unknown
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/90674a70-85ad-42bb-8877-9d4fe78940db/pools?order_by=created_at_asc&page=1&status=unknown
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/220ee062-8e89-47b8-96d9-ebe282662eb0/pools?order_by=created_at_asc&page=1&status=unknown
         method: GET
       response:
         proto: HTTP/2.0
@@ -297,14 +297,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:05:27 GMT
+                - Tue, 18 Aug 2026 09:38:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 581aabce-f02b-4adc-a2ff-aa8d18ae31bb
+                - 6110ba47-dd5b-412d-90a7-5c7250afb18a
         status: 200 OK
         code: 200
-        duration: 59.512998ms
+        duration: 26.790678ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -314,29 +314,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/90674a70-85ad-42bb-8877-9d4fe78940db
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/220ee062-8e89-47b8-96d9-ebe282662eb0
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 1636
-        body: '{"region":"fr-par","id":"90674a70-85ad-42bb-8877-9d4fe78940db","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-06-01T11:05:22.167457Z","updated_at":"2026-06-01T11:05:22.669924Z","type":"kapsule","name":"test-pool-taints-and-labels","description":"","status":"pool_required","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"cluster_url":"https://90674a70-85ad-42bb-8877-9d4fe78940db.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.90674a70-85ad-42bb-8877-9d4fe78940db.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":2},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"03958c89-e8ad-4344-90e1-f1d02267e843","commitment_ends_at":"2026-06-01T11:05:22.167465Z","acl_available":true,"iam_nodes_group_id":"08fab0b3-c94e-4243-93c0-d8ff43e1d01d","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        body: '{"region":"fr-par","id":"220ee062-8e89-47b8-96d9-ebe282662eb0","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-08-18T09:38:02.905614Z","updated_at":"2026-08-18T09:38:03.328790Z","type":"kapsule","name":"test-pool-taints-and-labels","description":"","status":"pool_required","version":"1.36.1","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"cluster_url":"https://220ee062-8e89-47b8-96d9-ebe282662eb0.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.220ee062-8e89-47b8-96d9-ebe282662eb0.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":2},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"e85f0802-5637-46d2-88c2-8ceb6767c532","commitment_ends_at":"2026-08-18T09:38:02.905622Z","acl_available":true,"iam_nodes_group_id":"586830d7-c0e2-4bcd-a605-15e937921fc5","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
         headers:
             Content-Length:
                 - "1636"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:05:27 GMT
+                - Tue, 18 Aug 2026 09:38:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 7f95a91a-b6c0-4a23-9fff-e41f44e9426b
+                - a90efc58-7feb-4cc3-be07-b01d8449fa71
         status: 200 OK
         code: 200
-        duration: 21.591646ms
+        duration: 21.874387ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -346,29 +346,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/90674a70-85ad-42bb-8877-9d4fe78940db/kubeconfig
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/220ee062-8e89-47b8-96d9-ebe282662eb0/kubeconfig
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 1752
-        body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscyIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVUpYZWtORFFWRkhaMEYzU1VKQlowbENRVVJCUzBKblozRm9hMnBQVUZGUlJFRnFRVlpOVWsxM1JWRlpSRlpSVVVSRmQzQnlaRmRLYkdOdE5Xd0taRWRXZWsxQ05GaEVWRWt5VFVSVmVrMVVSWGhOUkZWNVRXeHZXRVJVVFRKTlJGVjZUVlJGZUUxRVZYbE5iRzkzUmxSRlZFMUNSVWRCTVZWRlFYaE5Td3BoTTFacFdsaEtkVnBZVW14amVrSmFUVUpOUjBKNWNVZFRUVFE1UVdkRlIwTkRjVWRUVFRRNVFYZEZTRUV3U1VGQ1FWUTFWMkV2U0d0eWNtWlJWWEUzQ25kc05Fd3ZZVFozZFZCTmEzSTFVRlZ1WjFRck0waFZUMnhyUkRWQ09FUjNNMEpvT0hBeFpWWXJUbGhHTDNwMlVFZ3pTVEV3ZWxBeFF6bGFPV3Q2U2swS1RqTmhiMlZEVjJwUmFrSkJUVUUwUjBFeFZXUkVkMFZDTDNkUlJVRjNTVU53UkVGUVFtZE9Wa2hTVFVKQlpqaEZRbFJCUkVGUlNDOU5RakJIUVRGVlpBcEVaMUZYUWtKUk9VOXRWVVZHYms5RFVuWTVkMk5zVG5reWRHWktiell5YW1scVFVdENaMmR4YUd0cVQxQlJVVVJCWjA1SlFVUkNSa0ZwUVU5c2RVRndDa0ZDYmtzMVUwcDFMMlYzWkU0NFYybENWVFExVmtoa1UyRlljWFJGTVdzMlpIZEhiV3BuU1doQlRTdE1XRlVyVlRSTE9XZzJNemgzWWs5RFFUQnhTWFlLWWxsUVpITTVkV05LUjFGSVFWSlJUelJQUXprS0xTMHRMUzFGVGtRZ1EwVlNWRWxHU1VOQlZFVXRMUzB0TFFvPQogICAgc2VydmVyOiBodHRwczovLzkwNjc0YTcwLTg1YWQtNDJiYi04ODc3LTlkNGZlNzg5NDBkYi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wtdGFpbnRzLWFuZC1sYWJlbHMKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscyIKICAgIHVzZXI6IHRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscy1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscwpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscy1hZG1pbgogIHVzZXI6CiAgICB0b2tlbjogdVhtQ2FlSXN6Y2JwU3dWbDcwU0FOa205RUg2RG1PMTZqMHRSbFRhU0VUTExseHpzWENkVE9LRXg="}'
+        body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscyIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVUpYZWtORFFWRkhaMEYzU1VKQlowbENRVVJCUzBKblozRm9hMnBQVUZGUlJFRnFRVlpOVWsxM1JWRlpSRlpSVVVSRmQzQnlaRmRLYkdOdE5Xd0taRWRXZWsxQ05GaEVWRWt5VFVSbmVFNTZRVFZOZW1kM1RXeHZXRVJVVFRKTlJHZDRUbnBCTlUxNlozZE5iRzkzUmxSRlZFMUNSVWRCTVZWRlFYaE5Td3BoTTFacFdsaEtkVnBZVW14amVrSmFUVUpOUjBKNWNVZFRUVFE1UVdkRlIwTkRjVWRUVFRRNVFYZEZTRUV3U1VGQ1RFOVBha3cyVTNaRE5HSXlSVlZLQ25aaGVXbENiR2wzY1RCemFuWmFWMDB4YlRKUlVHOVVSMng1VGpaTVRHTnZlVkJ6VUcxSVpUWk1lVGtyY0VVclVsUlJObU5FSzB4R1Z6UmFOM3BYUkdRS1JXbEdSVFJ3WldwUmFrSkJUVUUwUjBFeFZXUkVkMFZDTDNkUlJVRjNTVU53UkVGUVFtZE9Wa2hTVFVKQlpqaEZRbFJCUkVGUlNDOU5RakJIUVRGVlpBcEVaMUZYUWtKVFdrbExiemRrYmk5a1UzWTFUV05rVkhSemMwNVVkbEJCUTFwcVFVdENaMmR4YUd0cVQxQlJVVVJCWjA1SlFVUkNSa0ZwUlVGMk1qWkxDbk5IVVRKNU5tNDNhbkJyY21OcFowbDFWSGRsZVZSUWJVVk5OV04yTjFwUVduTnJRMjFoU1VOSlJDOWFhVVV2VUhnMlRTdFNTRmMzWm1OUlpWSlFNMUlLVTJaS1NHRmhRamRYWlU5UVMyaHVWVmRSVkUwS0xTMHRMUzFGVGtRZ1EwVlNWRWxHU1VOQlZFVXRMUzB0TFFvPQogICAgc2VydmVyOiBodHRwczovLzIyMGVlMDYyLThlODktNDdiOC05NmQ5LWViZTI4MjY2MmViMC5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wtdGFpbnRzLWFuZC1sYWJlbHMKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscyIKICAgIHVzZXI6IHRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscy1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscwpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscy1hZG1pbgogIHVzZXI6CiAgICB0b2tlbjogSHdXNzVwZU0ycmFjMmZEUFhyZ2xVVmNhN0dlcFRmam5qS0ZDeHdYeE04VjFxaTdJR3oxclJ1T2E="}'
         headers:
             Content-Length:
                 - "1752"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:05:27 GMT
+                - Tue, 18 Aug 2026 09:38:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 9a7dcc26-2118-4552-a96e-b3c7777235b0
+                - 3c8cf273-9b57-491a-af69-8bcb40c19e9e
         status: 200 OK
         code: 200
-        duration: 54.209228ms
+        duration: 48.012171ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -381,33 +381,33 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 41367
-        body: '{"servers": {"BASIC2-A16C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 150.891, "hourly_price": 0.2067, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 503316480, "end_of_service": false}, "BASIC2-A16C-64G": {"alt_names": [], "arch": "arm64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 201.188, "hourly_price": 0.2756, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 503316480, "end_of_service": false}, "BASIC2-A2C-4G": {"alt_names": [], "arch": "arm64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 16.79, "hourly_price": 0.023, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 83886080, "end_of_service": false}, "BASIC2-A2C-8G": {"alt_names": [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 25.185, "hourly_price": 0.0345, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 83886080, "end_of_service": false}, "BASIC2-A4C-16G": {"alt_names": [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 50.297, "hourly_price": 0.0689, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 125829120, "end_of_service": false}, "BASIC2-A4C-8G": {"alt_names": [], "arch": "arm64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 37.741, "hourly_price": 0.0517, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 125829120, "end_of_service": false}, "BASIC2-A8C-16G": {"alt_names": [], "arch": "arm64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 75.482, "hourly_price": 0.1034, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 251658240, "end_of_service": false}, "BASIC2-A8C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 100.594, "hourly_price": 0.1378, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 251658240, "end_of_service": false}, "BASIC3-X16C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 259.33031, "hourly_price": 0.355247, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "BASIC3-X16C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 345.49805, "hourly_price": 0.473285, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "BASIC3-X2C-4G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 28.79777, "hourly_price": 0.039449, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth": 350000000, "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth": 350000000}]}, "block_bandwidth": 131072000, "end_of_service": false}, "BASIC3-X2C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 43.23425, "hourly_price": 0.059225, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth": 350000000, "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth": 350000000}]}, "block_bandwidth": 131072000, "end_of_service": false}, "BASIC3-X4C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 86.4685, "hourly_price": 0.11845, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth": 700000000, "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth": 700000000}]}, "block_bandwidth": 262144000, "end_of_service": false}, "BASIC3-X4C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 57.67073, "hourly_price": 0.079001, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth": 700000000, "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth": 700000000}]}, "block_bandwidth": 262144000, "end_of_service": false}, "BASIC3-X8C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 129.70275, "hourly_price": 0.177675, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 524288000, "end_of_service": false}, "BASIC3-X8C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 172.86181, "hourly_price": 0.236797, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 524288000, "end_of_service": false}, "COMPUTE3-X16C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 320000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 341.786, "hourly_price": 0.4682, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 4000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 4000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "COMPUTE3-X2C-4G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 40000000000, "scratch_storage_max_volumes_count": 1, "monthly_price": 42.705, "hourly_price": 0.0585, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "COMPUTE3-X32C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 640000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 683.499, "hourly_price": 0.9363, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 8000000000, "sum_internet_bandwidth": 8000000000, "interfaces": [{"internal_bandwidth": 8000000000, "internet_bandwidth": 8000000000}]}, "block_bandwidth": 1000341504, "end_of_service": false}, "COMPUTE3-X48C-96G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 103079215104, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 960000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1019.81, "hourly_price": 1.397, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "COMPUTE3-X4C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 80000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 85.41, "hourly_price": 0.117, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "COMPUTE3-X64C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 1280000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1366.998, "hourly_price": 1.8726, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "COMPUTE3-X8C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 160000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 170.893, "hourly_price": 0.2341, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "COMPUTE3-X96C-192G": {"alt_names": [], "arch": "x86_64", "ncpus": 96, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 1280000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 2039.62, "hourly_price": 2.794, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "DEV1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 80000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 31.2732, "hourly_price": 0.04284, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 209715200, "end_of_service": false}, "DEV1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 3, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 40000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 14.74308, "hourly_price": 0.020196, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth": 300000000}]}, "block_bandwidth": 157286400, "end_of_service": false}, "DEV1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 20000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 6.55248, "hourly_price": 0.008976, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 104857600, "end_of_service": false}, "DEV1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 12884901888, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 120000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 47.50548, "hourly_price": 0.065076, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 262144000, "end_of_service": false}, "GP1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 565.1514, "hourly_price": 0.77418, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]}, "block_bandwidth": 1073741824, "end_of_service": false}, "GP1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 279.9696, "hourly_price": 0.38352, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "GP1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 300000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 139.2402, "hourly_price": 0.19074, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 524288000, "end_of_service": false}, "GP1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1221.8886, "hourly_price": 1.67382, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]}, "block_bandwidth": 2147483648, "end_of_service": false}, "GP1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 150000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 67.7586, "hourly_price": 0.09282, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 314572800, "end_of_service": false}, "L4-1-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 51539607552, "gpu": 1, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 574.875, "hourly_price": 0.7875, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 2500000000, "sum_internet_bandwidth": 2500000000, "interfaces": [{"internal_bandwidth": 2500000000, "internet_bandwidth": 2500000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "L4-2-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 103079215104, "gpu": 2, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1149.75, "hourly_price": 1.575, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]}, "block_bandwidth": 1572864000, "end_of_service": false}, "L4-4-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 206158430208, "gpu": 4, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 2299.5, "hourly_price": 3.15, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]}, "block_bandwidth": 2621440000, "end_of_service": false}, "L4-8-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 412316860416, "gpu": 8, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 4599.0, "hourly_price": 6.3, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 20000000000, "sum_internet_bandwidth": 20000000000, "interfaces": [{"internal_bandwidth": 20000000000, "internet_bandwidth": 20000000000}]}, "block_bandwidth": 5242880000, "end_of_service": false}, "MEMORY3-X16C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 320000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 661.672, "hourly_price": 0.9064, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 4000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 4000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "MEMORY3-X2C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 40000000000, "scratch_storage_max_volumes_count": 1, "monthly_price": 82.709, "hourly_price": 0.1133, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "MEMORY3-X32C-256G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 640000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 1323.344, "hourly_price": 1.8128, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 8000000000, "sum_internet_bandwidth": 8000000000, "interfaces": [{"internal_bandwidth": 8000000000, "internet_bandwidth": 8000000000}]}, "block_bandwidth": 1000341504, "end_of_service": false}, "MEMORY3-X48C-384G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 412316860416, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 960000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1983.41, "hourly_price": 2.717, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "MEMORY3-X4C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 80000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 165.418, "hourly_price": 0.2266, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "MEMORY3-X8C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 160000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 330.836, "hourly_price": 0.4532, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "PLAY2-MICRO": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 40.2084, "hourly_price": 0.05508, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 167772160, "end_of_service": false}, "PLAY2-NANO": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 20.1042, "hourly_price": 0.02754, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 83886080, "end_of_service": false}, "PLAY2-PICO": {"alt_names": [], "arch": "x86_64", "ncpus": 1, "ram": 2147483648, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 10.4244, "hourly_price": 0.01428, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]}, "block_bandwidth": 41943040, "end_of_service": false}, "POP2-16C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 430.7, "hourly_price": 0.59, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-16C-64G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1063.391, "hourly_price": 1.4567, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-2C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 53.655, "hourly_price": 0.0735, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-2C-8G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 133.079, "hourly_price": 0.1823, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}}}'
+        content_length: 41390
+        body: '{"servers": {"BASIC2-A12C-24G": {"alt_names": [], "arch": "arm64", "ncpus": 12, "ram": 25769803776, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 115.194, "hourly_price": 0.1578, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1200000000, "sum_internet_bandwidth": 1200000000, "interfaces": [{"internal_bandwidth": 1200000000, "internet_bandwidth": 1200000000}]}, "block_bandwidth": 335544320, "end_of_service": false}, "BASIC2-A12C-48G": {"alt_names": [], "arch": "arm64", "ncpus": 12, "ram": 51539607552, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 131.911, "hourly_price": 0.1807, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1200000000, "sum_internet_bandwidth": 1200000000, "interfaces": [{"internal_bandwidth": 1200000000, "internet_bandwidth": 1200000000}]}, "block_bandwidth": 335544320, "end_of_service": false}, "BASIC2-A16C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 150.891, "hourly_price": 0.2067, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 503316480, "end_of_service": false}, "BASIC2-A16C-64G": {"alt_names": [], "arch": "arm64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 201.188, "hourly_price": 0.2756, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 503316480, "end_of_service": false}, "BASIC2-A2C-4G": {"alt_names": [], "arch": "arm64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 16.79, "hourly_price": 0.023, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 83886080, "end_of_service": false}, "BASIC2-A2C-8G": {"alt_names": [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 25.185, "hourly_price": 0.0345, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 83886080, "end_of_service": false}, "BASIC2-A4C-16G": {"alt_names": [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 50.297, "hourly_price": 0.0689, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 125829120, "end_of_service": false}, "BASIC2-A4C-8G": {"alt_names": [], "arch": "arm64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 37.741, "hourly_price": 0.0517, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 125829120, "end_of_service": false}, "BASIC2-A6C-12G": {"alt_names": [], "arch": "arm64", "ncpus": 6, "ram": 12884901888, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 57.597, "hourly_price": 0.0789, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 600000000, "sum_internet_bandwidth": 600000000, "interfaces": [{"internal_bandwidth": 600000000, "internet_bandwidth": 600000000}]}, "block_bandwidth": 188743680, "end_of_service": false}, "BASIC2-A6C-24G": {"alt_names": [], "arch": "arm64", "ncpus": 6, "ram": 25769803776, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 65.919, "hourly_price": 0.0903, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 600000000, "sum_internet_bandwidth": 600000000, "interfaces": [{"internal_bandwidth": 600000000, "internet_bandwidth": 600000000}]}, "block_bandwidth": 188743680, "end_of_service": false}, "BASIC2-A8C-16G": {"alt_names": [], "arch": "arm64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 75.482, "hourly_price": 0.1034, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 251658240, "end_of_service": false}, "BASIC2-A8C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 100.594, "hourly_price": 0.1378, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 251658240, "end_of_service": false}, "BASIC3-X12C-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 12, "ram": 25769803776, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 197.903, "hourly_price": 0.2711, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 2250000000, "sum_internet_bandwidth": 2250000000, "interfaces": [{"internal_bandwidth": 2250000000, "internet_bandwidth": 2250000000}]}, "block_bandwidth": 786432000, "end_of_service": false}, "BASIC3-X12C-48G": {"alt_names": [], "arch": "x86_64", "ncpus": 12, "ram": 51539607552, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 226.592, "hourly_price": 0.3104, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 2250000000, "sum_internet_bandwidth": 2250000000, "interfaces": [{"internal_bandwidth": 2250000000, "internet_bandwidth": 2250000000}]}, "block_bandwidth": 786432000, "end_of_service": false}, "BASIC3-X16C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 259.33031, "hourly_price": 0.355247, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "BASIC3-X16C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 345.49805, "hourly_price": 0.473285, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "BASIC3-X2C-4G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 28.79777, "hourly_price": 0.039449, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth": 350000000, "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth": 350000000}]}, "block_bandwidth": 131072000, "end_of_service": false}, "BASIC3-X2C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 43.23425, "hourly_price": 0.059225, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth": 350000000, "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth": 350000000}]}, "block_bandwidth": 131072000, "end_of_service": false}, "BASIC3-X4C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 86.4685, "hourly_price": 0.11845, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth": 700000000, "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth": 700000000}]}, "block_bandwidth": 262144000, "end_of_service": false}, "BASIC3-X4C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 57.67073, "hourly_price": 0.079001, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth": 700000000, "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth": 700000000}]}, "block_bandwidth": 262144000, "end_of_service": false}, "BASIC3-X6C-12G": {"alt_names": [], "arch": "x86_64", "ncpus": 6, "ram": 12884901888, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 98.988, "hourly_price": 0.1356, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1050000000, "sum_internet_bandwidth": 1050000000, "interfaces": [{"internal_bandwidth": 1050000000, "internet_bandwidth": 1050000000}]}, "block_bandwidth": 393216000, "end_of_service": false}, "BASIC3-X6C-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 6, "ram": 25769803776, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 113.369, "hourly_price": 0.1553, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1050000000, "sum_internet_bandwidth": 1050000000, "interfaces": [{"internal_bandwidth": 1050000000, "internet_bandwidth": 1050000000}]}, "block_bandwidth": 393216000, "end_of_service": false}, "BASIC3-X8C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 129.70275, "hourly_price": 0.177675, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 524288000, "end_of_service": false}, "BASIC3-X8C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 172.86181, "hourly_price": 0.236797, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 524288000, "end_of_service": false}, "COMPUTE3-X12C-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 12, "ram": 25769803776, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 240000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 256.317, "hourly_price": 0.3511, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 4000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 4000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "COMPUTE3-X16C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 320000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 341.786, "hourly_price": 0.4682, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 4000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 4000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "COMPUTE3-X24C-48G": {"alt_names": [], "arch": "x86_64", "ncpus": 24, "ram": 51539607552, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 480000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 512.3176, "hourly_price": 0.7022, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6000000000, "sum_internet_bandwidth": 6000000000, "interfaces": [{"internal_bandwidth": 6000000000, "internet_bandwidth": 6000000000}]}, "block_bandwidth": 749731840, "end_of_service": false}, "COMPUTE3-X2C-4G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 40000000000, "scratch_storage_max_volumes_count": 1, "monthly_price": 42.705, "hourly_price": 0.0585, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "COMPUTE3-X32C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 640000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 683.499, "hourly_price": 0.9363, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 8000000000, "sum_internet_bandwidth": 8000000000, "interfaces": [{"internal_bandwidth": 8000000000, "internet_bandwidth": 8000000000}]}, "block_bandwidth": 1000341504, "end_of_service": false}, "COMPUTE3-X48C-96G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 103079215104, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 960000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1019.81, "hourly_price": 1.397, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "COMPUTE3-X4C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 80000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 85.41, "hourly_price": 0.117, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "COMPUTE3-X64C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 1280000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1366.998, "hourly_price": 1.8726, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "COMPUTE3-X6C-12G": {"alt_names": [], "arch": "x86_64", "ncpus": 6, "ram": 12884901888, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 120000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 128.1588, "hourly_price": 0.1756, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 3}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "COMPUTE3-X8C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 160000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 170.893, "hourly_price": 0.2341, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "COMPUTE3-X96C-192G": {"alt_names": [], "arch": "x86_64", "ncpus": 96, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 1280000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 2039.62, "hourly_price": 2.794, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "DEV1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 80000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 31.2732, "hourly_price": 0.04284, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 209715200, "end_of_service": false}, "DEV1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 3, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 40000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 14.74308, "hourly_price": 0.020196, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth": 300000000}]}, "block_bandwidth": 157286400, "end_of_service": false}, "DEV1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 20000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 6.55248, "hourly_price": 0.008976, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 104857600, "end_of_service": false}, "DEV1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 12884901888, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 120000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 47.50548, "hourly_price": 0.065076, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 262144000, "end_of_service": false}, "GP1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 565.1514, "hourly_price": 0.77418, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]}, "block_bandwidth": 1073741824, "end_of_service": false}, "GP1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 279.9696, "hourly_price": 0.38352, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "GP1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 300000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 139.2402, "hourly_price": 0.19074, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 524288000, "end_of_service": false}, "GP1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1221.8886, "hourly_price": 1.67382, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]}, "block_bandwidth": 2147483648, "end_of_service": false}, "GP1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 150000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 67.7586, "hourly_price": 0.09282, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 314572800, "end_of_service": false}, "L4-1-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 51539607552, "gpu": 1, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 574.875, "hourly_price": 0.7875, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 2500000000, "sum_internet_bandwidth": 2500000000, "interfaces": [{"internal_bandwidth": 2500000000, "internet_bandwidth": 2500000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "L4-2-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 103079215104, "gpu": 2, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1149.75, "hourly_price": 1.575, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]}, "block_bandwidth": 1572864000, "end_of_service": false}, "L4-4-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 206158430208, "gpu": 4, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 2299.5, "hourly_price": 3.15, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]}, "block_bandwidth": 2621440000, "end_of_service": false}, "L4-8-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 412316860416, "gpu": 8, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 4599.0, "hourly_price": 6.3, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 20000000000, "sum_internet_bandwidth": 20000000000, "interfaces": [{"internal_bandwidth": 20000000000, "internet_bandwidth": 20000000000}]}, "block_bandwidth": 5242880000, "end_of_service": false}, "MEMORY3-X12C-96G": {"alt_names": [], "arch": "x86_64", "ncpus": 12, "ram": 103079215104, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 240000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 496.254, "hourly_price": 0.6798, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 4000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 4000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "MEMORY3-X16C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 320000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 661.672, "hourly_price": 0.9064, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 4000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 4000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}}}'
         headers:
             Content-Length:
-                - "41367"
+                - "41390"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:05:27 GMT
+                - Tue, 18 Aug 2026 09:38:08 GMT
             Link:
                 - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=3&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 4fa850ac-ff79-4ce3-b73f-a543e1ab5a91
+                - 021c4ac8-2cd7-4f60-b354-48aadd8a4102
             X-Total-Count:
-                - "107"
+                - "136"
         status: 200 OK
         code: 200
-        duration: 22.892474ms
+        duration: 69.596003ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -420,33 +420,33 @@ interactions:
                 - "2"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 41028
-        body: '{"servers": {"POP2-32C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 861.4, "hourly_price": 1.18, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-32C-128G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 2126.709, "hourly_price": 2.9133, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-48C-192G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1292.1, "hourly_price": 1.77, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-4C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 107.31, "hourly_price": 0.147, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-4C-16G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 265.501, "hourly_price": 0.3637, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-64C-256G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-8C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 211.7, "hourly_price": 0.29, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-8C-32G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 528.009, "hourly_price": 0.7233, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HC-16C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 310.688, "hourly_price": 0.4256, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-HC-2C-4G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 38.836, "hourly_price": 0.0532, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HC-32C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 621.376, "hourly_price": 0.8512, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HC-48C-96G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 103079215104, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 927.1, "hourly_price": 1.27, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HC-4C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 77.672, "hourly_price": 0.1064, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HC-64C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1242.752, "hourly_price": 1.7024, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HC-8C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 155.344, "hourly_price": 0.2128, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HM-16C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 601.52, "hourly_price": 0.824, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-HM-2C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 75.19, "hourly_price": 0.103, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HM-32C-256G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1203.04, "hourly_price": 1.648, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HM-48C-384G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 412316860416, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1803.1, "hourly_price": 2.47, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HM-4C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 150.38, "hourly_price": 0.206, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HM-64C-512G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 549755813888, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 2406.08, "hourly_price": 3.296, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HM-8C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 300.76, "hourly_price": 0.412, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HN-10": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 530.272, "hourly_price": 0.7264, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HN-3": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 186.442, "hourly_price": 0.2554, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HN-5": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 330.252, "hourly_price": 0.4524, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "PRO2-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 653.0142, "hourly_price": 0.89454, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6000000000, "sum_internet_bandwidth": 6000000000, "interfaces": [{"internal_bandwidth": 6000000000, "internet_bandwidth": 6000000000}]}, "block_bandwidth": 2097152000, "end_of_service": false}, "PRO2-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 326.1348, "hourly_price": 0.44676, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "PRO2-S": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 163.0674, "hourly_price": 0.22338, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 524288000, "end_of_service": false}, "PRO2-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 81.906, "hourly_price": 0.1122, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth": 700000000, "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth": 700000000}]}, "block_bandwidth": 262144000, "end_of_service": false}, "PRO2-XXS": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 40.953, "hourly_price": 0.0561, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth": 350000000, "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth": 350000000}]}, "block_bandwidth": 131072000, "end_of_service": false}, "RENDER-S": {"alt_names": [], "arch": "x86_64", "ncpus": 10, "ram": 45097156608, "gpu": 1, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "P100", "gpu_memory": 17179869184}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 400000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 891.33, "hourly_price": 1.221, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 2000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth": 2000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 2147483648, "end_of_service": false}, "STANDARD2-A16C-64G": {"alt_names": [], "arch": "arm64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 367.847, "hourly_price": 0.5039, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "STANDARD2-A2C-8G": {"alt_names": [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 42.778, "hourly_price": 0.0586, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "STANDARD2-A32C-128G": {"alt_names": [], "arch": "arm64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 874.394, "hourly_price": 1.1978, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5033164800, "end_of_service": false}, "STANDARD2-A48C-192G": {"alt_names": [], "arch": "arm64", "ncpus": 48, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1103.541, "hourly_price": 1.5117, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5033164800, "end_of_service": false}, "STANDARD2-A4C-16G": {"alt_names": [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 85.483, "hourly_price": 0.1171, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "STANDARD2-A64C-256G": {"alt_names": [], "arch": "arm64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1470.366, "hourly_price": 2.0142, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5033164800, "end_of_service": false}, "STANDARD2-A8C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 171.039, "hourly_price": 0.2343, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "STANDARD3-X16C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 320000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 473.77, "hourly_price": 0.649, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 4000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 4000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "STANDARD3-X2C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 40000000000, "scratch_storage_max_volumes_count": 1, "monthly_price": 59.057, "hourly_price": 0.0809, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "STANDARD3-X32C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 640000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 947.54, "hourly_price": 1.298, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 8000000000, "sum_internet_bandwidth": 8000000000, "interfaces": [{"internal_bandwidth": 8000000000, "internet_bandwidth": 8000000000}]}, "block_bandwidth": 1000341504, "end_of_service": false}, "STANDARD3-X48C-192G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 960000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1421.31, "hourly_price": 1.947, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "STANDARD3-X4C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 80000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 118.041, "hourly_price": 0.1617, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "STANDARD3-X64C-256G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 1280000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1887.05, "hourly_price": 2.585, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "STANDARD3-X8C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 160000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 232.87, "hourly_price": 0.319, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "STARDUST1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 1, "ram": 1073741824, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 10000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 0.438, "hourly_price": 0.0006, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]}, "block_bandwidth": 52428800, "end_of_service": false}, "START1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 26.864, "hourly_price": 0.0368, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "START1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 100000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 14.162, "hourly_price": 0.0194, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth": 300000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "START1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 50000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 7.738, "hourly_price": 0.0106, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "START1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 1, "ram": 1073741824, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 25000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 4.526, "hourly_price": 0.0062, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]}, "block_bandwidth": 41943040, "end_of_service": true}}}'
+        content_length: 40809
+        body: '{"servers": {"MEMORY3-X24C-192G": {"alt_names": [], "arch": "x86_64", "ncpus": 24, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 480000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 992.508, "hourly_price": 1.3596, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 6}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6000000000, "sum_internet_bandwidth": 6000000000, "interfaces": [{"internal_bandwidth": 6000000000, "internet_bandwidth": 6000000000}]}, "block_bandwidth": 749731840, "end_of_service": false}, "MEMORY3-X2C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 40000000000, "scratch_storage_max_volumes_count": 1, "monthly_price": 82.709, "hourly_price": 0.1133, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "MEMORY3-X32C-256G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 640000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 1323.344, "hourly_price": 1.8128, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 8000000000, "sum_internet_bandwidth": 8000000000, "interfaces": [{"internal_bandwidth": 8000000000, "internet_bandwidth": 8000000000}]}, "block_bandwidth": 1000341504, "end_of_service": false}, "MEMORY3-X48C-384G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 412316860416, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 960000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1983.41, "hourly_price": 2.717, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "MEMORY3-X4C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 80000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 165.418, "hourly_price": 0.2266, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "MEMORY3-X6C-48G": {"alt_names": [], "arch": "x86_64", "ncpus": 6, "ram": 51539607552, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 120000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 248.127, "hourly_price": 0.3399, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 3}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "MEMORY3-X8C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 160000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 330.836, "hourly_price": 0.4532, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "PLAY2-MICRO": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 40.2084, "hourly_price": 0.05508, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 167772160, "end_of_service": false}, "PLAY2-NANO": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 20.1042, "hourly_price": 0.02754, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 83886080, "end_of_service": false}, "PLAY2-PICO": {"alt_names": [], "arch": "x86_64", "ncpus": 1, "ram": 2147483648, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 10.4244, "hourly_price": 0.01428, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]}, "block_bandwidth": 41943040, "end_of_service": false}, "POP2-12C-48G": {"alt_names": [], "arch": "x86_64", "ncpus": 12, "ram": 51539607552, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 317.55, "hourly_price": 0.435, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 3}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 2400000000, "sum_internet_bandwidth": 2400000000, "interfaces": [{"internal_bandwidth": 2400000000, "internet_bandwidth": 2400000000}]}, "block_bandwidth": 2516582400, "end_of_service": false}, "POP2-16C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 430.7, "hourly_price": 0.59, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-16C-64G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1063.391, "hourly_price": 1.4567, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-24C-96G": {"alt_names": [], "arch": "x86_64", "ncpus": 24, "ram": 103079215104, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 643.05, "hourly_price": 0.885, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 6}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4800000000, "sum_internet_bandwidth": 4800000000, "interfaces": [{"internal_bandwidth": 4800000000, "internet_bandwidth": 4800000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-2C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 53.655, "hourly_price": 0.0735, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-2C-8G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 133.079, "hourly_price": 0.1823, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-32C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 861.4, "hourly_price": 1.18, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-32C-128G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 2126.709, "hourly_price": 2.9133, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-48C-192G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1292.1, "hourly_price": 1.77, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-4C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 107.31, "hourly_price": 0.147, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-4C-16G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 265.501, "hourly_price": 0.3637, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-64C-256G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-6C-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 6, "ram": 25769803776, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 160.965, "hourly_price": 0.225, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1200000000, "sum_internet_bandwidth": 1200000000, "interfaces": [{"internal_bandwidth": 1200000000, "internet_bandwidth": 1200000000}]}, "block_bandwidth": 1258291200, "end_of_service": false}, "POP2-8C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 211.7, "hourly_price": 0.29, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-8C-32G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 528.009, "hourly_price": 0.7233, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HC-12C-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 12, "ram": 25769803776, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 233.016, "hourly_price": 0.3192, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 3}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 2400000000, "sum_internet_bandwidth": 2400000000, "interfaces": [{"internal_bandwidth": 2400000000, "internet_bandwidth": 2400000000}]}, "block_bandwidth": 2516582400, "end_of_service": false}, "POP2-HC-16C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 310.688, "hourly_price": 0.4256, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-HC-24C-48G": {"alt_names": [], "arch": "x86_64", "ncpus": 24, "ram": 51539607552, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 466.032, "hourly_price": 0.6384, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 6}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4800000000, "sum_internet_bandwidth": 4800000000, "interfaces": [{"internal_bandwidth": 4800000000, "internet_bandwidth": 4800000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-HC-2C-4G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 38.836, "hourly_price": 0.0532, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HC-32C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 621.376, "hourly_price": 0.8512, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HC-48C-96G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 103079215104, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 927.1, "hourly_price": 1.27, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HC-4C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 77.672, "hourly_price": 0.1064, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HC-64C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1242.752, "hourly_price": 1.7024, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HC-6C-12G": {"alt_names": [], "arch": "x86_64", "ncpus": 6, "ram": 12884901888, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 116.508, "hourly_price": 0.1596, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1200000000, "sum_internet_bandwidth": 1200000000, "interfaces": [{"internal_bandwidth": 1200000000, "internet_bandwidth": 1200000000}]}, "block_bandwidth": 1258291200, "end_of_service": false}, "POP2-HC-8C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 155.344, "hourly_price": 0.2128, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HM-12C-96G": {"alt_names": [], "arch": "x86_64", "ncpus": 12, "ram": 103079215104, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 451.14, "hourly_price": 0.618, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 3}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 2400000000, "sum_internet_bandwidth": 2400000000, "interfaces": [{"internal_bandwidth": 2400000000, "internet_bandwidth": 2400000000}]}, "block_bandwidth": 2516582400, "end_of_service": false}, "POP2-HM-16C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 601.52, "hourly_price": 0.824, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-HM-24C-192G": {"alt_names": [], "arch": "x86_64", "ncpus": 24, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 902.28, "hourly_price": 1.236, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 6}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4800000000, "sum_internet_bandwidth": 4800000000, "interfaces": [{"internal_bandwidth": 4800000000, "internet_bandwidth": 4800000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-HM-2C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 75.19, "hourly_price": 0.103, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HM-32C-256G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1203.04, "hourly_price": 1.648, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HM-48C-384G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 412316860416, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1803.1, "hourly_price": 2.47, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HM-4C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 150.38, "hourly_price": 0.206, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HM-64C-512G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 549755813888, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 2406.08, "hourly_price": 3.296, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HM-6C-48G": {"alt_names": [], "arch": "x86_64", "ncpus": 6, "ram": 51539607552, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 225.57, "hourly_price": 0.309, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1200000000, "sum_internet_bandwidth": 1200000000, "interfaces": [{"internal_bandwidth": 1200000000, "internet_bandwidth": 1200000000}]}, "block_bandwidth": 1258291200, "end_of_service": false}, "POP2-HM-8C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 300.76, "hourly_price": 0.412, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HN-10": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 530.272, "hourly_price": 0.7264, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HN-3": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 186.442, "hourly_price": 0.2554, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HN-5": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 330.252, "hourly_price": 0.4524, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "PRO2-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 653.0142, "hourly_price": 0.89454, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6000000000, "sum_internet_bandwidth": 6000000000, "interfaces": [{"internal_bandwidth": 6000000000, "internet_bandwidth": 6000000000}]}, "block_bandwidth": 2097152000, "end_of_service": false}, "PRO2-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 326.1348, "hourly_price": 0.44676, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}}}'
         headers:
             Content-Length:
-                - "41028"
+                - "40809"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:05:27 GMT
+                - Tue, 18 Aug 2026 09:38:08 GMT
             Link:
                 - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=3&per_page=50&>; rel="next",</products/servers?page=3&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 2fc604a8-93f9-4456-b7f8-d28ec5fde151
+                - 630efd4a-5f0c-4da8-9d89-ac6743141c45
             X-Total-Count:
-                - "107"
+                - "136"
         status: 200 OK
         code: 200
-        duration: 21.92011ms
+        duration: 25.546287ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -459,33 +459,33 @@ interactions:
                 - "3"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=3
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 5871
-        body: '{"servers": {"VC1L": {"alt_names": ["X64-8GB"], "arch": "x86_64", "ncpus": 6, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 18.0164, "hourly_price": 0.02468, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "VC1M": {"alt_names": ["X64-4GB"], "arch": "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 100000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 11.3515, "hourly_price": 0.01555, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "VC1S": {"alt_names": ["X64-2GB"], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 50000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 6.2926, "hourly_price": 0.00862, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "X64-120GB": {"alt_names": [], "arch": "x86_64", "ncpus": 12, "ram": 128849018880, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 800000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 310.7902, "hourly_price": 0.42574, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 1000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "X64-15GB": {"alt_names": [], "arch": "x86_64", "ncpus": 6, "ram": 16106127360, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 44.0336, "hourly_price": 0.06032, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 250000000, "sum_internet_bandwidth": 250000000, "interfaces": [{"internal_bandwidth": 250000000, "internet_bandwidth": 250000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "X64-30GB": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 32212254720, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 400000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 86.9138, "hourly_price": 0.11906, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "X64-60GB": {"alt_names": [], "arch": "x86_64", "ncpus": 10, "ram": 64424509440, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 700000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 155.49, "hourly_price": 0.213, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 1000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 41943040, "end_of_service": true}}}'
+        content_length: 29849
+        body: '{"servers": {"PRO2-S": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 163.0674, "hourly_price": 0.22338, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 524288000, "end_of_service": false}, "PRO2-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 81.906, "hourly_price": 0.1122, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth": 700000000, "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth": 700000000}]}, "block_bandwidth": 262144000, "end_of_service": false}, "PRO2-XXS": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 40.953, "hourly_price": 0.0561, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth": 350000000, "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth": 350000000}]}, "block_bandwidth": 131072000, "end_of_service": false}, "RENDER-S": {"alt_names": [], "arch": "x86_64", "ncpus": 10, "ram": 45097156608, "gpu": 1, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "P100", "gpu_memory": 17179869184}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 400000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 891.33, "hourly_price": 1.221, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 2000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth": 2000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 2147483648, "end_of_service": false}, "STANDARD2-A12C-48G": {"alt_names": [], "arch": "arm64", "ncpus": 12, "ram": 51539607552, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 223.964, "hourly_price": 0.3068, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 2400000000, "sum_internet_bandwidth": 2400000000, "interfaces": [{"internal_bandwidth": 2400000000, "internet_bandwidth": 2400000000}]}, "block_bandwidth": 2516582400, "end_of_service": false}, "STANDARD2-A16C-64G": {"alt_names": [], "arch": "arm64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 367.847, "hourly_price": 0.5039, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "STANDARD2-A24C-96G": {"alt_names": [], "arch": "arm64", "ncpus": 24, "ram": 103079215104, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 478.223, "hourly_price": 0.6551, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 6}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4800000000, "sum_internet_bandwidth": 4800000000, "interfaces": [{"internal_bandwidth": 4800000000, "internet_bandwidth": 4800000000}]}, "block_bandwidth": 5033164800, "end_of_service": false}, "STANDARD2-A2C-8G": {"alt_names": [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 42.778, "hourly_price": 0.0586, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "STANDARD2-A32C-128G": {"alt_names": [], "arch": "arm64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 874.394, "hourly_price": 1.1978, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5033164800, "end_of_service": false}, "STANDARD2-A48C-192G": {"alt_names": [], "arch": "arm64", "ncpus": 48, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1103.541, "hourly_price": 1.5117, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5033164800, "end_of_service": false}, "STANDARD2-A4C-16G": {"alt_names": [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 85.483, "hourly_price": 0.1171, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "STANDARD2-A64C-256G": {"alt_names": [], "arch": "arm64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1470.366, "hourly_price": 2.0142, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5033164800, "end_of_service": false}, "STANDARD2-A6C-24G": {"alt_names": [], "arch": "arm64", "ncpus": 6, "ram": 25769803776, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 111.909, "hourly_price": 0.1533, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 3}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1200000000, "sum_internet_bandwidth": 1200000000, "interfaces": [{"internal_bandwidth": 1200000000, "internet_bandwidth": 1200000000}]}, "block_bandwidth": 1258291200, "end_of_service": false}, "STANDARD2-A8C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 171.039, "hourly_price": 0.2343, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "STANDARD3-X12C-48G": {"alt_names": [], "arch": "x86_64", "ncpus": 12, "ram": 51539607552, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 240000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 337.698, "hourly_price": 0.4626, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 4000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 4000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "STANDARD3-X16C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 320000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 473.77, "hourly_price": 0.649, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 4000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 4000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "STANDARD3-X24C-96G": {"alt_names": [], "arch": "x86_64", "ncpus": 24, "ram": 103079215104, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 480000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 687.003, "hourly_price": 0.9411, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 6}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6000000000, "sum_internet_bandwidth": 6000000000, "interfaces": [{"internal_bandwidth": 6000000000, "internet_bandwidth": 6000000000}]}, "block_bandwidth": 749731840, "end_of_service": false}, "STANDARD3-X2C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 40000000000, "scratch_storage_max_volumes_count": 1, "monthly_price": 59.057, "hourly_price": 0.0809, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "STANDARD3-X32C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 640000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 947.54, "hourly_price": 1.298, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 8000000000, "sum_internet_bandwidth": 8000000000, "interfaces": [{"internal_bandwidth": 8000000000, "internet_bandwidth": 8000000000}]}, "block_bandwidth": 1000341504, "end_of_service": false}, "STANDARD3-X48C-192G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 960000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1421.31, "hourly_price": 1.947, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "STANDARD3-X4C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 80000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 118.041, "hourly_price": 0.1617, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "STANDARD3-X64C-256G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 1280000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1887.05, "hourly_price": 2.585, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "STANDARD3-X6C-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 6, "ram": 25769803776, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 120000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 177.185, "hourly_price": 0.2425, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 3}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "STANDARD3-X8C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 160000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 232.87, "hourly_price": 0.319, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "STARDUST1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 1, "ram": 1073741824, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 10000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 0.438, "hourly_price": 0.0006, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]}, "block_bandwidth": 52428800, "end_of_service": false}, "START1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 26.864, "hourly_price": 0.0368, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "START1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 100000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 14.162, "hourly_price": 0.0194, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth": 300000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "START1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 50000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 7.738, "hourly_price": 0.0106, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "START1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 1, "ram": 1073741824, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 25000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 4.526, "hourly_price": 0.0062, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "VC1L": {"alt_names": ["X64-8GB"], "arch": "x86_64", "ncpus": 6, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 18.0164, "hourly_price": 0.02468, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "VC1M": {"alt_names": ["X64-4GB"], "arch": "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 100000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 11.3515, "hourly_price": 0.01555, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "VC1S": {"alt_names": ["X64-2GB"], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 50000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 6.2926, "hourly_price": 0.00862, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "X64-120GB": {"alt_names": [], "arch": "x86_64", "ncpus": 12, "ram": 128849018880, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 800000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 310.7902, "hourly_price": 0.42574, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 1000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "X64-15GB": {"alt_names": [], "arch": "x86_64", "ncpus": 6, "ram": 16106127360, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 44.0336, "hourly_price": 0.06032, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 250000000, "sum_internet_bandwidth": 250000000, "interfaces": [{"internal_bandwidth": 250000000, "internet_bandwidth": 250000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "X64-30GB": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 32212254720, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 400000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 86.9138, "hourly_price": 0.11906, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "X64-60GB": {"alt_names": [], "arch": "x86_64", "ncpus": 10, "ram": 64424509440, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 700000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 155.49, "hourly_price": 0.213, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 1000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 41943040, "end_of_service": true}}}'
         headers:
             Content-Length:
-                - "5871"
+                - "29849"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:05:27 GMT
+                - Tue, 18 Aug 2026 09:38:08 GMT
             Link:
                 - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=2&per_page=50&>; rel="previous",</products/servers?page=3&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 03bb47c7-d1d0-4f16-a7c5-461f04f36b29
+                - 7d3c5da8-b200-44d2-b391-7320f75ee380
             X-Total-Count:
-                - "107"
+                - "136"
         status: 200 OK
         code: 200
-        duration: 25.384932ms
+        duration: 33.910929ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -495,64 +495,64 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/90674a70-85ad-42bb-8877-9d4fe78940db
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/220ee062-8e89-47b8-96d9-ebe282662eb0
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 1636
-        body: '{"region":"fr-par","id":"90674a70-85ad-42bb-8877-9d4fe78940db","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-06-01T11:05:22.167457Z","updated_at":"2026-06-01T11:05:22.669924Z","type":"kapsule","name":"test-pool-taints-and-labels","description":"","status":"pool_required","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"cluster_url":"https://90674a70-85ad-42bb-8877-9d4fe78940db.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.90674a70-85ad-42bb-8877-9d4fe78940db.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":2},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"03958c89-e8ad-4344-90e1-f1d02267e843","commitment_ends_at":"2026-06-01T11:05:22.167465Z","acl_available":true,"iam_nodes_group_id":"08fab0b3-c94e-4243-93c0-d8ff43e1d01d","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        body: '{"region":"fr-par","id":"220ee062-8e89-47b8-96d9-ebe282662eb0","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-08-18T09:38:02.905614Z","updated_at":"2026-08-18T09:38:03.328790Z","type":"kapsule","name":"test-pool-taints-and-labels","description":"","status":"pool_required","version":"1.36.1","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"cluster_url":"https://220ee062-8e89-47b8-96d9-ebe282662eb0.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.220ee062-8e89-47b8-96d9-ebe282662eb0.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":2},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"e85f0802-5637-46d2-88c2-8ceb6767c532","commitment_ends_at":"2026-08-18T09:38:02.905622Z","acl_available":true,"iam_nodes_group_id":"586830d7-c0e2-4bcd-a605-15e937921fc5","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
         headers:
             Content-Length:
                 - "1636"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:05:27 GMT
+                - Tue, 18 Aug 2026 09:38:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 785e99f5-542c-4d1b-bf70-2c7437394fe3
+                - 754e259e-0e7c-4790-be01-43207510b185
         status: 200 OK
         code: 200
-        duration: 22.851126ms
+        duration: 53.178802ms
     - id: 15
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 526
+        content_length: 593
         host: api.scaleway.com
-        body: '{"name":"test-pool-taints-and-labels","node_type":"PRO2_XXS","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"kubelet_args":{},"zone":"fr-par-1","root_volume_type":"default_volume_type","public_ip_disabled":false,"labels":{"foo":"bar","goo":"car","hoo":"dar"},"taints":[{"key":"key2","value":"value2","effect":"NoExecute"},{"key":"key1","value":"value1","effect":"NoSchedule"}],"startup_taints":null}'
+        body: '{"name":"test-pool-taints-and-labels","node_type":"PRO2_XXS","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"kubelet_args":{},"zone":"fr-par-1","root_volume_type":"default_volume_type","public_ip_disabled":false,"labels":{"foo":"bar","goo":"car","hoo":"dar"},"taints":[{"key":"key2","value":"value2","effect":"NoExecute"},{"key":"key1","value":"value1","effect":"NoSchedule"}],"startup_taints":[{"key":"startup-key1","value":"startup-value1","effect":"NoSchedule"}]}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/90674a70-85ad-42bb-8877-9d4fe78940db/pools
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/220ee062-8e89-47b8-96d9-ebe282662eb0/pools
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 918
-        body: '{"region":"fr-par","id":"43608e44-60ad-45a3-b903-1a04b08d20e0","cluster_id":"90674a70-85ad-42bb-8877-9d4fe78940db","created_at":"2026-06-01T11:05:27.641937Z","updated_at":"2026-06-01T11:05:27.641937Z","name":"test-pool-taints-and-labels","status":"scaling","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{"foo":"bar","goo":"car","hoo":"dar"},"taints":[{"key":"key1","value":"value1","effect":"NoSchedule"},{"key":"key2","value":"value2","effect":"NoExecute"}],"startup_taints":[]}'
+        content_length: 1008
+        body: '{"region":"fr-par","id":"ca90b529-2fb6-4390-8277-c3cfa1113ef4","cluster_id":"220ee062-8e89-47b8-96d9-ebe282662eb0","created_at":"2026-08-18T09:38:08.558497Z","updated_at":"2026-08-18T09:38:08.558497Z","name":"test-pool-taints-and-labels","status":"scaling","version":"1.36.1","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{"foo":"bar","goo":"car","hoo":"dar"},"taints":[{"key":"key1","value":"value1","effect":"NoSchedule"},{"key":"key2","value":"value2","effect":"NoExecute"}],"startup_taints":[{"key":"startup-key1","value":"startup-value1","effect":"NoSchedule"}],"error_message":null}'
         headers:
             Content-Length:
-                - "918"
+                - "1008"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:05:27 GMT
+                - Tue, 18 Aug 2026 09:38:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - fcaebebc-d6eb-44f0-bd53-380708589fa9
+                - 7f45de25-579c-4a9c-8ecb-919f320e5f76
         status: 200 OK
         code: 200
-        duration: 117.964132ms
+        duration: 222.186944ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -562,29 +562,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/90674a70-85ad-42bb-8877-9d4fe78940db
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/220ee062-8e89-47b8-96d9-ebe282662eb0
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 1631
-        body: '{"region":"fr-par","id":"90674a70-85ad-42bb-8877-9d4fe78940db","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-06-01T11:05:22.167457Z","updated_at":"2026-06-01T11:05:27.641937Z","type":"kapsule","name":"test-pool-taints-and-labels","description":"","status":"creating","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"cluster_url":"https://90674a70-85ad-42bb-8877-9d4fe78940db.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.90674a70-85ad-42bb-8877-9d4fe78940db.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":2},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"03958c89-e8ad-4344-90e1-f1d02267e843","commitment_ends_at":"2026-06-01T11:05:22.167465Z","acl_available":true,"iam_nodes_group_id":"08fab0b3-c94e-4243-93c0-d8ff43e1d01d","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        body: '{"region":"fr-par","id":"220ee062-8e89-47b8-96d9-ebe282662eb0","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-08-18T09:38:02.905614Z","updated_at":"2026-08-18T09:38:08.558497Z","type":"kapsule","name":"test-pool-taints-and-labels","description":"","status":"creating","version":"1.36.1","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"cluster_url":"https://220ee062-8e89-47b8-96d9-ebe282662eb0.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.220ee062-8e89-47b8-96d9-ebe282662eb0.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":2},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"e85f0802-5637-46d2-88c2-8ceb6767c532","commitment_ends_at":"2026-08-18T09:38:02.905622Z","acl_available":true,"iam_nodes_group_id":"586830d7-c0e2-4bcd-a605-15e937921fc5","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
         headers:
             Content-Length:
                 - "1631"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:05:27 GMT
+                - Tue, 18 Aug 2026 09:38:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 0157c5e2-e773-4c49-a649-5443efb14433
+                - b753bc16-72c4-4b47-a278-397cec83eba9
         status: 200 OK
         code: 200
-        duration: 22.47889ms
+        duration: 27.196758ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -594,29 +594,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/90674a70-85ad-42bb-8877-9d4fe78940db
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/220ee062-8e89-47b8-96d9-ebe282662eb0
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 1628
-        body: '{"region":"fr-par","id":"90674a70-85ad-42bb-8877-9d4fe78940db","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-06-01T11:05:22.167457Z","updated_at":"2026-06-01T11:16:56.177605Z","type":"kapsule","name":"test-pool-taints-and-labels","description":"","status":"ready","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"cluster_url":"https://90674a70-85ad-42bb-8877-9d4fe78940db.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.90674a70-85ad-42bb-8877-9d4fe78940db.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":2},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"03958c89-e8ad-4344-90e1-f1d02267e843","commitment_ends_at":"2026-06-01T11:05:22.167465Z","acl_available":true,"iam_nodes_group_id":"08fab0b3-c94e-4243-93c0-d8ff43e1d01d","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        body: '{"region":"fr-par","id":"220ee062-8e89-47b8-96d9-ebe282662eb0","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-08-18T09:38:02.905614Z","updated_at":"2026-08-18T09:39:26.593396Z","type":"kapsule","name":"test-pool-taints-and-labels","description":"","status":"ready","version":"1.36.1","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"cluster_url":"https://220ee062-8e89-47b8-96d9-ebe282662eb0.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.220ee062-8e89-47b8-96d9-ebe282662eb0.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":2},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"e85f0802-5637-46d2-88c2-8ceb6767c532","commitment_ends_at":"2026-08-18T09:38:02.905622Z","acl_available":true,"iam_nodes_group_id":"586830d7-c0e2-4bcd-a605-15e937921fc5","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
         headers:
             Content-Length:
                 - "1628"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:01 GMT
+                - Tue, 18 Aug 2026 09:39:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - e89dfbe7-6c9c-4f4e-acba-ba4e34714bc5
+                - 890aeb54-1165-4d5e-8bb2-f8a39e386192
         status: 200 OK
         code: 200
-        duration: 59.510886ms
+        duration: 57.745198ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -626,29 +626,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/43608e44-60ad-45a3-b903-1a04b08d20e0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca90b529-2fb6-4390-8277-c3cfa1113ef4
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 918
-        body: '{"region":"fr-par","id":"43608e44-60ad-45a3-b903-1a04b08d20e0","cluster_id":"90674a70-85ad-42bb-8877-9d4fe78940db","created_at":"2026-06-01T11:05:27.641937Z","updated_at":"2026-06-01T11:05:27.641937Z","name":"test-pool-taints-and-labels","status":"scaling","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{"foo":"bar","goo":"car","hoo":"dar"},"taints":[{"key":"key1","value":"value1","effect":"NoSchedule"},{"key":"key2","value":"value2","effect":"NoExecute"}],"startup_taints":[]}'
+        content_length: 1008
+        body: '{"region":"fr-par","id":"ca90b529-2fb6-4390-8277-c3cfa1113ef4","cluster_id":"220ee062-8e89-47b8-96d9-ebe282662eb0","created_at":"2026-08-18T09:38:08.558497Z","updated_at":"2026-08-18T09:38:08.558497Z","name":"test-pool-taints-and-labels","status":"scaling","version":"1.36.1","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{"foo":"bar","goo":"car","hoo":"dar"},"taints":[{"key":"key1","value":"value1","effect":"NoSchedule"},{"key":"key2","value":"value2","effect":"NoExecute"}],"startup_taints":[{"key":"startup-key1","value":"startup-value1","effect":"NoSchedule"}],"error_message":null}'
         headers:
             Content-Length:
-                - "918"
+                - "1008"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:01 GMT
+                - Tue, 18 Aug 2026 09:39:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - f64e7a3a-f45d-4a1f-94f3-7d31be62f14d
+                - 80dabe92-0dc0-428e-901b-b0073161e5f6
         status: 200 OK
         code: 200
-        duration: 30.303738ms
+        duration: 26.052322ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -662,34 +662,34 @@ interactions:
             page:
                 - "1"
             pool_id:
-                - 43608e44-60ad-45a3-b903-1a04b08d20e0
+                - ca90b529-2fb6-4390-8277-c3cfa1113ef4
             status:
                 - unknown
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/90674a70-85ad-42bb-8877-9d4fe78940db/nodes?order_by=created_at_asc&page=1&pool_id=43608e44-60ad-45a3-b903-1a04b08d20e0&status=unknown
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/220ee062-8e89-47b8-96d9-ebe282662eb0/nodes?order_by=created_at_asc&page=1&pool_id=ca90b529-2fb6-4390-8277-c3cfa1113ef4&status=unknown
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 542
-        body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"10490eba-9b6c-4005-942d-111777eff73c","cluster_id":"90674a70-85ad-42bb-8877-9d4fe78940db","created_at":"2026-06-01T11:16:56.482452Z","updated_at":"2026-06-01T11:16:59.990269Z","pool_id":"43608e44-60ad-45a3-b903-1a04b08d20e0","status":"creating","conditions":{"Creating":"True","Ready":"False"},"name":"scw-test-pool-taints--test-pool-taints--10490e","public_ip_v4":"","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/6e91f0ef-d962-402d-ba24-0ad208082096","error_message":""}]}'
+        content_length: 28
+        body: '{"total_count":0,"nodes":[]}'
         headers:
             Content-Length:
-                - "542"
+                - "28"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:01 GMT
+                - Tue, 18 Aug 2026 09:39:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 9cc24f72-ef4c-4c47-b582-31ba41bd352f
+                - f0ba9429-15dc-4469-8218-891f5fd067d6
         status: 200 OK
         code: 200
-        duration: 39.222599ms
+        duration: 45.412ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -699,29 +699,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/90674a70-85ad-42bb-8877-9d4fe78940db
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/220ee062-8e89-47b8-96d9-ebe282662eb0
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 1628
-        body: '{"region":"fr-par","id":"90674a70-85ad-42bb-8877-9d4fe78940db","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-06-01T11:05:22.167457Z","updated_at":"2026-06-01T11:16:56.177605Z","type":"kapsule","name":"test-pool-taints-and-labels","description":"","status":"ready","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"cluster_url":"https://90674a70-85ad-42bb-8877-9d4fe78940db.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.90674a70-85ad-42bb-8877-9d4fe78940db.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":2},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"03958c89-e8ad-4344-90e1-f1d02267e843","commitment_ends_at":"2026-06-01T11:05:22.167465Z","acl_available":true,"iam_nodes_group_id":"08fab0b3-c94e-4243-93c0-d8ff43e1d01d","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        body: '{"region":"fr-par","id":"220ee062-8e89-47b8-96d9-ebe282662eb0","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-08-18T09:38:02.905614Z","updated_at":"2026-08-18T09:39:26.593396Z","type":"kapsule","name":"test-pool-taints-and-labels","description":"","status":"ready","version":"1.36.1","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"cluster_url":"https://220ee062-8e89-47b8-96d9-ebe282662eb0.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.220ee062-8e89-47b8-96d9-ebe282662eb0.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":2},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"e85f0802-5637-46d2-88c2-8ceb6767c532","commitment_ends_at":"2026-08-18T09:38:02.905622Z","acl_available":true,"iam_nodes_group_id":"586830d7-c0e2-4bcd-a605-15e937921fc5","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
         headers:
             Content-Length:
                 - "1628"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:01 GMT
+                - Tue, 18 Aug 2026 09:39:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - a3325626-e0dc-4831-af1f-ed467ff61f12
+                - 431d5f36-d86a-4103-9cdf-493a4f18571a
         status: 200 OK
         code: 200
-        duration: 20.575275ms
+        duration: 21.705742ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -729,40 +729,31 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: api.scaleway.com
-        form:
-            order_by:
-                - created_at_desc
-            project_id:
-                - fa1e3217-dc80-42ac-85c3-3f034b78b552
-            resource_name:
-                - scw-test-pool-taints--test-pool-taints--10490e
-            resource_type:
-                - unknown_type
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=fa1e3217-dc80-42ac-85c3-3f034b78b552&resource_name=scw-test-pool-taints--test-pool-taints--10490e&resource_type=unknown_type
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/220ee062-8e89-47b8-96d9-ebe282662eb0
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 1091
-        body: '{"total_count":2,"ips":[{"id":"541fe1fb-7f9e-4875-a455-69e1c71dafab","address":"fd63:256c:45f7:f16:930f:a821:6e71:110b/64","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_ipv6":true,"created_at":"2026-06-01T11:16:59.449732Z","updated_at":"2026-06-01T11:16:59.449732Z","source":{"subnet_id":"ed5bae7d-26b2-42b1-a42c-4cf74a572077"},"resource":{"type":"instance_private_nic","id":"6de5c600-3612-455d-9ede-3b9d8338d833","mac_address":"02:00:00:11:CF:3A","name":"scw-test-pool-taints--test-pool-taints--10490e"},"tags":[],"reverses":[],"region":"fr-par","zone":null},{"id":"66576ee5-d496-4c77-b5d9-0e84757a32be","address":"172.16.24.2/22","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_ipv6":false,"created_at":"2026-06-01T11:16:59.266750Z","updated_at":"2026-06-01T11:16:59.266750Z","source":{"subnet_id":"d9bd5591-544c-4b08-9d13-efd5a4fa044b"},"resource":{"type":"instance_private_nic","id":"6de5c600-3612-455d-9ede-3b9d8338d833","mac_address":"02:00:00:11:CF:3A","name":"scw-test-pool-taints--test-pool-taints--10490e"},"tags":[],"reverses":[],"region":"fr-par","zone":null}]}'
+        content_length: 1628
+        body: '{"region":"fr-par","id":"220ee062-8e89-47b8-96d9-ebe282662eb0","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-08-18T09:38:02.905614Z","updated_at":"2026-08-18T09:39:26.593396Z","type":"kapsule","name":"test-pool-taints-and-labels","description":"","status":"ready","version":"1.36.1","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"cluster_url":"https://220ee062-8e89-47b8-96d9-ebe282662eb0.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.220ee062-8e89-47b8-96d9-ebe282662eb0.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":2},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"e85f0802-5637-46d2-88c2-8ceb6767c532","commitment_ends_at":"2026-08-18T09:38:02.905622Z","acl_available":true,"iam_nodes_group_id":"586830d7-c0e2-4bcd-a605-15e937921fc5","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
         headers:
             Content-Length:
-                - "1091"
+                - "1628"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:01 GMT
+                - Tue, 18 Aug 2026 09:39:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 63745c2c-7f0f-4d72-ab41-84ff2dd4ac89
+                - 923d7fed-7f9e-4249-81f0-b9719fa6c1e1
         status: 200 OK
         code: 200
-        duration: 53.213137ms
+        duration: 24.173413ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -772,29 +763,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/90674a70-85ad-42bb-8877-9d4fe78940db
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca90b529-2fb6-4390-8277-c3cfa1113ef4
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 1628
-        body: '{"region":"fr-par","id":"90674a70-85ad-42bb-8877-9d4fe78940db","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-06-01T11:05:22.167457Z","updated_at":"2026-06-01T11:16:56.177605Z","type":"kapsule","name":"test-pool-taints-and-labels","description":"","status":"ready","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"cluster_url":"https://90674a70-85ad-42bb-8877-9d4fe78940db.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.90674a70-85ad-42bb-8877-9d4fe78940db.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":2},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"03958c89-e8ad-4344-90e1-f1d02267e843","commitment_ends_at":"2026-06-01T11:05:22.167465Z","acl_available":true,"iam_nodes_group_id":"08fab0b3-c94e-4243-93c0-d8ff43e1d01d","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        content_length: 1008
+        body: '{"region":"fr-par","id":"ca90b529-2fb6-4390-8277-c3cfa1113ef4","cluster_id":"220ee062-8e89-47b8-96d9-ebe282662eb0","created_at":"2026-08-18T09:38:08.558497Z","updated_at":"2026-08-18T09:38:08.558497Z","name":"test-pool-taints-and-labels","status":"scaling","version":"1.36.1","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{"foo":"bar","goo":"car","hoo":"dar"},"taints":[{"key":"key2","value":"value2","effect":"NoExecute"},{"key":"key1","value":"value1","effect":"NoSchedule"}],"startup_taints":[{"key":"startup-key1","value":"startup-value1","effect":"NoSchedule"}],"error_message":null}'
         headers:
             Content-Length:
-                - "1628"
+                - "1008"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:01 GMT
+                - Tue, 18 Aug 2026 09:39:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 572d7249-17c1-4edf-b418-d0da5463149c
+                - 5b08354d-ec04-4265-a8eb-eeee587cce77
         status: 200 OK
         code: 200
-        duration: 27.486637ms
+        duration: 23.580403ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -804,29 +795,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/43608e44-60ad-45a3-b903-1a04b08d20e0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/621f79dd-9a8d-48fb-80eb-8b7db805149e
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 918
-        body: '{"region":"fr-par","id":"43608e44-60ad-45a3-b903-1a04b08d20e0","cluster_id":"90674a70-85ad-42bb-8877-9d4fe78940db","created_at":"2026-06-01T11:05:27.641937Z","updated_at":"2026-06-01T11:05:27.641937Z","name":"test-pool-taints-and-labels","status":"scaling","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{"foo":"bar","goo":"car","hoo":"dar"},"taints":[{"key":"key1","value":"value1","effect":"NoSchedule"},{"key":"key2","value":"value2","effect":"NoExecute"}],"startup_taints":[]}'
+        content_length: 470
+        body: '{"id":"621f79dd-9a8d-48fb-80eb-8b7db805149e","name":"tf-vpc-hardcore-mestorf","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-08-18T09:38:01.532361Z","updated_at":"2026-08-18T09:38:01.532361Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_default":false,"private_network_count":1,"routing_enabled":true,"custom_routes_propagation_enabled":true,"transitivity_enabled":false,"s3_integration_enabled":false,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "918"
+                - "470"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:01 GMT
+                - Tue, 18 Aug 2026 09:39:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 94f66a33-2452-407a-89bf-d08cc733a225
+                - 07d99c5a-7134-499c-883e-a5a498340149
         status: 200 OK
         code: 200
-        duration: 27.060285ms
+        duration: 53.280256ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -836,29 +827,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/0f3756af-afff-43f7-b90c-e70492598b1b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e85f0802-5637-46d2-88c2-8ceb6767c532
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 413
-        body: '{"id":"0f3756af-afff-43f7-b90c-e70492598b1b","name":"tf-vpc-interesting-ritchie","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-06-01T11:05:21.038572Z","updated_at":"2026-06-01T11:05:21.038572Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_default":false,"private_network_count":1,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        content_length: 1136
+        body: '{"id":"e85f0802-5637-46d2-88c2-8ceb6767c532","name":"test-pool-taints-and-labels","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-08-18T09:38:01.802133Z","updated_at":"2026-08-18T09:38:01.802133Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":[{"id":"b07d02f2-cb17-4f4b-a7c8-128f3dd8562d","created_at":"2026-08-18T09:38:01.802133Z","updated_at":"2026-08-18T09:38:01.802133Z","subnet":"172.16.64.0/22","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e85f0802-5637-46d2-88c2-8ceb6767c532","vpc_id":"621f79dd-9a8d-48fb-80eb-8b7db805149e","region":"fr-par"},{"id":"2c1ea306-c6c0-4637-bfcd-a88c8d860ee1","created_at":"2026-08-18T09:38:01.802133Z","updated_at":"2026-08-18T09:38:01.802133Z","subnet":"fd63:256c:45f7:a125::/64","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e85f0802-5637-46d2-88c2-8ceb6767c532","vpc_id":"621f79dd-9a8d-48fb-80eb-8b7db805149e","region":"fr-par"}],"vpc_id":"621f79dd-9a8d-48fb-80eb-8b7db805149e","dhcp_enabled":true,"default_route_propagation_enabled":false,"has_s3_integration":false,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "413"
+                - "1136"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:02 GMT
+                - Tue, 18 Aug 2026 09:39:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 5f5111a0-6026-43e7-b4b2-fb95e2941f31
+                - c06e0ec9-1050-48f3-9877-b8b61dd34344
         status: 200 OK
         code: 200
-        duration: 463.907918ms
+        duration: 109.479107ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -868,29 +859,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/03958c89-e8ad-4344-90e1-f1d02267e843
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/220ee062-8e89-47b8-96d9-ebe282662eb0
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 1072
-        body: '{"id":"03958c89-e8ad-4344-90e1-f1d02267e843","name":"test-pool-taints-and-labels","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-06-01T11:05:21.197514Z","updated_at":"2026-06-01T11:05:21.197514Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":[{"id":"d9bd5591-544c-4b08-9d13-efd5a4fa044b","created_at":"2026-06-01T11:05:21.197514Z","updated_at":"2026-06-01T11:05:21.197514Z","subnet":"172.16.24.0/22","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"03958c89-e8ad-4344-90e1-f1d02267e843","vpc_id":"0f3756af-afff-43f7-b90c-e70492598b1b"},{"id":"ed5bae7d-26b2-42b1-a42c-4cf74a572077","created_at":"2026-06-01T11:05:21.197514Z","updated_at":"2026-06-01T11:05:21.197514Z","subnet":"fd63:256c:45f7:f16::/64","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"03958c89-e8ad-4344-90e1-f1d02267e843","vpc_id":"0f3756af-afff-43f7-b90c-e70492598b1b"}],"vpc_id":"0f3756af-afff-43f7-b90c-e70492598b1b","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        content_length: 1628
+        body: '{"region":"fr-par","id":"220ee062-8e89-47b8-96d9-ebe282662eb0","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-08-18T09:38:02.905614Z","updated_at":"2026-08-18T09:39:26.593396Z","type":"kapsule","name":"test-pool-taints-and-labels","description":"","status":"ready","version":"1.36.1","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"cluster_url":"https://220ee062-8e89-47b8-96d9-ebe282662eb0.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.220ee062-8e89-47b8-96d9-ebe282662eb0.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":2},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"e85f0802-5637-46d2-88c2-8ceb6767c532","commitment_ends_at":"2026-08-18T09:38:02.905622Z","acl_available":true,"iam_nodes_group_id":"586830d7-c0e2-4bcd-a605-15e937921fc5","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
         headers:
             Content-Length:
-                - "1072"
+                - "1628"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:02 GMT
+                - Tue, 18 Aug 2026 09:39:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - c37817da-5be8-4979-a39e-07b21cceba24
+                - f7bc1a28-84cd-40ce-9890-80d825421503
         status: 200 OK
         code: 200
-        duration: 62.275137ms
+        duration: 26.564762ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -900,29 +891,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/90674a70-85ad-42bb-8877-9d4fe78940db
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/220ee062-8e89-47b8-96d9-ebe282662eb0/kubeconfig
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 1628
-        body: '{"region":"fr-par","id":"90674a70-85ad-42bb-8877-9d4fe78940db","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-06-01T11:05:22.167457Z","updated_at":"2026-06-01T11:16:56.177605Z","type":"kapsule","name":"test-pool-taints-and-labels","description":"","status":"ready","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"cluster_url":"https://90674a70-85ad-42bb-8877-9d4fe78940db.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.90674a70-85ad-42bb-8877-9d4fe78940db.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":2},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"03958c89-e8ad-4344-90e1-f1d02267e843","commitment_ends_at":"2026-06-01T11:05:22.167465Z","acl_available":true,"iam_nodes_group_id":"08fab0b3-c94e-4243-93c0-d8ff43e1d01d","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        content_length: 1752
+        body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscyIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVUpYZWtORFFWRkhaMEYzU1VKQlowbENRVVJCUzBKblozRm9hMnBQVUZGUlJFRnFRVlpOVWsxM1JWRlpSRlpSVVVSRmQzQnlaRmRLYkdOdE5Xd0taRWRXZWsxQ05GaEVWRWt5VFVSbmVFNTZRVFZOZW1kM1RXeHZXRVJVVFRKTlJHZDRUbnBCTlUxNlozZE5iRzkzUmxSRlZFMUNSVWRCTVZWRlFYaE5Td3BoTTFacFdsaEtkVnBZVW14amVrSmFUVUpOUjBKNWNVZFRUVFE1UVdkRlIwTkRjVWRUVFRRNVFYZEZTRUV3U1VGQ1RFOVBha3cyVTNaRE5HSXlSVlZLQ25aaGVXbENiR2wzY1RCemFuWmFWMDB4YlRKUlVHOVVSMng1VGpaTVRHTnZlVkJ6VUcxSVpUWk1lVGtyY0VVclVsUlJObU5FSzB4R1Z6UmFOM3BYUkdRS1JXbEdSVFJ3WldwUmFrSkJUVUUwUjBFeFZXUkVkMFZDTDNkUlJVRjNTVU53UkVGUVFtZE9Wa2hTVFVKQlpqaEZRbFJCUkVGUlNDOU5RakJIUVRGVlpBcEVaMUZYUWtKVFdrbExiemRrYmk5a1UzWTFUV05rVkhSemMwNVVkbEJCUTFwcVFVdENaMmR4YUd0cVQxQlJVVVJCWjA1SlFVUkNSa0ZwUlVGMk1qWkxDbk5IVVRKNU5tNDNhbkJyY21OcFowbDFWSGRsZVZSUWJVVk5OV04yTjFwUVduTnJRMjFoU1VOSlJDOWFhVVV2VUhnMlRTdFNTRmMzWm1OUlpWSlFNMUlLVTJaS1NHRmhRamRYWlU5UVMyaHVWVmRSVkUwS0xTMHRMUzFGVGtRZ1EwVlNWRWxHU1VOQlZFVXRMUzB0TFFvPQogICAgc2VydmVyOiBodHRwczovLzIyMGVlMDYyLThlODktNDdiOC05NmQ5LWViZTI4MjY2MmViMC5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wtdGFpbnRzLWFuZC1sYWJlbHMKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscyIKICAgIHVzZXI6IHRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscy1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscwpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscy1hZG1pbgogIHVzZXI6CiAgICB0b2tlbjogSHdXNzVwZU0ycmFjMmZEUFhyZ2xVVmNhN0dlcFRmam5qS0ZDeHdYeE04VjFxaTdJR3oxclJ1T2E="}'
         headers:
             Content-Length:
-                - "1628"
+                - "1752"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:02 GMT
+                - Tue, 18 Aug 2026 09:39:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 87b91ea3-e746-4bd3-bc37-edab88fa3f86
+                - d2206534-3daf-47d7-88ab-daf142df5993
         status: 200 OK
         code: 200
-        duration: 64.202387ms
+        duration: 43.329379ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -932,62 +923,30 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/90674a70-85ad-42bb-8877-9d4fe78940db/kubeconfig
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca90b529-2fb6-4390-8277-c3cfa1113ef4
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 1752
-        body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscyIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVUpYZWtORFFWRkhaMEYzU1VKQlowbENRVVJCUzBKblozRm9hMnBQVUZGUlJFRnFRVlpOVWsxM1JWRlpSRlpSVVVSRmQzQnlaRmRLYkdOdE5Xd0taRWRXZWsxQ05GaEVWRWt5VFVSVmVrMVVSWGhOUkZWNVRXeHZXRVJVVFRKTlJGVjZUVlJGZUUxRVZYbE5iRzkzUmxSRlZFMUNSVWRCTVZWRlFYaE5Td3BoTTFacFdsaEtkVnBZVW14amVrSmFUVUpOUjBKNWNVZFRUVFE1UVdkRlIwTkRjVWRUVFRRNVFYZEZTRUV3U1VGQ1FWUTFWMkV2U0d0eWNtWlJWWEUzQ25kc05Fd3ZZVFozZFZCTmEzSTFVRlZ1WjFRck0waFZUMnhyUkRWQ09FUjNNMEpvT0hBeFpWWXJUbGhHTDNwMlVFZ3pTVEV3ZWxBeFF6bGFPV3Q2U2swS1RqTmhiMlZEVjJwUmFrSkJUVUUwUjBFeFZXUkVkMFZDTDNkUlJVRjNTVU53UkVGUVFtZE9Wa2hTVFVKQlpqaEZRbFJCUkVGUlNDOU5RakJIUVRGVlpBcEVaMUZYUWtKUk9VOXRWVVZHYms5RFVuWTVkMk5zVG5reWRHWktiell5YW1scVFVdENaMmR4YUd0cVQxQlJVVVJCWjA1SlFVUkNSa0ZwUVU5c2RVRndDa0ZDYmtzMVUwcDFMMlYzWkU0NFYybENWVFExVmtoa1UyRlljWFJGTVdzMlpIZEhiV3BuU1doQlRTdE1XRlVyVlRSTE9XZzJNemgzWWs5RFFUQnhTWFlLWWxsUVpITTVkV05LUjFGSVFWSlJUelJQUXprS0xTMHRMUzFGVGtRZ1EwVlNWRWxHU1VOQlZFVXRMUzB0TFFvPQogICAgc2VydmVyOiBodHRwczovLzkwNjc0YTcwLTg1YWQtNDJiYi04ODc3LTlkNGZlNzg5NDBkYi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wtdGFpbnRzLWFuZC1sYWJlbHMKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscyIKICAgIHVzZXI6IHRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscy1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscwpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscy1hZG1pbgogIHVzZXI6CiAgICB0b2tlbjogdVhtQ2FlSXN6Y2JwU3dWbDcwU0FOa205RUg2RG1PMTZqMHRSbFRhU0VUTExseHpzWENkVE9LRXg="}'
+        content_length: 1008
+        body: '{"region":"fr-par","id":"ca90b529-2fb6-4390-8277-c3cfa1113ef4","cluster_id":"220ee062-8e89-47b8-96d9-ebe282662eb0","created_at":"2026-08-18T09:38:08.558497Z","updated_at":"2026-08-18T09:38:08.558497Z","name":"test-pool-taints-and-labels","status":"scaling","version":"1.36.1","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{"foo":"bar","goo":"car","hoo":"dar"},"taints":[{"key":"key1","value":"value1","effect":"NoSchedule"},{"key":"key2","value":"value2","effect":"NoExecute"}],"startup_taints":[{"key":"startup-key1","value":"startup-value1","effect":"NoSchedule"}],"error_message":null}'
         headers:
             Content-Length:
-                - "1752"
+                - "1008"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:02 GMT
+                - Tue, 18 Aug 2026 09:39:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 3fef4092-6e09-4f8b-8257-38364fbb5c8f
+                - e5e8c92d-198f-4258-b3f8-c56ef4981fbb
         status: 200 OK
         code: 200
-        duration: 42.33227ms
+        duration: 20.160398ms
     - id: 28
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/43608e44-60ad-45a3-b903-1a04b08d20e0
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 918
-        body: '{"region":"fr-par","id":"43608e44-60ad-45a3-b903-1a04b08d20e0","cluster_id":"90674a70-85ad-42bb-8877-9d4fe78940db","created_at":"2026-06-01T11:05:27.641937Z","updated_at":"2026-06-01T11:05:27.641937Z","name":"test-pool-taints-and-labels","status":"scaling","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{"foo":"bar","goo":"car","hoo":"dar"},"taints":[{"key":"key1","value":"value1","effect":"NoSchedule"},{"key":"key2","value":"value2","effect":"NoExecute"}],"startup_taints":[]}'
-        headers:
-            Content-Length:
-                - "918"
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 01 Jun 2026 11:17:02 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            X-Request-Id:
-                - d3388cd3-31e1-483a-87be-a3f221116aa4
-        status: 200 OK
-        code: 200
-        duration: 61.62698ms
-    - id: 29
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1000,34 +959,66 @@ interactions:
             page:
                 - "1"
             pool_id:
-                - 43608e44-60ad-45a3-b903-1a04b08d20e0
+                - ca90b529-2fb6-4390-8277-c3cfa1113ef4
             status:
                 - unknown
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/90674a70-85ad-42bb-8877-9d4fe78940db/nodes?order_by=created_at_asc&page=1&pool_id=43608e44-60ad-45a3-b903-1a04b08d20e0&status=unknown
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/220ee062-8e89-47b8-96d9-ebe282662eb0/nodes?order_by=created_at_asc&page=1&pool_id=ca90b529-2fb6-4390-8277-c3cfa1113ef4&status=unknown
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 542
-        body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"10490eba-9b6c-4005-942d-111777eff73c","cluster_id":"90674a70-85ad-42bb-8877-9d4fe78940db","created_at":"2026-06-01T11:16:56.482452Z","updated_at":"2026-06-01T11:16:59.990269Z","pool_id":"43608e44-60ad-45a3-b903-1a04b08d20e0","status":"creating","conditions":{"Creating":"True","Ready":"False"},"name":"scw-test-pool-taints--test-pool-taints--10490e","public_ip_v4":"","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/6e91f0ef-d962-402d-ba24-0ad208082096","error_message":""}]}'
+        content_length: 28
+        body: '{"total_count":0,"nodes":[]}'
         headers:
             Content-Length:
-                - "542"
+                - "28"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:02 GMT
+                - Tue, 18 Aug 2026 09:39:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 99454dd5-0122-471b-8a83-90f0687b2bf2
+                - 95601973-5ca5-4079-b9e3-a82875911d32
         status: 200 OK
         code: 200
-        duration: 23.881595ms
+        duration: 31.258152ms
+    - id: 29
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/220ee062-8e89-47b8-96d9-ebe282662eb0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1628
+        body: '{"region":"fr-par","id":"220ee062-8e89-47b8-96d9-ebe282662eb0","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-08-18T09:38:02.905614Z","updated_at":"2026-08-18T09:39:26.593396Z","type":"kapsule","name":"test-pool-taints-and-labels","description":"","status":"ready","version":"1.36.1","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"cluster_url":"https://220ee062-8e89-47b8-96d9-ebe282662eb0.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.220ee062-8e89-47b8-96d9-ebe282662eb0.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":2},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"e85f0802-5637-46d2-88c2-8ceb6767c532","commitment_ends_at":"2026-08-18T09:38:02.905622Z","acl_available":true,"iam_nodes_group_id":"586830d7-c0e2-4bcd-a605-15e937921fc5","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1628"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 18 Aug 2026 09:39:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - 33718ae1-ed7a-4e5c-a726-1e06917d37fd
+        status: 200 OK
+        code: 200
+        duration: 23.073272ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1037,29 +1028,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/90674a70-85ad-42bb-8877-9d4fe78940db
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/621f79dd-9a8d-48fb-80eb-8b7db805149e
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 1628
-        body: '{"region":"fr-par","id":"90674a70-85ad-42bb-8877-9d4fe78940db","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-06-01T11:05:22.167457Z","updated_at":"2026-06-01T11:16:56.177605Z","type":"kapsule","name":"test-pool-taints-and-labels","description":"","status":"ready","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"cluster_url":"https://90674a70-85ad-42bb-8877-9d4fe78940db.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.90674a70-85ad-42bb-8877-9d4fe78940db.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":2},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"03958c89-e8ad-4344-90e1-f1d02267e843","commitment_ends_at":"2026-06-01T11:05:22.167465Z","acl_available":true,"iam_nodes_group_id":"08fab0b3-c94e-4243-93c0-d8ff43e1d01d","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        content_length: 470
+        body: '{"id":"621f79dd-9a8d-48fb-80eb-8b7db805149e","name":"tf-vpc-hardcore-mestorf","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-08-18T09:38:01.532361Z","updated_at":"2026-08-18T09:38:01.532361Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_default":false,"private_network_count":1,"routing_enabled":true,"custom_routes_propagation_enabled":true,"transitivity_enabled":false,"s3_integration_enabled":false,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "1628"
+                - "470"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:02 GMT
+                - Tue, 18 Aug 2026 09:39:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - da9102af-b1a4-489a-81ac-c7e41f0d6324
+                - 7a301376-26b6-442d-9ec2-b5dbefe661f4
         status: 200 OK
         code: 200
-        duration: 23.995509ms
+        duration: 95.177403ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1067,40 +1058,31 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: api.scaleway.com
-        form:
-            order_by:
-                - created_at_desc
-            project_id:
-                - fa1e3217-dc80-42ac-85c3-3f034b78b552
-            resource_name:
-                - scw-test-pool-taints--test-pool-taints--10490e
-            resource_type:
-                - unknown_type
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=fa1e3217-dc80-42ac-85c3-3f034b78b552&resource_name=scw-test-pool-taints--test-pool-taints--10490e&resource_type=unknown_type
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e85f0802-5637-46d2-88c2-8ceb6767c532
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 1091
-        body: '{"total_count":2,"ips":[{"id":"541fe1fb-7f9e-4875-a455-69e1c71dafab","address":"fd63:256c:45f7:f16:930f:a821:6e71:110b/64","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_ipv6":true,"created_at":"2026-06-01T11:16:59.449732Z","updated_at":"2026-06-01T11:16:59.449732Z","source":{"subnet_id":"ed5bae7d-26b2-42b1-a42c-4cf74a572077"},"resource":{"type":"instance_private_nic","id":"6de5c600-3612-455d-9ede-3b9d8338d833","mac_address":"02:00:00:11:CF:3A","name":"scw-test-pool-taints--test-pool-taints--10490e"},"tags":[],"reverses":[],"region":"fr-par","zone":null},{"id":"66576ee5-d496-4c77-b5d9-0e84757a32be","address":"172.16.24.2/22","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_ipv6":false,"created_at":"2026-06-01T11:16:59.266750Z","updated_at":"2026-06-01T11:16:59.266750Z","source":{"subnet_id":"d9bd5591-544c-4b08-9d13-efd5a4fa044b"},"resource":{"type":"instance_private_nic","id":"6de5c600-3612-455d-9ede-3b9d8338d833","mac_address":"02:00:00:11:CF:3A","name":"scw-test-pool-taints--test-pool-taints--10490e"},"tags":[],"reverses":[],"region":"fr-par","zone":null}]}'
+        content_length: 1136
+        body: '{"id":"e85f0802-5637-46d2-88c2-8ceb6767c532","name":"test-pool-taints-and-labels","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-08-18T09:38:01.802133Z","updated_at":"2026-08-18T09:38:01.802133Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":[{"id":"b07d02f2-cb17-4f4b-a7c8-128f3dd8562d","created_at":"2026-08-18T09:38:01.802133Z","updated_at":"2026-08-18T09:38:01.802133Z","subnet":"172.16.64.0/22","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e85f0802-5637-46d2-88c2-8ceb6767c532","vpc_id":"621f79dd-9a8d-48fb-80eb-8b7db805149e","region":"fr-par"},{"id":"2c1ea306-c6c0-4637-bfcd-a88c8d860ee1","created_at":"2026-08-18T09:38:01.802133Z","updated_at":"2026-08-18T09:38:01.802133Z","subnet":"fd63:256c:45f7:a125::/64","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e85f0802-5637-46d2-88c2-8ceb6767c532","vpc_id":"621f79dd-9a8d-48fb-80eb-8b7db805149e","region":"fr-par"}],"vpc_id":"621f79dd-9a8d-48fb-80eb-8b7db805149e","dhcp_enabled":true,"default_route_propagation_enabled":false,"has_s3_integration":false,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "1091"
+                - "1136"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:02 GMT
+                - Tue, 18 Aug 2026 09:39:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - b3f36b1f-4b8f-408d-ac7b-f82851f77135
+                - 29c79204-40b6-44c1-8578-21dd470bdfb8
         status: 200 OK
         code: 200
-        duration: 91.38938ms
+        duration: 30.833136ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1110,29 +1092,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/0f3756af-afff-43f7-b90c-e70492598b1b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/220ee062-8e89-47b8-96d9-ebe282662eb0
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 413
-        body: '{"id":"0f3756af-afff-43f7-b90c-e70492598b1b","name":"tf-vpc-interesting-ritchie","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-06-01T11:05:21.038572Z","updated_at":"2026-06-01T11:05:21.038572Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_default":false,"private_network_count":1,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        content_length: 1628
+        body: '{"region":"fr-par","id":"220ee062-8e89-47b8-96d9-ebe282662eb0","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-08-18T09:38:02.905614Z","updated_at":"2026-08-18T09:39:26.593396Z","type":"kapsule","name":"test-pool-taints-and-labels","description":"","status":"ready","version":"1.36.1","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"cluster_url":"https://220ee062-8e89-47b8-96d9-ebe282662eb0.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.220ee062-8e89-47b8-96d9-ebe282662eb0.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":2},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"e85f0802-5637-46d2-88c2-8ceb6767c532","commitment_ends_at":"2026-08-18T09:38:02.905622Z","acl_available":true,"iam_nodes_group_id":"586830d7-c0e2-4bcd-a605-15e937921fc5","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
         headers:
             Content-Length:
-                - "413"
+                - "1628"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:02 GMT
+                - Tue, 18 Aug 2026 09:39:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - fc3ede4b-0413-4fc8-b137-fcb9923f15fb
+                - 6f82cd5b-9af4-4818-9675-4a27a371ab3e
         status: 200 OK
         code: 200
-        duration: 50.261493ms
+        duration: 56.088716ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1142,29 +1124,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/03958c89-e8ad-4344-90e1-f1d02267e843
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/220ee062-8e89-47b8-96d9-ebe282662eb0/kubeconfig
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 1072
-        body: '{"id":"03958c89-e8ad-4344-90e1-f1d02267e843","name":"test-pool-taints-and-labels","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-06-01T11:05:21.197514Z","updated_at":"2026-06-01T11:05:21.197514Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":[{"id":"d9bd5591-544c-4b08-9d13-efd5a4fa044b","created_at":"2026-06-01T11:05:21.197514Z","updated_at":"2026-06-01T11:05:21.197514Z","subnet":"172.16.24.0/22","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"03958c89-e8ad-4344-90e1-f1d02267e843","vpc_id":"0f3756af-afff-43f7-b90c-e70492598b1b"},{"id":"ed5bae7d-26b2-42b1-a42c-4cf74a572077","created_at":"2026-06-01T11:05:21.197514Z","updated_at":"2026-06-01T11:05:21.197514Z","subnet":"fd63:256c:45f7:f16::/64","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"03958c89-e8ad-4344-90e1-f1d02267e843","vpc_id":"0f3756af-afff-43f7-b90c-e70492598b1b"}],"vpc_id":"0f3756af-afff-43f7-b90c-e70492598b1b","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        content_length: 1752
+        body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscyIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVUpYZWtORFFWRkhaMEYzU1VKQlowbENRVVJCUzBKblozRm9hMnBQVUZGUlJFRnFRVlpOVWsxM1JWRlpSRlpSVVVSRmQzQnlaRmRLYkdOdE5Xd0taRWRXZWsxQ05GaEVWRWt5VFVSbmVFNTZRVFZOZW1kM1RXeHZXRVJVVFRKTlJHZDRUbnBCTlUxNlozZE5iRzkzUmxSRlZFMUNSVWRCTVZWRlFYaE5Td3BoTTFacFdsaEtkVnBZVW14amVrSmFUVUpOUjBKNWNVZFRUVFE1UVdkRlIwTkRjVWRUVFRRNVFYZEZTRUV3U1VGQ1RFOVBha3cyVTNaRE5HSXlSVlZLQ25aaGVXbENiR2wzY1RCemFuWmFWMDB4YlRKUlVHOVVSMng1VGpaTVRHTnZlVkJ6VUcxSVpUWk1lVGtyY0VVclVsUlJObU5FSzB4R1Z6UmFOM3BYUkdRS1JXbEdSVFJ3WldwUmFrSkJUVUUwUjBFeFZXUkVkMFZDTDNkUlJVRjNTVU53UkVGUVFtZE9Wa2hTVFVKQlpqaEZRbFJCUkVGUlNDOU5RakJIUVRGVlpBcEVaMUZYUWtKVFdrbExiemRrYmk5a1UzWTFUV05rVkhSemMwNVVkbEJCUTFwcVFVdENaMmR4YUd0cVQxQlJVVVJCWjA1SlFVUkNSa0ZwUlVGMk1qWkxDbk5IVVRKNU5tNDNhbkJyY21OcFowbDFWSGRsZVZSUWJVVk5OV04yTjFwUVduTnJRMjFoU1VOSlJDOWFhVVV2VUhnMlRTdFNTRmMzWm1OUlpWSlFNMUlLVTJaS1NHRmhRamRYWlU5UVMyaHVWVmRSVkUwS0xTMHRMUzFGVGtRZ1EwVlNWRWxHU1VOQlZFVXRMUzB0TFFvPQogICAgc2VydmVyOiBodHRwczovLzIyMGVlMDYyLThlODktNDdiOC05NmQ5LWViZTI4MjY2MmViMC5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wtdGFpbnRzLWFuZC1sYWJlbHMKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscyIKICAgIHVzZXI6IHRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscy1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscwpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscy1hZG1pbgogIHVzZXI6CiAgICB0b2tlbjogSHdXNzVwZU0ycmFjMmZEUFhyZ2xVVmNhN0dlcFRmam5qS0ZDeHdYeE04VjFxaTdJR3oxclJ1T2E="}'
         headers:
             Content-Length:
-                - "1072"
+                - "1752"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:02 GMT
+                - Tue, 18 Aug 2026 09:39:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 263d06f4-bd78-462e-a86f-05f7665d590c
+                - 2f2aee9d-9e6c-480d-b2cc-a2359a1a5cc4
         status: 200 OK
         code: 200
-        duration: 20.74815ms
+        duration: 48.948843ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1174,94 +1156,30 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/90674a70-85ad-42bb-8877-9d4fe78940db
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca90b529-2fb6-4390-8277-c3cfa1113ef4
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 1628
-        body: '{"region":"fr-par","id":"90674a70-85ad-42bb-8877-9d4fe78940db","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-06-01T11:05:22.167457Z","updated_at":"2026-06-01T11:16:56.177605Z","type":"kapsule","name":"test-pool-taints-and-labels","description":"","status":"ready","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"cluster_url":"https://90674a70-85ad-42bb-8877-9d4fe78940db.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.90674a70-85ad-42bb-8877-9d4fe78940db.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":2},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"03958c89-e8ad-4344-90e1-f1d02267e843","commitment_ends_at":"2026-06-01T11:05:22.167465Z","acl_available":true,"iam_nodes_group_id":"08fab0b3-c94e-4243-93c0-d8ff43e1d01d","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        content_length: 1008
+        body: '{"region":"fr-par","id":"ca90b529-2fb6-4390-8277-c3cfa1113ef4","cluster_id":"220ee062-8e89-47b8-96d9-ebe282662eb0","created_at":"2026-08-18T09:38:08.558497Z","updated_at":"2026-08-18T09:38:08.558497Z","name":"test-pool-taints-and-labels","status":"scaling","version":"1.36.1","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{"foo":"bar","goo":"car","hoo":"dar"},"taints":[{"key":"key1","value":"value1","effect":"NoSchedule"},{"key":"key2","value":"value2","effect":"NoExecute"}],"startup_taints":[{"key":"startup-key1","value":"startup-value1","effect":"NoSchedule"}],"error_message":null}'
         headers:
             Content-Length:
-                - "1628"
+                - "1008"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:02 GMT
+                - Tue, 18 Aug 2026 09:39:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 86eaabb7-4f46-4e28-a408-5bbb98cbf018
+                - 7dd469f0-3207-4474-b4cf-f65958867dfb
         status: 200 OK
         code: 200
-        duration: 21.262396ms
+        duration: 37.405745ms
     - id: 35
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/90674a70-85ad-42bb-8877-9d4fe78940db/kubeconfig
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 1752
-        body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscyIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVUpYZWtORFFWRkhaMEYzU1VKQlowbENRVVJCUzBKblozRm9hMnBQVUZGUlJFRnFRVlpOVWsxM1JWRlpSRlpSVVVSRmQzQnlaRmRLYkdOdE5Xd0taRWRXZWsxQ05GaEVWRWt5VFVSVmVrMVVSWGhOUkZWNVRXeHZXRVJVVFRKTlJGVjZUVlJGZUUxRVZYbE5iRzkzUmxSRlZFMUNSVWRCTVZWRlFYaE5Td3BoTTFacFdsaEtkVnBZVW14amVrSmFUVUpOUjBKNWNVZFRUVFE1UVdkRlIwTkRjVWRUVFRRNVFYZEZTRUV3U1VGQ1FWUTFWMkV2U0d0eWNtWlJWWEUzQ25kc05Fd3ZZVFozZFZCTmEzSTFVRlZ1WjFRck0waFZUMnhyUkRWQ09FUjNNMEpvT0hBeFpWWXJUbGhHTDNwMlVFZ3pTVEV3ZWxBeFF6bGFPV3Q2U2swS1RqTmhiMlZEVjJwUmFrSkJUVUUwUjBFeFZXUkVkMFZDTDNkUlJVRjNTVU53UkVGUVFtZE9Wa2hTVFVKQlpqaEZRbFJCUkVGUlNDOU5RakJIUVRGVlpBcEVaMUZYUWtKUk9VOXRWVVZHYms5RFVuWTVkMk5zVG5reWRHWktiell5YW1scVFVdENaMmR4YUd0cVQxQlJVVVJCWjA1SlFVUkNSa0ZwUVU5c2RVRndDa0ZDYmtzMVUwcDFMMlYzWkU0NFYybENWVFExVmtoa1UyRlljWFJGTVdzMlpIZEhiV3BuU1doQlRTdE1XRlVyVlRSTE9XZzJNemgzWWs5RFFUQnhTWFlLWWxsUVpITTVkV05LUjFGSVFWSlJUelJQUXprS0xTMHRMUzFGVGtRZ1EwVlNWRWxHU1VOQlZFVXRMUzB0TFFvPQogICAgc2VydmVyOiBodHRwczovLzkwNjc0YTcwLTg1YWQtNDJiYi04ODc3LTlkNGZlNzg5NDBkYi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wtdGFpbnRzLWFuZC1sYWJlbHMKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscyIKICAgIHVzZXI6IHRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscy1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscwpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscy1hZG1pbgogIHVzZXI6CiAgICB0b2tlbjogdVhtQ2FlSXN6Y2JwU3dWbDcwU0FOa205RUg2RG1PMTZqMHRSbFRhU0VUTExseHpzWENkVE9LRXg="}'
-        headers:
-            Content-Length:
-                - "1752"
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 01 Jun 2026 11:17:02 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            X-Request-Id:
-                - ba815c61-785d-40ee-a354-8c34ad2f773e
-        status: 200 OK
-        code: 200
-        duration: 47.616004ms
-    - id: 36
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/43608e44-60ad-45a3-b903-1a04b08d20e0
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 918
-        body: '{"region":"fr-par","id":"43608e44-60ad-45a3-b903-1a04b08d20e0","cluster_id":"90674a70-85ad-42bb-8877-9d4fe78940db","created_at":"2026-06-01T11:05:27.641937Z","updated_at":"2026-06-01T11:05:27.641937Z","name":"test-pool-taints-and-labels","status":"scaling","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{"foo":"bar","goo":"car","hoo":"dar"},"taints":[{"key":"key1","value":"value1","effect":"NoSchedule"},{"key":"key2","value":"value2","effect":"NoExecute"}],"startup_taints":[]}'
-        headers:
-            Content-Length:
-                - "918"
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 01 Jun 2026 11:17:02 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            X-Request-Id:
-                - 0f740b34-e60b-432d-812d-a516d93e40a4
-        status: 200 OK
-        code: 200
-        duration: 22.950346ms
-    - id: 37
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1274,140 +1192,99 @@ interactions:
             page:
                 - "1"
             pool_id:
-                - 43608e44-60ad-45a3-b903-1a04b08d20e0
+                - ca90b529-2fb6-4390-8277-c3cfa1113ef4
             status:
                 - unknown
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/90674a70-85ad-42bb-8877-9d4fe78940db/nodes?order_by=created_at_asc&page=1&pool_id=43608e44-60ad-45a3-b903-1a04b08d20e0&status=unknown
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/220ee062-8e89-47b8-96d9-ebe282662eb0/nodes?order_by=created_at_asc&page=1&pool_id=ca90b529-2fb6-4390-8277-c3cfa1113ef4&status=unknown
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 542
-        body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"10490eba-9b6c-4005-942d-111777eff73c","cluster_id":"90674a70-85ad-42bb-8877-9d4fe78940db","created_at":"2026-06-01T11:16:56.482452Z","updated_at":"2026-06-01T11:16:59.990269Z","pool_id":"43608e44-60ad-45a3-b903-1a04b08d20e0","status":"creating","conditions":{"Creating":"True","Ready":"False"},"name":"scw-test-pool-taints--test-pool-taints--10490e","public_ip_v4":"","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/6e91f0ef-d962-402d-ba24-0ad208082096","error_message":""}]}'
+        content_length: 28
+        body: '{"total_count":0,"nodes":[]}'
         headers:
             Content-Length:
-                - "542"
+                - "28"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:02 GMT
+                - Tue, 18 Aug 2026 09:39:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - b4026e4c-d497-433b-bb30-ad17905b65e1
+                - 7d62e934-c131-4280-8bd1-f2c7dc09d730
         status: 200 OK
         code: 200
-        duration: 26.722101ms
+        duration: 27.525181ms
+    - id: 36
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/220ee062-8e89-47b8-96d9-ebe282662eb0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1628
+        body: '{"region":"fr-par","id":"220ee062-8e89-47b8-96d9-ebe282662eb0","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-08-18T09:38:02.905614Z","updated_at":"2026-08-18T09:39:26.593396Z","type":"kapsule","name":"test-pool-taints-and-labels","description":"","status":"ready","version":"1.36.1","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"cluster_url":"https://220ee062-8e89-47b8-96d9-ebe282662eb0.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.220ee062-8e89-47b8-96d9-ebe282662eb0.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":2},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"e85f0802-5637-46d2-88c2-8ceb6767c532","commitment_ends_at":"2026-08-18T09:38:02.905622Z","acl_available":true,"iam_nodes_group_id":"586830d7-c0e2-4bcd-a605-15e937921fc5","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1628"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 18 Aug 2026 09:39:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - 7d4c6ed4-da72-43fc-ab0d-99210c285561
+        status: 200 OK
+        code: 200
+        duration: 26.068773ms
+    - id: 37
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/220ee062-8e89-47b8-96d9-ebe282662eb0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1628
+        body: '{"region":"fr-par","id":"220ee062-8e89-47b8-96d9-ebe282662eb0","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-08-18T09:38:02.905614Z","updated_at":"2026-08-18T09:39:26.593396Z","type":"kapsule","name":"test-pool-taints-and-labels","description":"","status":"ready","version":"1.36.1","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"cluster_url":"https://220ee062-8e89-47b8-96d9-ebe282662eb0.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.220ee062-8e89-47b8-96d9-ebe282662eb0.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":2},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"e85f0802-5637-46d2-88c2-8ceb6767c532","commitment_ends_at":"2026-08-18T09:38:02.905622Z","acl_available":true,"iam_nodes_group_id":"586830d7-c0e2-4bcd-a605-15e937921fc5","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1628"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 18 Aug 2026 09:39:31 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - 072686fb-3ac2-431e-a942-cb7f4656edea
+        status: 200 OK
+        code: 200
+        duration: 23.60073ms
     - id: 38
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/90674a70-85ad-42bb-8877-9d4fe78940db
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 1628
-        body: '{"region":"fr-par","id":"90674a70-85ad-42bb-8877-9d4fe78940db","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-06-01T11:05:22.167457Z","updated_at":"2026-06-01T11:16:56.177605Z","type":"kapsule","name":"test-pool-taints-and-labels","description":"","status":"ready","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"cluster_url":"https://90674a70-85ad-42bb-8877-9d4fe78940db.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.90674a70-85ad-42bb-8877-9d4fe78940db.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":2},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"03958c89-e8ad-4344-90e1-f1d02267e843","commitment_ends_at":"2026-06-01T11:05:22.167465Z","acl_available":true,"iam_nodes_group_id":"08fab0b3-c94e-4243-93c0-d8ff43e1d01d","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
-        headers:
-            Content-Length:
-                - "1628"
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 01 Jun 2026 11:17:02 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            X-Request-Id:
-                - 85457832-cda4-4c91-9572-eeba6722bf50
-        status: 200 OK
-        code: 200
-        duration: 23.794832ms
-    - id: 39
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        form:
-            order_by:
-                - created_at_desc
-            project_id:
-                - fa1e3217-dc80-42ac-85c3-3f034b78b552
-            resource_name:
-                - scw-test-pool-taints--test-pool-taints--10490e
-            resource_type:
-                - unknown_type
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=fa1e3217-dc80-42ac-85c3-3f034b78b552&resource_name=scw-test-pool-taints--test-pool-taints--10490e&resource_type=unknown_type
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 1091
-        body: '{"total_count":2,"ips":[{"id":"541fe1fb-7f9e-4875-a455-69e1c71dafab","address":"fd63:256c:45f7:f16:930f:a821:6e71:110b/64","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_ipv6":true,"created_at":"2026-06-01T11:16:59.449732Z","updated_at":"2026-06-01T11:16:59.449732Z","source":{"subnet_id":"ed5bae7d-26b2-42b1-a42c-4cf74a572077"},"resource":{"type":"instance_private_nic","id":"6de5c600-3612-455d-9ede-3b9d8338d833","mac_address":"02:00:00:11:CF:3A","name":"scw-test-pool-taints--test-pool-taints--10490e"},"tags":[],"reverses":[],"region":"fr-par","zone":null},{"id":"66576ee5-d496-4c77-b5d9-0e84757a32be","address":"172.16.24.2/22","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_ipv6":false,"created_at":"2026-06-01T11:16:59.266750Z","updated_at":"2026-06-01T11:16:59.266750Z","source":{"subnet_id":"d9bd5591-544c-4b08-9d13-efd5a4fa044b"},"resource":{"type":"instance_private_nic","id":"6de5c600-3612-455d-9ede-3b9d8338d833","mac_address":"02:00:00:11:CF:3A","name":"scw-test-pool-taints--test-pool-taints--10490e"},"tags":[],"reverses":[],"region":"fr-par","zone":null}]}'
-        headers:
-            Content-Length:
-                - "1091"
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 01 Jun 2026 11:17:03 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            X-Request-Id:
-                - cce3d31f-5132-4fe8-81ff-bcde2a006d38
-        status: 200 OK
-        code: 200
-        duration: 106.000683ms
-    - id: 40
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/90674a70-85ad-42bb-8877-9d4fe78940db
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 1628
-        body: '{"region":"fr-par","id":"90674a70-85ad-42bb-8877-9d4fe78940db","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-06-01T11:05:22.167457Z","updated_at":"2026-06-01T11:16:56.177605Z","type":"kapsule","name":"test-pool-taints-and-labels","description":"","status":"ready","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"cluster_url":"https://90674a70-85ad-42bb-8877-9d4fe78940db.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.90674a70-85ad-42bb-8877-9d4fe78940db.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":2},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"03958c89-e8ad-4344-90e1-f1d02267e843","commitment_ends_at":"2026-06-01T11:05:22.167465Z","acl_available":true,"iam_nodes_group_id":"08fab0b3-c94e-4243-93c0-d8ff43e1d01d","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
-        headers:
-            Content-Length:
-                - "1628"
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 01 Jun 2026 11:17:03 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            X-Request-Id:
-                - a1d6af94-995c-4215-b559-ca9d7a0522d0
-        status: 200 OK
-        code: 200
-        duration: 26.529969ms
-    - id: 41
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1419,30 +1296,30 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/43608e44-60ad-45a3-b903-1a04b08d20e0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca90b529-2fb6-4390-8277-c3cfa1113ef4
         method: PATCH
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 918
-        body: '{"region":"fr-par","id":"43608e44-60ad-45a3-b903-1a04b08d20e0","cluster_id":"90674a70-85ad-42bb-8877-9d4fe78940db","created_at":"2026-06-01T11:05:27.641937Z","updated_at":"2026-06-01T11:17:03.293379Z","name":"test-pool-taints-and-labels","status":"scaling","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{"foo":"bar","goo":"car","hoo":"dar"},"taints":[{"key":"key1","value":"value1","effect":"NoSchedule"},{"key":"key2","value":"value2","effect":"NoExecute"}],"startup_taints":[]}'
+        content_length: 1008
+        body: '{"region":"fr-par","id":"ca90b529-2fb6-4390-8277-c3cfa1113ef4","cluster_id":"220ee062-8e89-47b8-96d9-ebe282662eb0","created_at":"2026-08-18T09:38:08.558497Z","updated_at":"2026-08-18T09:39:31.229564Z","name":"test-pool-taints-and-labels","status":"scaling","version":"1.36.1","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{"foo":"bar","goo":"car","hoo":"dar"},"taints":[{"key":"key1","value":"value1","effect":"NoSchedule"},{"key":"key2","value":"value2","effect":"NoExecute"}],"startup_taints":[{"key":"startup-key1","value":"startup-value1","effect":"NoSchedule"}],"error_message":null}'
         headers:
             Content-Length:
-                - "918"
+                - "1008"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:03 GMT
+                - Tue, 18 Aug 2026 09:39:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 7323aec1-c5f5-44d0-9355-40adb553a30e
+                - 0cb96d5e-e861-4974-942a-f1e38a6a97e2
         status: 200 OK
         code: 200
-        duration: 43.418459ms
-    - id: 42
+        duration: 32.789419ms
+    - id: 39
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1454,30 +1331,30 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/43608e44-60ad-45a3-b903-1a04b08d20e0/set-labels
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca90b529-2fb6-4390-8277-c3cfa1113ef4/set-labels
         method: PUT
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 894
-        body: '{"region":"fr-par","id":"43608e44-60ad-45a3-b903-1a04b08d20e0","cluster_id":"90674a70-85ad-42bb-8877-9d4fe78940db","created_at":"2026-06-01T11:05:27.641937Z","updated_at":"2026-06-01T11:17:03.344824Z","name":"test-pool-taints-and-labels","status":"scaling","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{"foo":"bar"},"taints":[{"key":"key1","value":"value1","effect":"NoSchedule"},{"key":"key2","value":"value2","effect":"NoExecute"}],"startup_taints":[]}'
+        content_length: 984
+        body: '{"region":"fr-par","id":"ca90b529-2fb6-4390-8277-c3cfa1113ef4","cluster_id":"220ee062-8e89-47b8-96d9-ebe282662eb0","created_at":"2026-08-18T09:38:08.558497Z","updated_at":"2026-08-18T09:39:31.266620Z","name":"test-pool-taints-and-labels","status":"scaling","version":"1.36.1","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{"foo":"bar"},"taints":[{"key":"key1","value":"value1","effect":"NoSchedule"},{"key":"key2","value":"value2","effect":"NoExecute"}],"startup_taints":[{"key":"startup-key1","value":"startup-value1","effect":"NoSchedule"}],"error_message":null}'
         headers:
             Content-Length:
-                - "894"
+                - "984"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:03 GMT
+                - Tue, 18 Aug 2026 09:39:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 474962e3-cca6-4059-8152-6d935607c9fe
+                - 5ba91941-9ddc-4de0-bcc1-41e939137c0e
         status: 200 OK
         code: 200
-        duration: 42.585454ms
-    - id: 43
+        duration: 33.656323ms
+    - id: 40
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1489,64 +1366,166 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/43608e44-60ad-45a3-b903-1a04b08d20e0/set-taints
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca90b529-2fb6-4390-8277-c3cfa1113ef4/set-taints
         method: PUT
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 902
-        body: '{"region":"fr-par","id":"43608e44-60ad-45a3-b903-1a04b08d20e0","cluster_id":"90674a70-85ad-42bb-8877-9d4fe78940db","created_at":"2026-06-01T11:05:27.641937Z","updated_at":"2026-06-01T11:17:03.380819Z","name":"test-pool-taints-and-labels","status":"scaling","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{"foo":"bar"},"taints":[{"key":"key2","value":"new-value2","effect":"NoExecute"},{"key":"new-key1","value":"value1","effect":"NoSchedule"}],"startup_taints":[]}'
+        content_length: 992
+        body: '{"region":"fr-par","id":"ca90b529-2fb6-4390-8277-c3cfa1113ef4","cluster_id":"220ee062-8e89-47b8-96d9-ebe282662eb0","created_at":"2026-08-18T09:38:08.558497Z","updated_at":"2026-08-18T09:39:31.305689Z","name":"test-pool-taints-and-labels","status":"scaling","version":"1.36.1","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{"foo":"bar"},"taints":[{"key":"key2","value":"new-value2","effect":"NoExecute"},{"key":"new-key1","value":"value1","effect":"NoSchedule"}],"startup_taints":[{"key":"startup-key1","value":"startup-value1","effect":"NoSchedule"}],"error_message":null}'
         headers:
             Content-Length:
-                - "902"
+                - "992"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:03 GMT
+                - Tue, 18 Aug 2026 09:39:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 5318023c-d6e7-4d2a-ac9a-cd7a7b4e810e
+                - ea47c911-4de0-41c5-aacb-0ef72c4d2a49
         status: 200 OK
         code: 200
-        duration: 36.596716ms
+        duration: 39.005481ms
+    - id: 41
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca90b529-2fb6-4390-8277-c3cfa1113ef4
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 992
+        body: '{"region":"fr-par","id":"ca90b529-2fb6-4390-8277-c3cfa1113ef4","cluster_id":"220ee062-8e89-47b8-96d9-ebe282662eb0","created_at":"2026-08-18T09:38:08.558497Z","updated_at":"2026-08-18T09:39:31.305689Z","name":"test-pool-taints-and-labels","status":"scaling","version":"1.36.1","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{"foo":"bar"},"taints":[{"key":"key2","value":"new-value2","effect":"NoExecute"},{"key":"new-key1","value":"value1","effect":"NoSchedule"}],"startup_taints":[{"key":"startup-key1","value":"startup-value1","effect":"NoSchedule"}],"error_message":null}'
+        headers:
+            Content-Length:
+                - "992"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 18 Aug 2026 09:39:31 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - 2fcc16af-4236-4c8e-aba5-53e1fa6489ad
+        status: 200 OK
+        code: 200
+        duration: 56.666487ms
+    - id: 42
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_asc
+            page:
+                - "1"
+            pool_id:
+                - ca90b529-2fb6-4390-8277-c3cfa1113ef4
+            status:
+                - unknown
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/220ee062-8e89-47b8-96d9-ebe282662eb0/nodes?order_by=created_at_asc&page=1&pool_id=ca90b529-2fb6-4390-8277-c3cfa1113ef4&status=unknown
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 28
+        body: '{"total_count":0,"nodes":[]}'
+        headers:
+            Content-Length:
+                - "28"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 18 Aug 2026 09:39:31 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - 61534215-918f-428c-ad92-f2fce98ea1c7
+        status: 200 OK
+        code: 200
+        duration: 20.114231ms
+    - id: 43
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/220ee062-8e89-47b8-96d9-ebe282662eb0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1628
+        body: '{"region":"fr-par","id":"220ee062-8e89-47b8-96d9-ebe282662eb0","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-08-18T09:38:02.905614Z","updated_at":"2026-08-18T09:39:26.593396Z","type":"kapsule","name":"test-pool-taints-and-labels","description":"","status":"ready","version":"1.36.1","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"cluster_url":"https://220ee062-8e89-47b8-96d9-ebe282662eb0.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.220ee062-8e89-47b8-96d9-ebe282662eb0.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":2},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"e85f0802-5637-46d2-88c2-8ceb6767c532","commitment_ends_at":"2026-08-18T09:38:02.905622Z","acl_available":true,"iam_nodes_group_id":"586830d7-c0e2-4bcd-a605-15e937921fc5","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1628"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 18 Aug 2026 09:39:31 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - be09f209-3dd3-4699-9655-503a37990749
+        status: 200 OK
+        code: 200
+        duration: 40.093018ms
     - id: 44
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 90
+        content_length: 0
         host: api.scaleway.com
-        body: '{"startup_taints":[{"key":"startup-key1","value":"startup-value1","effect":"NoSchedule"}]}'
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/43608e44-60ad-45a3-b903-1a04b08d20e0/set-startup-taints
-        method: PUT
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/220ee062-8e89-47b8-96d9-ebe282662eb0
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 971
-        body: '{"region":"fr-par","id":"43608e44-60ad-45a3-b903-1a04b08d20e0","cluster_id":"90674a70-85ad-42bb-8877-9d4fe78940db","created_at":"2026-06-01T11:05:27.641937Z","updated_at":"2026-06-01T11:17:03.442192Z","name":"test-pool-taints-and-labels","status":"scaling","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{"foo":"bar"},"taints":[{"key":"key2","value":"new-value2","effect":"NoExecute"},{"key":"new-key1","value":"value1","effect":"NoSchedule"}],"startup_taints":[{"key":"startup-key1","value":"startup-value1","effect":"NoSchedule"}]}'
+        content_length: 1628
+        body: '{"region":"fr-par","id":"220ee062-8e89-47b8-96d9-ebe282662eb0","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-08-18T09:38:02.905614Z","updated_at":"2026-08-18T09:39:26.593396Z","type":"kapsule","name":"test-pool-taints-and-labels","description":"","status":"ready","version":"1.36.1","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"cluster_url":"https://220ee062-8e89-47b8-96d9-ebe282662eb0.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.220ee062-8e89-47b8-96d9-ebe282662eb0.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":2},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"e85f0802-5637-46d2-88c2-8ceb6767c532","commitment_ends_at":"2026-08-18T09:38:02.905622Z","acl_available":true,"iam_nodes_group_id":"586830d7-c0e2-4bcd-a605-15e937921fc5","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
         headers:
             Content-Length:
-                - "971"
+                - "1628"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:03 GMT
+                - Tue, 18 Aug 2026 09:39:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - d06f46e3-739e-4d93-8554-081ec65ee623
+                - d5ec7073-0049-435f-ac7b-7a0cf3b2bc16
         status: 200 OK
         code: 200
-        duration: 60.257116ms
+        duration: 34.195092ms
     - id: 45
       request:
         proto: HTTP/1.1
@@ -1556,29 +1535,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/43608e44-60ad-45a3-b903-1a04b08d20e0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca90b529-2fb6-4390-8277-c3cfa1113ef4
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 971
-        body: '{"region":"fr-par","id":"43608e44-60ad-45a3-b903-1a04b08d20e0","cluster_id":"90674a70-85ad-42bb-8877-9d4fe78940db","created_at":"2026-06-01T11:05:27.641937Z","updated_at":"2026-06-01T11:17:03.442192Z","name":"test-pool-taints-and-labels","status":"scaling","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{"foo":"bar"},"taints":[{"key":"key2","value":"new-value2","effect":"NoExecute"},{"key":"new-key1","value":"value1","effect":"NoSchedule"}],"startup_taints":[{"key":"startup-key1","value":"startup-value1","effect":"NoSchedule"}]}'
+        content_length: 992
+        body: '{"region":"fr-par","id":"ca90b529-2fb6-4390-8277-c3cfa1113ef4","cluster_id":"220ee062-8e89-47b8-96d9-ebe282662eb0","created_at":"2026-08-18T09:38:08.558497Z","updated_at":"2026-08-18T09:39:31.305689Z","name":"test-pool-taints-and-labels","status":"scaling","version":"1.36.1","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{"foo":"bar"},"taints":[{"key":"key2","value":"new-value2","effect":"NoExecute"},{"key":"new-key1","value":"value1","effect":"NoSchedule"}],"startup_taints":[{"key":"startup-key1","value":"startup-value1","effect":"NoSchedule"}],"error_message":null}'
         headers:
             Content-Length:
-                - "971"
+                - "992"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:03 GMT
+                - Tue, 18 Aug 2026 09:39:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 3279f5dc-b662-49f3-8671-9fd58c254d6d
+                - 2b289922-e968-4e0f-9409-ee78462d3a4b
         status: 200 OK
         code: 200
-        duration: 23.84671ms
+        duration: 22.215355ms
     - id: 46
       request:
         proto: HTTP/1.1
@@ -1586,40 +1565,31 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: api.scaleway.com
-        form:
-            order_by:
-                - created_at_asc
-            page:
-                - "1"
-            pool_id:
-                - 43608e44-60ad-45a3-b903-1a04b08d20e0
-            status:
-                - unknown
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/90674a70-85ad-42bb-8877-9d4fe78940db/nodes?order_by=created_at_asc&page=1&pool_id=43608e44-60ad-45a3-b903-1a04b08d20e0&status=unknown
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/621f79dd-9a8d-48fb-80eb-8b7db805149e
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 542
-        body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"10490eba-9b6c-4005-942d-111777eff73c","cluster_id":"90674a70-85ad-42bb-8877-9d4fe78940db","created_at":"2026-06-01T11:16:56.482452Z","updated_at":"2026-06-01T11:16:59.990269Z","pool_id":"43608e44-60ad-45a3-b903-1a04b08d20e0","status":"creating","conditions":{"Creating":"True","Ready":"False"},"name":"scw-test-pool-taints--test-pool-taints--10490e","public_ip_v4":"","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/6e91f0ef-d962-402d-ba24-0ad208082096","error_message":""}]}'
+        content_length: 470
+        body: '{"id":"621f79dd-9a8d-48fb-80eb-8b7db805149e","name":"tf-vpc-hardcore-mestorf","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-08-18T09:38:01.532361Z","updated_at":"2026-08-18T09:38:01.532361Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_default":false,"private_network_count":1,"routing_enabled":true,"custom_routes_propagation_enabled":true,"transitivity_enabled":false,"s3_integration_enabled":false,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "542"
+                - "470"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:03 GMT
+                - Tue, 18 Aug 2026 09:39:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - f3f205dc-b3db-4ebc-ae45-f7b73d771943
+                - 788a9a1e-88e0-474e-a6bd-4b27b14d408f
         status: 200 OK
         code: 200
-        duration: 25.120862ms
+        duration: 115.758897ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -1629,29 +1599,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/90674a70-85ad-42bb-8877-9d4fe78940db
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e85f0802-5637-46d2-88c2-8ceb6767c532
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 1628
-        body: '{"region":"fr-par","id":"90674a70-85ad-42bb-8877-9d4fe78940db","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-06-01T11:05:22.167457Z","updated_at":"2026-06-01T11:16:56.177605Z","type":"kapsule","name":"test-pool-taints-and-labels","description":"","status":"ready","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"cluster_url":"https://90674a70-85ad-42bb-8877-9d4fe78940db.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.90674a70-85ad-42bb-8877-9d4fe78940db.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":2},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"03958c89-e8ad-4344-90e1-f1d02267e843","commitment_ends_at":"2026-06-01T11:05:22.167465Z","acl_available":true,"iam_nodes_group_id":"08fab0b3-c94e-4243-93c0-d8ff43e1d01d","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        content_length: 1136
+        body: '{"id":"e85f0802-5637-46d2-88c2-8ceb6767c532","name":"test-pool-taints-and-labels","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-08-18T09:38:01.802133Z","updated_at":"2026-08-18T09:38:01.802133Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":[{"id":"b07d02f2-cb17-4f4b-a7c8-128f3dd8562d","created_at":"2026-08-18T09:38:01.802133Z","updated_at":"2026-08-18T09:38:01.802133Z","subnet":"172.16.64.0/22","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e85f0802-5637-46d2-88c2-8ceb6767c532","vpc_id":"621f79dd-9a8d-48fb-80eb-8b7db805149e","region":"fr-par"},{"id":"2c1ea306-c6c0-4637-bfcd-a88c8d860ee1","created_at":"2026-08-18T09:38:01.802133Z","updated_at":"2026-08-18T09:38:01.802133Z","subnet":"fd63:256c:45f7:a125::/64","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e85f0802-5637-46d2-88c2-8ceb6767c532","vpc_id":"621f79dd-9a8d-48fb-80eb-8b7db805149e","region":"fr-par"}],"vpc_id":"621f79dd-9a8d-48fb-80eb-8b7db805149e","dhcp_enabled":true,"default_route_propagation_enabled":false,"has_s3_integration":false,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "1628"
+                - "1136"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:03 GMT
+                - Tue, 18 Aug 2026 09:39:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - f1207bb7-19ed-45a8-8ea1-e8829c388468
+                - ae829343-bc9e-4a7a-be88-769a4525f289
         status: 200 OK
         code: 200
-        duration: 26.589461ms
+        duration: 91.847664ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -1659,40 +1629,31 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: api.scaleway.com
-        form:
-            order_by:
-                - created_at_desc
-            project_id:
-                - fa1e3217-dc80-42ac-85c3-3f034b78b552
-            resource_name:
-                - scw-test-pool-taints--test-pool-taints--10490e
-            resource_type:
-                - unknown_type
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=fa1e3217-dc80-42ac-85c3-3f034b78b552&resource_name=scw-test-pool-taints--test-pool-taints--10490e&resource_type=unknown_type
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/220ee062-8e89-47b8-96d9-ebe282662eb0
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 1091
-        body: '{"total_count":2,"ips":[{"id":"541fe1fb-7f9e-4875-a455-69e1c71dafab","address":"fd63:256c:45f7:f16:930f:a821:6e71:110b/64","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_ipv6":true,"created_at":"2026-06-01T11:16:59.449732Z","updated_at":"2026-06-01T11:16:59.449732Z","source":{"subnet_id":"ed5bae7d-26b2-42b1-a42c-4cf74a572077"},"resource":{"type":"instance_private_nic","id":"6de5c600-3612-455d-9ede-3b9d8338d833","mac_address":"02:00:00:11:CF:3A","name":"scw-test-pool-taints--test-pool-taints--10490e"},"tags":[],"reverses":[],"region":"fr-par","zone":null},{"id":"66576ee5-d496-4c77-b5d9-0e84757a32be","address":"172.16.24.2/22","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_ipv6":false,"created_at":"2026-06-01T11:16:59.266750Z","updated_at":"2026-06-01T11:16:59.266750Z","source":{"subnet_id":"d9bd5591-544c-4b08-9d13-efd5a4fa044b"},"resource":{"type":"instance_private_nic","id":"6de5c600-3612-455d-9ede-3b9d8338d833","mac_address":"02:00:00:11:CF:3A","name":"scw-test-pool-taints--test-pool-taints--10490e"},"tags":[],"reverses":[],"region":"fr-par","zone":null}]}'
+        content_length: 1628
+        body: '{"region":"fr-par","id":"220ee062-8e89-47b8-96d9-ebe282662eb0","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-08-18T09:38:02.905614Z","updated_at":"2026-08-18T09:39:26.593396Z","type":"kapsule","name":"test-pool-taints-and-labels","description":"","status":"ready","version":"1.36.1","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"cluster_url":"https://220ee062-8e89-47b8-96d9-ebe282662eb0.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.220ee062-8e89-47b8-96d9-ebe282662eb0.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":2},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"e85f0802-5637-46d2-88c2-8ceb6767c532","commitment_ends_at":"2026-08-18T09:38:02.905622Z","acl_available":true,"iam_nodes_group_id":"586830d7-c0e2-4bcd-a605-15e937921fc5","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
         headers:
             Content-Length:
-                - "1091"
+                - "1628"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:03 GMT
+                - Tue, 18 Aug 2026 09:39:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 36eae1bb-6d20-4252-aa56-c31cf4238ce4
+                - ddc84c5e-4134-4817-8685-ae86142e8d08
         status: 200 OK
         code: 200
-        duration: 29.856788ms
+        duration: 50.402976ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -1702,29 +1663,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/90674a70-85ad-42bb-8877-9d4fe78940db
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/220ee062-8e89-47b8-96d9-ebe282662eb0/kubeconfig
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 1628
-        body: '{"region":"fr-par","id":"90674a70-85ad-42bb-8877-9d4fe78940db","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-06-01T11:05:22.167457Z","updated_at":"2026-06-01T11:16:56.177605Z","type":"kapsule","name":"test-pool-taints-and-labels","description":"","status":"ready","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"cluster_url":"https://90674a70-85ad-42bb-8877-9d4fe78940db.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.90674a70-85ad-42bb-8877-9d4fe78940db.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":2},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"03958c89-e8ad-4344-90e1-f1d02267e843","commitment_ends_at":"2026-06-01T11:05:22.167465Z","acl_available":true,"iam_nodes_group_id":"08fab0b3-c94e-4243-93c0-d8ff43e1d01d","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        content_length: 1752
+        body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscyIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVUpYZWtORFFWRkhaMEYzU1VKQlowbENRVVJCUzBKblozRm9hMnBQVUZGUlJFRnFRVlpOVWsxM1JWRlpSRlpSVVVSRmQzQnlaRmRLYkdOdE5Xd0taRWRXZWsxQ05GaEVWRWt5VFVSbmVFNTZRVFZOZW1kM1RXeHZXRVJVVFRKTlJHZDRUbnBCTlUxNlozZE5iRzkzUmxSRlZFMUNSVWRCTVZWRlFYaE5Td3BoTTFacFdsaEtkVnBZVW14amVrSmFUVUpOUjBKNWNVZFRUVFE1UVdkRlIwTkRjVWRUVFRRNVFYZEZTRUV3U1VGQ1RFOVBha3cyVTNaRE5HSXlSVlZLQ25aaGVXbENiR2wzY1RCemFuWmFWMDB4YlRKUlVHOVVSMng1VGpaTVRHTnZlVkJ6VUcxSVpUWk1lVGtyY0VVclVsUlJObU5FSzB4R1Z6UmFOM3BYUkdRS1JXbEdSVFJ3WldwUmFrSkJUVUUwUjBFeFZXUkVkMFZDTDNkUlJVRjNTVU53UkVGUVFtZE9Wa2hTVFVKQlpqaEZRbFJCUkVGUlNDOU5RakJIUVRGVlpBcEVaMUZYUWtKVFdrbExiemRrYmk5a1UzWTFUV05rVkhSemMwNVVkbEJCUTFwcVFVdENaMmR4YUd0cVQxQlJVVVJCWjA1SlFVUkNSa0ZwUlVGMk1qWkxDbk5IVVRKNU5tNDNhbkJyY21OcFowbDFWSGRsZVZSUWJVVk5OV04yTjFwUVduTnJRMjFoU1VOSlJDOWFhVVV2VUhnMlRTdFNTRmMzWm1OUlpWSlFNMUlLVTJaS1NHRmhRamRYWlU5UVMyaHVWVmRSVkUwS0xTMHRMUzFGVGtRZ1EwVlNWRWxHU1VOQlZFVXRMUzB0TFFvPQogICAgc2VydmVyOiBodHRwczovLzIyMGVlMDYyLThlODktNDdiOC05NmQ5LWViZTI4MjY2MmViMC5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wtdGFpbnRzLWFuZC1sYWJlbHMKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscyIKICAgIHVzZXI6IHRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscy1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscwpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscy1hZG1pbgogIHVzZXI6CiAgICB0b2tlbjogSHdXNzVwZU0ycmFjMmZEUFhyZ2xVVmNhN0dlcFRmam5qS0ZDeHdYeE04VjFxaTdJR3oxclJ1T2E="}'
         headers:
             Content-Length:
-                - "1628"
+                - "1752"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:03 GMT
+                - Tue, 18 Aug 2026 09:39:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 556f1688-b0ed-4939-aa5f-503b6fa34023
+                - 1e7e21d3-8e30-42dc-a53c-5281ea78a4c5
         status: 200 OK
         code: 200
-        duration: 22.423116ms
+        duration: 44.577296ms
     - id: 50
       request:
         proto: HTTP/1.1
@@ -1734,29 +1695,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/43608e44-60ad-45a3-b903-1a04b08d20e0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca90b529-2fb6-4390-8277-c3cfa1113ef4
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 971
-        body: '{"region":"fr-par","id":"43608e44-60ad-45a3-b903-1a04b08d20e0","cluster_id":"90674a70-85ad-42bb-8877-9d4fe78940db","created_at":"2026-06-01T11:05:27.641937Z","updated_at":"2026-06-01T11:17:03.442192Z","name":"test-pool-taints-and-labels","status":"scaling","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{"foo":"bar"},"taints":[{"key":"key2","value":"new-value2","effect":"NoExecute"},{"key":"new-key1","value":"value1","effect":"NoSchedule"}],"startup_taints":[{"key":"startup-key1","value":"startup-value1","effect":"NoSchedule"}]}'
+        content_length: 992
+        body: '{"region":"fr-par","id":"ca90b529-2fb6-4390-8277-c3cfa1113ef4","cluster_id":"220ee062-8e89-47b8-96d9-ebe282662eb0","created_at":"2026-08-18T09:38:08.558497Z","updated_at":"2026-08-18T09:39:31.305689Z","name":"test-pool-taints-and-labels","status":"scaling","version":"1.36.1","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{"foo":"bar"},"taints":[{"key":"key2","value":"new-value2","effect":"NoExecute"},{"key":"new-key1","value":"value1","effect":"NoSchedule"}],"startup_taints":[{"key":"startup-key1","value":"startup-value1","effect":"NoSchedule"}],"error_message":null}'
         headers:
             Content-Length:
-                - "971"
+                - "992"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:03 GMT
+                - Tue, 18 Aug 2026 09:39:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - cd137915-8da6-44d3-9980-5c18a9ac9abf
+                - 9b087bf1-d740-4581-b1e1-c4653c1b9997
         status: 200 OK
         code: 200
-        duration: 23.1708ms
+        duration: 22.204976ms
     - id: 51
       request:
         proto: HTTP/1.1
@@ -1764,31 +1725,40 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_asc
+            page:
+                - "1"
+            pool_id:
+                - ca90b529-2fb6-4390-8277-c3cfa1113ef4
+            status:
+                - unknown
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/0f3756af-afff-43f7-b90c-e70492598b1b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/220ee062-8e89-47b8-96d9-ebe282662eb0/nodes?order_by=created_at_asc&page=1&pool_id=ca90b529-2fb6-4390-8277-c3cfa1113ef4&status=unknown
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 413
-        body: '{"id":"0f3756af-afff-43f7-b90c-e70492598b1b","name":"tf-vpc-interesting-ritchie","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-06-01T11:05:21.038572Z","updated_at":"2026-06-01T11:05:21.038572Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_default":false,"private_network_count":1,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        content_length: 477
+        body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"babee4a8-d70b-46f2-917a-056e5c5ab3f5","cluster_id":"220ee062-8e89-47b8-96d9-ebe282662eb0","created_at":"2026-08-18T09:39:31.488524Z","updated_at":"2026-08-18T09:39:31.488524Z","pool_id":"ca90b529-2fb6-4390-8277-c3cfa1113ef4","status":"creating","conditions":{"Creating":"True","Ready":"False"},"name":"scw-test-pool-taints--test-pool-taints--babee4","public_ip_v4":"","public_ip_v6":null,"provider_id":"","error_message":""}]}'
         headers:
             Content-Length:
-                - "413"
+                - "477"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:04 GMT
+                - Tue, 18 Aug 2026 09:39:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - a9663798-ccf4-4da2-96cd-a5ef361d71e8
+                - 0e857929-9365-4111-b4e8-078af9720542
         status: 200 OK
         code: 200
-        duration: 25.887332ms
+        duration: 39.695372ms
     - id: 52
       request:
         proto: HTTP/1.1
@@ -1798,29 +1768,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/03958c89-e8ad-4344-90e1-f1d02267e843
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/220ee062-8e89-47b8-96d9-ebe282662eb0
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 1072
-        body: '{"id":"03958c89-e8ad-4344-90e1-f1d02267e843","name":"test-pool-taints-and-labels","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-06-01T11:05:21.197514Z","updated_at":"2026-06-01T11:05:21.197514Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":[{"id":"d9bd5591-544c-4b08-9d13-efd5a4fa044b","created_at":"2026-06-01T11:05:21.197514Z","updated_at":"2026-06-01T11:05:21.197514Z","subnet":"172.16.24.0/22","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"03958c89-e8ad-4344-90e1-f1d02267e843","vpc_id":"0f3756af-afff-43f7-b90c-e70492598b1b"},{"id":"ed5bae7d-26b2-42b1-a42c-4cf74a572077","created_at":"2026-06-01T11:05:21.197514Z","updated_at":"2026-06-01T11:05:21.197514Z","subnet":"fd63:256c:45f7:f16::/64","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"03958c89-e8ad-4344-90e1-f1d02267e843","vpc_id":"0f3756af-afff-43f7-b90c-e70492598b1b"}],"vpc_id":"0f3756af-afff-43f7-b90c-e70492598b1b","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        content_length: 1628
+        body: '{"region":"fr-par","id":"220ee062-8e89-47b8-96d9-ebe282662eb0","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-08-18T09:38:02.905614Z","updated_at":"2026-08-18T09:39:26.593396Z","type":"kapsule","name":"test-pool-taints-and-labels","description":"","status":"ready","version":"1.36.1","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"cluster_url":"https://220ee062-8e89-47b8-96d9-ebe282662eb0.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.220ee062-8e89-47b8-96d9-ebe282662eb0.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":2},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"e85f0802-5637-46d2-88c2-8ceb6767c532","commitment_ends_at":"2026-08-18T09:38:02.905622Z","acl_available":true,"iam_nodes_group_id":"586830d7-c0e2-4bcd-a605-15e937921fc5","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
         headers:
             Content-Length:
-                - "1072"
+                - "1628"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:04 GMT
+                - Tue, 18 Aug 2026 09:39:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 7b3a6e66-44a7-41b2-a37c-a7b598c2d65d
+                - 14aaee39-8c7e-4c99-9bf3-3938e613b3d4
         status: 200 OK
         code: 200
-        duration: 44.321424ms
+        duration: 22.076215ms
     - id: 53
       request:
         proto: HTTP/1.1
@@ -1828,31 +1798,40 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_desc
+            project_id:
+                - fa1e3217-dc80-42ac-85c3-3f034b78b552
+            resource_name:
+                - scw-test-pool-taints--test-pool-taints--babee4
+            resource_type:
+                - unknown_type
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/90674a70-85ad-42bb-8877-9d4fe78940db
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=fa1e3217-dc80-42ac-85c3-3f034b78b552&resource_name=scw-test-pool-taints--test-pool-taints--babee4&resource_type=unknown_type
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 1628
-        body: '{"region":"fr-par","id":"90674a70-85ad-42bb-8877-9d4fe78940db","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-06-01T11:05:22.167457Z","updated_at":"2026-06-01T11:16:56.177605Z","type":"kapsule","name":"test-pool-taints-and-labels","description":"","status":"ready","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"cluster_url":"https://90674a70-85ad-42bb-8877-9d4fe78940db.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.90674a70-85ad-42bb-8877-9d4fe78940db.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":2},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"03958c89-e8ad-4344-90e1-f1d02267e843","commitment_ends_at":"2026-06-01T11:05:22.167465Z","acl_available":true,"iam_nodes_group_id":"08fab0b3-c94e-4243-93c0-d8ff43e1d01d","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        content_length: 26
+        body: '{"total_count":0,"ips":[]}'
         headers:
             Content-Length:
-                - "1628"
+                - "26"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:04 GMT
+                - Tue, 18 Aug 2026 09:39:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - b5148f84-6d0d-4d49-86e0-b8f7a12d35f7
+                - fd73aeb3-411d-4a87-b061-785f05341f74
         status: 200 OK
         code: 200
-        duration: 25.507137ms
+        duration: 109.352407ms
     - id: 54
       request:
         proto: HTTP/1.1
@@ -1862,29 +1841,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/90674a70-85ad-42bb-8877-9d4fe78940db/kubeconfig
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/621f79dd-9a8d-48fb-80eb-8b7db805149e
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 1752
-        body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscyIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVUpYZWtORFFWRkhaMEYzU1VKQlowbENRVVJCUzBKblozRm9hMnBQVUZGUlJFRnFRVlpOVWsxM1JWRlpSRlpSVVVSRmQzQnlaRmRLYkdOdE5Xd0taRWRXZWsxQ05GaEVWRWt5VFVSVmVrMVVSWGhOUkZWNVRXeHZXRVJVVFRKTlJGVjZUVlJGZUUxRVZYbE5iRzkzUmxSRlZFMUNSVWRCTVZWRlFYaE5Td3BoTTFacFdsaEtkVnBZVW14amVrSmFUVUpOUjBKNWNVZFRUVFE1UVdkRlIwTkRjVWRUVFRRNVFYZEZTRUV3U1VGQ1FWUTFWMkV2U0d0eWNtWlJWWEUzQ25kc05Fd3ZZVFozZFZCTmEzSTFVRlZ1WjFRck0waFZUMnhyUkRWQ09FUjNNMEpvT0hBeFpWWXJUbGhHTDNwMlVFZ3pTVEV3ZWxBeFF6bGFPV3Q2U2swS1RqTmhiMlZEVjJwUmFrSkJUVUUwUjBFeFZXUkVkMFZDTDNkUlJVRjNTVU53UkVGUVFtZE9Wa2hTVFVKQlpqaEZRbFJCUkVGUlNDOU5RakJIUVRGVlpBcEVaMUZYUWtKUk9VOXRWVVZHYms5RFVuWTVkMk5zVG5reWRHWktiell5YW1scVFVdENaMmR4YUd0cVQxQlJVVVJCWjA1SlFVUkNSa0ZwUVU5c2RVRndDa0ZDYmtzMVUwcDFMMlYzWkU0NFYybENWVFExVmtoa1UyRlljWFJGTVdzMlpIZEhiV3BuU1doQlRTdE1XRlVyVlRSTE9XZzJNemgzWWs5RFFUQnhTWFlLWWxsUVpITTVkV05LUjFGSVFWSlJUelJQUXprS0xTMHRMUzFGVGtRZ1EwVlNWRWxHU1VOQlZFVXRMUzB0TFFvPQogICAgc2VydmVyOiBodHRwczovLzkwNjc0YTcwLTg1YWQtNDJiYi04ODc3LTlkNGZlNzg5NDBkYi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wtdGFpbnRzLWFuZC1sYWJlbHMKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscyIKICAgIHVzZXI6IHRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscy1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscwpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscy1hZG1pbgogIHVzZXI6CiAgICB0b2tlbjogdVhtQ2FlSXN6Y2JwU3dWbDcwU0FOa205RUg2RG1PMTZqMHRSbFRhU0VUTExseHpzWENkVE9LRXg="}'
+        content_length: 470
+        body: '{"id":"621f79dd-9a8d-48fb-80eb-8b7db805149e","name":"tf-vpc-hardcore-mestorf","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-08-18T09:38:01.532361Z","updated_at":"2026-08-18T09:38:01.532361Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_default":false,"private_network_count":1,"routing_enabled":true,"custom_routes_propagation_enabled":true,"transitivity_enabled":false,"s3_integration_enabled":false,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "1752"
+                - "470"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:04 GMT
+                - Tue, 18 Aug 2026 09:39:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 7f4f477a-f7b6-4822-9f2f-31d14a6d29f5
+                - bf8ca045-44d9-4178-8094-122f3ead7833
         status: 200 OK
         code: 200
-        duration: 52.556131ms
+        duration: 82.281359ms
     - id: 55
       request:
         proto: HTTP/1.1
@@ -1894,29 +1873,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/43608e44-60ad-45a3-b903-1a04b08d20e0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e85f0802-5637-46d2-88c2-8ceb6767c532
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 971
-        body: '{"region":"fr-par","id":"43608e44-60ad-45a3-b903-1a04b08d20e0","cluster_id":"90674a70-85ad-42bb-8877-9d4fe78940db","created_at":"2026-06-01T11:05:27.641937Z","updated_at":"2026-06-01T11:17:03.442192Z","name":"test-pool-taints-and-labels","status":"scaling","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{"foo":"bar"},"taints":[{"key":"key2","value":"new-value2","effect":"NoExecute"},{"key":"new-key1","value":"value1","effect":"NoSchedule"}],"startup_taints":[{"key":"startup-key1","value":"startup-value1","effect":"NoSchedule"}]}'
+        content_length: 1136
+        body: '{"id":"e85f0802-5637-46d2-88c2-8ceb6767c532","name":"test-pool-taints-and-labels","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-08-18T09:38:01.802133Z","updated_at":"2026-08-18T09:38:01.802133Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":[{"id":"b07d02f2-cb17-4f4b-a7c8-128f3dd8562d","created_at":"2026-08-18T09:38:01.802133Z","updated_at":"2026-08-18T09:38:01.802133Z","subnet":"172.16.64.0/22","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e85f0802-5637-46d2-88c2-8ceb6767c532","vpc_id":"621f79dd-9a8d-48fb-80eb-8b7db805149e","region":"fr-par"},{"id":"2c1ea306-c6c0-4637-bfcd-a88c8d860ee1","created_at":"2026-08-18T09:38:01.802133Z","updated_at":"2026-08-18T09:38:01.802133Z","subnet":"fd63:256c:45f7:a125::/64","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e85f0802-5637-46d2-88c2-8ceb6767c532","vpc_id":"621f79dd-9a8d-48fb-80eb-8b7db805149e","region":"fr-par"}],"vpc_id":"621f79dd-9a8d-48fb-80eb-8b7db805149e","dhcp_enabled":true,"default_route_propagation_enabled":false,"has_s3_integration":false,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "971"
+                - "1136"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:04 GMT
+                - Tue, 18 Aug 2026 09:39:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 57acb3ac-0683-4a3f-b3a8-fc453256d58b
+                - 6788056c-ae82-4871-8da2-3665ac183295
         status: 200 OK
         code: 200
-        duration: 23.216155ms
+        duration: 33.157699ms
     - id: 56
       request:
         proto: HTTP/1.1
@@ -1924,40 +1903,31 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: api.scaleway.com
-        form:
-            order_by:
-                - created_at_asc
-            page:
-                - "1"
-            pool_id:
-                - 43608e44-60ad-45a3-b903-1a04b08d20e0
-            status:
-                - unknown
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/90674a70-85ad-42bb-8877-9d4fe78940db/nodes?order_by=created_at_asc&page=1&pool_id=43608e44-60ad-45a3-b903-1a04b08d20e0&status=unknown
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/220ee062-8e89-47b8-96d9-ebe282662eb0
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 542
-        body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"10490eba-9b6c-4005-942d-111777eff73c","cluster_id":"90674a70-85ad-42bb-8877-9d4fe78940db","created_at":"2026-06-01T11:16:56.482452Z","updated_at":"2026-06-01T11:16:59.990269Z","pool_id":"43608e44-60ad-45a3-b903-1a04b08d20e0","status":"creating","conditions":{"Creating":"True","Ready":"False"},"name":"scw-test-pool-taints--test-pool-taints--10490e","public_ip_v4":"","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/6e91f0ef-d962-402d-ba24-0ad208082096","error_message":""}]}'
+        content_length: 1628
+        body: '{"region":"fr-par","id":"220ee062-8e89-47b8-96d9-ebe282662eb0","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-08-18T09:38:02.905614Z","updated_at":"2026-08-18T09:39:26.593396Z","type":"kapsule","name":"test-pool-taints-and-labels","description":"","status":"ready","version":"1.36.1","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"cluster_url":"https://220ee062-8e89-47b8-96d9-ebe282662eb0.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.220ee062-8e89-47b8-96d9-ebe282662eb0.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":2},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"e85f0802-5637-46d2-88c2-8ceb6767c532","commitment_ends_at":"2026-08-18T09:38:02.905622Z","acl_available":true,"iam_nodes_group_id":"586830d7-c0e2-4bcd-a605-15e937921fc5","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
         headers:
             Content-Length:
-                - "542"
+                - "1628"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:04 GMT
+                - Tue, 18 Aug 2026 09:39:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 643e7785-e32e-487d-8eb3-ed2f356df9fa
+                - d068c490-e3be-489c-884c-4b895e0b0b9a
         status: 200 OK
         code: 200
-        duration: 58.527647ms
+        duration: 70.932674ms
     - id: 57
       request:
         proto: HTTP/1.1
@@ -1967,29 +1937,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/90674a70-85ad-42bb-8877-9d4fe78940db
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/220ee062-8e89-47b8-96d9-ebe282662eb0/kubeconfig
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 1628
-        body: '{"region":"fr-par","id":"90674a70-85ad-42bb-8877-9d4fe78940db","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-06-01T11:05:22.167457Z","updated_at":"2026-06-01T11:16:56.177605Z","type":"kapsule","name":"test-pool-taints-and-labels","description":"","status":"ready","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"cluster_url":"https://90674a70-85ad-42bb-8877-9d4fe78940db.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.90674a70-85ad-42bb-8877-9d4fe78940db.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":2},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"03958c89-e8ad-4344-90e1-f1d02267e843","commitment_ends_at":"2026-06-01T11:05:22.167465Z","acl_available":true,"iam_nodes_group_id":"08fab0b3-c94e-4243-93c0-d8ff43e1d01d","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        content_length: 1752
+        body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscyIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVUpYZWtORFFWRkhaMEYzU1VKQlowbENRVVJCUzBKblozRm9hMnBQVUZGUlJFRnFRVlpOVWsxM1JWRlpSRlpSVVVSRmQzQnlaRmRLYkdOdE5Xd0taRWRXZWsxQ05GaEVWRWt5VFVSbmVFNTZRVFZOZW1kM1RXeHZXRVJVVFRKTlJHZDRUbnBCTlUxNlozZE5iRzkzUmxSRlZFMUNSVWRCTVZWRlFYaE5Td3BoTTFacFdsaEtkVnBZVW14amVrSmFUVUpOUjBKNWNVZFRUVFE1UVdkRlIwTkRjVWRUVFRRNVFYZEZTRUV3U1VGQ1RFOVBha3cyVTNaRE5HSXlSVlZLQ25aaGVXbENiR2wzY1RCemFuWmFWMDB4YlRKUlVHOVVSMng1VGpaTVRHTnZlVkJ6VUcxSVpUWk1lVGtyY0VVclVsUlJObU5FSzB4R1Z6UmFOM3BYUkdRS1JXbEdSVFJ3WldwUmFrSkJUVUUwUjBFeFZXUkVkMFZDTDNkUlJVRjNTVU53UkVGUVFtZE9Wa2hTVFVKQlpqaEZRbFJCUkVGUlNDOU5RakJIUVRGVlpBcEVaMUZYUWtKVFdrbExiemRrYmk5a1UzWTFUV05rVkhSemMwNVVkbEJCUTFwcVFVdENaMmR4YUd0cVQxQlJVVVJCWjA1SlFVUkNSa0ZwUlVGMk1qWkxDbk5IVVRKNU5tNDNhbkJyY21OcFowbDFWSGRsZVZSUWJVVk5OV04yTjFwUVduTnJRMjFoU1VOSlJDOWFhVVV2VUhnMlRTdFNTRmMzWm1OUlpWSlFNMUlLVTJaS1NHRmhRamRYWlU5UVMyaHVWVmRSVkUwS0xTMHRMUzFGVGtRZ1EwVlNWRWxHU1VOQlZFVXRMUzB0TFFvPQogICAgc2VydmVyOiBodHRwczovLzIyMGVlMDYyLThlODktNDdiOC05NmQ5LWViZTI4MjY2MmViMC5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wtdGFpbnRzLWFuZC1sYWJlbHMKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscyIKICAgIHVzZXI6IHRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscy1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscwpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscy1hZG1pbgogIHVzZXI6CiAgICB0b2tlbjogSHdXNzVwZU0ycmFjMmZEUFhyZ2xVVmNhN0dlcFRmam5qS0ZDeHdYeE04VjFxaTdJR3oxclJ1T2E="}'
         headers:
             Content-Length:
-                - "1628"
+                - "1752"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:04 GMT
+                - Tue, 18 Aug 2026 09:39:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - cb497281-be3c-4613-96dc-f1925efb9b26
+                - 02c42578-d8d8-4f00-9e77-df0b210323d9
         status: 200 OK
         code: 200
-        duration: 23.619011ms
+        duration: 30.180202ms
     - id: 58
       request:
         proto: HTTP/1.1
@@ -1997,201 +1967,32 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: api.scaleway.com
-        form:
-            order_by:
-                - created_at_desc
-            project_id:
-                - fa1e3217-dc80-42ac-85c3-3f034b78b552
-            resource_name:
-                - scw-test-pool-taints--test-pool-taints--10490e
-            resource_type:
-                - unknown_type
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=fa1e3217-dc80-42ac-85c3-3f034b78b552&resource_name=scw-test-pool-taints--test-pool-taints--10490e&resource_type=unknown_type
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca90b529-2fb6-4390-8277-c3cfa1113ef4
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 1091
-        body: '{"total_count":2,"ips":[{"id":"541fe1fb-7f9e-4875-a455-69e1c71dafab","address":"fd63:256c:45f7:f16:930f:a821:6e71:110b/64","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_ipv6":true,"created_at":"2026-06-01T11:16:59.449732Z","updated_at":"2026-06-01T11:16:59.449732Z","source":{"subnet_id":"ed5bae7d-26b2-42b1-a42c-4cf74a572077"},"resource":{"type":"instance_private_nic","id":"6de5c600-3612-455d-9ede-3b9d8338d833","mac_address":"02:00:00:11:CF:3A","name":"scw-test-pool-taints--test-pool-taints--10490e"},"tags":[],"reverses":[],"region":"fr-par","zone":null},{"id":"66576ee5-d496-4c77-b5d9-0e84757a32be","address":"172.16.24.2/22","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_ipv6":false,"created_at":"2026-06-01T11:16:59.266750Z","updated_at":"2026-06-01T11:16:59.266750Z","source":{"subnet_id":"d9bd5591-544c-4b08-9d13-efd5a4fa044b"},"resource":{"type":"instance_private_nic","id":"6de5c600-3612-455d-9ede-3b9d8338d833","mac_address":"02:00:00:11:CF:3A","name":"scw-test-pool-taints--test-pool-taints--10490e"},"tags":[],"reverses":[],"region":"fr-par","zone":null}]}'
+        content_length: 992
+        body: '{"region":"fr-par","id":"ca90b529-2fb6-4390-8277-c3cfa1113ef4","cluster_id":"220ee062-8e89-47b8-96d9-ebe282662eb0","created_at":"2026-08-18T09:38:08.558497Z","updated_at":"2026-08-18T09:39:31.305689Z","name":"test-pool-taints-and-labels","status":"scaling","version":"1.36.1","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{"foo":"bar"},"taints":[{"key":"key2","value":"new-value2","effect":"NoExecute"},{"key":"new-key1","value":"value1","effect":"NoSchedule"}],"startup_taints":[{"key":"startup-key1","value":"startup-value1","effect":"NoSchedule"}],"error_message":null}'
         headers:
             Content-Length:
-                - "1091"
+                - "992"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:04 GMT
+                - Tue, 18 Aug 2026 09:39:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 89723aa1-a1c6-4a2c-8d04-2813736d43a3
+                - c46776fc-7af8-4d42-85c3-9c390dcd7d8f
         status: 200 OK
         code: 200
-        duration: 36.863607ms
+        duration: 20.248883ms
     - id: 59
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/0f3756af-afff-43f7-b90c-e70492598b1b
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 413
-        body: '{"id":"0f3756af-afff-43f7-b90c-e70492598b1b","name":"tf-vpc-interesting-ritchie","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-06-01T11:05:21.038572Z","updated_at":"2026-06-01T11:05:21.038572Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_default":false,"private_network_count":1,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "413"
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 01 Jun 2026 11:17:04 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            X-Request-Id:
-                - d7b8ba7a-0431-4216-b98e-904f357c5466
-        status: 200 OK
-        code: 200
-        duration: 57.569076ms
-    - id: 60
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/03958c89-e8ad-4344-90e1-f1d02267e843
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 1072
-        body: '{"id":"03958c89-e8ad-4344-90e1-f1d02267e843","name":"test-pool-taints-and-labels","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-06-01T11:05:21.197514Z","updated_at":"2026-06-01T11:05:21.197514Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":[{"id":"d9bd5591-544c-4b08-9d13-efd5a4fa044b","created_at":"2026-06-01T11:05:21.197514Z","updated_at":"2026-06-01T11:05:21.197514Z","subnet":"172.16.24.0/22","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"03958c89-e8ad-4344-90e1-f1d02267e843","vpc_id":"0f3756af-afff-43f7-b90c-e70492598b1b"},{"id":"ed5bae7d-26b2-42b1-a42c-4cf74a572077","created_at":"2026-06-01T11:05:21.197514Z","updated_at":"2026-06-01T11:05:21.197514Z","subnet":"fd63:256c:45f7:f16::/64","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"03958c89-e8ad-4344-90e1-f1d02267e843","vpc_id":"0f3756af-afff-43f7-b90c-e70492598b1b"}],"vpc_id":"0f3756af-afff-43f7-b90c-e70492598b1b","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "1072"
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 01 Jun 2026 11:17:04 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            X-Request-Id:
-                - 01d7c624-9281-4290-b534-0a334dae6c4a
-        status: 200 OK
-        code: 200
-        duration: 49.921232ms
-    - id: 61
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/90674a70-85ad-42bb-8877-9d4fe78940db
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 1628
-        body: '{"region":"fr-par","id":"90674a70-85ad-42bb-8877-9d4fe78940db","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-06-01T11:05:22.167457Z","updated_at":"2026-06-01T11:16:56.177605Z","type":"kapsule","name":"test-pool-taints-and-labels","description":"","status":"ready","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"cluster_url":"https://90674a70-85ad-42bb-8877-9d4fe78940db.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.90674a70-85ad-42bb-8877-9d4fe78940db.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":2},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"03958c89-e8ad-4344-90e1-f1d02267e843","commitment_ends_at":"2026-06-01T11:05:22.167465Z","acl_available":true,"iam_nodes_group_id":"08fab0b3-c94e-4243-93c0-d8ff43e1d01d","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
-        headers:
-            Content-Length:
-                - "1628"
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 01 Jun 2026 11:17:04 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            X-Request-Id:
-                - 2a520298-5543-43e1-9946-f3313f72f030
-        status: 200 OK
-        code: 200
-        duration: 46.568244ms
-    - id: 62
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/90674a70-85ad-42bb-8877-9d4fe78940db/kubeconfig
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 1752
-        body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscyIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVUpYZWtORFFWRkhaMEYzU1VKQlowbENRVVJCUzBKblozRm9hMnBQVUZGUlJFRnFRVlpOVWsxM1JWRlpSRlpSVVVSRmQzQnlaRmRLYkdOdE5Xd0taRWRXZWsxQ05GaEVWRWt5VFVSVmVrMVVSWGhOUkZWNVRXeHZXRVJVVFRKTlJGVjZUVlJGZUUxRVZYbE5iRzkzUmxSRlZFMUNSVWRCTVZWRlFYaE5Td3BoTTFacFdsaEtkVnBZVW14amVrSmFUVUpOUjBKNWNVZFRUVFE1UVdkRlIwTkRjVWRUVFRRNVFYZEZTRUV3U1VGQ1FWUTFWMkV2U0d0eWNtWlJWWEUzQ25kc05Fd3ZZVFozZFZCTmEzSTFVRlZ1WjFRck0waFZUMnhyUkRWQ09FUjNNMEpvT0hBeFpWWXJUbGhHTDNwMlVFZ3pTVEV3ZWxBeFF6bGFPV3Q2U2swS1RqTmhiMlZEVjJwUmFrSkJUVUUwUjBFeFZXUkVkMFZDTDNkUlJVRjNTVU53UkVGUVFtZE9Wa2hTVFVKQlpqaEZRbFJCUkVGUlNDOU5RakJIUVRGVlpBcEVaMUZYUWtKUk9VOXRWVVZHYms5RFVuWTVkMk5zVG5reWRHWktiell5YW1scVFVdENaMmR4YUd0cVQxQlJVVVJCWjA1SlFVUkNSa0ZwUVU5c2RVRndDa0ZDYmtzMVUwcDFMMlYzWkU0NFYybENWVFExVmtoa1UyRlljWFJGTVdzMlpIZEhiV3BuU1doQlRTdE1XRlVyVlRSTE9XZzJNemgzWWs5RFFUQnhTWFlLWWxsUVpITTVkV05LUjFGSVFWSlJUelJQUXprS0xTMHRMUzFGVGtRZ1EwVlNWRWxHU1VOQlZFVXRMUzB0TFFvPQogICAgc2VydmVyOiBodHRwczovLzkwNjc0YTcwLTg1YWQtNDJiYi04ODc3LTlkNGZlNzg5NDBkYi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wtdGFpbnRzLWFuZC1sYWJlbHMKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscyIKICAgIHVzZXI6IHRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscy1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscwpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscy1hZG1pbgogIHVzZXI6CiAgICB0b2tlbjogdVhtQ2FlSXN6Y2JwU3dWbDcwU0FOa205RUg2RG1PMTZqMHRSbFRhU0VUTExseHpzWENkVE9LRXg="}'
-        headers:
-            Content-Length:
-                - "1752"
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 01 Jun 2026 11:17:04 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            X-Request-Id:
-                - df6e8bba-a36a-424e-aac2-545e3d7d86e7
-        status: 200 OK
-        code: 200
-        duration: 31.377483ms
-    - id: 63
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/43608e44-60ad-45a3-b903-1a04b08d20e0
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 971
-        body: '{"region":"fr-par","id":"43608e44-60ad-45a3-b903-1a04b08d20e0","cluster_id":"90674a70-85ad-42bb-8877-9d4fe78940db","created_at":"2026-06-01T11:05:27.641937Z","updated_at":"2026-06-01T11:17:03.442192Z","name":"test-pool-taints-and-labels","status":"scaling","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{"foo":"bar"},"taints":[{"key":"key2","value":"new-value2","effect":"NoExecute"},{"key":"new-key1","value":"value1","effect":"NoSchedule"}],"startup_taints":[{"key":"startup-key1","value":"startup-value1","effect":"NoSchedule"}]}'
-        headers:
-            Content-Length:
-                - "971"
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 01 Jun 2026 11:17:04 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            X-Request-Id:
-                - ca100c60-0822-487f-afcf-1defa5c54afd
-        status: 200 OK
-        code: 200
-        duration: 33.256983ms
-    - id: 64
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2204,35 +2005,35 @@ interactions:
             page:
                 - "1"
             pool_id:
-                - 43608e44-60ad-45a3-b903-1a04b08d20e0
+                - ca90b529-2fb6-4390-8277-c3cfa1113ef4
             status:
                 - unknown
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/90674a70-85ad-42bb-8877-9d4fe78940db/nodes?order_by=created_at_asc&page=1&pool_id=43608e44-60ad-45a3-b903-1a04b08d20e0&status=unknown
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/220ee062-8e89-47b8-96d9-ebe282662eb0/nodes?order_by=created_at_asc&page=1&pool_id=ca90b529-2fb6-4390-8277-c3cfa1113ef4&status=unknown
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 542
-        body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"10490eba-9b6c-4005-942d-111777eff73c","cluster_id":"90674a70-85ad-42bb-8877-9d4fe78940db","created_at":"2026-06-01T11:16:56.482452Z","updated_at":"2026-06-01T11:16:59.990269Z","pool_id":"43608e44-60ad-45a3-b903-1a04b08d20e0","status":"creating","conditions":{"Creating":"True","Ready":"False"},"name":"scw-test-pool-taints--test-pool-taints--10490e","public_ip_v4":"","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/6e91f0ef-d962-402d-ba24-0ad208082096","error_message":""}]}'
+        content_length: 477
+        body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"babee4a8-d70b-46f2-917a-056e5c5ab3f5","cluster_id":"220ee062-8e89-47b8-96d9-ebe282662eb0","created_at":"2026-08-18T09:39:31.488524Z","updated_at":"2026-08-18T09:39:31.488524Z","pool_id":"ca90b529-2fb6-4390-8277-c3cfa1113ef4","status":"creating","conditions":{"Creating":"True","Ready":"False"},"name":"scw-test-pool-taints--test-pool-taints--babee4","public_ip_v4":"","public_ip_v6":null,"provider_id":"","error_message":""}]}'
         headers:
             Content-Length:
-                - "542"
+                - "477"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:04 GMT
+                - Tue, 18 Aug 2026 09:39:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - f2b86b31-9fae-49b3-b7cd-a246b45e27c8
+                - c629921e-a610-4d81-bb96-b5fe1d605710
         status: 200 OK
         code: 200
-        duration: 27.082938ms
-    - id: 65
+        duration: 27.271946ms
+    - id: 60
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2241,30 +2042,30 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/90674a70-85ad-42bb-8877-9d4fe78940db
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/220ee062-8e89-47b8-96d9-ebe282662eb0
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 1628
-        body: '{"region":"fr-par","id":"90674a70-85ad-42bb-8877-9d4fe78940db","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-06-01T11:05:22.167457Z","updated_at":"2026-06-01T11:16:56.177605Z","type":"kapsule","name":"test-pool-taints-and-labels","description":"","status":"ready","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"cluster_url":"https://90674a70-85ad-42bb-8877-9d4fe78940db.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.90674a70-85ad-42bb-8877-9d4fe78940db.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":2},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"03958c89-e8ad-4344-90e1-f1d02267e843","commitment_ends_at":"2026-06-01T11:05:22.167465Z","acl_available":true,"iam_nodes_group_id":"08fab0b3-c94e-4243-93c0-d8ff43e1d01d","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        body: '{"region":"fr-par","id":"220ee062-8e89-47b8-96d9-ebe282662eb0","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-08-18T09:38:02.905614Z","updated_at":"2026-08-18T09:39:26.593396Z","type":"kapsule","name":"test-pool-taints-and-labels","description":"","status":"ready","version":"1.36.1","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"cluster_url":"https://220ee062-8e89-47b8-96d9-ebe282662eb0.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.220ee062-8e89-47b8-96d9-ebe282662eb0.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":2},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"e85f0802-5637-46d2-88c2-8ceb6767c532","commitment_ends_at":"2026-08-18T09:38:02.905622Z","acl_available":true,"iam_nodes_group_id":"586830d7-c0e2-4bcd-a605-15e937921fc5","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
         headers:
             Content-Length:
                 - "1628"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:04 GMT
+                - Tue, 18 Aug 2026 09:39:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - a11bf4a8-ab2d-4c9d-86d2-5bf217ed0e02
+                - 7adc3b96-2c65-46dc-b00c-0db63fe42521
         status: 200 OK
         code: 200
-        duration: 33.397718ms
-    - id: 66
+        duration: 25.198282ms
+    - id: 61
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2277,35 +2078,35 @@ interactions:
             project_id:
                 - fa1e3217-dc80-42ac-85c3-3f034b78b552
             resource_name:
-                - scw-test-pool-taints--test-pool-taints--10490e
+                - scw-test-pool-taints--test-pool-taints--babee4
             resource_type:
                 - unknown_type
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=fa1e3217-dc80-42ac-85c3-3f034b78b552&resource_name=scw-test-pool-taints--test-pool-taints--10490e&resource_type=unknown_type
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=fa1e3217-dc80-42ac-85c3-3f034b78b552&resource_name=scw-test-pool-taints--test-pool-taints--babee4&resource_type=unknown_type
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 1091
-        body: '{"total_count":2,"ips":[{"id":"541fe1fb-7f9e-4875-a455-69e1c71dafab","address":"fd63:256c:45f7:f16:930f:a821:6e71:110b/64","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_ipv6":true,"created_at":"2026-06-01T11:16:59.449732Z","updated_at":"2026-06-01T11:16:59.449732Z","source":{"subnet_id":"ed5bae7d-26b2-42b1-a42c-4cf74a572077"},"resource":{"type":"instance_private_nic","id":"6de5c600-3612-455d-9ede-3b9d8338d833","mac_address":"02:00:00:11:CF:3A","name":"scw-test-pool-taints--test-pool-taints--10490e"},"tags":[],"reverses":[],"region":"fr-par","zone":null},{"id":"66576ee5-d496-4c77-b5d9-0e84757a32be","address":"172.16.24.2/22","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_ipv6":false,"created_at":"2026-06-01T11:16:59.266750Z","updated_at":"2026-06-01T11:16:59.266750Z","source":{"subnet_id":"d9bd5591-544c-4b08-9d13-efd5a4fa044b"},"resource":{"type":"instance_private_nic","id":"6de5c600-3612-455d-9ede-3b9d8338d833","mac_address":"02:00:00:11:CF:3A","name":"scw-test-pool-taints--test-pool-taints--10490e"},"tags":[],"reverses":[],"region":"fr-par","zone":null}]}'
+        content_length: 26
+        body: '{"total_count":0,"ips":[]}'
         headers:
             Content-Length:
-                - "1091"
+                - "26"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:04 GMT
+                - Tue, 18 Aug 2026 09:39:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 03fe46f5-794e-4416-b548-8dac74d28d2d
+                - 9b6495ec-3e1b-4977-8a6b-5bcaccc8eae5
         status: 200 OK
         code: 200
-        duration: 28.641294ms
-    - id: 67
+        duration: 115.7296ms
+    - id: 62
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2314,30 +2115,30 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/90674a70-85ad-42bb-8877-9d4fe78940db
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/220ee062-8e89-47b8-96d9-ebe282662eb0
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 1628
-        body: '{"region":"fr-par","id":"90674a70-85ad-42bb-8877-9d4fe78940db","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-06-01T11:05:22.167457Z","updated_at":"2026-06-01T11:16:56.177605Z","type":"kapsule","name":"test-pool-taints-and-labels","description":"","status":"ready","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"cluster_url":"https://90674a70-85ad-42bb-8877-9d4fe78940db.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.90674a70-85ad-42bb-8877-9d4fe78940db.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":2},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"03958c89-e8ad-4344-90e1-f1d02267e843","commitment_ends_at":"2026-06-01T11:05:22.167465Z","acl_available":true,"iam_nodes_group_id":"08fab0b3-c94e-4243-93c0-d8ff43e1d01d","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        body: '{"region":"fr-par","id":"220ee062-8e89-47b8-96d9-ebe282662eb0","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-08-18T09:38:02.905614Z","updated_at":"2026-08-18T09:39:26.593396Z","type":"kapsule","name":"test-pool-taints-and-labels","description":"","status":"ready","version":"1.36.1","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"cluster_url":"https://220ee062-8e89-47b8-96d9-ebe282662eb0.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.220ee062-8e89-47b8-96d9-ebe282662eb0.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":2},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"e85f0802-5637-46d2-88c2-8ceb6767c532","commitment_ends_at":"2026-08-18T09:38:02.905622Z","acl_available":true,"iam_nodes_group_id":"586830d7-c0e2-4bcd-a605-15e937921fc5","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
         headers:
             Content-Length:
                 - "1628"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:05 GMT
+                - Tue, 18 Aug 2026 09:39:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 21a13c88-b043-4b5c-8c2c-4263a73429b1
+                - dbec42a1-a830-4c19-b5e6-9162a57bfc67
         status: 200 OK
         code: 200
-        duration: 23.197008ms
-    - id: 68
+        duration: 24.55678ms
+    - id: 63
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2349,30 +2150,30 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/43608e44-60ad-45a3-b903-1a04b08d20e0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca90b529-2fb6-4390-8277-c3cfa1113ef4
         method: PATCH
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 971
-        body: '{"region":"fr-par","id":"43608e44-60ad-45a3-b903-1a04b08d20e0","cluster_id":"90674a70-85ad-42bb-8877-9d4fe78940db","created_at":"2026-06-01T11:05:27.641937Z","updated_at":"2026-06-01T11:17:05.050779Z","name":"test-pool-taints-and-labels","status":"scaling","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{"foo":"bar"},"taints":[{"key":"key2","value":"new-value2","effect":"NoExecute"},{"key":"new-key1","value":"value1","effect":"NoSchedule"}],"startup_taints":[{"key":"startup-key1","value":"startup-value1","effect":"NoSchedule"}]}'
+        content_length: 992
+        body: '{"region":"fr-par","id":"ca90b529-2fb6-4390-8277-c3cfa1113ef4","cluster_id":"220ee062-8e89-47b8-96d9-ebe282662eb0","created_at":"2026-08-18T09:38:08.558497Z","updated_at":"2026-08-18T09:39:33.343016Z","name":"test-pool-taints-and-labels","status":"scaling","version":"1.36.1","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{"foo":"bar"},"taints":[{"key":"key2","value":"new-value2","effect":"NoExecute"},{"key":"new-key1","value":"value1","effect":"NoSchedule"}],"startup_taints":[{"key":"startup-key1","value":"startup-value1","effect":"NoSchedule"}],"error_message":null}'
         headers:
             Content-Length:
-                - "971"
+                - "992"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:05 GMT
+                - Tue, 18 Aug 2026 09:39:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - ac8599ce-b8c3-45d0-83fc-4acae080239e
+                - 76b4313d-095a-4e4c-9014-90620f5411fd
         status: 200 OK
         code: 200
-        duration: 35.211113ms
-    - id: 69
+        duration: 54.558678ms
+    - id: 64
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2384,30 +2185,30 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/43608e44-60ad-45a3-b903-1a04b08d20e0/set-labels
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca90b529-2fb6-4390-8277-c3cfa1113ef4/set-labels
         method: PUT
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 960
-        body: '{"region":"fr-par","id":"43608e44-60ad-45a3-b903-1a04b08d20e0","cluster_id":"90674a70-85ad-42bb-8877-9d4fe78940db","created_at":"2026-06-01T11:05:27.641937Z","updated_at":"2026-06-01T11:17:05.090909Z","name":"test-pool-taints-and-labels","status":"scaling","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{},"taints":[{"key":"key2","value":"new-value2","effect":"NoExecute"},{"key":"new-key1","value":"value1","effect":"NoSchedule"}],"startup_taints":[{"key":"startup-key1","value":"startup-value1","effect":"NoSchedule"}]}'
+        content_length: 981
+        body: '{"region":"fr-par","id":"ca90b529-2fb6-4390-8277-c3cfa1113ef4","cluster_id":"220ee062-8e89-47b8-96d9-ebe282662eb0","created_at":"2026-08-18T09:38:08.558497Z","updated_at":"2026-08-18T09:39:33.419118Z","name":"test-pool-taints-and-labels","status":"scaling","version":"1.36.1","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{},"taints":[{"key":"key2","value":"new-value2","effect":"NoExecute"},{"key":"new-key1","value":"value1","effect":"NoSchedule"}],"startup_taints":[{"key":"startup-key1","value":"startup-value1","effect":"NoSchedule"}],"error_message":null}'
         headers:
             Content-Length:
-                - "960"
+                - "981"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:05 GMT
+                - Tue, 18 Aug 2026 09:39:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 9b672d2b-ad1d-4586-bff2-3103a19aeb15
+                - 5c5c47cb-fbbf-4d0d-b7f0-7f1a3fe3ac23
         status: 200 OK
         code: 200
-        duration: 37.420011ms
-    - id: 70
+        duration: 53.818031ms
+    - id: 65
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2419,30 +2220,30 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/43608e44-60ad-45a3-b903-1a04b08d20e0/set-taints
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca90b529-2fb6-4390-8277-c3cfa1113ef4/set-taints
         method: PUT
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 846
-        body: '{"region":"fr-par","id":"43608e44-60ad-45a3-b903-1a04b08d20e0","cluster_id":"90674a70-85ad-42bb-8877-9d4fe78940db","created_at":"2026-06-01T11:05:27.641937Z","updated_at":"2026-06-01T11:17:05.132013Z","name":"test-pool-taints-and-labels","status":"scaling","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{},"taints":[],"startup_taints":[{"key":"startup-key1","value":"startup-value1","effect":"NoSchedule"}]}'
+        content_length: 867
+        body: '{"region":"fr-par","id":"ca90b529-2fb6-4390-8277-c3cfa1113ef4","cluster_id":"220ee062-8e89-47b8-96d9-ebe282662eb0","created_at":"2026-08-18T09:38:08.558497Z","updated_at":"2026-08-18T09:39:33.456119Z","name":"test-pool-taints-and-labels","status":"scaling","version":"1.36.1","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{},"taints":[],"startup_taints":[{"key":"startup-key1","value":"startup-value1","effect":"NoSchedule"}],"error_message":null}'
         headers:
             Content-Length:
-                - "846"
+                - "867"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:05 GMT
+                - Tue, 18 Aug 2026 09:39:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - b3018817-2b02-4b67-b9e1-a1261c3edab3
+                - ecd5874c-830c-42aa-b007-8e0a8bbabafb
         status: 200 OK
         code: 200
-        duration: 41.394456ms
-    - id: 71
+        duration: 39.963143ms
+    - id: 66
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2454,29 +2255,207 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/43608e44-60ad-45a3-b903-1a04b08d20e0/set-startup-taints
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca90b529-2fb6-4390-8277-c3cfa1113ef4/set-startup-taints
         method: PUT
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 777
-        body: '{"region":"fr-par","id":"43608e44-60ad-45a3-b903-1a04b08d20e0","cluster_id":"90674a70-85ad-42bb-8877-9d4fe78940db","created_at":"2026-06-01T11:05:27.641937Z","updated_at":"2026-06-01T11:17:05.175075Z","name":"test-pool-taints-and-labels","status":"scaling","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{},"taints":[],"startup_taints":[]}'
+        content_length: 798
+        body: '{"region":"fr-par","id":"ca90b529-2fb6-4390-8277-c3cfa1113ef4","cluster_id":"220ee062-8e89-47b8-96d9-ebe282662eb0","created_at":"2026-08-18T09:38:08.558497Z","updated_at":"2026-08-18T09:39:33.495298Z","name":"test-pool-taints-and-labels","status":"scaling","version":"1.36.1","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{},"taints":[],"startup_taints":[],"error_message":null}'
         headers:
             Content-Length:
-                - "777"
+                - "798"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:05 GMT
+                - Tue, 18 Aug 2026 09:39:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 90101b37-5b2f-4099-a5c9-f4669a2e3438
+                - 7887e3e6-4819-4fb3-8a7a-e5304f946a9a
         status: 200 OK
         code: 200
-        duration: 37.638132ms
+        duration: 37.233722ms
+    - id: 67
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca90b529-2fb6-4390-8277-c3cfa1113ef4
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 798
+        body: '{"region":"fr-par","id":"ca90b529-2fb6-4390-8277-c3cfa1113ef4","cluster_id":"220ee062-8e89-47b8-96d9-ebe282662eb0","created_at":"2026-08-18T09:38:08.558497Z","updated_at":"2026-08-18T09:39:33.495298Z","name":"test-pool-taints-and-labels","status":"scaling","version":"1.36.1","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{},"taints":[],"startup_taints":[],"error_message":null}'
+        headers:
+            Content-Length:
+                - "798"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 18 Aug 2026 09:39:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - 941858b5-b9a7-4420-8488-76f1e3304886
+        status: 200 OK
+        code: 200
+        duration: 31.803021ms
+    - id: 68
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_asc
+            page:
+                - "1"
+            pool_id:
+                - ca90b529-2fb6-4390-8277-c3cfa1113ef4
+            status:
+                - unknown
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/220ee062-8e89-47b8-96d9-ebe282662eb0/nodes?order_by=created_at_asc&page=1&pool_id=ca90b529-2fb6-4390-8277-c3cfa1113ef4&status=unknown
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 477
+        body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"babee4a8-d70b-46f2-917a-056e5c5ab3f5","cluster_id":"220ee062-8e89-47b8-96d9-ebe282662eb0","created_at":"2026-08-18T09:39:31.488524Z","updated_at":"2026-08-18T09:39:31.488524Z","pool_id":"ca90b529-2fb6-4390-8277-c3cfa1113ef4","status":"creating","conditions":{"Creating":"True","Ready":"False"},"name":"scw-test-pool-taints--test-pool-taints--babee4","public_ip_v4":"","public_ip_v6":null,"provider_id":"","error_message":""}]}'
+        headers:
+            Content-Length:
+                - "477"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 18 Aug 2026 09:39:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - 7551ebad-1e83-486f-ab8b-858485f0e0a9
+        status: 200 OK
+        code: 200
+        duration: 36.146265ms
+    - id: 69
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/220ee062-8e89-47b8-96d9-ebe282662eb0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1628
+        body: '{"region":"fr-par","id":"220ee062-8e89-47b8-96d9-ebe282662eb0","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-08-18T09:38:02.905614Z","updated_at":"2026-08-18T09:39:26.593396Z","type":"kapsule","name":"test-pool-taints-and-labels","description":"","status":"ready","version":"1.36.1","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"cluster_url":"https://220ee062-8e89-47b8-96d9-ebe282662eb0.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.220ee062-8e89-47b8-96d9-ebe282662eb0.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":2},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"e85f0802-5637-46d2-88c2-8ceb6767c532","commitment_ends_at":"2026-08-18T09:38:02.905622Z","acl_available":true,"iam_nodes_group_id":"586830d7-c0e2-4bcd-a605-15e937921fc5","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1628"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 18 Aug 2026 09:39:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - 8412d13f-3c4a-467c-993f-fd49e1e69e9b
+        status: 200 OK
+        code: 200
+        duration: 25.899205ms
+    - id: 70
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_desc
+            project_id:
+                - fa1e3217-dc80-42ac-85c3-3f034b78b552
+            resource_name:
+                - scw-test-pool-taints--test-pool-taints--babee4
+            resource_type:
+                - unknown_type
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=fa1e3217-dc80-42ac-85c3-3f034b78b552&resource_name=scw-test-pool-taints--test-pool-taints--babee4&resource_type=unknown_type
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 26
+        body: '{"total_count":0,"ips":[]}'
+        headers:
+            Content-Length:
+                - "26"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 18 Aug 2026 09:39:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - a0269b23-9262-4db7-a1dd-03689234b65a
+        status: 200 OK
+        code: 200
+        duration: 87.357093ms
+    - id: 71
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/220ee062-8e89-47b8-96d9-ebe282662eb0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1628
+        body: '{"region":"fr-par","id":"220ee062-8e89-47b8-96d9-ebe282662eb0","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-08-18T09:38:02.905614Z","updated_at":"2026-08-18T09:39:26.593396Z","type":"kapsule","name":"test-pool-taints-and-labels","description":"","status":"ready","version":"1.36.1","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"cluster_url":"https://220ee062-8e89-47b8-96d9-ebe282662eb0.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.220ee062-8e89-47b8-96d9-ebe282662eb0.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":2},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"e85f0802-5637-46d2-88c2-8ceb6767c532","commitment_ends_at":"2026-08-18T09:38:02.905622Z","acl_available":true,"iam_nodes_group_id":"586830d7-c0e2-4bcd-a605-15e937921fc5","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1628"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 18 Aug 2026 09:39:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - 394bc5d8-08ea-45b8-8a14-2c63888237f3
+        status: 200 OK
+        code: 200
+        duration: 33.980559ms
     - id: 72
       request:
         proto: HTTP/1.1
@@ -2486,29 +2465,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/43608e44-60ad-45a3-b903-1a04b08d20e0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca90b529-2fb6-4390-8277-c3cfa1113ef4
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 777
-        body: '{"region":"fr-par","id":"43608e44-60ad-45a3-b903-1a04b08d20e0","cluster_id":"90674a70-85ad-42bb-8877-9d4fe78940db","created_at":"2026-06-01T11:05:27.641937Z","updated_at":"2026-06-01T11:17:05.175075Z","name":"test-pool-taints-and-labels","status":"scaling","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{},"taints":[],"startup_taints":[]}'
+        content_length: 798
+        body: '{"region":"fr-par","id":"ca90b529-2fb6-4390-8277-c3cfa1113ef4","cluster_id":"220ee062-8e89-47b8-96d9-ebe282662eb0","created_at":"2026-08-18T09:38:08.558497Z","updated_at":"2026-08-18T09:39:33.495298Z","name":"test-pool-taints-and-labels","status":"scaling","version":"1.36.1","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{},"taints":[],"startup_taints":[],"error_message":null}'
         headers:
             Content-Length:
-                - "777"
+                - "798"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:05 GMT
+                - Tue, 18 Aug 2026 09:39:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 0d08093a-7280-442f-aa13-e055ca3e9066
+                - 80234472-e37c-4c0a-a829-9c6001343a3a
         status: 200 OK
         code: 200
-        duration: 28.611868ms
+        duration: 32.181861ms
     - id: 73
       request:
         proto: HTTP/1.1
@@ -2516,40 +2495,31 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: api.scaleway.com
-        form:
-            order_by:
-                - created_at_asc
-            page:
-                - "1"
-            pool_id:
-                - 43608e44-60ad-45a3-b903-1a04b08d20e0
-            status:
-                - unknown
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/90674a70-85ad-42bb-8877-9d4fe78940db/nodes?order_by=created_at_asc&page=1&pool_id=43608e44-60ad-45a3-b903-1a04b08d20e0&status=unknown
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/621f79dd-9a8d-48fb-80eb-8b7db805149e
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 542
-        body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"10490eba-9b6c-4005-942d-111777eff73c","cluster_id":"90674a70-85ad-42bb-8877-9d4fe78940db","created_at":"2026-06-01T11:16:56.482452Z","updated_at":"2026-06-01T11:16:59.990269Z","pool_id":"43608e44-60ad-45a3-b903-1a04b08d20e0","status":"creating","conditions":{"Creating":"True","Ready":"False"},"name":"scw-test-pool-taints--test-pool-taints--10490e","public_ip_v4":"","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/6e91f0ef-d962-402d-ba24-0ad208082096","error_message":""}]}'
+        content_length: 470
+        body: '{"id":"621f79dd-9a8d-48fb-80eb-8b7db805149e","name":"tf-vpc-hardcore-mestorf","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-08-18T09:38:01.532361Z","updated_at":"2026-08-18T09:38:01.532361Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_default":false,"private_network_count":1,"routing_enabled":true,"custom_routes_propagation_enabled":true,"transitivity_enabled":false,"s3_integration_enabled":false,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "542"
+                - "470"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:05 GMT
+                - Tue, 18 Aug 2026 09:39:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 3eac2df5-d8f0-4f14-801b-c745d532a20f
+                - 7706a713-459c-45c6-a607-cda59fbf965b
         status: 200 OK
         code: 200
-        duration: 31.088289ms
+        duration: 29.463079ms
     - id: 74
       request:
         proto: HTTP/1.1
@@ -2559,29 +2529,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/90674a70-85ad-42bb-8877-9d4fe78940db
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e85f0802-5637-46d2-88c2-8ceb6767c532
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 1628
-        body: '{"region":"fr-par","id":"90674a70-85ad-42bb-8877-9d4fe78940db","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-06-01T11:05:22.167457Z","updated_at":"2026-06-01T11:16:56.177605Z","type":"kapsule","name":"test-pool-taints-and-labels","description":"","status":"ready","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"cluster_url":"https://90674a70-85ad-42bb-8877-9d4fe78940db.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.90674a70-85ad-42bb-8877-9d4fe78940db.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":2},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"03958c89-e8ad-4344-90e1-f1d02267e843","commitment_ends_at":"2026-06-01T11:05:22.167465Z","acl_available":true,"iam_nodes_group_id":"08fab0b3-c94e-4243-93c0-d8ff43e1d01d","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        content_length: 1136
+        body: '{"id":"e85f0802-5637-46d2-88c2-8ceb6767c532","name":"test-pool-taints-and-labels","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-08-18T09:38:01.802133Z","updated_at":"2026-08-18T09:38:01.802133Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":[{"id":"b07d02f2-cb17-4f4b-a7c8-128f3dd8562d","created_at":"2026-08-18T09:38:01.802133Z","updated_at":"2026-08-18T09:38:01.802133Z","subnet":"172.16.64.0/22","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e85f0802-5637-46d2-88c2-8ceb6767c532","vpc_id":"621f79dd-9a8d-48fb-80eb-8b7db805149e","region":"fr-par"},{"id":"2c1ea306-c6c0-4637-bfcd-a88c8d860ee1","created_at":"2026-08-18T09:38:01.802133Z","updated_at":"2026-08-18T09:38:01.802133Z","subnet":"fd63:256c:45f7:a125::/64","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e85f0802-5637-46d2-88c2-8ceb6767c532","vpc_id":"621f79dd-9a8d-48fb-80eb-8b7db805149e","region":"fr-par"}],"vpc_id":"621f79dd-9a8d-48fb-80eb-8b7db805149e","dhcp_enabled":true,"default_route_propagation_enabled":false,"has_s3_integration":false,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "1628"
+                - "1136"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:05 GMT
+                - Tue, 18 Aug 2026 09:39:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - b217ee75-32cd-4c67-990c-7c2051d44a9f
+                - cb012ad4-c2cc-4a38-8dad-97cefa156eec
         status: 200 OK
         code: 200
-        duration: 20.494913ms
+        duration: 24.626731ms
     - id: 75
       request:
         proto: HTTP/1.1
@@ -2589,40 +2559,31 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: api.scaleway.com
-        form:
-            order_by:
-                - created_at_desc
-            project_id:
-                - fa1e3217-dc80-42ac-85c3-3f034b78b552
-            resource_name:
-                - scw-test-pool-taints--test-pool-taints--10490e
-            resource_type:
-                - unknown_type
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=fa1e3217-dc80-42ac-85c3-3f034b78b552&resource_name=scw-test-pool-taints--test-pool-taints--10490e&resource_type=unknown_type
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/220ee062-8e89-47b8-96d9-ebe282662eb0
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 1091
-        body: '{"total_count":2,"ips":[{"id":"541fe1fb-7f9e-4875-a455-69e1c71dafab","address":"fd63:256c:45f7:f16:930f:a821:6e71:110b/64","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_ipv6":true,"created_at":"2026-06-01T11:16:59.449732Z","updated_at":"2026-06-01T11:16:59.449732Z","source":{"subnet_id":"ed5bae7d-26b2-42b1-a42c-4cf74a572077"},"resource":{"type":"instance_private_nic","id":"6de5c600-3612-455d-9ede-3b9d8338d833","mac_address":"02:00:00:11:CF:3A","name":"scw-test-pool-taints--test-pool-taints--10490e"},"tags":[],"reverses":[],"region":"fr-par","zone":null},{"id":"66576ee5-d496-4c77-b5d9-0e84757a32be","address":"172.16.24.2/22","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_ipv6":false,"created_at":"2026-06-01T11:16:59.266750Z","updated_at":"2026-06-01T11:16:59.266750Z","source":{"subnet_id":"d9bd5591-544c-4b08-9d13-efd5a4fa044b"},"resource":{"type":"instance_private_nic","id":"6de5c600-3612-455d-9ede-3b9d8338d833","mac_address":"02:00:00:11:CF:3A","name":"scw-test-pool-taints--test-pool-taints--10490e"},"tags":[],"reverses":[],"region":"fr-par","zone":null}]}'
+        content_length: 1628
+        body: '{"region":"fr-par","id":"220ee062-8e89-47b8-96d9-ebe282662eb0","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-08-18T09:38:02.905614Z","updated_at":"2026-08-18T09:39:26.593396Z","type":"kapsule","name":"test-pool-taints-and-labels","description":"","status":"ready","version":"1.36.1","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"cluster_url":"https://220ee062-8e89-47b8-96d9-ebe282662eb0.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.220ee062-8e89-47b8-96d9-ebe282662eb0.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":2},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"e85f0802-5637-46d2-88c2-8ceb6767c532","commitment_ends_at":"2026-08-18T09:38:02.905622Z","acl_available":true,"iam_nodes_group_id":"586830d7-c0e2-4bcd-a605-15e937921fc5","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
         headers:
             Content-Length:
-                - "1091"
+                - "1628"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:05 GMT
+                - Tue, 18 Aug 2026 09:39:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 09888c5b-9fa5-4d46-bc6f-af6be382f67b
+                - e43ed286-717d-4dc5-9e76-00f98a3164fd
         status: 200 OK
         code: 200
-        duration: 29.851707ms
+        duration: 22.721954ms
     - id: 76
       request:
         proto: HTTP/1.1
@@ -2632,29 +2593,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/90674a70-85ad-42bb-8877-9d4fe78940db
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/220ee062-8e89-47b8-96d9-ebe282662eb0/kubeconfig
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 1628
-        body: '{"region":"fr-par","id":"90674a70-85ad-42bb-8877-9d4fe78940db","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-06-01T11:05:22.167457Z","updated_at":"2026-06-01T11:16:56.177605Z","type":"kapsule","name":"test-pool-taints-and-labels","description":"","status":"ready","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"cluster_url":"https://90674a70-85ad-42bb-8877-9d4fe78940db.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.90674a70-85ad-42bb-8877-9d4fe78940db.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":2},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"03958c89-e8ad-4344-90e1-f1d02267e843","commitment_ends_at":"2026-06-01T11:05:22.167465Z","acl_available":true,"iam_nodes_group_id":"08fab0b3-c94e-4243-93c0-d8ff43e1d01d","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        content_length: 1752
+        body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscyIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVUpYZWtORFFWRkhaMEYzU1VKQlowbENRVVJCUzBKblozRm9hMnBQVUZGUlJFRnFRVlpOVWsxM1JWRlpSRlpSVVVSRmQzQnlaRmRLYkdOdE5Xd0taRWRXZWsxQ05GaEVWRWt5VFVSbmVFNTZRVFZOZW1kM1RXeHZXRVJVVFRKTlJHZDRUbnBCTlUxNlozZE5iRzkzUmxSRlZFMUNSVWRCTVZWRlFYaE5Td3BoTTFacFdsaEtkVnBZVW14amVrSmFUVUpOUjBKNWNVZFRUVFE1UVdkRlIwTkRjVWRUVFRRNVFYZEZTRUV3U1VGQ1RFOVBha3cyVTNaRE5HSXlSVlZLQ25aaGVXbENiR2wzY1RCemFuWmFWMDB4YlRKUlVHOVVSMng1VGpaTVRHTnZlVkJ6VUcxSVpUWk1lVGtyY0VVclVsUlJObU5FSzB4R1Z6UmFOM3BYUkdRS1JXbEdSVFJ3WldwUmFrSkJUVUUwUjBFeFZXUkVkMFZDTDNkUlJVRjNTVU53UkVGUVFtZE9Wa2hTVFVKQlpqaEZRbFJCUkVGUlNDOU5RakJIUVRGVlpBcEVaMUZYUWtKVFdrbExiemRrYmk5a1UzWTFUV05rVkhSemMwNVVkbEJCUTFwcVFVdENaMmR4YUd0cVQxQlJVVVJCWjA1SlFVUkNSa0ZwUlVGMk1qWkxDbk5IVVRKNU5tNDNhbkJyY21OcFowbDFWSGRsZVZSUWJVVk5OV04yTjFwUVduTnJRMjFoU1VOSlJDOWFhVVV2VUhnMlRTdFNTRmMzWm1OUlpWSlFNMUlLVTJaS1NHRmhRamRYWlU5UVMyaHVWVmRSVkUwS0xTMHRMUzFGVGtRZ1EwVlNWRWxHU1VOQlZFVXRMUzB0TFFvPQogICAgc2VydmVyOiBodHRwczovLzIyMGVlMDYyLThlODktNDdiOC05NmQ5LWViZTI4MjY2MmViMC5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wtdGFpbnRzLWFuZC1sYWJlbHMKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscyIKICAgIHVzZXI6IHRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscy1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscwpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscy1hZG1pbgogIHVzZXI6CiAgICB0b2tlbjogSHdXNzVwZU0ycmFjMmZEUFhyZ2xVVmNhN0dlcFRmam5qS0ZDeHdYeE04VjFxaTdJR3oxclJ1T2E="}'
         headers:
             Content-Length:
-                - "1628"
+                - "1752"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:05 GMT
+                - Tue, 18 Aug 2026 09:39:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - fa5ff4aa-1030-443f-8813-a6867db1adf4
+                - d890b249-8d7a-488e-80ff-2cfeffe08143
         status: 200 OK
         code: 200
-        duration: 51.750327ms
+        duration: 22.796624ms
     - id: 77
       request:
         proto: HTTP/1.1
@@ -2664,190 +2625,30 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/43608e44-60ad-45a3-b903-1a04b08d20e0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca90b529-2fb6-4390-8277-c3cfa1113ef4
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 777
-        body: '{"region":"fr-par","id":"43608e44-60ad-45a3-b903-1a04b08d20e0","cluster_id":"90674a70-85ad-42bb-8877-9d4fe78940db","created_at":"2026-06-01T11:05:27.641937Z","updated_at":"2026-06-01T11:17:05.175075Z","name":"test-pool-taints-and-labels","status":"scaling","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{},"taints":[],"startup_taints":[]}'
+        content_length: 798
+        body: '{"region":"fr-par","id":"ca90b529-2fb6-4390-8277-c3cfa1113ef4","cluster_id":"220ee062-8e89-47b8-96d9-ebe282662eb0","created_at":"2026-08-18T09:38:08.558497Z","updated_at":"2026-08-18T09:39:33.495298Z","name":"test-pool-taints-and-labels","status":"scaling","version":"1.36.1","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{},"taints":[],"startup_taints":[],"error_message":null}'
         headers:
             Content-Length:
-                - "777"
+                - "798"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:05 GMT
+                - Tue, 18 Aug 2026 09:39:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - fbae06da-91c1-40e8-bcfe-ff14f946b98f
+                - 66ad0f1b-90e8-4d22-9813-6d7b6b2abcea
         status: 200 OK
         code: 200
-        duration: 27.283374ms
+        duration: 26.659619ms
     - id: 78
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/0f3756af-afff-43f7-b90c-e70492598b1b
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 413
-        body: '{"id":"0f3756af-afff-43f7-b90c-e70492598b1b","name":"tf-vpc-interesting-ritchie","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-06-01T11:05:21.038572Z","updated_at":"2026-06-01T11:05:21.038572Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_default":false,"private_network_count":1,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "413"
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 01 Jun 2026 11:17:05 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            X-Request-Id:
-                - 64fd7d46-50ad-4227-a83f-b239272ec96b
-        status: 200 OK
-        code: 200
-        duration: 26.102485ms
-    - id: 79
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/03958c89-e8ad-4344-90e1-f1d02267e843
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 1072
-        body: '{"id":"03958c89-e8ad-4344-90e1-f1d02267e843","name":"test-pool-taints-and-labels","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-06-01T11:05:21.197514Z","updated_at":"2026-06-01T11:05:21.197514Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":[{"id":"d9bd5591-544c-4b08-9d13-efd5a4fa044b","created_at":"2026-06-01T11:05:21.197514Z","updated_at":"2026-06-01T11:05:21.197514Z","subnet":"172.16.24.0/22","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"03958c89-e8ad-4344-90e1-f1d02267e843","vpc_id":"0f3756af-afff-43f7-b90c-e70492598b1b"},{"id":"ed5bae7d-26b2-42b1-a42c-4cf74a572077","created_at":"2026-06-01T11:05:21.197514Z","updated_at":"2026-06-01T11:05:21.197514Z","subnet":"fd63:256c:45f7:f16::/64","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"03958c89-e8ad-4344-90e1-f1d02267e843","vpc_id":"0f3756af-afff-43f7-b90c-e70492598b1b"}],"vpc_id":"0f3756af-afff-43f7-b90c-e70492598b1b","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "1072"
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 01 Jun 2026 11:17:05 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            X-Request-Id:
-                - f9353bf4-5b91-472f-83ad-b22b5ed2828d
-        status: 200 OK
-        code: 200
-        duration: 24.421378ms
-    - id: 80
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/90674a70-85ad-42bb-8877-9d4fe78940db
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 1628
-        body: '{"region":"fr-par","id":"90674a70-85ad-42bb-8877-9d4fe78940db","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-06-01T11:05:22.167457Z","updated_at":"2026-06-01T11:16:56.177605Z","type":"kapsule","name":"test-pool-taints-and-labels","description":"","status":"ready","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"cluster_url":"https://90674a70-85ad-42bb-8877-9d4fe78940db.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.90674a70-85ad-42bb-8877-9d4fe78940db.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":2},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"03958c89-e8ad-4344-90e1-f1d02267e843","commitment_ends_at":"2026-06-01T11:05:22.167465Z","acl_available":true,"iam_nodes_group_id":"08fab0b3-c94e-4243-93c0-d8ff43e1d01d","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
-        headers:
-            Content-Length:
-                - "1628"
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 01 Jun 2026 11:17:05 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            X-Request-Id:
-                - 304f107a-3458-499e-bbd6-668dda629f48
-        status: 200 OK
-        code: 200
-        duration: 48.42435ms
-    - id: 81
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/90674a70-85ad-42bb-8877-9d4fe78940db/kubeconfig
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 1752
-        body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscyIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVUpYZWtORFFWRkhaMEYzU1VKQlowbENRVVJCUzBKblozRm9hMnBQVUZGUlJFRnFRVlpOVWsxM1JWRlpSRlpSVVVSRmQzQnlaRmRLYkdOdE5Xd0taRWRXZWsxQ05GaEVWRWt5VFVSVmVrMVVSWGhOUkZWNVRXeHZXRVJVVFRKTlJGVjZUVlJGZUUxRVZYbE5iRzkzUmxSRlZFMUNSVWRCTVZWRlFYaE5Td3BoTTFacFdsaEtkVnBZVW14amVrSmFUVUpOUjBKNWNVZFRUVFE1UVdkRlIwTkRjVWRUVFRRNVFYZEZTRUV3U1VGQ1FWUTFWMkV2U0d0eWNtWlJWWEUzQ25kc05Fd3ZZVFozZFZCTmEzSTFVRlZ1WjFRck0waFZUMnhyUkRWQ09FUjNNMEpvT0hBeFpWWXJUbGhHTDNwMlVFZ3pTVEV3ZWxBeFF6bGFPV3Q2U2swS1RqTmhiMlZEVjJwUmFrSkJUVUUwUjBFeFZXUkVkMFZDTDNkUlJVRjNTVU53UkVGUVFtZE9Wa2hTVFVKQlpqaEZRbFJCUkVGUlNDOU5RakJIUVRGVlpBcEVaMUZYUWtKUk9VOXRWVVZHYms5RFVuWTVkMk5zVG5reWRHWktiell5YW1scVFVdENaMmR4YUd0cVQxQlJVVVJCWjA1SlFVUkNSa0ZwUVU5c2RVRndDa0ZDYmtzMVUwcDFMMlYzWkU0NFYybENWVFExVmtoa1UyRlljWFJGTVdzMlpIZEhiV3BuU1doQlRTdE1XRlVyVlRSTE9XZzJNemgzWWs5RFFUQnhTWFlLWWxsUVpITTVkV05LUjFGSVFWSlJUelJQUXprS0xTMHRMUzFGVGtRZ1EwVlNWRWxHU1VOQlZFVXRMUzB0TFFvPQogICAgc2VydmVyOiBodHRwczovLzkwNjc0YTcwLTg1YWQtNDJiYi04ODc3LTlkNGZlNzg5NDBkYi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wtdGFpbnRzLWFuZC1sYWJlbHMKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscyIKICAgIHVzZXI6IHRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscy1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscwpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC10YWludHMtYW5kLWxhYmVscy1hZG1pbgogIHVzZXI6CiAgICB0b2tlbjogdVhtQ2FlSXN6Y2JwU3dWbDcwU0FOa205RUg2RG1PMTZqMHRSbFRhU0VUTExseHpzWENkVE9LRXg="}'
-        headers:
-            Content-Length:
-                - "1752"
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 01 Jun 2026 11:17:05 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            X-Request-Id:
-                - 4bc33aa3-70ed-4b5a-a470-b1e705ad5504
-        status: 200 OK
-        code: 200
-        duration: 49.331484ms
-    - id: 82
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/43608e44-60ad-45a3-b903-1a04b08d20e0
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 777
-        body: '{"region":"fr-par","id":"43608e44-60ad-45a3-b903-1a04b08d20e0","cluster_id":"90674a70-85ad-42bb-8877-9d4fe78940db","created_at":"2026-06-01T11:05:27.641937Z","updated_at":"2026-06-01T11:17:05.175075Z","name":"test-pool-taints-and-labels","status":"scaling","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{},"taints":[],"startup_taints":[]}'
-        headers:
-            Content-Length:
-                - "777"
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 01 Jun 2026 11:17:05 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            X-Request-Id:
-                - 6fa02e19-6b9a-433c-80ff-d206102ab572
-        status: 200 OK
-        code: 200
-        duration: 23.544722ms
-    - id: 83
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2860,35 +2661,35 @@ interactions:
             page:
                 - "1"
             pool_id:
-                - 43608e44-60ad-45a3-b903-1a04b08d20e0
+                - ca90b529-2fb6-4390-8277-c3cfa1113ef4
             status:
                 - unknown
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/90674a70-85ad-42bb-8877-9d4fe78940db/nodes?order_by=created_at_asc&page=1&pool_id=43608e44-60ad-45a3-b903-1a04b08d20e0&status=unknown
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/220ee062-8e89-47b8-96d9-ebe282662eb0/nodes?order_by=created_at_asc&page=1&pool_id=ca90b529-2fb6-4390-8277-c3cfa1113ef4&status=unknown
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 542
-        body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"10490eba-9b6c-4005-942d-111777eff73c","cluster_id":"90674a70-85ad-42bb-8877-9d4fe78940db","created_at":"2026-06-01T11:16:56.482452Z","updated_at":"2026-06-01T11:16:59.990269Z","pool_id":"43608e44-60ad-45a3-b903-1a04b08d20e0","status":"creating","conditions":{"Creating":"True","Ready":"False"},"name":"scw-test-pool-taints--test-pool-taints--10490e","public_ip_v4":"","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/6e91f0ef-d962-402d-ba24-0ad208082096","error_message":""}]}'
+        content_length: 477
+        body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"babee4a8-d70b-46f2-917a-056e5c5ab3f5","cluster_id":"220ee062-8e89-47b8-96d9-ebe282662eb0","created_at":"2026-08-18T09:39:31.488524Z","updated_at":"2026-08-18T09:39:31.488524Z","pool_id":"ca90b529-2fb6-4390-8277-c3cfa1113ef4","status":"creating","conditions":{"Creating":"True","Ready":"False"},"name":"scw-test-pool-taints--test-pool-taints--babee4","public_ip_v4":"","public_ip_v6":null,"provider_id":"","error_message":""}]}'
         headers:
             Content-Length:
-                - "542"
+                - "477"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:05 GMT
+                - Tue, 18 Aug 2026 09:39:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 1412b17a-4a21-41fb-8410-2268e1258ca1
+                - 896f1988-4779-4226-af30-23bee6099d49
         status: 200 OK
         code: 200
-        duration: 25.592878ms
-    - id: 84
+        duration: 27.048055ms
+    - id: 79
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2897,30 +2698,30 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/90674a70-85ad-42bb-8877-9d4fe78940db
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/220ee062-8e89-47b8-96d9-ebe282662eb0
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 1628
-        body: '{"region":"fr-par","id":"90674a70-85ad-42bb-8877-9d4fe78940db","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-06-01T11:05:22.167457Z","updated_at":"2026-06-01T11:16:56.177605Z","type":"kapsule","name":"test-pool-taints-and-labels","description":"","status":"ready","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"cluster_url":"https://90674a70-85ad-42bb-8877-9d4fe78940db.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.90674a70-85ad-42bb-8877-9d4fe78940db.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":2},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"03958c89-e8ad-4344-90e1-f1d02267e843","commitment_ends_at":"2026-06-01T11:05:22.167465Z","acl_available":true,"iam_nodes_group_id":"08fab0b3-c94e-4243-93c0-d8ff43e1d01d","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        body: '{"region":"fr-par","id":"220ee062-8e89-47b8-96d9-ebe282662eb0","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-08-18T09:38:02.905614Z","updated_at":"2026-08-18T09:39:26.593396Z","type":"kapsule","name":"test-pool-taints-and-labels","description":"","status":"ready","version":"1.36.1","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"cluster_url":"https://220ee062-8e89-47b8-96d9-ebe282662eb0.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.220ee062-8e89-47b8-96d9-ebe282662eb0.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":2},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"e85f0802-5637-46d2-88c2-8ceb6767c532","commitment_ends_at":"2026-08-18T09:38:02.905622Z","acl_available":true,"iam_nodes_group_id":"586830d7-c0e2-4bcd-a605-15e937921fc5","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
         headers:
             Content-Length:
                 - "1628"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:06 GMT
+                - Tue, 18 Aug 2026 09:39:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 5232ec90-42de-464e-be2e-86cc093db053
+                - ff146154-ec09-4cad-a52e-c1914a57a208
         status: 200 OK
         code: 200
-        duration: 43.727639ms
-    - id: 85
+        duration: 25.554238ms
+    - id: 80
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2933,35 +2734,35 @@ interactions:
             project_id:
                 - fa1e3217-dc80-42ac-85c3-3f034b78b552
             resource_name:
-                - scw-test-pool-taints--test-pool-taints--10490e
+                - scw-test-pool-taints--test-pool-taints--babee4
             resource_type:
                 - unknown_type
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=fa1e3217-dc80-42ac-85c3-3f034b78b552&resource_name=scw-test-pool-taints--test-pool-taints--10490e&resource_type=unknown_type
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=fa1e3217-dc80-42ac-85c3-3f034b78b552&resource_name=scw-test-pool-taints--test-pool-taints--babee4&resource_type=unknown_type
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 1091
-        body: '{"total_count":2,"ips":[{"id":"541fe1fb-7f9e-4875-a455-69e1c71dafab","address":"fd63:256c:45f7:f16:930f:a821:6e71:110b/64","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_ipv6":true,"created_at":"2026-06-01T11:16:59.449732Z","updated_at":"2026-06-01T11:16:59.449732Z","source":{"subnet_id":"ed5bae7d-26b2-42b1-a42c-4cf74a572077"},"resource":{"type":"instance_private_nic","id":"6de5c600-3612-455d-9ede-3b9d8338d833","mac_address":"02:00:00:11:CF:3A","name":"scw-test-pool-taints--test-pool-taints--10490e"},"tags":[],"reverses":[],"region":"fr-par","zone":null},{"id":"66576ee5-d496-4c77-b5d9-0e84757a32be","address":"172.16.24.2/22","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_ipv6":false,"created_at":"2026-06-01T11:16:59.266750Z","updated_at":"2026-06-01T11:16:59.266750Z","source":{"subnet_id":"d9bd5591-544c-4b08-9d13-efd5a4fa044b"},"resource":{"type":"instance_private_nic","id":"6de5c600-3612-455d-9ede-3b9d8338d833","mac_address":"02:00:00:11:CF:3A","name":"scw-test-pool-taints--test-pool-taints--10490e"},"tags":[],"reverses":[],"region":"fr-par","zone":null}]}'
+        content_length: 26
+        body: '{"total_count":0,"ips":[]}'
         headers:
             Content-Length:
-                - "1091"
+                - "26"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:06 GMT
+                - Tue, 18 Aug 2026 09:39:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 50136a9d-907b-4d44-9055-fef4f9f5fa2f
+                - efb9c547-8d4a-442d-a2a6-fe17b6695c58
         status: 200 OK
         code: 200
-        duration: 27.261001ms
-    - id: 86
+        duration: 30.784193ms
+    - id: 81
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2970,30 +2771,30 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/43608e44-60ad-45a3-b903-1a04b08d20e0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca90b529-2fb6-4390-8277-c3cfa1113ef4
         method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 778
-        body: '{"region":"fr-par","id":"43608e44-60ad-45a3-b903-1a04b08d20e0","cluster_id":"90674a70-85ad-42bb-8877-9d4fe78940db","created_at":"2026-06-01T11:05:27.641937Z","updated_at":"2026-06-01T11:17:06.354581Z","name":"test-pool-taints-and-labels","status":"deleting","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{},"taints":[],"startup_taints":[]}'
+        content_length: 799
+        body: '{"region":"fr-par","id":"ca90b529-2fb6-4390-8277-c3cfa1113ef4","cluster_id":"220ee062-8e89-47b8-96d9-ebe282662eb0","created_at":"2026-08-18T09:38:08.558497Z","updated_at":"2026-08-18T09:39:34.792614Z","name":"test-pool-taints-and-labels","status":"deleting","version":"1.36.1","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{},"taints":[],"startup_taints":[],"error_message":null}'
         headers:
             Content-Length:
-                - "778"
+                - "799"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:06 GMT
+                - Tue, 18 Aug 2026 09:39:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 54ba0341-5628-4eb1-a9f7-92c4fb6ec158
+                - 3e9fd075-60b9-4d6a-95e3-f643c10d28f8
         status: 200 OK
         code: 200
-        duration: 47.79623ms
-    - id: 87
+        duration: 66.272075ms
+    - id: 82
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3002,30 +2803,30 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/43608e44-60ad-45a3-b903-1a04b08d20e0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca90b529-2fb6-4390-8277-c3cfa1113ef4
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 778
-        body: '{"region":"fr-par","id":"43608e44-60ad-45a3-b903-1a04b08d20e0","cluster_id":"90674a70-85ad-42bb-8877-9d4fe78940db","created_at":"2026-06-01T11:05:27.641937Z","updated_at":"2026-06-01T11:17:06.354581Z","name":"test-pool-taints-and-labels","status":"deleting","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{},"taints":[],"startup_taints":[]}'
+        content_length: 799
+        body: '{"region":"fr-par","id":"ca90b529-2fb6-4390-8277-c3cfa1113ef4","cluster_id":"220ee062-8e89-47b8-96d9-ebe282662eb0","created_at":"2026-08-18T09:38:08.558497Z","updated_at":"2026-08-18T09:39:34.792614Z","name":"test-pool-taints-and-labels","status":"deleting","version":"1.36.1","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{},"taints":[],"startup_taints":[],"error_message":null}'
         headers:
             Content-Length:
-                - "778"
+                - "799"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:06 GMT
+                - Tue, 18 Aug 2026 09:39:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - ac3b6acb-ea47-4a3c-b6f9-30395bc0e47b
+                - fe37055d-be45-420a-8c48-b4c87597d4c6
         status: 200 OK
         code: 200
-        duration: 19.417269ms
-    - id: 88
+        duration: 37.308201ms
+    - id: 83
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3034,30 +2835,30 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/43608e44-60ad-45a3-b903-1a04b08d20e0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca90b529-2fb6-4390-8277-c3cfa1113ef4
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 125
-        body: '{"message":"resource is not found","resource":"pool","resource_id":"43608e44-60ad-45a3-b903-1a04b08d20e0","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"pool","resource_id":"ca90b529-2fb6-4390-8277-c3cfa1113ef4","type":"not_found"}'
         headers:
             Content-Length:
                 - "125"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:51 GMT
+                - Tue, 18 Aug 2026 09:40:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 9d8c996f-ab53-4090-8921-ec398d4f0483
+                - 96cd698f-7110-423e-aad7-27a87ca7236e
         status: 404 Not Found
         code: 404
-        duration: 27.243363ms
-    - id: 89
+        duration: 29.229964ms
+    - id: 84
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3069,29 +2870,185 @@ interactions:
                 - "false"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/90674a70-85ad-42bb-8877-9d4fe78940db?with_additional_resources=false
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/220ee062-8e89-47b8-96d9-ebe282662eb0?with_additional_resources=false
         method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 1631
-        body: '{"region":"fr-par","id":"90674a70-85ad-42bb-8877-9d4fe78940db","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-06-01T11:05:22.167457Z","updated_at":"2026-06-01T11:17:51.571994Z","type":"kapsule","name":"test-pool-taints-and-labels","description":"","status":"deleting","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"cluster_url":"https://90674a70-85ad-42bb-8877-9d4fe78940db.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.90674a70-85ad-42bb-8877-9d4fe78940db.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":2},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"03958c89-e8ad-4344-90e1-f1d02267e843","commitment_ends_at":"2026-06-01T11:05:22.167465Z","acl_available":true,"iam_nodes_group_id":"08fab0b3-c94e-4243-93c0-d8ff43e1d01d","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        body: '{"region":"fr-par","id":"220ee062-8e89-47b8-96d9-ebe282662eb0","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-08-18T09:38:02.905614Z","updated_at":"2026-08-18T09:40:04.994688Z","type":"kapsule","name":"test-pool-taints-and-labels","description":"","status":"deleting","version":"1.36.1","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"cluster_url":"https://220ee062-8e89-47b8-96d9-ebe282662eb0.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.220ee062-8e89-47b8-96d9-ebe282662eb0.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":2},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"e85f0802-5637-46d2-88c2-8ceb6767c532","commitment_ends_at":"2026-08-18T09:38:02.905622Z","acl_available":true,"iam_nodes_group_id":"586830d7-c0e2-4bcd-a605-15e937921fc5","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
         headers:
             Content-Length:
                 - "1631"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:51 GMT
+                - Tue, 18 Aug 2026 09:40:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 9d8ff31f-e958-4d23-ba44-6b5e08a9343f
+                - 6f8b7b84-ded1-4117-9bf7-3394f5088af1
         status: 200 OK
         code: 200
-        duration: 128.243856ms
+        duration: 124.038315ms
+    - id: 85
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/220ee062-8e89-47b8-96d9-ebe282662eb0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1631
+        body: '{"region":"fr-par","id":"220ee062-8e89-47b8-96d9-ebe282662eb0","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-08-18T09:38:02.905614Z","updated_at":"2026-08-18T09:40:04.994688Z","type":"kapsule","name":"test-pool-taints-and-labels","description":"","status":"deleting","version":"1.36.1","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"cluster_url":"https://220ee062-8e89-47b8-96d9-ebe282662eb0.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.220ee062-8e89-47b8-96d9-ebe282662eb0.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":2},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"e85f0802-5637-46d2-88c2-8ceb6767c532","commitment_ends_at":"2026-08-18T09:38:02.905622Z","acl_available":true,"iam_nodes_group_id":"586830d7-c0e2-4bcd-a605-15e937921fc5","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1631"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 18 Aug 2026 09:40:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - 744e6804-bc56-4058-907b-b8c133df76b1
+        status: 200 OK
+        code: 200
+        duration: 67.984743ms
+    - id: 86
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/220ee062-8e89-47b8-96d9-ebe282662eb0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 128
+        body: '{"message":"resource is not found","resource":"cluster","resource_id":"220ee062-8e89-47b8-96d9-ebe282662eb0","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "128"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 18 Aug 2026 09:40:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - 31f14f25-0e06-407d-8f9f-ad72f4c94833
+        status: 404 Not Found
+        code: 404
+        duration: 25.825514ms
+    - id: 87
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e85f0802-5637-46d2-88c2-8ceb6767c532
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 18 Aug 2026 09:40:27 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - b0df6620-c2d7-459a-b980-031e5a657d0e
+        status: 204 No Content
+        code: 204
+        duration: 1.819788896s
+    - id: 88
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/621f79dd-9a8d-48fb-80eb-8b7db805149e
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 18 Aug 2026 09:40:27 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - 35ff1da1-0a43-4766-a155-44f7befe0204
+        status: 204 No Content
+        code: 204
+        duration: 502.787379ms
+    - id: 89
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca90b529-2fb6-4390-8277-c3cfa1113ef4
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 125
+        body: '{"message":"resource is not found","resource":"pool","resource_id":"ca90b529-2fb6-4390-8277-c3cfa1113ef4","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "125"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 18 Aug 2026 09:40:27 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - 3b4182c0-2b96-4511-89d2-d84abf5cc96f
+        status: 404 Not Found
+        code: 404
+        duration: 19.60121ms
     - id: 90
       request:
         proto: HTTP/1.1
@@ -3101,29 +3058,29 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/90674a70-85ad-42bb-8877-9d4fe78940db
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/220ee062-8e89-47b8-96d9-ebe282662eb0
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 1631
-        body: '{"region":"fr-par","id":"90674a70-85ad-42bb-8877-9d4fe78940db","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-06-01T11:05:22.167457Z","updated_at":"2026-06-01T11:17:51.571994Z","type":"kapsule","name":"test-pool-taints-and-labels","description":"","status":"deleting","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","taints-and-labels"],"cluster_url":"https://90674a70-85ad-42bb-8877-9d4fe78940db.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.90674a70-85ad-42bb-8877-9d4fe78940db.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":2},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"03958c89-e8ad-4344-90e1-f1d02267e843","commitment_ends_at":"2026-06-01T11:05:22.167465Z","acl_available":true,"iam_nodes_group_id":"08fab0b3-c94e-4243-93c0-d8ff43e1d01d","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        content_length: 128
+        body: '{"message":"resource is not found","resource":"cluster","resource_id":"220ee062-8e89-47b8-96d9-ebe282662eb0","type":"not_found"}'
         headers:
             Content-Length:
-                - "1631"
+                - "128"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:17:51 GMT
+                - Tue, 18 Aug 2026 09:40:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 067d9248-c479-47fe-9dcb-2d4687cf969c
-        status: 200 OK
-        code: 200
-        duration: 43.945454ms
+                - b1c78d0b-2076-46b3-b648-ad396fcd07d4
+        status: 404 Not Found
+        code: 404
+        duration: 20.833467ms
     - id: 91
       request:
         proto: HTTP/1.1
@@ -3133,182 +3090,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/90674a70-85ad-42bb-8877-9d4fe78940db
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 128
-        body: '{"message":"resource is not found","resource":"cluster","resource_id":"90674a70-85ad-42bb-8877-9d4fe78940db","type":"not_found"}'
-        headers:
-            Content-Length:
-                - "128"
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 01 Jun 2026 11:18:01 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            X-Request-Id:
-                - 747a7216-ce05-4856-913f-57a4d53508dd
-        status: 404 Not Found
-        code: 404
-        duration: 26.2683ms
-    - id: 92
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/03958c89-e8ad-4344-90e1-f1d02267e843
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 0
-        body: ""
-        headers:
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 01 Jun 2026 11:18:03 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            X-Request-Id:
-                - 7af4b4c0-1ee1-48ce-9aa3-48ea594e04ac
-        status: 204 No Content
-        code: 204
-        duration: 1.572057004s
-    - id: 93
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/0f3756af-afff-43f7-b90c-e70492598b1b
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 0
-        body: ""
-        headers:
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 01 Jun 2026 11:18:03 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            X-Request-Id:
-                - 609476ae-1d44-46d0-abc0-8117867d8d27
-        status: 204 No Content
-        code: 204
-        duration: 438.073152ms
-    - id: 94
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/43608e44-60ad-45a3-b903-1a04b08d20e0
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 125
-        body: '{"message":"resource is not found","resource":"pool","resource_id":"43608e44-60ad-45a3-b903-1a04b08d20e0","type":"not_found"}'
-        headers:
-            Content-Length:
-                - "125"
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 01 Jun 2026 11:18:03 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            X-Request-Id:
-                - a806e090-fcef-47b7-af45-ef7889204e7b
-        status: 404 Not Found
-        code: 404
-        duration: 21.644307ms
-    - id: 95
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/90674a70-85ad-42bb-8877-9d4fe78940db
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 128
-        body: '{"message":"resource is not found","resource":"cluster","resource_id":"90674a70-85ad-42bb-8877-9d4fe78940db","type":"not_found"}'
-        headers:
-            Content-Length:
-                - "128"
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 01 Jun 2026 11:18:03 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            X-Request-Id:
-                - 2a86820c-1af4-4939-b01a-25da27013496
-        status: 404 Not Found
-        code: 404
-        duration: 25.170648ms
-    - id: 96
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/03958c89-e8ad-4344-90e1-f1d02267e843
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e85f0802-5637-46d2-88c2-8ceb6767c532
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 136
-        body: '{"message":"resource is not found","resource":"private_network","resource_id":"03958c89-e8ad-4344-90e1-f1d02267e843","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"private_network","resource_id":"e85f0802-5637-46d2-88c2-8ceb6767c532","type":"not_found"}'
         headers:
             Content-Length:
                 - "136"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 01 Jun 2026 11:18:03 GMT
+                - Tue, 18 Aug 2026 09:40:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 1831d53f-56b2-4b9a-98a1-d0db7f15ad32
+                - 52ea6b4f-c3cf-47ea-9ed7-3d69ec8dcc1f
         status: 404 Not Found
         code: 404
-        duration: 28.358453ms
+        duration: 39.029065ms


### PR DESCRIPTION
Fixes #4266.

### The fix

`ResourceK8SPoolCreate` assigns `startup_taints` to `req.Taints` instead of `req.StartupTaints`, so the second block overwrites the first:

```go
	if taints, ok := d.GetOk("taints"); ok {
		req.Taints = expandCoreV1Taints(taints)
	}

	if startupTaints, ok := d.GetOk("startup_taints"); ok {
		req.Taints = expandCoreV1Taints(startupTaints)   // before
	}
```

A pool created with both blocks therefore comes up with its regular taints **gone**, and the startup taints installed as **reconciled** taints — which inverts what `startup_taints` is for, since Scaleway then re-adds them after every removal and nothing in-cluster can clear them.

`resourceK8SPoolUpdate` was already correct (`SetPoolTaints` and `SetPoolStartupTaints` are separate calls), so only create is affected, and a second `terraform apply` repairs it through the update path.

### The test

`TestAccPool_TaintsAndLabels` could not have caught this, which is worth fixing along with the bug:

* **step 1 created** the pool with `taints` only, asserting `startup_taints.# == 0`
* **step 2 updated** it to add `startup_taints`

So every `startup_taints` assertion ran against the update path — the one that works — and the create path was only ever exercised without the second block, where the offending `if` never fires.

This PR adds a `startup_taints` block to step 1 and asserts both lists after creation. On `main` that step fails (`taints.#` comes back `0`); with the fix it passes.

### Acceptance test recording

I have not re-recorded `internal/services/k8s/testdata/pool-taints-and-labels.cassette.yaml`, so that cassette no longer matches the modified step 1 and will need re-recording on your side.

I would rather not record it from here: doing so means creating a real pool whose regular taints get silently dropped, and the only project I have available is one running production workloads that rely on a dedicated-node taint. `.github/contributing/acceptance_test.md` says best-effort tests are acceptable and that you will run them, so I have followed that — happy to adjust the test shape if you would prefer a separate test function with its own cassette instead of extending this one.

### Verified

* `go build ./...`, `go vet ./internal/services/k8s/`, `gofmt` clean.
* `go test -run TestAccPool_TaintsAndLabels ./internal/services/k8s/` compiles and skips without `TF_ACC`.
* The bug was found on `v2.80.0` and reproduced by reading `main`; both carry the same line.
* `k8s.CreatePoolRequest` does have a `StartupTaints` field, so this is the intended assignment rather than a missing capability.

### Scope

Only `scaleway_k8s_pool` exposes `startup_taints` — `grep -rn 'startup_taints\|StartupTaints' internal/services/k8s/*.go` shows no other resource is affected. (My issue speculated `scaleway_k8s_cluster` might share the shape via `CreateClusterRequestPoolConfig`; it does not, and I will correct that there.)
