### PR TITLE
chore(sweep): ensure sweeper warns and continues instead of exit on error

### DIFF
--- a/internal/services/account/testfuncs/sweep.go
+++ b/internal/services/account/testfuncs/sweep.go
@@ -1,8 +1,6 @@
 package accounttestfuncs
 
 import (
-	"fmt"
-
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	accountSDK "github.com/scaleway/scaleway-sdk-go/api/account/v3"
 	"github.com/scaleway/scaleway-sdk-go/scw"
@@ -27,7 +25,9 @@ func testSweepAccountProject(_ string) error {
 
 		listProjects, err := accountAPI.ListProjects(req, scw.WithAllPages())
 		if err != nil {
-			return fmt.Errorf("failed to list projects: %w", err)
+			logging.L.Warningf("failed to list projects: %s", err)
+
+			return nil
 		}
 
 		for _, project := range listProjects.Projects {
@@ -40,7 +40,7 @@ func testSweepAccountProject(_ string) error {
 				ProjectID: project.ID,
 			})
 			if err != nil {
-				logging.L.Debugf("sweeper: failed to delete project %s: %w", project.ID, err)
+				logging.L.Debugf("sweeper: failed to delete project %s: %s", project.ID, err)
 
 				continue
 			}

--- a/internal/services/applesilicon/testfuncs/sweep.go
+++ b/internal/services/applesilicon/testfuncs/sweep.go
@@ -1,8 +1,6 @@
 package applesilicontestfuncs
 
 import (
-	"fmt"
-
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	applesiliconSDK "github.com/scaleway/scaleway-sdk-go/api/applesilicon/v1alpha1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
@@ -25,7 +23,9 @@ func testSweepAppleSiliconServer(_ string) error {
 
 		listServers, err := asAPI.ListServers(&applesiliconSDK.ListServersRequest{Zone: zone}, scw.WithAllPages())
 		if err != nil {
-			return fmt.Errorf("error listing apple silicon servers in (%s) in sweeper: %w", zone, err)
+			logging.L.Warningf("error listing apple silicon servers in (%s) in sweeper: %s", zone, err)
+
+			return nil
 		}
 
 		for _, server := range listServers.Servers {
@@ -34,7 +34,7 @@ func testSweepAppleSiliconServer(_ string) error {
 				Zone:     zone,
 			})
 			if errDelete != nil {
-				return fmt.Errorf("error deleting apple silicon server in sweeper: %w", err)
+				logging.L.Warningf("error deleting apple silicon server in sweeper: %s", err)
 			}
 		}
 

--- a/internal/services/autoscaling/testfuncs/sweep.go
+++ b/internal/services/autoscaling/testfuncs/sweep.go
@@ -1,8 +1,6 @@
 package autoscalingtestfuncs
 
 import (
-	"fmt"
-
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	autoscaling "github.com/scaleway/scaleway-sdk-go/api/autoscaling/v1alpha1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
@@ -38,7 +36,9 @@ func testSweepInstanceGroup(_ string) error {
 				Zone: zone,
 			}, scw.WithAllPages())
 		if err != nil {
-			return fmt.Errorf("error listing instancegroup in (%s) in sweeper: %w", zone, err)
+			logging.L.Warningf("error listing instancegroup in (%s) in sweeper: %s", zone, err)
+
+			return nil
 		}
 
 		for _, instanceGroup := range listInstanceGroups.InstanceGroups {
@@ -47,9 +47,7 @@ func testSweepInstanceGroup(_ string) error {
 				Zone:            zone,
 			})
 			if err != nil {
-				logging.L.Debugf("sweeper: error (%w)", err)
-
-				return fmt.Errorf("error deleting instance group in sweeper: %w", err)
+				logging.L.Warningf("error deleting instance group in sweeper: %s", err)
 			}
 		}
 
@@ -68,7 +66,9 @@ func testSweepInstanceTemplate(_ string) error {
 				Zone: zone,
 			}, scw.WithAllPages())
 		if err != nil {
-			return fmt.Errorf("error listing instance templates in (%s) in sweeper: %w", zone, err)
+			logging.L.Warningf("error listing instance templates in (%s) in sweeper: %s", zone, err)
+
+			return nil
 		}
 
 		for _, instanceTemplate := range listInstanceTemplates.InstanceTemplates {
@@ -77,9 +77,7 @@ func testSweepInstanceTemplate(_ string) error {
 				Zone:       zone,
 			})
 			if err != nil {
-				logging.L.Debugf("sweeper: error (%w)", err)
-
-				return fmt.Errorf("error deleting instance template in sweeper: %w", err)
+				logging.L.Warningf("error deleting instance template in sweeper: %s", err)
 			}
 		}
 
@@ -97,7 +95,9 @@ func testSweepInstancePolicy(_ string) error {
 			Zone: zone,
 		}, scw.WithAllPages())
 		if err != nil {
-			return fmt.Errorf("error listing instance policy in (%s) in sweeper: %w", zone, err)
+			logging.L.Warningf("error listing instance policy in (%s) in sweeper: %s", zone, err)
+
+			return nil
 		}
 
 		for _, instancePolicy := range listInstancePolicies.Policies {
@@ -106,9 +106,7 @@ func testSweepInstancePolicy(_ string) error {
 				Zone:     zone,
 			})
 			if err != nil {
-				logging.L.Debugf("sweeper: error (%w)", err)
-
-				return fmt.Errorf("error deleting instance policy in sweeper: %w", err)
+				logging.L.Warningf("error deleting instance policy in sweeper: %s", err)
 			}
 		}
 

--- a/internal/services/baremetal/testfuncs/sweep.go
+++ b/internal/services/baremetal/testfuncs/sweep.go
@@ -1,8 +1,6 @@
 package baremetaltestfuncs
 
 import (
-	"fmt"
-
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	baremetalSDK "github.com/scaleway/scaleway-sdk-go/api/baremetal/v1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
@@ -36,7 +34,7 @@ func testSweepServer(_ string) error {
 				ServerID: server.ID,
 			})
 			if err != nil {
-				return fmt.Errorf("error deleting server in sweeper: %w", err)
+				logging.L.Warningf("error deleting server in sweeper: %s", err)
 			}
 		}
 

--- a/internal/services/billing/testfuncs/sweep.go
+++ b/internal/services/billing/testfuncs/sweep.go
@@ -2,7 +2,6 @@ package billingtestfuncs
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	billingSDK "github.com/scaleway/scaleway-sdk-go/api/billing/v2"
@@ -41,7 +40,9 @@ func testSweepBillingBudget(_ string) error {
 			OrganizationID: &orgID,
 		})
 		if err != nil {
-			return fmt.Errorf("failed to list budgets: %w", err)
+			logging.L.Warningf("failed to list budgets: %s", err)
+
+			return nil
 		}
 
 		for _, budget := range listBudgets.Budgets {
@@ -49,7 +50,7 @@ func testSweepBillingBudget(_ string) error {
 				BudgetID: budget.ID,
 			})
 			if err != nil {
-				return fmt.Errorf("failed to delete budget: %w", err)
+				logging.L.Warningf("failed to delete budget: %s", err)
 			}
 		}
 
@@ -72,7 +73,9 @@ func testSweepBillingBudgetAlert(_ string) error {
 			OrganizationID: &orgID,
 		})
 		if err != nil {
-			return fmt.Errorf("failed to list budgets: %w", err)
+			logging.L.Warningf("failed to list budgets: %s", err)
+
+			return nil
 		}
 
 		for _, budget := range listBudgets.Budgets {
@@ -81,7 +84,7 @@ func testSweepBillingBudgetAlert(_ string) error {
 					BudgetAlertID: alert.ID,
 				})
 				if err != nil {
-					return fmt.Errorf("failed to delete budget alert: %w", err)
+					logging.L.Warningf("failed to delete budget alert: %s", err)
 				}
 			}
 		}
@@ -105,7 +108,9 @@ func testSweepBillingBudgetAlertNotification(_ string) error {
 			OrganizationID: &orgID,
 		})
 		if err != nil {
-			return fmt.Errorf("failed to list budgets: %w", err)
+			logging.L.Warningf("failed to list budgets: %s", err)
+
+			return nil
 		}
 
 		for _, budget := range listBudgets.Budgets {
@@ -115,7 +120,7 @@ func testSweepBillingBudgetAlertNotification(_ string) error {
 						BudgetAlertNotificationID: notification.ID,
 					})
 					if err != nil {
-						return fmt.Errorf("failed to delete budget alert notification: %w", err)
+						logging.L.Warningf("failed to delete budget alert notification: %s", err)
 					}
 				}
 			}

--- a/internal/services/block/testfuncs/sweep.go
+++ b/internal/services/block/testfuncs/sweep.go
@@ -1,8 +1,6 @@
 package blocktestfuncs
 
 import (
-	"fmt"
-
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/scaleway/scaleway-sdk-go/api/block/v1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
@@ -32,7 +30,9 @@ func testSweepBlockVolume(_ string) error {
 				Zone: zone,
 			}, scw.WithAllPages())
 		if err != nil {
-			return fmt.Errorf("error listing volume in (%s) in sweeper: %w", zone, err)
+			logging.L.Warningf("error listing volume in (%s) in sweeper: %s", zone, err)
+
+			return nil
 		}
 
 		for _, volume := range listVolumes.Volumes {
@@ -41,9 +41,7 @@ func testSweepBlockVolume(_ string) error {
 				Zone:     zone,
 			})
 			if err != nil {
-				logging.L.Debugf("sweeper: error (%s)", err)
-
-				return fmt.Errorf("error deleting volume in sweeper: %w", err)
+				logging.L.Warningf("error deleting volume in sweeper: %s", err)
 			}
 		}
 
@@ -62,7 +60,9 @@ func testSweepSnapshot(_ string) error {
 				Zone: zone,
 			}, scw.WithAllPages())
 		if err != nil {
-			return fmt.Errorf("error listing snapshot in (%s) in sweeper: %w", zone, err)
+			logging.L.Warningf("error listing snapshot in (%s) in sweeper: %s", zone, err)
+
+			return nil
 		}
 
 		for _, snapshot := range listSnapshots.Snapshots {
@@ -71,9 +71,7 @@ func testSweepSnapshot(_ string) error {
 				Zone:       zone,
 			})
 			if err != nil {
-				logging.L.Debugf("sweeper: error (%s)", err)
-
-				return fmt.Errorf("error deleting snapshot in sweeper: %w", err)
+				logging.L.Warningf("error deleting snapshot in sweeper: %s", err)
 			}
 		}
 

--- a/internal/services/cockpit/testfuncs/sweep.go
+++ b/internal/services/cockpit/testfuncs/sweep.go
@@ -57,7 +57,9 @@ func testSweepCockpitToken(_ string) error {
 					continue
 				}
 
-				return fmt.Errorf("failed to list tokens: %w", err)
+				logging.L.Warningf("failed to list tokens: %s", err)
+
+				continue
 			}
 
 			for _, token := range listTokens.Tokens {
@@ -66,7 +68,7 @@ func testSweepCockpitToken(_ string) error {
 				})
 				if err != nil {
 					if !httperrors.Is404(err) {
-						return fmt.Errorf("failed to delete token: %w", err)
+						logging.L.Warningf("failed to delete token: %s", err)
 					}
 				}
 			}
@@ -99,7 +101,9 @@ func testSweepCockpitGrafanaUser(_ string) error {
 					continue
 				}
 
-				return fmt.Errorf("failed to list grafana users: %w", err)
+				logging.L.Warningf("failed to list grafana users: %s", err)
+
+				continue
 			}
 
 			for _, grafanaUser := range listGrafanaUsers.GrafanaUsers {
@@ -109,7 +113,7 @@ func testSweepCockpitGrafanaUser(_ string) error {
 				})
 				if err != nil {
 					if !httperrors.Is404(err) {
-						return fmt.Errorf("failed to delete grafana user: %w", err)
+						logging.L.Warningf("failed to delete grafana user: %s", err)
 					}
 				}
 			}
@@ -151,7 +155,9 @@ func testSweepCockpitDataSource(_ string) error {
 			}, scw.WithAllPages())
 			if err != nil {
 				if !httperrors.Is404(err) {
-					return fmt.Errorf("failed to list sources: %w", err)
+					logging.L.Warningf("failed to list sources: %s", err)
+
+					continue
 				}
 			} else {
 				for _, datasource := range listDatasources.DataSources {
@@ -183,7 +189,7 @@ func testSweepCockpitDataSource(_ string) error {
 				})
 				if err != nil {
 					if !httperrors.Is404(err) {
-						logging.L.Warningf("sweeper: failed to delete cockpit source: %w", err)
+						logging.L.Warningf("sweeper: failed to delete cockpit source: %s", err)
 
 						continue
 					}
@@ -215,7 +221,7 @@ func testSweepCockpitAlertManager(_ string) error {
 			})
 			if err != nil {
 				if !httperrors.Is404(err) {
-					logging.L.Warningf("failed to disable alert manager on project %s: %w", project.ID, err)
+					logging.L.Warningf("failed to disable alert manager on project %s: %s", project.ID, err)
 				}
 			}
 		}

--- a/internal/services/container/testfuncs/sweep.go
+++ b/internal/services/container/testfuncs/sweep.go
@@ -1,8 +1,6 @@
 package containertestfuncs
 
 import (
-	"fmt"
-
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/scaleway/scaleway-sdk-go/api/container/v1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
@@ -37,7 +35,9 @@ func testSweepTrigger(_ string) error {
 				Region: region,
 			}, scw.WithAllPages())
 		if err != nil {
-			return fmt.Errorf("error listing trigger in (%s) in sweeper: %w", region, err)
+			logging.L.Warningf("error listing trigger in (%s) in sweeper: %s", region, err)
+
+			return nil
 		}
 
 		for _, trigger := range listTriggers.Triggers {
@@ -46,9 +46,7 @@ func testSweepTrigger(_ string) error {
 				Region:    region,
 			})
 			if err != nil {
-				logging.L.Debugf("sweeper: error (%s)", err)
-
-				return fmt.Errorf("error deleting trigger in sweeper: %w", err)
+				logging.L.Warningf("error deleting trigger in sweeper: %s", err)
 			}
 		}
 
@@ -67,7 +65,9 @@ func testSweepContainer(_ string) error {
 				Region: region,
 			}, scw.WithAllPages())
 		if err != nil {
-			return fmt.Errorf("error listing containers in (%s) in sweeper: %w", region, err)
+			logging.L.Warningf("error listing containers in (%s) in sweeper: %s", region, err)
+
+			return nil
 		}
 
 		for _, cont := range listNamespaces.Containers {
@@ -76,9 +76,7 @@ func testSweepContainer(_ string) error {
 				Region:      region,
 			})
 			if err != nil {
-				logging.L.Debugf("sweeper: error (%s)", err)
-
-				return fmt.Errorf("error deleting container in sweeper: %w", err)
+				logging.L.Warningf("error deleting container in sweeper: %s", err)
 			}
 		}
 
@@ -97,7 +95,9 @@ func testSweepNamespace(_ string) error {
 				Region: region,
 			}, scw.WithAllPages())
 		if err != nil {
-			return fmt.Errorf("error listing namespaces in (%s) in sweeper: %w", region, err)
+			logging.L.Warningf("error listing namespaces in (%s) in sweeper: %s", region, err)
+
+			return nil
 		}
 
 		for _, ns := range listNamespaces.Namespaces {
@@ -106,9 +106,7 @@ func testSweepNamespace(_ string) error {
 				Region:      region,
 			})
 			if err != nil {
-				logging.L.Debugf("sweeper: error (%s)", err)
-
-				return fmt.Errorf("error deleting namespace in sweeper: %w", err)
+				logging.L.Warningf("error deleting namespace in sweeper: %s", err)
 			}
 		}
 

--- a/internal/services/datawarehouse/testfuncs/sweep.go
+++ b/internal/services/datawarehouse/testfuncs/sweep.go
@@ -1,8 +1,6 @@
 package testfuncs
 
 import (
-	"fmt"
-
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	datawarehouseSDK "github.com/scaleway/scaleway-sdk-go/api/datawarehouse/v1beta1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
@@ -27,7 +25,9 @@ func testSweepDatawarehouseDeployment(_ string) error {
 			Region: region,
 		}, scw.WithAllPages())
 		if err != nil {
-			return fmt.Errorf("error listing datawarehouse deployments in (%s) in sweeper: %w", region, err)
+			logging.L.Warningf("error listing datawarehouse deployments in (%s) in sweeper: %s", region, err)
+
+			return nil
 		}
 
 		for _, deployment := range listDeployments.Deployments {
@@ -36,9 +36,7 @@ func testSweepDatawarehouseDeployment(_ string) error {
 				DeploymentID: deployment.ID,
 			})
 			if err != nil {
-				logging.L.Debugf("sweeper: error deleting datawarehouse deployment %s in (%s): %s", deployment.ID, region, err)
-
-				continue
+				logging.L.Warningf("error deleting datawarehouse deployment %s in (%s): %s", deployment.ID, region, err)
 			}
 		}
 

--- a/internal/services/edgeservices/testfuncs/sweep.go
+++ b/internal/services/edgeservices/testfuncs/sweep.go
@@ -1,12 +1,11 @@
 package edgeservicestestfuncs
 
 import (
-	"fmt"
-
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	edge "github.com/scaleway/scaleway-sdk-go/api/edge_services/v1beta1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/acctest"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/logging"
 )
 
 func AddTestSweepers() {
@@ -50,7 +49,9 @@ func testSweepPipeline(_ string) error {
 
 		listPipelines, err := edgeAPI.ListPipelines(&edge.ListPipelinesRequest{})
 		if err != nil {
-			return fmt.Errorf("failed to list pipelines: %w", err)
+			logging.L.Warningf("failed to list pipelines in sweeper: %s", err)
+
+			return nil
 		}
 
 		for _, pipeline := range listPipelines.Pipelines {
@@ -58,7 +59,7 @@ func testSweepPipeline(_ string) error {
 				PipelineID: pipeline.ID,
 			})
 			if err != nil {
-				return fmt.Errorf("failed to delete pipeline: %w", err)
+				logging.L.Warningf("failed to delete pipeline %s: %s", pipeline.ID, err)
 			}
 		}
 
@@ -72,7 +73,9 @@ func testSweepDNS(_ string) error {
 
 		listPipelines, err := edgeAPI.ListPipelines(&edge.ListPipelinesRequest{})
 		if err != nil {
-			return fmt.Errorf("failed to list pipelines: %w", err)
+			logging.L.Warningf("failed to list pipelines in sweeper: %s", err)
+
+			return nil
 		}
 
 		for _, pipeline := range listPipelines.Pipelines {
@@ -80,7 +83,9 @@ func testSweepDNS(_ string) error {
 				PipelineID: pipeline.ID,
 			})
 			if err != nil {
-				return fmt.Errorf("failed to list DNS stages: %w", err)
+				logging.L.Warningf("failed to list DNS stages for pipeline %s: %s", pipeline.ID, err)
+
+				continue
 			}
 
 			for _, stage := range listDNS.Stages {
@@ -88,7 +93,7 @@ func testSweepDNS(_ string) error {
 					DNSStageID: stage.ID,
 				})
 				if err != nil {
-					return fmt.Errorf("failed to delete DNS stage: %w", err)
+					logging.L.Warningf("failed to delete DNS stage %s: %s", stage.ID, err)
 				}
 			}
 		}
@@ -103,7 +108,9 @@ func testSweepTLS(_ string) error {
 
 		listPipelines, err := edgeAPI.ListPipelines(&edge.ListPipelinesRequest{})
 		if err != nil {
-			return fmt.Errorf("failed to list pipelines: %w", err)
+			logging.L.Warningf("failed to list pipelines in sweeper: %s", err)
+
+			return nil
 		}
 
 		for _, pipeline := range listPipelines.Pipelines {
@@ -111,7 +118,9 @@ func testSweepTLS(_ string) error {
 				PipelineID: pipeline.ID,
 			})
 			if err != nil {
-				return fmt.Errorf("failed to list TLS stages: %w", err)
+				logging.L.Warningf("failed to list TLS stages for pipeline %s: %s", pipeline.ID, err)
+
+				continue
 			}
 
 			for _, stage := range listTLS.Stages {
@@ -119,7 +128,7 @@ func testSweepTLS(_ string) error {
 					TLSStageID: stage.ID,
 				})
 				if err != nil {
-					return fmt.Errorf("failed to delete TLS stage: %w", err)
+					logging.L.Warningf("failed to delete TLS stage %s: %s", stage.ID, err)
 				}
 			}
 		}
@@ -134,7 +143,9 @@ func testSweepCache(_ string) error {
 
 		listPipelines, err := edgeAPI.ListPipelines(&edge.ListPipelinesRequest{})
 		if err != nil {
-			return fmt.Errorf("failed to list pipelines: %w", err)
+			logging.L.Warningf("failed to list pipelines in sweeper: %s", err)
+
+			return nil
 		}
 
 		for _, pipeline := range listPipelines.Pipelines {
@@ -142,7 +153,9 @@ func testSweepCache(_ string) error {
 				PipelineID: pipeline.ID,
 			})
 			if err != nil {
-				return fmt.Errorf("failed to list cache stages: %w", err)
+				logging.L.Warningf("failed to list cache stages for pipeline %s: %s", pipeline.ID, err)
+
+				continue
 			}
 
 			for _, stage := range listCaches.Stages {
@@ -150,7 +163,7 @@ func testSweepCache(_ string) error {
 					CacheStageID: stage.ID,
 				})
 				if err != nil {
-					return fmt.Errorf("failed to delete cache stage: %w", err)
+					logging.L.Warningf("failed to delete cache stage %s: %s", stage.ID, err)
 				}
 			}
 		}
@@ -165,7 +178,9 @@ func testSweepBackend(_ string) error {
 
 		listPipelines, err := edgeAPI.ListPipelines(&edge.ListPipelinesRequest{})
 		if err != nil {
-			return fmt.Errorf("failed to list pipelines: %w", err)
+			logging.L.Warningf("failed to list pipelines in sweeper: %s", err)
+
+			return nil
 		}
 
 		for _, pipeline := range listPipelines.Pipelines {
@@ -173,7 +188,9 @@ func testSweepBackend(_ string) error {
 				PipelineID: pipeline.ID,
 			})
 			if err != nil {
-				return fmt.Errorf("failed to list backend stage: %w", err)
+				logging.L.Warningf("failed to list backend stages for pipeline %s: %s", pipeline.ID, err)
+
+				continue
 			}
 
 			for _, stage := range listBackends.Stages {
@@ -181,7 +198,7 @@ func testSweepBackend(_ string) error {
 					BackendStageID: stage.ID,
 				})
 				if err != nil {
-					return fmt.Errorf("failed to delete backend stage: %w", err)
+					logging.L.Warningf("failed to delete backend stage %s: %s", stage.ID, err)
 				}
 			}
 		}
@@ -196,7 +213,9 @@ func testSweepPlan(_ string) error {
 
 		listPipelines, err := edgeAPI.ListPipelines(&edge.ListPipelinesRequest{})
 		if err != nil {
-			return fmt.Errorf("failed to list pipelines when deleting plan: %w", err)
+			logging.L.Warningf("failed to list pipelines when deleting plan: %s", err)
+
+			return nil
 		}
 
 		for _, pipeline := range listPipelines.Pipelines {
@@ -204,7 +223,7 @@ func testSweepPlan(_ string) error {
 				ProjectID: pipeline.ProjectID,
 			})
 			if err != nil {
-				return fmt.Errorf("failed to delete current plan: %w", err)
+				logging.L.Warningf("failed to delete current plan for project %s: %s", pipeline.ProjectID, err)
 			}
 		}
 
@@ -218,7 +237,9 @@ func testSweepWAF(_ string) error {
 
 		listPipelines, err := edgeAPI.ListPipelines(&edge.ListPipelinesRequest{})
 		if err != nil {
-			return fmt.Errorf("failed to list pipelines: %w", err)
+			logging.L.Warningf("failed to list pipelines in sweeper: %s", err)
+
+			return nil
 		}
 
 		for _, pipeline := range listPipelines.Pipelines {
@@ -226,7 +247,9 @@ func testSweepWAF(_ string) error {
 				PipelineID: pipeline.ID,
 			})
 			if err != nil {
-				return fmt.Errorf("failed to list WAF stage: %w", err)
+				logging.L.Warningf("failed to list WAF stages for pipeline %s: %s", pipeline.ID, err)
+
+				continue
 			}
 
 			for _, stage := range listWAF.Stages {
@@ -234,7 +257,7 @@ func testSweepWAF(_ string) error {
 					WafStageID: stage.ID,
 				})
 				if err != nil {
-					return fmt.Errorf("failed to delete WAF stage: %w", err)
+					logging.L.Warningf("failed to delete WAF stage %s: %s", stage.ID, err)
 				}
 			}
 		}
@@ -249,7 +272,9 @@ func testSweepRoute(_ string) error {
 
 		listPipelines, err := edgeAPI.ListPipelines(&edge.ListPipelinesRequest{})
 		if err != nil {
-			return fmt.Errorf("failed to list pipelines: %w", err)
+			logging.L.Warningf("failed to list pipelines in sweeper: %s", err)
+
+			return nil
 		}
 
 		for _, pipeline := range listPipelines.Pipelines {
@@ -257,7 +282,9 @@ func testSweepRoute(_ string) error {
 				PipelineID: pipeline.ID,
 			})
 			if err != nil {
-				return fmt.Errorf("failed to list route stage: %w", err)
+				logging.L.Warningf("failed to list route stages for pipeline %s: %s", pipeline.ID, err)
+
+				continue
 			}
 
 			for _, stage := range listRoutes.Stages {
@@ -265,7 +292,7 @@ func testSweepRoute(_ string) error {
 					RouteStageID: stage.ID,
 				})
 				if err != nil {
-					return fmt.Errorf("failed to delete route stage: %w", err)
+					logging.L.Warningf("failed to delete route stage %s: %s", stage.ID, err)
 				}
 			}
 		}

--- a/internal/services/function/testfuncs/sweep.go
+++ b/internal/services/function/testfuncs/sweep.go
@@ -1,8 +1,6 @@
 package functiontestfuncs
 
 import (
-	"fmt"
-
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	functionSDK "github.com/scaleway/scaleway-sdk-go/api/function/v1beta1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
@@ -41,7 +39,9 @@ func testSweepFunctionTrigger(_ string) error {
 				Region: region,
 			}, scw.WithAllPages())
 		if err != nil {
-			return fmt.Errorf("error listing trigger in (%s) in sweeper: %w", region, err)
+			logging.L.Warningf("error listing trigger in (%s) in sweeper: %s", region, err)
+
+			return nil
 		}
 
 		for _, trigger := range listTriggers.Triggers {
@@ -50,9 +50,7 @@ func testSweepFunctionTrigger(_ string) error {
 				Region:    region,
 			})
 			if err != nil {
-				logging.L.Debugf("sweeper: error (%s)", err)
-
-				return fmt.Errorf("error deleting trigger in sweeper: %w", err)
+				logging.L.Warningf("error deleting trigger in sweeper: %s", err)
 			}
 		}
 
@@ -71,7 +69,9 @@ func testSweepFunctionNamespace(_ string) error {
 				Region: region,
 			}, scw.WithAllPages())
 		if err != nil {
-			return fmt.Errorf("error listing namespaces in (%s) in sweeper: %w", region, err)
+			logging.L.Warningf("error listing namespaces in (%s) in sweeper: %s", region, err)
+
+			return nil
 		}
 
 		for _, ns := range listNamespaces.Namespaces {
@@ -80,9 +80,7 @@ func testSweepFunctionNamespace(_ string) error {
 				Region:      region,
 			})
 			if err != nil {
-				logging.L.Debugf("sweeper: error (%s)", err)
-
-				return fmt.Errorf("error deleting namespace in sweeper: %w", err)
+				logging.L.Warningf("error deleting namespace in sweeper: %s", err)
 			}
 		}
 
@@ -101,7 +99,9 @@ func testSweepFunction(_ string) error {
 				Region: region,
 			}, scw.WithAllPages())
 		if err != nil {
-			return fmt.Errorf("error listing functions in (%s) in sweeper: %w", region, err)
+			logging.L.Warningf("error listing functions in (%s) in sweeper: %s", region, err)
+
+			return nil
 		}
 
 		for _, f := range listFunctions.Functions {
@@ -110,9 +110,7 @@ func testSweepFunction(_ string) error {
 				Region:     region,
 			})
 			if err != nil && !httperrors.Is404(err) {
-				logging.L.Debugf("sweeper: error (%s)", err)
-
-				return fmt.Errorf("error deleting functions in sweeper: %w", err)
+				logging.L.Warningf("error deleting functions in sweeper: %s", err)
 			}
 		}
 
@@ -131,7 +129,9 @@ func testSweepFunctionCron(_ string) error {
 				Region: region,
 			}, scw.WithAllPages())
 		if err != nil {
-			return fmt.Errorf("error listing cron in (%s) in sweeper: %w", region, err)
+			logging.L.Warningf("error listing cron in (%s) in sweeper: %s", region, err)
+
+			return nil
 		}
 
 		for _, cron := range listCron.Crons {
@@ -140,9 +140,7 @@ func testSweepFunctionCron(_ string) error {
 				Region: region,
 			})
 			if err != nil {
-				logging.L.Debugf("sweeper: error (%s)", err)
-
-				return fmt.Errorf("error deleting cron in sweeper: %w", err)
+				logging.L.Warningf("error deleting cron in sweeper: %s", err)
 			}
 		}
 

--- a/internal/services/iam/testfuncs/sweep.go
+++ b/internal/services/iam/testfuncs/sweep.go
@@ -2,7 +2,6 @@ package iamtestfuncs
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	iamSDK "github.com/scaleway/scaleway-sdk-go/api/iam/v1alpha1"
@@ -60,7 +59,9 @@ func testSweepUser(_ string) error {
 			OrganizationID: &orgID,
 		})
 		if err != nil {
-			return fmt.Errorf("failed to list users: %w", err)
+			logging.L.Warningf("failed to list users: %s", err)
+
+			return nil
 		}
 
 		for _, user := range listUsers.Users {
@@ -72,7 +73,7 @@ func testSweepUser(_ string) error {
 				UserID: user.ID,
 			})
 			if err != nil {
-				return fmt.Errorf("failed to delete user: %w", err)
+				logging.L.Warningf("failed to delete user: %s", err)
 			}
 		}
 
@@ -88,7 +89,9 @@ func testSweepSSHKey(_ string) error {
 
 		listSSHKeys, err := iamAPI.ListSSHKeys(&iamSDK.ListSSHKeysRequest{}, scw.WithAllPages())
 		if err != nil {
-			return fmt.Errorf("error listing SSH keys in sweeper: %w", err)
+			logging.L.Warningf("error listing SSH keys in sweeper: %s", err)
+
+			return nil
 		}
 
 		for _, sshKey := range listSSHKeys.SSHKeys {
@@ -100,7 +103,7 @@ func testSweepSSHKey(_ string) error {
 				SSHKeyID: sshKey.ID,
 			})
 			if err != nil {
-				return fmt.Errorf("error deleting SSH key in sweeper: %w", err)
+				logging.L.Warningf("error deleting SSH key in sweeper: %s", err)
 			}
 		}
 
@@ -121,7 +124,9 @@ func testSweepIamPolicy(_ string) error {
 			OrganizationID: orgID,
 		})
 		if err != nil {
-			return fmt.Errorf("failed to list policies: %w", err)
+			logging.L.Warningf("failed to list policies: %s", err)
+
+			return nil
 		}
 
 		for _, pol := range listPols.Policies {
@@ -133,7 +138,7 @@ func testSweepIamPolicy(_ string) error {
 				PolicyID: pol.ID,
 			})
 			if err != nil {
-				return fmt.Errorf("failed to delete policy: %w", err)
+				logging.L.Warningf("failed to delete policy: %s", err)
 			}
 		}
 
@@ -154,7 +159,9 @@ func testSweepIamGroup(_ string) error {
 			OrganizationID: orgID,
 		})
 		if err != nil {
-			return fmt.Errorf("failed to list groups: %w", err)
+			logging.L.Warningf("failed to list groups: %s", err)
+
+			return nil
 		}
 
 		for _, group := range listApps.Groups {
@@ -166,7 +173,7 @@ func testSweepIamGroup(_ string) error {
 				GroupID: group.ID,
 			})
 			if err != nil {
-				return fmt.Errorf("failed to delete group: %w", err)
+				logging.L.Warningf("failed to delete group: %s", err)
 			}
 		}
 
@@ -187,7 +194,9 @@ func testSweepIamApplication(_ string) error {
 			OrganizationID: orgID,
 		})
 		if err != nil {
-			return fmt.Errorf("failed to list applications: %w", err)
+			logging.L.Warningf("failed to list applications: %s", err)
+
+			return nil
 		}
 
 		for _, app := range listApps.Applications {
@@ -199,7 +208,7 @@ func testSweepIamApplication(_ string) error {
 				ApplicationID: app.ID,
 			})
 			if err != nil {
-				return fmt.Errorf("failed to delete application: %w", err)
+				logging.L.Warningf("failed to delete application: %s", err)
 			}
 		}
 
@@ -222,7 +231,9 @@ func testSweepIamAPIKey(_ string) error {
 			OrganizationID: &orgID,
 		}, scw.WithAllPages())
 		if err != nil {
-			return fmt.Errorf("failed to list api keys: %w", err)
+			logging.L.Warningf("failed to list api keys: %s", err)
+
+			return nil
 		}
 
 		for _, key := range listAPIKeys.APIKeys {
@@ -234,7 +245,7 @@ func testSweepIamAPIKey(_ string) error {
 				AccessKey: key.AccessKey,
 			})
 			if err != nil {
-				return fmt.Errorf("failed to delete api key: %w", err)
+				logging.L.Warningf("failed to delete api key: %s", err)
 			}
 		}
 

--- a/internal/services/inference/testfuncs/sweep.go
+++ b/internal/services/inference/testfuncs/sweep.go
@@ -1,8 +1,6 @@
 package inferencetestfuncs
 
 import (
-	"fmt"
-
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/scaleway/scaleway-sdk-go/api/inference/v1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
@@ -34,7 +32,9 @@ func testSweepDeployment(_ string) error {
 				Region: region,
 			}, scw.WithAllPages())
 		if err != nil {
-			return fmt.Errorf("error listing deployment in (%s) in sweeper: %w", region, err)
+			logging.L.Warningf("error listing deployment in (%s) in sweeper: %s", region, err)
+
+			return nil
 		}
 
 		for _, deployment := range listDeployments.Deployments {
@@ -43,9 +43,7 @@ func testSweepDeployment(_ string) error {
 				Region:       region,
 			})
 			if err != nil {
-				logging.L.Debugf("sweeper: error (%s)", err)
-
-				return fmt.Errorf("error deleting deployment in sweeper: %w", err)
+				logging.L.Warningf("error deleting deployment in sweeper: %s", err)
 			}
 		}
 
@@ -63,7 +61,9 @@ func testSweepModel(_ string) error {
 			Region: region,
 		}, scw.WithAllPages())
 		if err != nil {
-			return fmt.Errorf("error listing models in (%s) in sweeper: %w", region, err)
+			logging.L.Warningf("error listing models in (%s) in sweeper: %s", region, err)
+
+			return nil
 		}
 
 		for _, model := range listModels.Models {
@@ -72,9 +72,7 @@ func testSweepModel(_ string) error {
 				ModelID: model.ID,
 			})
 			if err != nil {
-				logging.L.Debugf("sweeper: error (%s)", err)
-
-				return fmt.Errorf("error deleting model in sweeper: %w", err)
+				logging.L.Warningf("error deleting model in sweeper: %s", err)
 			}
 		}
 

--- a/internal/services/instance/testfuncs/sweep.go
+++ b/internal/services/instance/testfuncs/sweep.go
@@ -1,8 +1,6 @@
 package instancetestfuncs
 
 import (
-	"fmt"
-
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	instanceSDK "github.com/scaleway/scaleway-sdk-go/api/instance/v1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
@@ -52,7 +50,9 @@ func testSweepVolume(_ string) error {
 			Zone: zone,
 		}, scw.WithAllPages())
 		if err != nil {
-			return fmt.Errorf("error listing volumes in sweeper: %w", err)
+			logging.L.Warningf("error listing volumes in sweeper: %s", err)
+
+			return nil
 		}
 
 		for _, volume := range listVolumesResponse.Volumes {
@@ -62,7 +62,7 @@ func testSweepVolume(_ string) error {
 					VolumeID: volume.ID,
 				})
 				if err != nil {
-					return fmt.Errorf("error deleting volume in sweeper: %w", err)
+					logging.L.Warningf("error deleting volume in sweeper: %s", err)
 				}
 			}
 		}
@@ -81,7 +81,9 @@ func testSweepSnapshot(_ string) error {
 			Zone: zone,
 		}, scw.WithAllPages())
 		if err != nil {
-			return fmt.Errorf("error listing instance snapshots in sweeper: %w", err)
+			logging.L.Warningf("error listing instance snapshots in sweeper: %s", err)
+
+			return nil
 		}
 
 		for _, snapshot := range listSnapshotsResponse.Snapshots {
@@ -90,7 +92,7 @@ func testSweepSnapshot(_ string) error {
 				SnapshotID: snapshot.ID,
 			})
 			if err != nil {
-				return fmt.Errorf("error deleting instance snapshot in sweeper: %w", err)
+				logging.L.Warningf("error deleting instance snapshot in sweeper: %s", err)
 			}
 		}
 
@@ -119,7 +121,7 @@ func testSweepServer(_ string) error {
 					ServerID: srv.ID,
 				})
 				if err != nil {
-					return fmt.Errorf("error deleting server in sweeper: %w", err)
+					logging.L.Warningf("error deleting server in sweeper: %s", err)
 				}
 			case instanceSDK.ServerStateRunning:
 				_, err := instanceAPI.ServerAction(&instanceSDK.ServerActionRequest{
@@ -128,7 +130,7 @@ func testSweepServer(_ string) error {
 					Action:   instanceSDK.ServerActionTerminate,
 				})
 				if err != nil {
-					return fmt.Errorf("error terminating server in sweeper: %w", err)
+					logging.L.Warningf("error terminating server in sweeper: %s", err)
 				}
 			}
 		}
@@ -163,7 +165,7 @@ func testSweepSecurityGroup(_ string) error {
 				SecurityGroupID: securityGroup.ID,
 			})
 			if err != nil {
-				return fmt.Errorf("error deleting security groups in sweeper: %w", err)
+				logging.L.Warningf("error deleting security groups in sweeper: %s", err)
 			}
 		}
 
@@ -192,7 +194,7 @@ func testSweepPlacementGroup(_ string) error {
 				PlacementGroupID: pg.ID,
 			})
 			if err != nil {
-				return fmt.Errorf("error deleting placement group in sweeper: %w", err)
+				logging.L.Warningf("error deleting placement group in sweeper: %s", err)
 			}
 		}
 
@@ -217,7 +219,7 @@ func testSweepIP(_ string) error {
 				Zone: zone,
 			})
 			if err != nil {
-				return fmt.Errorf("error deleting ip in sweeper: %w", err)
+				logging.L.Warningf("error deleting ip in sweeper: %s", err)
 			}
 		}
 
@@ -236,7 +238,9 @@ func testSweepImage(_ string) error {
 			Public: new(false),
 		}, scw.WithAllPages())
 		if err != nil {
-			return fmt.Errorf("error listing instance images in sweeper: %w", err)
+			logging.L.Warningf("error listing instance images in sweeper: %s", err)
+
+			return nil
 		}
 
 		for _, image := range listImagesResponse.Images {
@@ -245,7 +249,7 @@ func testSweepImage(_ string) error {
 				ImageID: image.ID,
 			})
 			if err != nil {
-				return fmt.Errorf("error deleting instance image in sweeper: %w", err)
+				logging.L.Warningf("error deleting instance image in sweeper: %s", err)
 			}
 		}
 

--- a/internal/services/interlink/testfuncs/sweep.go
+++ b/internal/services/interlink/testfuncs/sweep.go
@@ -1,8 +1,6 @@
 package interlinktestfuncs
 
 import (
-	"fmt"
-
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	interlink "github.com/scaleway/scaleway-sdk-go/api/interlink/v1beta1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
@@ -33,7 +31,9 @@ func testSweepLink(_ string) error {
 			Region: region,
 		}, scw.WithAllPages())
 		if err != nil {
-			return fmt.Errorf("error listing interlink links in (%s) in sweeper: %w", region, err)
+			logging.L.Warningf("error listing interlink links in (%s) in sweeper: %s", region, err)
+
+			return nil
 		}
 
 		for _, link := range listLinks.Links {
@@ -42,7 +42,7 @@ func testSweepLink(_ string) error {
 				LinkID: link.ID,
 			})
 			if err != nil {
-				return fmt.Errorf("error deleting interlink link in sweeper: %w", err)
+				logging.L.Warningf("error deleting interlink link in sweeper: %s", err)
 			}
 		}
 
@@ -60,7 +60,9 @@ func testSweepRoutingPolicy(_ string) error {
 			Region: region,
 		}, scw.WithAllPages())
 		if err != nil {
-			return fmt.Errorf("error listing interlink routing policies in (%s) in sweeper: %w", region, err)
+			logging.L.Warningf("error listing interlink routing policies in (%s) in sweeper: %s", region, err)
+
+			return nil
 		}
 
 		for _, policy := range listPolicies.RoutingPolicies {
@@ -69,7 +71,7 @@ func testSweepRoutingPolicy(_ string) error {
 				RoutingPolicyID: policy.ID,
 			})
 			if err != nil {
-				return fmt.Errorf("error deleting interlink routing policy in sweeper: %w", err)
+				logging.L.Warningf("error deleting interlink routing policy in sweeper: %s", err)
 			}
 		}
 

--- a/internal/services/iot/testfuncs/sweep.go
+++ b/internal/services/iot/testfuncs/sweep.go
@@ -1,8 +1,6 @@
 package iottestfuncs
 
 import (
-	"fmt"
-
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	iotSDK "github.com/scaleway/scaleway-sdk-go/api/iot/v1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
@@ -25,9 +23,9 @@ func testSweepHub(_ string) error {
 
 		listHubs, err := iotAPI.ListHubs(&iotSDK.ListHubsRequest{Region: region}, scw.WithAllPages())
 		if err != nil {
-			logging.L.Debugf("sweeper: destroying the iot hub in (%s)", region)
+			logging.L.Warningf("error listing hubs in (%s) in sweeper: %s", region, err)
 
-			return fmt.Errorf("error listing hubs in (%s) in sweeper: %w", region, err)
+			return nil
 		}
 
 		deleteDevices := true
@@ -38,7 +36,7 @@ func testSweepHub(_ string) error {
 				DeleteDevices: &deleteDevices,
 			})
 			if err != nil {
-				return fmt.Errorf("error deleting hub in sweeper: %w", err)
+				logging.L.Warningf("error deleting hub in sweeper: %s", err)
 			}
 		}
 

--- a/internal/services/ipam/testfuncs/sweep.go
+++ b/internal/services/ipam/testfuncs/sweep.go
@@ -1,8 +1,6 @@
 package ipamtestfuncs
 
 import (
-	"fmt"
-
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	ipamSDK "github.com/scaleway/scaleway-sdk-go/api/ipam/v1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
@@ -25,7 +23,9 @@ func testSweepIPAMIP(_ string) error {
 
 		listIPs, err := ipamAPI.ListIPs(&ipamSDK.ListIPsRequest{Region: region}, scw.WithAllPages())
 		if err != nil {
-			return fmt.Errorf("error listing ips in (%s) in sweeper: %w", region, err)
+			logging.L.Warningf("error listing ips in (%s) in sweeper: %s", region, err)
+
+			return nil
 		}
 
 		for _, v := range listIPs.IPs {
@@ -34,9 +34,7 @@ func testSweepIPAMIP(_ string) error {
 				Region: region,
 			})
 			if err != nil {
-				logging.L.Debugf("sweeper: error (%s)", err)
-
-				return fmt.Errorf("error releasing IP in sweeper: %w", err)
+				logging.L.Warningf("error releasing IP in sweeper: %s", err)
 			}
 		}
 

--- a/internal/services/jobs/testfuncs/sweep.go
+++ b/internal/services/jobs/testfuncs/sweep.go
@@ -1,8 +1,6 @@
 package jobstestfuncs
 
 import (
-	"fmt"
-
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	jobsSDK "github.com/scaleway/scaleway-sdk-go/api/jobs/v1alpha2"
 	"github.com/scaleway/scaleway-sdk-go/scw"
@@ -28,7 +26,9 @@ func testSweepJobDefinition(_ string) error {
 				Region: region,
 			}, scw.WithAllPages())
 		if err != nil {
-			return fmt.Errorf("error listing definition in (%s) in sweeper: %w", region, err)
+			logging.L.Warningf("error listing definition in (%s) in sweeper: %s", region, err)
+
+			return nil
 		}
 
 		for _, definition := range listJobDefinitions.JobDefinitions {
@@ -37,9 +37,7 @@ func testSweepJobDefinition(_ string) error {
 				Region:          region,
 			})
 			if err != nil {
-				logging.L.Debugf("sweeper: error (%s)", err)
-
-				return fmt.Errorf("error deleting definition in sweeper: %w", err)
+				logging.L.Warningf("error deleting definition in sweeper: %s", err)
 			}
 		}
 

--- a/internal/services/k8s/testfuncs/sweep.go
+++ b/internal/services/k8s/testfuncs/sweep.go
@@ -1,8 +1,6 @@
 package k8stestfuncs
 
 import (
-	"fmt"
-
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	k8sSDK "github.com/scaleway/scaleway-sdk-go/api/k8s/v1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
@@ -25,7 +23,9 @@ func testSweepK8SCluster(_ string) error {
 
 		listClusters, err := k8sAPI.ListClusters(&k8sSDK.ListClustersRequest{Region: region}, scw.WithAllPages())
 		if err != nil {
-			return fmt.Errorf("error listing clusters in (%s) in sweeper: %w", region, err)
+			logging.L.Warningf("error listing clusters in (%s) in sweeper: %s", region, err)
+
+			return nil
 		}
 
 		for _, cluster := range listClusters.Clusters {
@@ -35,7 +35,9 @@ func testSweepK8SCluster(_ string) error {
 				ClusterID: cluster.ID,
 			}, scw.WithAllPages())
 			if err != nil {
-				return fmt.Errorf("error listing pool in (%s) in sweeper: %w", region, err)
+				logging.L.Warningf("error listing pool in (%s) in sweeper: %s", region, err)
+
+				continue
 			}
 
 			for _, pool := range listPools.Pools {
@@ -44,7 +46,7 @@ func testSweepK8SCluster(_ string) error {
 					PoolID: pool.ID,
 				})
 				if err != nil {
-					return fmt.Errorf("error deleting pool in sweeper: %w", err)
+					logging.L.Warningf("error deleting pool in sweeper: %s", err)
 				}
 			}
 
@@ -53,7 +55,7 @@ func testSweepK8SCluster(_ string) error {
 				ClusterID: cluster.ID,
 			})
 			if err != nil {
-				return fmt.Errorf("error deleting cluster in sweeper: %w", err)
+				logging.L.Warningf("error deleting cluster in sweeper: %s", err)
 			}
 		}
 

--- a/internal/services/kafka/testfuncs/sweep.go
+++ b/internal/services/kafka/testfuncs/sweep.go
@@ -1,8 +1,6 @@
 package testfuncs
 
 import (
-	"fmt"
-
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	kafkaSDK "github.com/scaleway/scaleway-sdk-go/api/kafka/v1alpha1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
@@ -28,7 +26,9 @@ func testSweepCluster(region string) error {
 			Region: region,
 		}, scw.WithAllPages())
 		if err != nil {
-			return fmt.Errorf("error listing kafka clusters in sweeper: %w", err)
+			logging.L.Warningf("error listing kafka clusters in sweeper: %s", err)
+
+			return nil
 		}
 
 		for _, cluster := range listClusters.Clusters {
@@ -37,9 +37,7 @@ func testSweepCluster(region string) error {
 				ClusterID: cluster.ID,
 			})
 			if err != nil {
-				logging.L.Debugf("sweeper: error (%s)", err)
-
-				return fmt.Errorf("error deleting kafka cluster in sweeper: %w", err)
+				logging.L.Warningf("error deleting kafka cluster in sweeper: %s", err)
 			}
 		}
 

--- a/internal/services/lb/testfuncs/sweep.go
+++ b/internal/services/lb/testfuncs/sweep.go
@@ -1,8 +1,6 @@
 package lbtestfuncs
 
 import (
-	"fmt"
-
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	lbSDK "github.com/scaleway/scaleway-sdk-go/api/lb/v1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
@@ -34,7 +32,9 @@ func testSweepLB(_ string) error {
 			Zone: zone,
 		}, scw.WithAllPages())
 		if err != nil {
-			return fmt.Errorf("error listing lbs in (%s) in sweeper: %w", zone, err)
+			logging.L.Warningf("error listing lbs in (%s) in sweeper: %s", zone, err)
+
+			return nil
 		}
 
 		for _, l := range listLBs.LBs {
@@ -51,7 +51,9 @@ func testSweepLB(_ string) error {
 				RetryInterval: &retryInterval,
 			})
 			if err != nil {
-				return fmt.Errorf("error waiting for lb in sweeper: %w", err)
+				logging.L.Warningf("error waiting for lb in sweeper: %s", err)
+
+				continue
 			}
 
 			err = lbAPI.DeleteLB(&lbSDK.ZonedAPIDeleteLBRequest{
@@ -60,7 +62,7 @@ func testSweepLB(_ string) error {
 				Zone:      zone,
 			})
 			if err != nil {
-				return fmt.Errorf("error deleting lb in sweeper: %w", err)
+				logging.L.Warningf("error deleting lb in sweeper: %s", err)
 			}
 		}
 
@@ -76,7 +78,9 @@ func testSweepIP(_ string) error {
 
 		listIPs, err := lbAPI.ListIPs(&lbSDK.ZonedAPIListIPsRequest{Zone: zone}, scw.WithAllPages())
 		if err != nil {
-			return fmt.Errorf("error listing lb ips in (%s) in sweeper: %w", zone, err)
+			logging.L.Warningf("error listing lb ips in (%s) in sweeper: %s", zone, err)
+
+			return nil
 		}
 
 		for _, ip := range listIPs.IPs {
@@ -86,7 +90,7 @@ func testSweepIP(_ string) error {
 					IPID: ip.ID,
 				})
 				if err != nil {
-					return fmt.Errorf("error deleting lb ip in sweeper: %w", err)
+					logging.L.Warningf("error deleting lb ip in sweeper: %s", err)
 				}
 			}
 		}

--- a/internal/services/mnq/testfuncs/sweep.go
+++ b/internal/services/mnq/testfuncs/sweep.go
@@ -51,7 +51,9 @@ func testSweepSQSCredentials(_ string) error {
 				return nil
 			}
 
-			return fmt.Errorf("error listing sqs credentials in (%s) in sweeper: %w", region, err)
+			logging.L.Warningf("error listing sqs credentials in (%s) in sweeper: %s", region, err)
+
+			return nil
 		}
 
 		for _, credentials := range listSqsCredentials.SqsCredentials {
@@ -66,9 +68,7 @@ func testSweepSQSCredentials(_ string) error {
 					continue
 				}
 
-				logging.L.Debugf("sweeper: error (%s)", err)
-
-				return fmt.Errorf("error deleting sqs credentials in sweeper: %w", err)
+				logging.L.Warningf("error deleting sqs credentials in sweeper: %s", err)
 			}
 		}
 
@@ -104,9 +104,7 @@ func testSweepSQS(_ string) error {
 					continue
 				}
 
-				logging.L.Debugf("sweeper: error (%s)", err)
-
-				return err
+				logging.L.Warningf("error deleting sqs in sweeper: %s", err)
 			}
 		}
 
@@ -129,7 +127,9 @@ func testSweepSNSCredentials(_ string) error {
 				return nil
 			}
 
-			return fmt.Errorf("error listing sns credentials in (%s) in sweeper: %w", region, err)
+			logging.L.Warningf("error listing sns credentials in (%s) in sweeper: %s", region, err)
+
+			return nil
 		}
 
 		for _, credentials := range listSnsCredentials.SnsCredentials {
@@ -144,9 +144,7 @@ func testSweepSNSCredentials(_ string) error {
 					continue
 				}
 
-				logging.L.Debugf("sweeper: error (%s)", err)
-
-				return fmt.Errorf("error deleting sns credentials in sweeper: %w", err)
+				logging.L.Warningf("error deleting sns credentials in sweeper: %s", err)
 			}
 		}
 
@@ -182,9 +180,7 @@ func testSweepSNS(_ string) error {
 					continue
 				}
 
-				logging.L.Debugf("sweeper: error (%s)", err)
-
-				return err
+				logging.L.Warningf("error deleting sns in sweeper: %s", err)
 			}
 		}
 
@@ -207,7 +203,9 @@ func testSweepNatsAccount(_ string) error {
 				return nil
 			}
 
-			return fmt.Errorf("error listing nats account in (%s) in sweeper: %w", region, err)
+			logging.L.Warningf("error listing nats account in (%s) in sweeper: %s", region, err)
+
+			return nil
 		}
 
 		for _, account := range listNatsAccounts.NatsAccounts {
@@ -222,9 +220,7 @@ func testSweepNatsAccount(_ string) error {
 					continue
 				}
 
-				logging.L.Debugf("sweeper: error (%s)", err)
-
-				return fmt.Errorf("error deleting nats account in sweeper: %w", err)
+				logging.L.Warningf("error deleting nats account in sweeper: %s", err)
 			}
 		}
 

--- a/internal/services/mongodb/testfuncs/sweep.go
+++ b/internal/services/mongodb/testfuncs/sweep.go
@@ -1,8 +1,6 @@
 package mongodbtestfuncs
 
 import (
-	"fmt"
-
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	mongodb "github.com/scaleway/scaleway-sdk-go/api/mongodb/v1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
@@ -29,14 +27,18 @@ func testSweepMongodbInstance(_ string) error {
 
 		extractRegion, err := zone.Region()
 		if err != nil {
-			return fmt.Errorf("error extract region in (%s) in sweeper: %w", zone, err)
+			logging.L.Warningf("error extract region in (%s) in sweeper: %s", zone, err)
+
+			return nil
 		}
 
 		listInstance, err := mongodbAPI.ListInstances(&mongodb.ListInstancesRequest{
 			Region: extractRegion,
 		})
 		if err != nil {
-			return fmt.Errorf("error listing mongodb instance in (%s) in sweeper: %w", zone, err)
+			logging.L.Warningf("error listing mongodb instance in (%s) in sweeper: %s", zone, err)
+
+			return nil
 		}
 
 		for _, instance := range listInstance.Instances {
@@ -45,7 +47,7 @@ func testSweepMongodbInstance(_ string) error {
 				InstanceID: instance.ID,
 			})
 			if err != nil {
-				logging.L.Warningf("error deleting mongodb instance %s in sweeper: %w", instance.ID, err)
+				logging.L.Warningf("error deleting mongodb instance %s in sweeper: %s", instance.ID, err)
 			}
 		}
 
@@ -61,14 +63,18 @@ func testSweepMongodbInstanceSnapshot(_ string) error {
 
 		extractRegion, err := zone.Region()
 		if err != nil {
-			return fmt.Errorf("error extract region in (%s) in sweeper: %w", zone, err)
+			logging.L.Warningf("error extract region in (%s) in sweeper: %s", zone, err)
+
+			return nil
 		}
 
 		listSnapshot, err := mongodbAPI.ListSnapshots(&mongodb.ListSnapshotsRequest{
 			Region: extractRegion,
 		})
 		if err != nil {
-			return fmt.Errorf("error listing mongodb instance snapshot in (%s) in sweeper: %w", zone, err)
+			logging.L.Warningf("error listing mongodb instance snapshot in (%s) in sweeper: %s", zone, err)
+
+			return nil
 		}
 
 		for _, snapshot := range listSnapshot.Snapshots {
@@ -77,7 +83,7 @@ func testSweepMongodbInstanceSnapshot(_ string) error {
 				SnapshotID: snapshot.ID,
 			})
 			if err != nil {
-				logging.L.Warningf("error deleting mongodb instance snapshot %s in sweeper: %w", snapshot.ID, err)
+				logging.L.Warningf("error deleting mongodb instance snapshot %s in sweeper: %s", snapshot.ID, err)
 			}
 		}
 

--- a/internal/services/object/testfuncs/sweep.go
+++ b/internal/services/object/testfuncs/sweep.go
@@ -2,7 +2,6 @@ package objecttestfuncs
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -25,12 +24,16 @@ func testSweepStorageObjectBucket(_ string) error {
 		ctx := context.Background()
 
 		if err != nil {
-			return fmt.Errorf("error getting client: %w", err)
+			logging.L.Warningf("error getting client: %s", err)
+
+			return nil
 		}
 
 		listBucketResponse, err := s3client.ListBuckets(ctx, &s3.ListBucketsInput{})
 		if err != nil {
-			return fmt.Errorf("couldn't list buckets: %w", err)
+			logging.L.Warningf("couldn't list buckets: %s", err)
+
+			return nil
 		}
 
 		for _, bucket := range listBucketResponse.Buckets {
@@ -41,7 +44,7 @@ func testSweepStorageObjectBucket(_ string) error {
 					Bucket: bucket.Name,
 				})
 				if err != nil {
-					return fmt.Errorf("error deleting bucket in Sweeper: %w", err)
+					logging.L.Warningf("error deleting bucket in Sweeper: %s", err)
 				}
 			}
 		}

--- a/internal/services/opensearch/testfuncs/sweep.go
+++ b/internal/services/opensearch/testfuncs/sweep.go
@@ -1,8 +1,6 @@
 package testfuncs
 
 import (
-	"fmt"
-
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	searchdbSDK "github.com/scaleway/scaleway-sdk-go/api/searchdb/v1alpha1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
@@ -27,7 +25,9 @@ func testSweepOpenSearchDeployment(_ string) error {
 			Region: region,
 		}, scw.WithAllPages())
 		if err != nil {
-			return fmt.Errorf("error listing opensearch deployments in (%s) in sweeper: %w", region, err)
+			logging.L.Warningf("error listing opensearch deployments in (%s) in sweeper: %s", region, err)
+
+			return nil
 		}
 
 		for _, deployment := range listDeployments.Deployments {
@@ -36,9 +36,7 @@ func testSweepOpenSearchDeployment(_ string) error {
 				DeploymentID: deployment.ID,
 			})
 			if err != nil {
-				logging.L.Debugf("sweeper: error deleting opensearch deployment %s in (%s): %s", deployment.ID, region, err)
-
-				continue
+				logging.L.Warningf("error deleting opensearch deployment %s in (%s): %s", deployment.ID, region, err)
 			}
 		}
 

--- a/internal/services/rdb/testfuncs/sweep.go
+++ b/internal/services/rdb/testfuncs/sweep.go
@@ -1,8 +1,6 @@
 package rdbtestfuncs
 
 import (
-	"fmt"
-
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	rdbSDK "github.com/scaleway/scaleway-sdk-go/api/rdb/v1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
@@ -27,7 +25,9 @@ func testSweepInstance(_ string) error {
 			Region: region,
 		}, scw.WithAllPages())
 		if err != nil {
-			return fmt.Errorf("error listing rdb instances in (%s) in sweeper: %w", region, err)
+			logging.L.Warningf("error listing rdb instances in (%s) in sweeper: %s", region, err)
+
+			return nil
 		}
 
 		for _, instance := range listInstances.Instances {
@@ -36,7 +36,7 @@ func testSweepInstance(_ string) error {
 				InstanceID: instance.ID,
 			})
 			if err != nil {
-				return fmt.Errorf("error deleting rdb instance in sweeper: %w", err)
+				logging.L.Warningf("error deleting rdb instance in sweeper: %s", err)
 			}
 		}
 

--- a/internal/services/redis/testfuncs/sweep.go
+++ b/internal/services/redis/testfuncs/sweep.go
@@ -1,8 +1,6 @@
 package redistestfuncs
 
 import (
-	"fmt"
-
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	redisSDK "github.com/scaleway/scaleway-sdk-go/api/redis/v1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
@@ -28,7 +26,9 @@ func testSweepRedisCluster(_ string) error {
 			Zone: zone,
 		}, scw.WithAllPages())
 		if err != nil {
-			return fmt.Errorf("error listing redis clusters in (%s) in sweeper: %w", zone, err)
+			logging.L.Warningf("error listing redis clusters in (%s) in sweeper: %s", zone, err)
+
+			return nil
 		}
 
 		for _, cluster := range listClusters.Clusters {
@@ -38,7 +38,7 @@ func testSweepRedisCluster(_ string) error {
 			})
 			if err != nil {
 				if !httperrors.Is404(err) {
-					logging.L.Warningf("error deleting redis cluster %s in sweeper: %w", cluster.ID, err)
+					logging.L.Warningf("error deleting redis cluster %s in sweeper: %s", cluster.ID, err)
 				}
 			}
 		}

--- a/internal/services/registry/testfuncs/sweep.go
+++ b/internal/services/registry/testfuncs/sweep.go
@@ -1,8 +1,6 @@
 package registrytestfuncs
 
 import (
-	"fmt"
-
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	registrySDK "github.com/scaleway/scaleway-sdk-go/api/registry/v1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
@@ -26,7 +24,9 @@ func testSweepNamespace(_ string) error {
 		listNamespaces, err := registryAPI.ListNamespaces(
 			&registrySDK.ListNamespacesRequest{Region: region}, scw.WithAllPages())
 		if err != nil {
-			return fmt.Errorf("error listing namespaces in (%s) in sweeper: %w", region, err)
+			logging.L.Warningf("error listing namespaces in (%s) in sweeper: %s", region, err)
+
+			return nil
 		}
 
 		for _, ns := range listNamespaces.Namespaces {
@@ -35,9 +35,7 @@ func testSweepNamespace(_ string) error {
 				Region:      region,
 			})
 			if err != nil {
-				logging.L.Debugf("sweeper: error (%s)", err)
-
-				return fmt.Errorf("error deleting namespace in sweeper: %w", err)
+				logging.L.Warningf("error deleting namespace in sweeper: %s", err)
 			}
 		}
 

--- a/internal/services/s2svpn/testfuncs/sweep.go
+++ b/internal/services/s2svpn/testfuncs/sweep.go
@@ -1,8 +1,6 @@
 package s2svpntestfuncs
 
 import (
-	"fmt"
-
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	s2s_vpn "github.com/scaleway/scaleway-sdk-go/api/s2s_vpn/v1alpha1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
@@ -45,7 +43,9 @@ func testSweepConnection(_ string) error {
 			Region: region,
 		}, scw.WithAllPages())
 		if err != nil {
-			return fmt.Errorf("error listing s2s vpn connections in (%s) in sweeper: %w", region, err)
+			logging.L.Warningf("error listing s2s vpn connections in (%s) in sweeper: %s", region, err)
+
+			return nil
 		}
 
 		for _, connection := range listConnections.Connections {
@@ -54,7 +54,7 @@ func testSweepConnection(_ string) error {
 				ConnectionID: connection.ID,
 			})
 			if err != nil {
-				return fmt.Errorf("error deleting s2s vpn connection in sweeper: %w", err)
+				logging.L.Warningf("error deleting s2s vpn connection %s: %s", connection.ID, err)
 			}
 		}
 
@@ -72,7 +72,9 @@ func testSweepVPNGateway(_ string) error {
 			Region: region,
 		}, scw.WithAllPages())
 		if err != nil {
-			return fmt.Errorf("error listing s2s vpn gateways in (%s) in sweeper: %w", region, err)
+			logging.L.Warningf("error listing s2s vpn gateways in (%s) in sweeper: %s", region, err)
+
+			return nil
 		}
 
 		for _, gateway := range listGateways.Gateways {
@@ -81,7 +83,7 @@ func testSweepVPNGateway(_ string) error {
 				GatewayID: gateway.ID,
 			})
 			if err != nil {
-				return fmt.Errorf("error deleting s2s vpn gateway in sweeper: %w", err)
+				logging.L.Warningf("error deleting s2s vpn gateway %s: %s", gateway.ID, err)
 			}
 		}
 
@@ -99,7 +101,9 @@ func testSweepCustomerGateway(_ string) error {
 			Region: region,
 		}, scw.WithAllPages())
 		if err != nil {
-			return fmt.Errorf("error listing s2s vpn customer gateways in (%s) in sweeper: %w", region, err)
+			logging.L.Warningf("error listing s2s vpn customer gateways in (%s) in sweeper: %s", region, err)
+
+			return nil
 		}
 
 		for _, gateway := range listGateways.Gateways {
@@ -108,7 +112,7 @@ func testSweepCustomerGateway(_ string) error {
 				GatewayID: gateway.ID,
 			})
 			if err != nil {
-				return fmt.Errorf("error deleting s2s vpn customer gateway in sweeper: %w", err)
+				logging.L.Warningf("error deleting s2s vpn customer gateway %s: %s", gateway.ID, err)
 			}
 		}
 
@@ -126,7 +130,9 @@ func testSweepRoutingPolicy(_ string) error {
 			Region: region,
 		}, scw.WithAllPages())
 		if err != nil {
-			return fmt.Errorf("error listing s2s vpn routing policies in (%s) in sweeper: %w", region, err)
+			logging.L.Warningf("error listing s2s vpn routing policies in (%s) in sweeper: %s", region, err)
+
+			return nil
 		}
 
 		for _, policy := range listPolicies.RoutingPolicies {
@@ -135,7 +141,7 @@ func testSweepRoutingPolicy(_ string) error {
 				RoutingPolicyID: policy.ID,
 			})
 			if err != nil {
-				return fmt.Errorf("error deleting s2s vpn routing policy in sweeper: %w", err)
+				logging.L.Warningf("error deleting s2s vpn routing policy %s: %s", policy.ID, err)
 			}
 		}
 

--- a/internal/services/sdb/testfuncs/sweep.go
+++ b/internal/services/sdb/testfuncs/sweep.go
@@ -1,8 +1,6 @@
 package sdbtestfuncs
 
 import (
-	"fmt"
-
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	sdbSDK "github.com/scaleway/scaleway-sdk-go/api/serverless_sqldb/v1alpha1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
@@ -28,7 +26,9 @@ func testSweepServerlessSQLDBDatabase(_ string) error {
 				Region: region,
 			}, scw.WithAllPages())
 		if err != nil {
-			return fmt.Errorf("error listing database in (%s) in sweeper: %w", region, err)
+			logging.L.Warningf("error listing database in (%s) in sweeper: %s", region, err)
+
+			return nil
 		}
 
 		for _, database := range listServerlessSQLDBDatabases.Databases {
@@ -37,9 +37,7 @@ func testSweepServerlessSQLDBDatabase(_ string) error {
 				Region:     region,
 			})
 			if err != nil {
-				logging.L.Debugf("sweeper: error (%s)", err)
-
-				return fmt.Errorf("error deleting database in sweeper: %w", err)
+				logging.L.Warningf("error deleting database in sweeper: %s", err)
 			}
 		}
 

--- a/internal/services/secret/testfuncs/sweep.go
+++ b/internal/services/secret/testfuncs/sweep.go
@@ -1,8 +1,6 @@
 package secrettestfuncs
 
 import (
-	"fmt"
-
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	secretSDK "github.com/scaleway/scaleway-sdk-go/api/secret/v1beta1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
@@ -33,7 +31,9 @@ func testSweepSecret(_ string) error {
 			ProjectID: projectID,
 		}, scw.WithAllPages())
 		if err != nil {
-			return fmt.Errorf("error listing secrets in (%s) in sweeper: %w", region, err)
+			logging.L.Warningf("error listing secrets in (%s) in sweeper: %s", region, err)
+
+			return nil
 		}
 
 		for _, se := range listSecrets.Secrets {
@@ -42,9 +42,7 @@ func testSweepSecret(_ string) error {
 				Region:   region,
 			})
 			if err != nil {
-				logging.L.Debugf("sweeper: error (%s)", err)
-
-				return fmt.Errorf("error deleting secret in sweeper: %w", err)
+				logging.L.Warningf("error deleting secret in sweeper: %s", err)
 			}
 		}
 

--- a/internal/services/tem/testfuncs/sweep.go
+++ b/internal/services/tem/testfuncs/sweep.go
@@ -1,8 +1,6 @@
 package temtestfuncs
 
 import (
-	"fmt"
-
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	temSDK "github.com/scaleway/scaleway-sdk-go/api/tem/v1alpha1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
@@ -25,7 +23,9 @@ func testSweepDomain(_ string) error {
 
 		listDomains, err := temAPI.ListDomains(&temSDK.ListDomainsRequest{Region: region}, scw.WithAllPages())
 		if err != nil {
-			return fmt.Errorf("error listing domains in (%s) in sweeper: %w", region, err)
+			logging.L.Warningf("error listing domains in (%s) in sweeper: %s", region, err)
+
+			return nil
 		}
 
 		for _, ns := range listDomains.Domains {
@@ -40,9 +40,7 @@ func testSweepDomain(_ string) error {
 				Region:   region,
 			})
 			if err != nil {
-				logging.L.Debugf("sweeper: error (%s)", err)
-
-				return fmt.Errorf("error revoking domain in sweeper: %w", err)
+				logging.L.Warningf("error revoking domain in sweeper: %s", err)
 			}
 		}
 

--- a/internal/services/vpc/testfuncs/sweep.go
+++ b/internal/services/vpc/testfuncs/sweep.go
@@ -1,8 +1,6 @@
 package vpctestfuncs
 
 import (
-	"fmt"
-
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	vpcSDK "github.com/scaleway/scaleway-sdk-go/api/vpc/v2"
 	"github.com/scaleway/scaleway-sdk-go/scw"
@@ -47,7 +45,9 @@ func testSweepVPC(_ string) error {
 
 		listVPCs, err := vpcAPI.ListVPCs(&vpcSDK.ListVPCsRequest{Region: region}, scw.WithAllPages())
 		if err != nil {
-			return fmt.Errorf("error listing VPCs in (%s) in sweeper: %w", region, err)
+			logging.L.Warningf("error listing VPCs in (%s) in sweeper: %s", region, err)
+
+			return nil
 		}
 
 		for _, v := range listVPCs.Vpcs {
@@ -60,7 +60,7 @@ func testSweepVPC(_ string) error {
 				Region: region,
 			})
 			if err != nil {
-				logging.L.Warningf("error deleting VPC %s in sweeper: %w", v.ID, err)
+				logging.L.Warningf("error deleting VPC %s in sweeper: %s", v.ID, err)
 			}
 		}
 
@@ -78,7 +78,9 @@ func testSweepVPCPrivateNetwork(_ string) error {
 			Region: region,
 		}, scw.WithAllPages())
 		if err != nil {
-			return fmt.Errorf("error listing private network in sweeper: %w", err)
+			logging.L.Warningf("error listing private network in sweeper: %s", err)
+
+			return nil
 		}
 
 		for _, pn := range listPNResponse.PrivateNetworks {
@@ -87,7 +89,7 @@ func testSweepVPCPrivateNetwork(_ string) error {
 				PrivateNetworkID: pn.ID,
 			})
 			if err != nil {
-				logging.L.Warningf("error deleting private network %s in sweeper: %w", pn.ID, err)
+				logging.L.Warningf("error deleting private network %s in sweeper: %s", pn.ID, err)
 			}
 		}
 
@@ -110,7 +112,9 @@ func testSweepVPCConnector(_ string) error {
 			Region: region,
 		}, scw.WithAllPages())
 		if err != nil {
-			return fmt.Errorf("error listing VPC connectors in (%s) in sweeper: %w", region, err)
+			logging.L.Warningf("error listing VPC connectors in (%s) in sweeper: %s", region, err)
+
+			return nil
 		}
 
 		for _, c := range listConnectors.VpcConnectors {
@@ -119,7 +123,7 @@ func testSweepVPCConnector(_ string) error {
 				Region:         region,
 			})
 			if err != nil {
-				logging.L.Warningf("error deleting VPC connector %s in sweeper: %w", c.ID, err)
+				logging.L.Warningf("error deleting VPC connector %s in sweeper: %s", c.ID, err)
 			}
 		}
 
@@ -137,7 +141,9 @@ func testSweepVPCIngressRule(_ string) error {
 			Region: region,
 		}, scw.WithAllPages())
 		if err != nil {
-			return fmt.Errorf("error listing VPC ingress rules in (%s) in sweeper: %w", region, err)
+			logging.L.Warningf("error listing VPC ingress rules in (%s) in sweeper: %s", region, err)
+
+			return nil
 		}
 
 		for _, rule := range listRules.Rules {
@@ -146,7 +152,7 @@ func testSweepVPCIngressRule(_ string) error {
 				Region: region,
 			})
 			if err != nil {
-				logging.L.Warningf("error deleting VPC ingress rule %s in sweeper: %w", rule.ID, err)
+				logging.L.Warningf("error deleting VPC ingress rule %s in sweeper: %s", rule.ID, err)
 			}
 		}
 
@@ -165,7 +171,9 @@ func testSweepVPCRoute(_ string) error {
 			Region: region,
 		}, scw.WithAllPages())
 		if err != nil {
-			return fmt.Errorf("error listing route in sweeper: %w", err)
+			logging.L.Warningf("error listing route in sweeper: %s", err)
+
+			return nil
 		}
 
 		for _, routeWithNexthop := range listRoutesResponse.Routes {
@@ -175,7 +183,7 @@ func testSweepVPCRoute(_ string) error {
 					RouteID: routeWithNexthop.Route.ID,
 				})
 				if err != nil {
-					logging.L.Warningf("error deleting route %s in sweeper: %w", routeWithNexthop.Route.ID, err)
+					logging.L.Warningf("error deleting route %s in sweeper: %s", routeWithNexthop.Route.ID, err)
 				}
 			} else {
 				logging.L.Warningf("route %s is nil in RouteWithNexthop: %v", routeWithNexthop.Route.ID, routeWithNexthop)

--- a/internal/services/vpcgw/testfuncs/sweep.go
+++ b/internal/services/vpcgw/testfuncs/sweep.go
@@ -1,8 +1,6 @@
 package vpcgwtestfuncs
 
 import (
-	"fmt"
-
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	v2 "github.com/scaleway/scaleway-sdk-go/api/vpcgw/v2"
 	"github.com/scaleway/scaleway-sdk-go/scw"
@@ -35,7 +33,9 @@ func testSweepVPCPublicGateway(_ string) error {
 			Zone: zone,
 		}, scw.WithAllPages())
 		if err != nil {
-			return fmt.Errorf("error listing public gateway in sweeper: %w", err)
+			logging.L.Warningf("error listing public gateway in sweeper: %s", err)
+
+			return nil
 		}
 
 		for _, gateway := range listGatewayResponse.Gateways {
@@ -44,7 +44,7 @@ func testSweepVPCPublicGateway(_ string) error {
 				GatewayID: gateway.ID,
 			})
 			if err != nil {
-				return fmt.Errorf("error deleting public gateway in sweeper: %w", err)
+				logging.L.Warningf("error deleting public gateway %s: %s", gateway.ID, err)
 			}
 		}
 
@@ -62,16 +62,18 @@ func testSweepVPCGatewayNetwork(_ string) error {
 			Zone: zone,
 		}, scw.WithAllPages())
 		if err != nil {
-			return fmt.Errorf("error listing gateway network in sweeper: %w", err)
+			logging.L.Warningf("error listing gateway network in sweeper: %s", err)
+
+			return nil
 		}
 
 		for _, gn := range listPNResponse.GatewayNetworks {
 			_, err := api.DeleteGatewayNetwork(&v2.DeleteGatewayNetworkRequest{
-				GatewayNetworkID: gn.GatewayID,
+				GatewayNetworkID: gn.ID,
 				Zone:             zone,
 			})
 			if err != nil {
-				return fmt.Errorf("error deleting gateway network in sweeper: %w", err)
+				logging.L.Warningf("error deleting gateway network %s: %s", gn.ID, err)
 			}
 		}
 
@@ -89,7 +91,9 @@ func testSweepVPCPublicGatewayIP(_ string) error {
 			Zone: zone,
 		}, scw.WithAllPages())
 		if err != nil {
-			return fmt.Errorf("error listing public gateway ip in sweeper: %w", err)
+			logging.L.Warningf("error listing public gateway ip in sweeper: %s", err)
+
+			return nil
 		}
 
 		for _, ip := range listIPResponse.IPs {
@@ -98,7 +102,7 @@ func testSweepVPCPublicGatewayIP(_ string) error {
 				IPID: ip.ID,
 			})
 			if err != nil {
-				return fmt.Errorf("error deleting public gateway ip in sweeper: %w", err)
+				logging.L.Warningf("error deleting public gateway ip %s: %s", ip.ID, err)
 			}
 		}
 

--- a/internal/services/webhosting/testfuncs/sweep.go
+++ b/internal/services/webhosting/testfuncs/sweep.go
@@ -1,8 +1,6 @@
 package webhostingtestfuncs
 
 import (
-	"fmt"
-
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	webhostingSDK "github.com/scaleway/scaleway-sdk-go/api/webhosting/v1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
@@ -25,7 +23,9 @@ func testSweepWebhosting(_ string) error {
 
 		listHostings, err := webhsotingAPI.ListHostings(&webhostingSDK.HostingAPIListHostingsRequest{Region: region}, scw.WithAllPages())
 		if err != nil {
-			return fmt.Errorf("error listing hostings in (%s) in sweeper: %w", region, err)
+			logging.L.Warningf("error listing hostings in (%s) in sweeper: %s", region, err)
+
+			return nil
 		}
 
 		for _, hosting := range listHostings.Hostings {
@@ -34,9 +34,7 @@ func testSweepWebhosting(_ string) error {
 				Region:    region,
 			})
 			if err != nil {
-				logging.L.Debugf("sweeper: error (%s)", err)
-
-				return fmt.Errorf("error deleting hosting in sweeper: %w", err)
+				logging.L.Warningf("error deleting hosting in sweeper: %s", err)
 			}
 		}
 


### PR DESCRIPTION
Currently some sweepers exit on error, which means the sweeper can be interrupted by just a failed sweep. In order to maximize resources cleanup, this PR aims at making the sweeper more resilient (warn on error without interrupting the whole process).