### PR TITLE
chore(interlink): update test pop names

### DIFF
--- a/internal/services/interlink/link_data_source_test.go
+++ b/internal/services/interlink/link_data_source_test.go
@@ -18,7 +18,7 @@ func TestAccDataSourceInterlinkLink_Basic(t *testing.T) {
 			{
 				Config: `
 					data "scaleway_interlink_pop" "pop" {
-						name   = "Telehouse TH2"
+						name   = "TeleHouse TH2"
 						region = "fr-par"
 					}
 
@@ -39,7 +39,7 @@ func TestAccDataSourceInterlinkLink_Basic(t *testing.T) {
 			{
 				Config: `
 					data "scaleway_interlink_pop" "pop" {
-						name   = "Telehouse TH2"
+						name   = "TeleHouse TH2"
 						region = "fr-par"
 					}
 

--- a/internal/services/interlink/link_test.go
+++ b/internal/services/interlink/link_test.go
@@ -23,7 +23,7 @@ func TestAccInterlinkLink_Basic(t *testing.T) {
 			{
 				Config: `
 					data "scaleway_interlink_pop" "pop" {
-						name   = "Telehouse TH2"
+						name   = "TeleHouse TH2"
 						region = "fr-par"
 					}
 
@@ -61,7 +61,7 @@ func TestAccInterlinkLink_Basic(t *testing.T) {
 			{
 				Config: `
 					data "scaleway_interlink_pop" "pop" {
-						name   = "Telehouse TH2"
+						name   = "TeleHouse TH2"
 						region = "fr-par"
 					}
 
@@ -106,7 +106,7 @@ func TestAccInterlinkLink_WithVPC(t *testing.T) {
 			{
 				Config: `
 					data "scaleway_interlink_pop" "pop" {
-						name   = "Telehouse TH2"
+						name   = "TeleHouse TH2"
 						region = "fr-par"
 					}
 
@@ -136,7 +136,7 @@ func TestAccInterlinkLink_WithVPC(t *testing.T) {
 			{
 				Config: `
 					data "scaleway_interlink_pop" "pop" {
-						name   = "Telehouse TH2"
+						name   = "TeleHouse TH2"
 						region = "fr-par"
 					}
 
@@ -169,7 +169,7 @@ func TestAccInterlinkLink_WithVPC(t *testing.T) {
 			{
 				Config: `
 					data "scaleway_interlink_pop" "pop" {
-						name   = "Telehouse TH2"
+						name   = "TeleHouse TH2"
 						region = "fr-par"
 					}
 
@@ -218,7 +218,7 @@ func TestAccInterlinkLink_RoutePropagation(t *testing.T) {
 			{
 				Config: `
 					data "scaleway_interlink_pop" "pop" {
-						name   = "Telehouse TH2"
+						name   = "TeleHouse TH2"
 						region = "fr-par"
 					}
 
@@ -243,7 +243,7 @@ func TestAccInterlinkLink_RoutePropagation(t *testing.T) {
 			{
 				Config: `
 					data "scaleway_interlink_pop" "pop" {
-						name   = "Telehouse TH2"
+						name   = "TeleHouse TH2"
 						region = "fr-par"
 					}
 

--- a/internal/services/interlink/pop_data_source_test.go
+++ b/internal/services/interlink/pop_data_source_test.go
@@ -17,15 +17,15 @@ func TestAccDataSourceInterlinkPop_ByName(t *testing.T) {
 			{
 				Config: `
 					data "scaleway_interlink_pop" "by_name" {
-					  name   = "DC2"
+					  name   = "TeleHouse TH2"
 					  region = "fr-par"
 					}
 				`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.scaleway_interlink_pop.by_name", "id"),
-					resource.TestCheckResourceAttr("data.scaleway_interlink_pop.by_name", "name", "DC2"),
-					resource.TestCheckResourceAttr("data.scaleway_interlink_pop.by_name", "hosting_provider_name", "OpCore"),
-					resource.TestCheckResourceAttr("data.scaleway_interlink_pop.by_name", "city", "Vitry-sur-Seine"),
+					resource.TestCheckResourceAttr("data.scaleway_interlink_pop.by_name", "name", "TeleHouse TH2"),
+					resource.TestCheckResourceAttr("data.scaleway_interlink_pop.by_name", "hosting_provider_name", "TeleHouse"),
+					resource.TestCheckResourceAttr("data.scaleway_interlink_pop.by_name", "city", "Paris"),
 				),
 			},
 		},
@@ -42,7 +42,7 @@ func TestAccDataSourceInterlinkPop_ByID(t *testing.T) {
 			{
 				Config: `
 					data "scaleway_interlink_pop" "by_name" {
-					  name   = "DC2"
+					  name   = "TeleHouse TH2"
 					  region = "fr-par"
 					}
 

--- a/internal/services/interlink/testdata/data-source-interlink-link-basic.cassette.yaml
+++ b/internal/services/interlink/testdata/data-source-interlink-link-basic.cassette.yaml
@@ -16,7 +16,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
         method: GET
       response:
@@ -25,20 +25,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 708
+        content_length: 1158
         uncompressed: false
-        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","updated_at":"2024-11-28T08:45:33.852946Z"}],"total_count":2}'
+        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","l3_connectivity":true,"logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","region":"","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","l3_connectivity":true,"logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","region":"","updated_at":"2024-11-28T08:45:33.852946Z"},{"contact_email":"contact.experience-client@linkt.fr","created_at":"2026-04-21T14:31:08.285733Z","id":"4e0dcaaf-467c-432c-ad93-f28be5878df0","l3_connectivity":true,"logo_url":"https://www.linkt.fr/wp-content/themes/linkt/assets/img/svg/logo-linkt-sticky.svg","name":"Linkt","portal_url":"https://www.linkt.fr/","region":"","updated_at":"2026-07-07T11:57:51.706396Z"}],"total_count":3}'
         headers:
             Content-Length:
-                - "708"
+                - "1158"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 14:54:50 GMT
+                - Mon, 24 Aug 2026 12:13:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -46,10 +46,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 218f5c94-b3a1-4b56-8a9a-00467de3701f
+                - 4cafe786-8df3-4b08-8163-e82e98504720
         status: 200 OK
         code: 200
-        duration: 185.888875ms
+        duration: 147.517309ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -65,8 +65,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=Telehouse+TH2&order_by=name_asc&page=1
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=TeleHouse+TH2&order_by=name_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -74,20 +74,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 431
+        content_length: 429
         uncompressed: false
-        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"- Telehouse TH2","region":"fr-par"}],"total_count":1}'
+        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"TeleHouse TH2","region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
-                - "431"
+                - "429"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 14:54:50 GMT
+                - Mon, 24 Aug 2026 12:13:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -95,50 +95,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b86e2ffb-9a2b-4b86-b381-77eb967c46e3
+                - 31523b74-37e8-4d3d-801c-50b69993d730
         status: 200 OK
         code: 200
-        duration: 191.15525ms
+        duration: 155.372755ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 218
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","name":"tf-test-interlink-link-ds","tags":[],"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","bandwidth_mbps":50,"partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links
-        method: POST
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/metadata
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 874
+        content_length: 59
         uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-15T14:54:50.645839Z","enable_route_propagation":false,"id":"9d547df7-29cd-41a8-9666-501cb4dfe793","name":"tf-test-interlink-link-ds","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"ec9aaab0-1761-4121-8625-4862235ff7b8","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.95/31","ipv6":"2001:1bc8:3812:fc60:fb98:99e8:1a74:6d01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.94/31","ipv6":"2001:1bc8:3812:fc60:fb98:99e8:1a74:6d00/127"},"status":"requested","tags":[],"updated_at":"2026-04-15T14:54:50.645839Z","vlan":2063}'
+        body: '{"domain":"scw.eu","partition":"scw","platform":"external"}'
         headers:
             Content-Length:
-                - "874"
+                - "59"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 14:54:50 GMT
+                - Mon, 24 Aug 2026 12:13:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +144,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f25155c5-2c9e-4cbb-aef9-5b08dc6dcbb7
+                - 14fb13c8-528a-4fc8-9ab7-6d00d50c6ee4
         status: 200 OK
         code: 200
-        duration: 453.561209ms
+        duration: 27.748746ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -165,8 +163,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/9d547df7-29cd-41a8-9666-501cb4dfe793
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/metadata
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,20 +172,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 874
+        content_length: 59
         uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-15T14:54:50.645839Z","enable_route_propagation":false,"id":"9d547df7-29cd-41a8-9666-501cb4dfe793","name":"tf-test-interlink-link-ds","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"ec9aaab0-1761-4121-8625-4862235ff7b8","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.95/31","ipv6":"2001:1bc8:3812:fc60:fb98:99e8:1a74:6d01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.94/31","ipv6":"2001:1bc8:3812:fc60:fb98:99e8:1a74:6d00/127"},"status":"requested","tags":[],"updated_at":"2026-04-15T14:54:50.645839Z","vlan":2063}'
+        body: '{"domain":"scw.eu","partition":"scw","platform":"external"}'
         headers:
             Content-Length:
-                - "874"
+                - "59"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 14:54:50 GMT
+                - Mon, 24 Aug 2026 12:13:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,48 +193,50 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 96ba903a-1317-422b-bcbb-a8d26a29bcdb
+                - 79bfd9c9-2468-400c-9c81-df0cc0756066
         status: 200 OK
         code: 200
-        duration: 45.696833ms
+        duration: 22.547015ms
     - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 218
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-interlink-link-ds","tags":[],"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","bandwidth_mbps":50,"partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/9d547df7-29cd-41a8-9666-501cb4dfe793
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 874
+        content_length: 898
         uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-15T14:54:50.645839Z","enable_route_propagation":false,"id":"9d547df7-29cd-41a8-9666-501cb4dfe793","name":"tf-test-interlink-link-ds","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"ec9aaab0-1761-4121-8625-4862235ff7b8","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.95/31","ipv6":"2001:1bc8:3812:fc60:fb98:99e8:1a74:6d01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.94/31","ipv6":"2001:1bc8:3812:fc60:fb98:99e8:1a74:6d00/127"},"status":"requested","tags":[],"updated_at":"2026-04-15T14:54:50.645839Z","vlan":2063}'
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.362904Z","enable_route_propagation":false,"id":"a3f9f822-ac57-4983-924c-a252c6ea73ad","name":"tf-test-interlink-link-ds","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"4df8ef47-86b0-460e-ac1b-825e6291b120","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.79/31","ipv6":"2001:1bc8:3812:fc60:751e:8e27:32b4:a601/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.78/31","ipv6":"2001:1bc8:3812:fc60:751e:8e27:32b4:a600/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:39.362904Z","vlan":3116}'
         headers:
             Content-Length:
-                - "874"
+                - "898"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 14:54:50 GMT
+                - Mon, 24 Aug 2026 12:13:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -244,10 +244,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c5293b45-f42e-4784-a59d-c00748036cae
+                - 03791556-5af4-49fd-9496-285cd1363336
         status: 200 OK
         code: 200
-        duration: 26.331875ms
+        duration: 229.23931ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -263,8 +263,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=Telehouse+TH2&order_by=name_asc&page=1
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/a3f9f822-ac57-4983-924c-a252c6ea73ad
         method: GET
       response:
         proto: HTTP/2.0
@@ -272,20 +272,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 431
+        content_length: 898
         uncompressed: false
-        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"- Telehouse TH2","region":"fr-par"}],"total_count":1}'
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.362904Z","enable_route_propagation":false,"id":"a3f9f822-ac57-4983-924c-a252c6ea73ad","name":"tf-test-interlink-link-ds","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"4df8ef47-86b0-460e-ac1b-825e6291b120","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.79/31","ipv6":"2001:1bc8:3812:fc60:751e:8e27:32b4:a601/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.78/31","ipv6":"2001:1bc8:3812:fc60:751e:8e27:32b4:a600/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:39.362904Z","vlan":3116}'
         headers:
             Content-Length:
-                - "431"
+                - "898"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 14:54:50 GMT
+                - Mon, 24 Aug 2026 12:13:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -293,10 +293,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - da8eb728-c6b2-416f-a8df-565e2d290e62
+                - 04acede2-0406-432d-ae35-8c7672312533
         status: 200 OK
         code: 200
-        duration: 30.845417ms
+        duration: 37.93071ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -312,8 +312,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/a3f9f822-ac57-4983-924c-a252c6ea73ad
         method: GET
       response:
         proto: HTTP/2.0
@@ -321,20 +321,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 708
+        content_length: 898
         uncompressed: false
-        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","updated_at":"2024-11-28T08:45:33.852946Z"}],"total_count":2}'
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.362904Z","enable_route_propagation":false,"id":"a3f9f822-ac57-4983-924c-a252c6ea73ad","name":"tf-test-interlink-link-ds","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"4df8ef47-86b0-460e-ac1b-825e6291b120","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.79/31","ipv6":"2001:1bc8:3812:fc60:751e:8e27:32b4:a601/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.78/31","ipv6":"2001:1bc8:3812:fc60:751e:8e27:32b4:a600/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:39.362904Z","vlan":3116}'
         headers:
             Content-Length:
-                - "708"
+                - "898"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 14:54:50 GMT
+                - Mon, 24 Aug 2026 12:13:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -342,10 +342,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f077e544-a647-44b3-948b-4503a7a3471c
+                - 7b7e06ac-03d6-4020-b740-710783cb5830
         status: 200 OK
         code: 200
-        duration: 37.219583ms
+        duration: 40.497711ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -361,8 +361,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=TeleHouse+TH2&order_by=name_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -370,20 +370,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 708
+        content_length: 429
         uncompressed: false
-        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","updated_at":"2024-11-28T08:45:33.852946Z"}],"total_count":2}'
+        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"TeleHouse TH2","region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
-                - "708"
+                - "429"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 14:54:51 GMT
+                - Mon, 24 Aug 2026 12:13:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -391,10 +391,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0641f0ef-1ae2-4037-b5b3-9d202b8809a8
+                - 8c3d8786-d71a-4d81-96e9-1922f8f15a73
         status: 200 OK
         code: 200
-        duration: 32.451583ms
+        duration: 41.862285ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -410,8 +410,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=Telehouse+TH2&order_by=name_asc&page=1
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -419,20 +419,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 431
+        content_length: 1158
         uncompressed: false
-        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"- Telehouse TH2","region":"fr-par"}],"total_count":1}'
+        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","l3_connectivity":true,"logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","region":"","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","l3_connectivity":true,"logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","region":"","updated_at":"2024-11-28T08:45:33.852946Z"},{"contact_email":"contact.experience-client@linkt.fr","created_at":"2026-04-21T14:31:08.285733Z","id":"4e0dcaaf-467c-432c-ad93-f28be5878df0","l3_connectivity":true,"logo_url":"https://www.linkt.fr/wp-content/themes/linkt/assets/img/svg/logo-linkt-sticky.svg","name":"Linkt","portal_url":"https://www.linkt.fr/","region":"","updated_at":"2026-07-07T11:57:51.706396Z"}],"total_count":3}'
         headers:
             Content-Length:
-                - "431"
+                - "1158"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 14:54:51 GMT
+                - Mon, 24 Aug 2026 12:13:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -440,10 +440,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d2ca31e1-b6ad-4d74-873e-673b60b91a9c
+                - 44c8a5f8-eeea-4c34-b6ef-eae400e6b225
         status: 200 OK
         code: 200
-        duration: 45.588458ms
+        duration: 41.966562ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -459,8 +459,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/9d547df7-29cd-41a8-9666-501cb4dfe793
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -468,20 +468,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 874
+        content_length: 1158
         uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-15T14:54:50.645839Z","enable_route_propagation":false,"id":"9d547df7-29cd-41a8-9666-501cb4dfe793","name":"tf-test-interlink-link-ds","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"ec9aaab0-1761-4121-8625-4862235ff7b8","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.95/31","ipv6":"2001:1bc8:3812:fc60:fb98:99e8:1a74:6d01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.94/31","ipv6":"2001:1bc8:3812:fc60:fb98:99e8:1a74:6d00/127"},"status":"requested","tags":[],"updated_at":"2026-04-15T14:54:50.645839Z","vlan":2063}'
+        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","l3_connectivity":true,"logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","region":"","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","l3_connectivity":true,"logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","region":"","updated_at":"2024-11-28T08:45:33.852946Z"},{"contact_email":"contact.experience-client@linkt.fr","created_at":"2026-04-21T14:31:08.285733Z","id":"4e0dcaaf-467c-432c-ad93-f28be5878df0","l3_connectivity":true,"logo_url":"https://www.linkt.fr/wp-content/themes/linkt/assets/img/svg/logo-linkt-sticky.svg","name":"Linkt","portal_url":"https://www.linkt.fr/","region":"","updated_at":"2026-07-07T11:57:51.706396Z"}],"total_count":3}'
         headers:
             Content-Length:
-                - "874"
+                - "1158"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 14:54:51 GMT
+                - Mon, 24 Aug 2026 12:13:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -489,10 +489,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a34452ed-abcd-405f-9b23-9d2518c3424f
+                - 90395393-c3c4-400d-8401-20d2831f56fc
         status: 200 OK
         code: 200
-        duration: 29.490708ms
+        duration: 41.826066ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -508,8 +508,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=TeleHouse+TH2&order_by=name_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -517,20 +517,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 708
+        content_length: 429
         uncompressed: false
-        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","updated_at":"2024-11-28T08:45:33.852946Z"}],"total_count":2}'
+        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"TeleHouse TH2","region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
-                - "708"
+                - "429"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 14:54:51 GMT
+                - Mon, 24 Aug 2026 12:13:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -538,10 +538,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 10bfd95d-118b-43ce-a954-25e439131790
+                - bda03e1f-9834-446c-8666-00e6501e18fb
         status: 200 OK
         code: 200
-        duration: 33.733583ms
+        duration: 51.160131ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -557,8 +557,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=Telehouse+TH2&order_by=name_asc&page=1
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/a3f9f822-ac57-4983-924c-a252c6ea73ad
         method: GET
       response:
         proto: HTTP/2.0
@@ -566,20 +566,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 431
+        content_length: 898
         uncompressed: false
-        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"- Telehouse TH2","region":"fr-par"}],"total_count":1}'
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.362904Z","enable_route_propagation":false,"id":"a3f9f822-ac57-4983-924c-a252c6ea73ad","name":"tf-test-interlink-link-ds","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"4df8ef47-86b0-460e-ac1b-825e6291b120","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.79/31","ipv6":"2001:1bc8:3812:fc60:751e:8e27:32b4:a601/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.78/31","ipv6":"2001:1bc8:3812:fc60:751e:8e27:32b4:a600/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:39.362904Z","vlan":3116}'
         headers:
             Content-Length:
-                - "431"
+                - "898"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 14:54:51 GMT
+                - Mon, 24 Aug 2026 12:13:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -587,10 +587,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7fa11fb5-7ac2-47ec-b7d5-4e1b79ffb1b3
+                - 6ddfd844-865a-45b4-82b2-4ef2dac512f1
         status: 200 OK
         code: 200
-        duration: 33.751542ms
+        duration: 44.801589ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -606,8 +606,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/9d547df7-29cd-41a8-9666-501cb4dfe793
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -615,20 +615,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 874
+        content_length: 1158
         uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-15T14:54:50.645839Z","enable_route_propagation":false,"id":"9d547df7-29cd-41a8-9666-501cb4dfe793","name":"tf-test-interlink-link-ds","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"ec9aaab0-1761-4121-8625-4862235ff7b8","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.95/31","ipv6":"2001:1bc8:3812:fc60:fb98:99e8:1a74:6d01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.94/31","ipv6":"2001:1bc8:3812:fc60:fb98:99e8:1a74:6d00/127"},"status":"requested","tags":[],"updated_at":"2026-04-15T14:54:50.645839Z","vlan":2063}'
+        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","l3_connectivity":true,"logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","region":"","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","l3_connectivity":true,"logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","region":"","updated_at":"2024-11-28T08:45:33.852946Z"},{"contact_email":"contact.experience-client@linkt.fr","created_at":"2026-04-21T14:31:08.285733Z","id":"4e0dcaaf-467c-432c-ad93-f28be5878df0","l3_connectivity":true,"logo_url":"https://www.linkt.fr/wp-content/themes/linkt/assets/img/svg/logo-linkt-sticky.svg","name":"Linkt","portal_url":"https://www.linkt.fr/","region":"","updated_at":"2026-07-07T11:57:51.706396Z"}],"total_count":3}'
         headers:
             Content-Length:
-                - "874"
+                - "1158"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 14:54:51 GMT
+                - Mon, 24 Aug 2026 12:13:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -636,10 +636,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ae069266-d677-4394-8ecb-25ab84c22723
+                - a275f9bb-8385-4d73-8f23-98bdea7e0b00
         status: 200 OK
         code: 200
-        duration: 28.689417ms
+        duration: 35.19524ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -655,8 +655,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/9d547df7-29cd-41a8-9666-501cb4dfe793
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=TeleHouse+TH2&order_by=name_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -664,20 +664,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 874
+        content_length: 429
         uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-15T14:54:50.645839Z","enable_route_propagation":false,"id":"9d547df7-29cd-41a8-9666-501cb4dfe793","name":"tf-test-interlink-link-ds","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"ec9aaab0-1761-4121-8625-4862235ff7b8","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.95/31","ipv6":"2001:1bc8:3812:fc60:fb98:99e8:1a74:6d01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.94/31","ipv6":"2001:1bc8:3812:fc60:fb98:99e8:1a74:6d00/127"},"status":"requested","tags":[],"updated_at":"2026-04-15T14:54:50.645839Z","vlan":2063}'
+        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"TeleHouse TH2","region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
-                - "874"
+                - "429"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 14:54:51 GMT
+                - Mon, 24 Aug 2026 12:13:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -685,10 +685,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 83f23f86-f39b-402d-ae9a-730894b5b97f
+                - 7576f853-d097-4543-a475-1db2b3a43c8f
         status: 200 OK
         code: 200
-        duration: 29.181375ms
+        duration: 50.086977ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -704,8 +704,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links?bgp_v4_status=unknown_bgp_status&bgp_v6_status=unknown_bgp_status&name=tf-test-interlink-link-ds&order_by=created_at_asc&status=unknown_link_status
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/a3f9f822-ac57-4983-924c-a252c6ea73ad
         method: GET
       response:
         proto: HTTP/2.0
@@ -713,20 +713,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 903
+        content_length: 898
         uncompressed: false
-        body: '{"links":[{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-15T14:54:50.645839Z","enable_route_propagation":false,"id":"9d547df7-29cd-41a8-9666-501cb4dfe793","name":"tf-test-interlink-link-ds","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"ec9aaab0-1761-4121-8625-4862235ff7b8","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.95/31","ipv6":"2001:1bc8:3812:fc60:fb98:99e8:1a74:6d01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.94/31","ipv6":"2001:1bc8:3812:fc60:fb98:99e8:1a74:6d00/127"},"status":"requested","tags":[],"updated_at":"2026-04-15T14:54:50.645839Z","vlan":2063}],"total_count":1}'
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.362904Z","enable_route_propagation":false,"id":"a3f9f822-ac57-4983-924c-a252c6ea73ad","name":"tf-test-interlink-link-ds","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"4df8ef47-86b0-460e-ac1b-825e6291b120","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.79/31","ipv6":"2001:1bc8:3812:fc60:751e:8e27:32b4:a601/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.78/31","ipv6":"2001:1bc8:3812:fc60:751e:8e27:32b4:a600/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:39.362904Z","vlan":3116}'
         headers:
             Content-Length:
-                - "903"
+                - "898"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 14:54:51 GMT
+                - Mon, 24 Aug 2026 12:13:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -734,10 +734,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fba98d30-97a8-4276-bb7f-3849b0ee9a98
+                - e351349b-8cb6-428a-891a-5493c539bd74
         status: 200 OK
         code: 200
-        duration: 73.865125ms
+        duration: 35.092336ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -753,8 +753,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/9d547df7-29cd-41a8-9666-501cb4dfe793
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/a3f9f822-ac57-4983-924c-a252c6ea73ad
         method: GET
       response:
         proto: HTTP/2.0
@@ -762,20 +762,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 874
+        content_length: 898
         uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-15T14:54:50.645839Z","enable_route_propagation":false,"id":"9d547df7-29cd-41a8-9666-501cb4dfe793","name":"tf-test-interlink-link-ds","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"ec9aaab0-1761-4121-8625-4862235ff7b8","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.95/31","ipv6":"2001:1bc8:3812:fc60:fb98:99e8:1a74:6d01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.94/31","ipv6":"2001:1bc8:3812:fc60:fb98:99e8:1a74:6d00/127"},"status":"requested","tags":[],"updated_at":"2026-04-15T14:54:50.645839Z","vlan":2063}'
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.362904Z","enable_route_propagation":false,"id":"a3f9f822-ac57-4983-924c-a252c6ea73ad","name":"tf-test-interlink-link-ds","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"4df8ef47-86b0-460e-ac1b-825e6291b120","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.79/31","ipv6":"2001:1bc8:3812:fc60:751e:8e27:32b4:a601/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.78/31","ipv6":"2001:1bc8:3812:fc60:751e:8e27:32b4:a600/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:39.362904Z","vlan":3116}'
         headers:
             Content-Length:
-                - "874"
+                - "898"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 14:54:51 GMT
+                - Mon, 24 Aug 2026 12:13:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -783,10 +783,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1c288684-83ad-4e25-b548-d142c5a22d59
+                - 2f9f42b5-05e9-45a1-b8f4-06074ec20d47
         status: 200 OK
         code: 200
-        duration: 31.39975ms
+        duration: 35.491339ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -802,8 +802,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/9d547df7-29cd-41a8-9666-501cb4dfe793
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links?bgp_v4_status=unknown_bgp_status&bgp_v6_status=unknown_bgp_status&name=tf-test-interlink-link-ds&order_by=created_at_asc&status=unknown_link_status
         method: GET
       response:
         proto: HTTP/2.0
@@ -811,20 +811,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 874
+        content_length: 927
         uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-15T14:54:50.645839Z","enable_route_propagation":false,"id":"9d547df7-29cd-41a8-9666-501cb4dfe793","name":"tf-test-interlink-link-ds","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"ec9aaab0-1761-4121-8625-4862235ff7b8","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.95/31","ipv6":"2001:1bc8:3812:fc60:fb98:99e8:1a74:6d01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.94/31","ipv6":"2001:1bc8:3812:fc60:fb98:99e8:1a74:6d00/127"},"status":"requested","tags":[],"updated_at":"2026-04-15T14:54:50.645839Z","vlan":2063}'
+        body: '{"links":[{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.362904Z","enable_route_propagation":false,"id":"a3f9f822-ac57-4983-924c-a252c6ea73ad","name":"tf-test-interlink-link-ds","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"4df8ef47-86b0-460e-ac1b-825e6291b120","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.79/31","ipv6":"2001:1bc8:3812:fc60:751e:8e27:32b4:a601/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.78/31","ipv6":"2001:1bc8:3812:fc60:751e:8e27:32b4:a600/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:39.362904Z","vlan":3116}],"total_count":1}'
         headers:
             Content-Length:
-                - "874"
+                - "927"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 14:54:51 GMT
+                - Mon, 24 Aug 2026 12:13:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -832,10 +832,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 22c26782-33e9-4749-a86a-6fc072e4722e
+                - 793554c8-03b9-48bd-8a65-4a048bb2368b
         status: 200 OK
         code: 200
-        duration: 25.954208ms
+        duration: 149.277535ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -851,8 +851,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/a3f9f822-ac57-4983-924c-a252c6ea73ad
         method: GET
       response:
         proto: HTTP/2.0
@@ -860,20 +860,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 708
+        content_length: 898
         uncompressed: false
-        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","updated_at":"2024-11-28T08:45:33.852946Z"}],"total_count":2}'
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.362904Z","enable_route_propagation":false,"id":"a3f9f822-ac57-4983-924c-a252c6ea73ad","name":"tf-test-interlink-link-ds","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"4df8ef47-86b0-460e-ac1b-825e6291b120","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.79/31","ipv6":"2001:1bc8:3812:fc60:751e:8e27:32b4:a601/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.78/31","ipv6":"2001:1bc8:3812:fc60:751e:8e27:32b4:a600/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:39.362904Z","vlan":3116}'
         headers:
             Content-Length:
-                - "708"
+                - "898"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 14:54:51 GMT
+                - Mon, 24 Aug 2026 12:13:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -881,10 +881,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 96e40c16-2051-49b6-b165-5aad153fe282
+                - d77e220f-d800-4a8e-9a83-2a1468a8abb7
         status: 200 OK
         code: 200
-        duration: 30.716041ms
+        duration: 41.439467ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -900,8 +900,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=Telehouse+TH2&order_by=name_asc&page=1
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/a3f9f822-ac57-4983-924c-a252c6ea73ad
         method: GET
       response:
         proto: HTTP/2.0
@@ -909,20 +909,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 431
+        content_length: 898
         uncompressed: false
-        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"- Telehouse TH2","region":"fr-par"}],"total_count":1}'
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.362904Z","enable_route_propagation":false,"id":"a3f9f822-ac57-4983-924c-a252c6ea73ad","name":"tf-test-interlink-link-ds","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"4df8ef47-86b0-460e-ac1b-825e6291b120","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.79/31","ipv6":"2001:1bc8:3812:fc60:751e:8e27:32b4:a601/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.78/31","ipv6":"2001:1bc8:3812:fc60:751e:8e27:32b4:a600/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:39.362904Z","vlan":3116}'
         headers:
             Content-Length:
-                - "431"
+                - "898"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 14:54:51 GMT
+                - Mon, 24 Aug 2026 12:13:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -930,10 +930,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e8e354e0-3dcf-4cd8-bd94-c2efb677a5aa
+                - 62ec36ec-5e45-414c-8f7d-80fc31cf6883
         status: 200 OK
         code: 200
-        duration: 30.505875ms
+        duration: 35.17996ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -949,8 +949,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/9d547df7-29cd-41a8-9666-501cb4dfe793
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=TeleHouse+TH2&order_by=name_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -958,20 +958,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 874
+        content_length: 429
         uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-15T14:54:50.645839Z","enable_route_propagation":false,"id":"9d547df7-29cd-41a8-9666-501cb4dfe793","name":"tf-test-interlink-link-ds","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"ec9aaab0-1761-4121-8625-4862235ff7b8","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.95/31","ipv6":"2001:1bc8:3812:fc60:fb98:99e8:1a74:6d01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.94/31","ipv6":"2001:1bc8:3812:fc60:fb98:99e8:1a74:6d00/127"},"status":"requested","tags":[],"updated_at":"2026-04-15T14:54:50.645839Z","vlan":2063}'
+        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"TeleHouse TH2","region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
-                - "874"
+                - "429"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 14:54:51 GMT
+                - Mon, 24 Aug 2026 12:13:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -979,10 +979,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 746b5003-0373-42e9-8826-365d50e3b40d
+                - 180d5f36-49ab-4cca-a1fc-c05b609ff7a2
         status: 200 OK
         code: 200
-        duration: 31.24975ms
+        duration: 31.988522ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -998,8 +998,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links?bgp_v4_status=unknown_bgp_status&bgp_v6_status=unknown_bgp_status&name=tf-test-interlink-link-ds&order_by=created_at_asc&status=unknown_link_status
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -1007,20 +1007,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 903
+        content_length: 1158
         uncompressed: false
-        body: '{"links":[{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-15T14:54:50.645839Z","enable_route_propagation":false,"id":"9d547df7-29cd-41a8-9666-501cb4dfe793","name":"tf-test-interlink-link-ds","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"ec9aaab0-1761-4121-8625-4862235ff7b8","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.95/31","ipv6":"2001:1bc8:3812:fc60:fb98:99e8:1a74:6d01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.94/31","ipv6":"2001:1bc8:3812:fc60:fb98:99e8:1a74:6d00/127"},"status":"requested","tags":[],"updated_at":"2026-04-15T14:54:50.645839Z","vlan":2063}],"total_count":1}'
+        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","l3_connectivity":true,"logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","region":"","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","l3_connectivity":true,"logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","region":"","updated_at":"2024-11-28T08:45:33.852946Z"},{"contact_email":"contact.experience-client@linkt.fr","created_at":"2026-04-21T14:31:08.285733Z","id":"4e0dcaaf-467c-432c-ad93-f28be5878df0","l3_connectivity":true,"logo_url":"https://www.linkt.fr/wp-content/themes/linkt/assets/img/svg/logo-linkt-sticky.svg","name":"Linkt","portal_url":"https://www.linkt.fr/","region":"","updated_at":"2026-07-07T11:57:51.706396Z"}],"total_count":3}'
         headers:
             Content-Length:
-                - "903"
+                - "1158"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 14:54:51 GMT
+                - Mon, 24 Aug 2026 12:13:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1028,10 +1028,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a1899ca1-5f56-44f7-aaa6-450e4583ee0f
+                - 6f05047a-c9f5-4299-bf47-708192a3d035
         status: 200 OK
         code: 200
-        duration: 55.727ms
+        duration: 33.476678ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1047,8 +1047,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/9d547df7-29cd-41a8-9666-501cb4dfe793
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/a3f9f822-ac57-4983-924c-a252c6ea73ad
         method: GET
       response:
         proto: HTTP/2.0
@@ -1056,20 +1056,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 874
+        content_length: 898
         uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-15T14:54:50.645839Z","enable_route_propagation":false,"id":"9d547df7-29cd-41a8-9666-501cb4dfe793","name":"tf-test-interlink-link-ds","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"ec9aaab0-1761-4121-8625-4862235ff7b8","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.95/31","ipv6":"2001:1bc8:3812:fc60:fb98:99e8:1a74:6d01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.94/31","ipv6":"2001:1bc8:3812:fc60:fb98:99e8:1a74:6d00/127"},"status":"requested","tags":[],"updated_at":"2026-04-15T14:54:50.645839Z","vlan":2063}'
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.362904Z","enable_route_propagation":false,"id":"a3f9f822-ac57-4983-924c-a252c6ea73ad","name":"tf-test-interlink-link-ds","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"4df8ef47-86b0-460e-ac1b-825e6291b120","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.79/31","ipv6":"2001:1bc8:3812:fc60:751e:8e27:32b4:a601/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.78/31","ipv6":"2001:1bc8:3812:fc60:751e:8e27:32b4:a600/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:39.362904Z","vlan":3116}'
         headers:
             Content-Length:
-                - "874"
+                - "898"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 14:54:51 GMT
+                - Mon, 24 Aug 2026 12:13:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1077,10 +1077,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 20bcf8fb-96bd-49b9-ad71-3a9d804391d2
+                - 6b2bd0b2-e7bf-4bc6-b3ad-605cde1f9799
         status: 200 OK
         code: 200
-        duration: 29.914292ms
+        duration: 39.187078ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1096,8 +1096,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links?bgp_v4_status=unknown_bgp_status&bgp_v6_status=unknown_bgp_status&name=tf-test-interlink-link-ds&order_by=created_at_asc&status=unknown_link_status
         method: GET
       response:
         proto: HTTP/2.0
@@ -1105,20 +1105,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 708
+        content_length: 927
         uncompressed: false
-        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","updated_at":"2024-11-28T08:45:33.852946Z"}],"total_count":2}'
+        body: '{"links":[{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.362904Z","enable_route_propagation":false,"id":"a3f9f822-ac57-4983-924c-a252c6ea73ad","name":"tf-test-interlink-link-ds","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"4df8ef47-86b0-460e-ac1b-825e6291b120","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.79/31","ipv6":"2001:1bc8:3812:fc60:751e:8e27:32b4:a601/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.78/31","ipv6":"2001:1bc8:3812:fc60:751e:8e27:32b4:a600/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:39.362904Z","vlan":3116}],"total_count":1}'
         headers:
             Content-Length:
-                - "708"
+                - "927"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 14:54:52 GMT
+                - Mon, 24 Aug 2026 12:13:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1126,10 +1126,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 68edec0e-435e-4b62-ad7d-b3acab26ef56
+                - a39037eb-cb6e-409b-97a4-747933f0e888
         status: 200 OK
         code: 200
-        duration: 27.459583ms
+        duration: 152.771121ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1145,8 +1145,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=Telehouse+TH2&order_by=name_asc&page=1
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/a3f9f822-ac57-4983-924c-a252c6ea73ad
         method: GET
       response:
         proto: HTTP/2.0
@@ -1154,20 +1154,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 431
+        content_length: 898
         uncompressed: false
-        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"- Telehouse TH2","region":"fr-par"}],"total_count":1}'
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.362904Z","enable_route_propagation":false,"id":"a3f9f822-ac57-4983-924c-a252c6ea73ad","name":"tf-test-interlink-link-ds","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"4df8ef47-86b0-460e-ac1b-825e6291b120","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.79/31","ipv6":"2001:1bc8:3812:fc60:751e:8e27:32b4:a601/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.78/31","ipv6":"2001:1bc8:3812:fc60:751e:8e27:32b4:a600/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:39.362904Z","vlan":3116}'
         headers:
             Content-Length:
-                - "431"
+                - "898"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 14:54:52 GMT
+                - Mon, 24 Aug 2026 12:13:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1175,10 +1175,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b01ddb4b-f400-4bf0-a90f-31c4b122303d
+                - dc846cd6-d7a6-4c57-acb4-05b468197376
         status: 200 OK
         code: 200
-        duration: 34.325375ms
+        duration: 36.078665ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1194,8 +1194,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/9d547df7-29cd-41a8-9666-501cb4dfe793
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -1203,20 +1203,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 874
+        content_length: 1158
         uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-15T14:54:50.645839Z","enable_route_propagation":false,"id":"9d547df7-29cd-41a8-9666-501cb4dfe793","name":"tf-test-interlink-link-ds","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"ec9aaab0-1761-4121-8625-4862235ff7b8","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.95/31","ipv6":"2001:1bc8:3812:fc60:fb98:99e8:1a74:6d01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.94/31","ipv6":"2001:1bc8:3812:fc60:fb98:99e8:1a74:6d00/127"},"status":"requested","tags":[],"updated_at":"2026-04-15T14:54:50.645839Z","vlan":2063}'
+        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","l3_connectivity":true,"logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","region":"","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","l3_connectivity":true,"logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","region":"","updated_at":"2024-11-28T08:45:33.852946Z"},{"contact_email":"contact.experience-client@linkt.fr","created_at":"2026-04-21T14:31:08.285733Z","id":"4e0dcaaf-467c-432c-ad93-f28be5878df0","l3_connectivity":true,"logo_url":"https://www.linkt.fr/wp-content/themes/linkt/assets/img/svg/logo-linkt-sticky.svg","name":"Linkt","portal_url":"https://www.linkt.fr/","region":"","updated_at":"2026-07-07T11:57:51.706396Z"}],"total_count":3}'
         headers:
             Content-Length:
-                - "874"
+                - "1158"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 14:54:52 GMT
+                - Mon, 24 Aug 2026 12:13:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1224,10 +1224,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 27b053e0-5631-4eb3-b918-4e147dae5b08
+                - 8473e5a6-51ea-4202-a11c-13b9687d80ad
         status: 200 OK
         code: 200
-        duration: 22.524541ms
+        duration: 34.482625ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1243,8 +1243,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/9d547df7-29cd-41a8-9666-501cb4dfe793
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=TeleHouse+TH2&order_by=name_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -1252,20 +1252,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 874
+        content_length: 429
         uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-15T14:54:50.645839Z","enable_route_propagation":false,"id":"9d547df7-29cd-41a8-9666-501cb4dfe793","name":"tf-test-interlink-link-ds","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"ec9aaab0-1761-4121-8625-4862235ff7b8","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.95/31","ipv6":"2001:1bc8:3812:fc60:fb98:99e8:1a74:6d01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.94/31","ipv6":"2001:1bc8:3812:fc60:fb98:99e8:1a74:6d00/127"},"status":"requested","tags":[],"updated_at":"2026-04-15T14:54:50.645839Z","vlan":2063}'
+        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"TeleHouse TH2","region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
-                - "874"
+                - "429"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 14:54:52 GMT
+                - Mon, 24 Aug 2026 12:13:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1273,10 +1273,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e1a48f14-fead-4b38-8302-c6d71444232c
+                - ea8449aa-b450-4902-93e0-30d743e9b7c1
         status: 200 OK
         code: 200
-        duration: 28.032125ms
+        duration: 38.414451ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1292,8 +1292,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links?bgp_v4_status=unknown_bgp_status&bgp_v6_status=unknown_bgp_status&name=tf-test-interlink-link-ds&order_by=created_at_asc&status=unknown_link_status
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/a3f9f822-ac57-4983-924c-a252c6ea73ad
         method: GET
       response:
         proto: HTTP/2.0
@@ -1301,20 +1301,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 903
+        content_length: 898
         uncompressed: false
-        body: '{"links":[{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-15T14:54:50.645839Z","enable_route_propagation":false,"id":"9d547df7-29cd-41a8-9666-501cb4dfe793","name":"tf-test-interlink-link-ds","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"ec9aaab0-1761-4121-8625-4862235ff7b8","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.95/31","ipv6":"2001:1bc8:3812:fc60:fb98:99e8:1a74:6d01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.94/31","ipv6":"2001:1bc8:3812:fc60:fb98:99e8:1a74:6d00/127"},"status":"requested","tags":[],"updated_at":"2026-04-15T14:54:50.645839Z","vlan":2063}],"total_count":1}'
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.362904Z","enable_route_propagation":false,"id":"a3f9f822-ac57-4983-924c-a252c6ea73ad","name":"tf-test-interlink-link-ds","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"4df8ef47-86b0-460e-ac1b-825e6291b120","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.79/31","ipv6":"2001:1bc8:3812:fc60:751e:8e27:32b4:a601/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.78/31","ipv6":"2001:1bc8:3812:fc60:751e:8e27:32b4:a600/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:39.362904Z","vlan":3116}'
         headers:
             Content-Length:
-                - "903"
+                - "898"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 14:54:52 GMT
+                - Mon, 24 Aug 2026 12:13:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1322,10 +1322,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b342b5a3-bc82-4cb1-917d-eb10d252b9ee
+                - 2df7e608-53d2-43b7-b97d-8d11232db8f1
         status: 200 OK
         code: 200
-        duration: 53.278541ms
+        duration: 34.661032ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1341,8 +1341,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/9d547df7-29cd-41a8-9666-501cb4dfe793
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/a3f9f822-ac57-4983-924c-a252c6ea73ad
         method: GET
       response:
         proto: HTTP/2.0
@@ -1350,20 +1350,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 874
+        content_length: 898
         uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-15T14:54:50.645839Z","enable_route_propagation":false,"id":"9d547df7-29cd-41a8-9666-501cb4dfe793","name":"tf-test-interlink-link-ds","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"ec9aaab0-1761-4121-8625-4862235ff7b8","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.95/31","ipv6":"2001:1bc8:3812:fc60:fb98:99e8:1a74:6d01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.94/31","ipv6":"2001:1bc8:3812:fc60:fb98:99e8:1a74:6d00/127"},"status":"requested","tags":[],"updated_at":"2026-04-15T14:54:50.645839Z","vlan":2063}'
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.362904Z","enable_route_propagation":false,"id":"a3f9f822-ac57-4983-924c-a252c6ea73ad","name":"tf-test-interlink-link-ds","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"4df8ef47-86b0-460e-ac1b-825e6291b120","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.79/31","ipv6":"2001:1bc8:3812:fc60:751e:8e27:32b4:a601/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.78/31","ipv6":"2001:1bc8:3812:fc60:751e:8e27:32b4:a600/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:39.362904Z","vlan":3116}'
         headers:
             Content-Length:
-                - "874"
+                - "898"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 14:54:52 GMT
+                - Mon, 24 Aug 2026 12:13:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1371,10 +1371,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 85121454-cb43-4443-b835-57a3f53fb987
+                - 97fe7a8e-9c8e-44ed-b1f5-eba2447c68a0
         status: 200 OK
         code: 200
-        duration: 28.065625ms
+        duration: 34.315551ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1390,29 +1390,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/9d547df7-29cd-41a8-9666-501cb4dfe793
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links?bgp_v4_status=unknown_bgp_status&bgp_v6_status=unknown_bgp_status&name=tf-test-interlink-link-ds&order_by=created_at_asc&status=unknown_link_status
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 872
+        content_length: 927
         uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-15T14:54:50.645839Z","enable_route_propagation":false,"id":"9d547df7-29cd-41a8-9666-501cb4dfe793","name":"tf-test-interlink-link-ds","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"ec9aaab0-1761-4121-8625-4862235ff7b8","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.95/31","ipv6":"2001:1bc8:3812:fc60:fb98:99e8:1a74:6d01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.94/31","ipv6":"2001:1bc8:3812:fc60:fb98:99e8:1a74:6d00/127"},"status":"deleted","tags":[],"updated_at":"2026-04-15T14:54:50.645839Z","vlan":2063}'
+        body: '{"links":[{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.362904Z","enable_route_propagation":false,"id":"a3f9f822-ac57-4983-924c-a252c6ea73ad","name":"tf-test-interlink-link-ds","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"4df8ef47-86b0-460e-ac1b-825e6291b120","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.79/31","ipv6":"2001:1bc8:3812:fc60:751e:8e27:32b4:a601/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.78/31","ipv6":"2001:1bc8:3812:fc60:751e:8e27:32b4:a600/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:39.362904Z","vlan":3116}],"total_count":1}'
         headers:
             Content-Length:
-                - "872"
+                - "927"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 14:54:52 GMT
+                - Mon, 24 Aug 2026 12:13:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1420,10 +1420,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c822b0af-b954-49a1-b6fb-995845f8b24b
+                - 1a177877-6a40-43d3-8853-fdf22f5af60c
         status: 200 OK
         code: 200
-        duration: 57.949709ms
+        duration: 126.840355ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1439,8 +1439,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/9d547df7-29cd-41a8-9666-501cb4dfe793
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/a3f9f822-ac57-4983-924c-a252c6ea73ad
         method: GET
       response:
         proto: HTTP/2.0
@@ -1448,20 +1448,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 125
+        content_length: 898
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"link","resource_id":"9d547df7-29cd-41a8-9666-501cb4dfe793","type":"not_found"}'
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.362904Z","enable_route_propagation":false,"id":"a3f9f822-ac57-4983-924c-a252c6ea73ad","name":"tf-test-interlink-link-ds","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"4df8ef47-86b0-460e-ac1b-825e6291b120","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.79/31","ipv6":"2001:1bc8:3812:fc60:751e:8e27:32b4:a601/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.78/31","ipv6":"2001:1bc8:3812:fc60:751e:8e27:32b4:a600/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:39.362904Z","vlan":3116}'
         headers:
             Content-Length:
-                - "125"
+                - "898"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 14:54:52 GMT
+                - Mon, 24 Aug 2026 12:13:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1469,10 +1469,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - aa3a013e-c675-4d1c-a1cf-3bcb77d3763b
-        status: 404 Not Found
-        code: 404
-        duration: 25.635625ms
+                - 0d6f18eb-0b19-4001-98f5-68938d9db818
+        status: 200 OK
+        code: 200
+        duration: 41.861562ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1488,29 +1488,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/9d547df7-29cd-41a8-9666-501cb4dfe793
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/a3f9f822-ac57-4983-924c-a252c6ea73ad
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 125
+        content_length: 896
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"link","resource_id":"9d547df7-29cd-41a8-9666-501cb4dfe793","type":"not_found"}'
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.362904Z","enable_route_propagation":false,"id":"a3f9f822-ac57-4983-924c-a252c6ea73ad","name":"tf-test-interlink-link-ds","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"4df8ef47-86b0-460e-ac1b-825e6291b120","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.79/31","ipv6":"2001:1bc8:3812:fc60:751e:8e27:32b4:a601/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.78/31","ipv6":"2001:1bc8:3812:fc60:751e:8e27:32b4:a600/127"},"status":"deleted","tags":[],"updated_at":"2026-08-24T12:13:39.362904Z","vlan":3116}'
         headers:
             Content-Length:
-                - "125"
+                - "896"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 14:54:52 GMT
+                - Mon, 24 Aug 2026 12:13:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1518,10 +1518,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - aeb4d0c3-1040-4ece-b027-89c7a28e6359
-        status: 404 Not Found
-        code: 404
-        duration: 27.6635ms
+                - 5433b27e-5b23-4301-b751-4cfec697e077
+        status: 200 OK
+        code: 200
+        duration: 55.418451ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1537,8 +1537,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/9d547df7-29cd-41a8-9666-501cb4dfe793
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/a3f9f822-ac57-4983-924c-a252c6ea73ad
         method: GET
       response:
         proto: HTTP/2.0
@@ -1548,7 +1548,7 @@ interactions:
         trailer: {}
         content_length: 125
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"link","resource_id":"9d547df7-29cd-41a8-9666-501cb4dfe793","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"link","resource_id":"a3f9f822-ac57-4983-924c-a252c6ea73ad","type":"not_found"}'
         headers:
             Content-Length:
                 - "125"
@@ -1557,9 +1557,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 14:54:52 GMT
+                - Mon, 24 Aug 2026 12:13:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1567,10 +1567,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 19129b9a-8a76-444b-a778-9881b2a188e8
+                - acb90c84-ec25-499f-9bcb-205b1794b9df
         status: 404 Not Found
         code: 404
-        duration: 28.26625ms
+        duration: 34.21979ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1586,8 +1586,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/9d547df7-29cd-41a8-9666-501cb4dfe793
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/a3f9f822-ac57-4983-924c-a252c6ea73ad
         method: GET
       response:
         proto: HTTP/2.0
@@ -1597,7 +1597,7 @@ interactions:
         trailer: {}
         content_length: 125
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"link","resource_id":"9d547df7-29cd-41a8-9666-501cb4dfe793","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"link","resource_id":"a3f9f822-ac57-4983-924c-a252c6ea73ad","type":"not_found"}'
         headers:
             Content-Length:
                 - "125"
@@ -1606,9 +1606,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 14:54:52 GMT
+                - Mon, 24 Aug 2026 12:13:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1616,7 +1616,105 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d0e4e718-0ad7-41ea-b918-9f07cd1424dd
+                - 5e259ca6-f656-48e8-85a9-60773474e635
         status: 404 Not Found
         code: 404
-        duration: 32.007791ms
+        duration: 36.188863ms
+    - id: 33
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/a3f9f822-ac57-4983-924c-a252c6ea73ad
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 125
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"link","resource_id":"a3f9f822-ac57-4983-924c-a252c6ea73ad","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "125"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 24 Aug 2026 12:13:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c510141b-3c6a-46e7-8a06-f1106ca876a1
+        status: 404 Not Found
+        code: 404
+        duration: 40.099519ms
+    - id: 34
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/a3f9f822-ac57-4983-924c-a252c6ea73ad
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 125
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"link","resource_id":"a3f9f822-ac57-4983-924c-a252c6ea73ad","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "125"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 24 Aug 2026 12:13:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c225f6c4-0643-4a68-96f1-4ab5adbc59ec
+        status: 404 Not Found
+        code: 404
+        duration: 33.583619ms

--- a/internal/services/interlink/testdata/data-source-interlink-partner-by-id.cassette.yaml
+++ b/internal/services/interlink/testdata/data-source-interlink-partner-by-id.cassette.yaml
@@ -16,7 +16,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
         method: GET
       response:
@@ -25,20 +25,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 708
+        content_length: 1158
         uncompressed: false
-        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","updated_at":"2024-11-28T08:45:33.852946Z"}],"total_count":2}'
+        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","l3_connectivity":true,"logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","region":"","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","l3_connectivity":true,"logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","region":"","updated_at":"2024-11-28T08:45:33.852946Z"},{"contact_email":"contact.experience-client@linkt.fr","created_at":"2026-04-21T14:31:08.285733Z","id":"4e0dcaaf-467c-432c-ad93-f28be5878df0","l3_connectivity":true,"logo_url":"https://www.linkt.fr/wp-content/themes/linkt/assets/img/svg/logo-linkt-sticky.svg","name":"Linkt","portal_url":"https://www.linkt.fr/","region":"","updated_at":"2026-07-07T11:57:51.706396Z"}],"total_count":3}'
         headers:
             Content-Length:
-                - "708"
+                - "1158"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 01 Apr 2026 08:44:01 GMT
+                - Mon, 24 Aug 2026 12:13:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -46,10 +46,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3db421f2-927f-471d-aa26-ae959eb7bc14
+                - 04aaa526-de85-4cc9-a8a5-286babe7c925
         status: 200 OK
         code: 200
-        duration: 155.755958ms
+        duration: 45.999177ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -65,8 +65,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners/930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/metadata
         method: GET
       response:
         proto: HTTP/2.0
@@ -74,20 +74,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 321
+        content_length: 59
         uncompressed: false
-        body: '{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","updated_at":"2024-11-28T08:45:33.852946Z"}'
+        body: '{"domain":"scw.eu","partition":"scw","platform":"external"}'
         headers:
             Content-Length:
-                - "321"
+                - "59"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 01 Apr 2026 08:44:01 GMT
+                - Mon, 24 Aug 2026 12:13:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -95,10 +95,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 05c04bf1-7cbb-4baf-b60e-691ce20ecfcd
+                - f85adede-dc0e-4c60-80b0-cdc53a2b102a
         status: 200 OK
         code: 200
-        duration: 30.01575ms
+        duration: 32.229186ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -114,8 +114,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners/930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05
         method: GET
       response:
         proto: HTTP/2.0
@@ -123,20 +123,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 708
+        content_length: 358
         uncompressed: false
-        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","updated_at":"2024-11-28T08:45:33.852946Z"}],"total_count":2}'
+        body: '{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","l3_connectivity":true,"logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","region":"","updated_at":"2024-11-28T08:45:33.852946Z"}'
         headers:
             Content-Length:
-                - "708"
+                - "358"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 01 Apr 2026 08:44:01 GMT
+                - Mon, 24 Aug 2026 12:13:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -144,10 +144,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d54c9f57-3c89-4ab9-b38d-bae287bbcc73
+                - c120bb9f-f529-4332-a2da-918d6e64ffe0
         status: 200 OK
         code: 200
-        duration: 32.008417ms
+        duration: 44.155209ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -163,8 +163,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners/930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -172,20 +172,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 321
+        content_length: 1158
         uncompressed: false
-        body: '{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","updated_at":"2024-11-28T08:45:33.852946Z"}'
+        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","l3_connectivity":true,"logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","region":"","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","l3_connectivity":true,"logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","region":"","updated_at":"2024-11-28T08:45:33.852946Z"},{"contact_email":"contact.experience-client@linkt.fr","created_at":"2026-04-21T14:31:08.285733Z","id":"4e0dcaaf-467c-432c-ad93-f28be5878df0","l3_connectivity":true,"logo_url":"https://www.linkt.fr/wp-content/themes/linkt/assets/img/svg/logo-linkt-sticky.svg","name":"Linkt","portal_url":"https://www.linkt.fr/","region":"","updated_at":"2026-07-07T11:57:51.706396Z"}],"total_count":3}'
         headers:
             Content-Length:
-                - "321"
+                - "1158"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 01 Apr 2026 08:44:01 GMT
+                - Mon, 24 Aug 2026 12:13:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -193,10 +193,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ea95001c-0c39-4c4b-9bca-5eee99b4dc38
+                - b00f34a8-8bae-4b13-8ad1-dfea9e727d57
         status: 200 OK
         code: 200
-        duration: 90.779625ms
+        duration: 46.327195ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -212,8 +212,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners/930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05
         method: GET
       response:
         proto: HTTP/2.0
@@ -221,20 +221,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 708
+        content_length: 358
         uncompressed: false
-        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","updated_at":"2024-11-28T08:45:33.852946Z"}],"total_count":2}'
+        body: '{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","l3_connectivity":true,"logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","region":"","updated_at":"2024-11-28T08:45:33.852946Z"}'
         headers:
             Content-Length:
-                - "708"
+                - "358"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 01 Apr 2026 08:44:01 GMT
+                - Mon, 24 Aug 2026 12:13:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -242,10 +242,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8acd84f5-3649-4534-8716-28e0b9113719
+                - 2fa00e78-7fb3-494f-9823-68313b772165
         status: 200 OK
         code: 200
-        duration: 33.215875ms
+        duration: 46.452421ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -261,7 +261,56 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1158
+        uncompressed: false
+        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","l3_connectivity":true,"logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","region":"","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","l3_connectivity":true,"logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","region":"","updated_at":"2024-11-28T08:45:33.852946Z"},{"contact_email":"contact.experience-client@linkt.fr","created_at":"2026-04-21T14:31:08.285733Z","id":"4e0dcaaf-467c-432c-ad93-f28be5878df0","l3_connectivity":true,"logo_url":"https://www.linkt.fr/wp-content/themes/linkt/assets/img/svg/logo-linkt-sticky.svg","name":"Linkt","portal_url":"https://www.linkt.fr/","region":"","updated_at":"2026-07-07T11:57:51.706396Z"}],"total_count":3}'
+        headers:
+            Content-Length:
+                - "1158"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 24 Aug 2026 12:13:41 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - acc51cab-f7be-4276-82be-a31664e0feb9
+        status: 200 OK
+        code: 200
+        duration: 32.870765ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners/930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05
         method: GET
       response:
@@ -270,20 +319,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 321
+        content_length: 358
         uncompressed: false
-        body: '{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","updated_at":"2024-11-28T08:45:33.852946Z"}'
+        body: '{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","l3_connectivity":true,"logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","region":"","updated_at":"2024-11-28T08:45:33.852946Z"}'
         headers:
             Content-Length:
-                - "321"
+                - "358"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 01 Apr 2026 08:44:01 GMT
+                - Mon, 24 Aug 2026 12:13:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -291,7 +340,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4b5c9ab1-c9cd-4194-a879-0d62266fc971
+                - d5a7b148-28b4-4520-9d80-157bc2c2d01f
         status: 200 OK
         code: 200
-        duration: 26.155875ms
+        duration: 35.745969ms

--- a/internal/services/interlink/testdata/data-source-interlink-partner-by-name.cassette.yaml
+++ b/internal/services/interlink/testdata/data-source-interlink-partner-by-name.cassette.yaml
@@ -16,7 +16,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
         method: GET
       response:
@@ -25,20 +25,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 708
+        content_length: 1158
         uncompressed: false
-        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","updated_at":"2024-11-28T08:45:33.852946Z"}],"total_count":2}'
+        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","l3_connectivity":true,"logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","region":"","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","l3_connectivity":true,"logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","region":"","updated_at":"2024-11-28T08:45:33.852946Z"},{"contact_email":"contact.experience-client@linkt.fr","created_at":"2026-04-21T14:31:08.285733Z","id":"4e0dcaaf-467c-432c-ad93-f28be5878df0","l3_connectivity":true,"logo_url":"https://www.linkt.fr/wp-content/themes/linkt/assets/img/svg/logo-linkt-sticky.svg","name":"Linkt","portal_url":"https://www.linkt.fr/","region":"","updated_at":"2026-07-07T11:57:51.706396Z"}],"total_count":3}'
         headers:
             Content-Length:
-                - "708"
+                - "1158"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 31 Mar 2026 14:34:54 GMT
+                - Mon, 24 Aug 2026 12:13:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -46,10 +46,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e1e4bfc7-c4e6-4d6b-bcf5-cd5dbd28f98e
+                - 624826d7-b658-43b7-8f10-83a76c056a74
         status: 200 OK
         code: 200
-        duration: 184.145ms
+        duration: 106.468077ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -65,8 +65,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/metadata
         method: GET
       response:
         proto: HTTP/2.0
@@ -74,20 +74,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 708
+        content_length: 59
         uncompressed: false
-        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","updated_at":"2024-11-28T08:45:33.852946Z"}],"total_count":2}'
+        body: '{"domain":"scw.eu","partition":"scw","platform":"external"}'
         headers:
             Content-Length:
-                - "708"
+                - "59"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 31 Mar 2026 14:34:54 GMT
+                - Mon, 24 Aug 2026 12:13:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -95,10 +95,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9b298fb3-6a4e-4ffa-a4a8-863da96d9074
+                - 437a2a30-b3bd-4c49-8b41-4fd8f216a68a
         status: 200 OK
         code: 200
-        duration: 40.376375ms
+        duration: 20.738955ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -114,7 +114,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
         method: GET
       response:
@@ -123,20 +123,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 708
+        content_length: 1158
         uncompressed: false
-        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","updated_at":"2024-11-28T08:45:33.852946Z"}],"total_count":2}'
+        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","l3_connectivity":true,"logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","region":"","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","l3_connectivity":true,"logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","region":"","updated_at":"2024-11-28T08:45:33.852946Z"},{"contact_email":"contact.experience-client@linkt.fr","created_at":"2026-04-21T14:31:08.285733Z","id":"4e0dcaaf-467c-432c-ad93-f28be5878df0","l3_connectivity":true,"logo_url":"https://www.linkt.fr/wp-content/themes/linkt/assets/img/svg/logo-linkt-sticky.svg","name":"Linkt","portal_url":"https://www.linkt.fr/","region":"","updated_at":"2026-07-07T11:57:51.706396Z"}],"total_count":3}'
         headers:
             Content-Length:
-                - "708"
+                - "1158"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 31 Mar 2026 14:34:54 GMT
+                - Mon, 24 Aug 2026 12:13:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -144,7 +144,56 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f1eff944-f32b-4b80-9273-a294904fce76
+                - 18b2067f-db59-44fa-b992-8639bc438328
         status: 200 OK
         code: 200
-        duration: 30.877708ms
+        duration: 41.042148ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1158
+        uncompressed: false
+        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","l3_connectivity":true,"logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","region":"","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","l3_connectivity":true,"logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","region":"","updated_at":"2024-11-28T08:45:33.852946Z"},{"contact_email":"contact.experience-client@linkt.fr","created_at":"2026-04-21T14:31:08.285733Z","id":"4e0dcaaf-467c-432c-ad93-f28be5878df0","l3_connectivity":true,"logo_url":"https://www.linkt.fr/wp-content/themes/linkt/assets/img/svg/logo-linkt-sticky.svg","name":"Linkt","portal_url":"https://www.linkt.fr/","region":"","updated_at":"2026-07-07T11:57:51.706396Z"}],"total_count":3}'
+        headers:
+            Content-Length:
+                - "1158"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 24 Aug 2026 12:13:39 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f7bb680f-7340-471a-b089-0c5223d11509
+        status: 200 OK
+        code: 200
+        duration: 37.424976ms

--- a/internal/services/interlink/testdata/data-source-interlink-partners-basic.cassette.yaml
+++ b/internal/services/interlink/testdata/data-source-interlink-partners-basic.cassette.yaml
@@ -16,7 +16,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc
         method: GET
       response:
@@ -25,20 +25,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 708
+        content_length: 1158
         uncompressed: false
-        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","updated_at":"2024-11-28T08:45:33.852946Z"}],"total_count":2}'
+        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","l3_connectivity":true,"logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","region":"","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","l3_connectivity":true,"logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","region":"","updated_at":"2024-11-28T08:45:33.852946Z"},{"contact_email":"contact.experience-client@linkt.fr","created_at":"2026-04-21T14:31:08.285733Z","id":"4e0dcaaf-467c-432c-ad93-f28be5878df0","l3_connectivity":true,"logo_url":"https://www.linkt.fr/wp-content/themes/linkt/assets/img/svg/logo-linkt-sticky.svg","name":"Linkt","portal_url":"https://www.linkt.fr/","region":"","updated_at":"2026-07-07T11:57:51.706396Z"}],"total_count":3}'
         headers:
             Content-Length:
-                - "708"
+                - "1158"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 31 Mar 2026 14:35:35 GMT
+                - Mon, 24 Aug 2026 12:13:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -46,10 +46,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 04a4c8eb-34b8-4261-a271-b00f2423b7c5
+                - f548ec6f-25fc-46e8-865c-c06ed2733754
         status: 200 OK
         code: 200
-        duration: 140.562125ms
+        duration: 37.979321ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -65,8 +65,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/metadata
         method: GET
       response:
         proto: HTTP/2.0
@@ -74,20 +74,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 708
+        content_length: 59
         uncompressed: false
-        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","updated_at":"2024-11-28T08:45:33.852946Z"}],"total_count":2}'
+        body: '{"domain":"scw.eu","partition":"scw","platform":"external"}'
         headers:
             Content-Length:
-                - "708"
+                - "59"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 31 Mar 2026 14:35:36 GMT
+                - Mon, 24 Aug 2026 12:13:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -95,10 +95,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8c776768-2167-4d96-abb2-dde0c3a7b3e5
+                - 084e3d04-dbe2-49e6-b6ab-33f3b7cb4a5b
         status: 200 OK
         code: 200
-        duration: 31.9225ms
+        duration: 37.732094ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -114,7 +114,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc
         method: GET
       response:
@@ -123,20 +123,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 708
+        content_length: 1158
         uncompressed: false
-        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","updated_at":"2024-11-28T08:45:33.852946Z"}],"total_count":2}'
+        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","l3_connectivity":true,"logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","region":"","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","l3_connectivity":true,"logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","region":"","updated_at":"2024-11-28T08:45:33.852946Z"},{"contact_email":"contact.experience-client@linkt.fr","created_at":"2026-04-21T14:31:08.285733Z","id":"4e0dcaaf-467c-432c-ad93-f28be5878df0","l3_connectivity":true,"logo_url":"https://www.linkt.fr/wp-content/themes/linkt/assets/img/svg/logo-linkt-sticky.svg","name":"Linkt","portal_url":"https://www.linkt.fr/","region":"","updated_at":"2026-07-07T11:57:51.706396Z"}],"total_count":3}'
         headers:
             Content-Length:
-                - "708"
+                - "1158"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 31 Mar 2026 14:35:36 GMT
+                - Mon, 24 Aug 2026 12:13:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -144,7 +144,56 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 615dc1ab-4817-44f3-ac90-9d5d92220485
+                - 9361c3a0-4999-43ec-a425-7ca1c6e96ab9
         status: 200 OK
         code: 200
-        duration: 104.697584ms
+        duration: 37.943283ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1158
+        uncompressed: false
+        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","l3_connectivity":true,"logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","region":"","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","l3_connectivity":true,"logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","region":"","updated_at":"2024-11-28T08:45:33.852946Z"},{"contact_email":"contact.experience-client@linkt.fr","created_at":"2026-04-21T14:31:08.285733Z","id":"4e0dcaaf-467c-432c-ad93-f28be5878df0","l3_connectivity":true,"logo_url":"https://www.linkt.fr/wp-content/themes/linkt/assets/img/svg/logo-linkt-sticky.svg","name":"Linkt","portal_url":"https://www.linkt.fr/","region":"","updated_at":"2026-07-07T11:57:51.706396Z"}],"total_count":3}'
+        headers:
+            Content-Length:
+                - "1158"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 24 Aug 2026 12:13:41 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - fd86acc9-7342-410c-8a6f-4a5d34e3baf6
+        status: 200 OK
+        code: 200
+        duration: 40.571109ms

--- a/internal/services/interlink/testdata/data-source-interlink-pop-by-id.cassette.yaml
+++ b/internal/services/interlink/testdata/data-source-interlink-pop-by-id.cassette.yaml
@@ -16,8 +16,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=DC2&order_by=name_asc&page=1
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=TeleHouse+TH2&order_by=name_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -25,20 +25,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 333
+        content_length: 429
         uncompressed: false
-        body: '{"pops":[{"address":"29 Rue Edith Cavell","available_link_bandwidths_mbps":[],"city":"Vitry-sur-Seine","display_name":"Paris - OpCore DC2","hosting_provider_name":"OpCore","id":"f2e1cf2f-efec-4798-a959-767310ab30ae","logo_url":"https://app.opcore.com/web/image/website/1/logo/OPCORE","name":"DC2","region":"fr-par"}],"total_count":1}'
+        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"TeleHouse TH2","region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
-                - "333"
+                - "429"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Apr 2026 06:21:34 GMT
+                - Mon, 24 Aug 2026 12:13:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -46,10 +46,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1535559a-6134-4f70-9949-00eed022d796
+                - fe45c3e7-4804-4c55-ad4d-13c1944d718e
         status: 200 OK
         code: 200
-        duration: 236.346417ms
+        duration: 147.202004ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -65,8 +65,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops/f2e1cf2f-efec-4798-a959-767310ab30ae
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/metadata
         method: GET
       response:
         proto: HTTP/2.0
@@ -74,20 +74,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 336
+        content_length: 59
         uncompressed: false
-        body: '{"address":"29 Rue Edith Cavell","available_link_bandwidths_mbps":[50,100,200,500,1000,5000,10000],"city":"Vitry-sur-Seine","display_name":"Paris - OpCore DC2","hosting_provider_name":"OpCore","id":"f2e1cf2f-efec-4798-a959-767310ab30ae","logo_url":"https://app.opcore.com/web/image/website/1/logo/OPCORE","name":"DC2","region":"fr-par"}'
+        body: '{"domain":"scw.eu","partition":"scw","platform":"external"}'
         headers:
             Content-Length:
-                - "336"
+                - "59"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Apr 2026 06:21:34 GMT
+                - Mon, 24 Aug 2026 12:13:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -95,10 +95,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7952ce1b-6063-4e5f-b935-66a2ccce45f1
+                - 5f4dc928-4d55-4b6e-80d0-a940eaa14981
         status: 200 OK
         code: 200
-        duration: 49.679667ms
+        duration: 27.992626ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -114,8 +114,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=DC2&order_by=name_asc&page=1
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops/fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -123,20 +123,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 333
+        content_length: 401
         uncompressed: false
-        body: '{"pops":[{"address":"29 Rue Edith Cavell","available_link_bandwidths_mbps":[],"city":"Vitry-sur-Seine","display_name":"Paris - OpCore DC2","hosting_provider_name":"OpCore","id":"f2e1cf2f-efec-4798-a959-767310ab30ae","logo_url":"https://app.opcore.com/web/image/website/1/logo/OPCORE","name":"DC2","region":"fr-par"}],"total_count":1}'
+        body: '{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"TeleHouse TH2","region":"fr-par"}'
         headers:
             Content-Length:
-                - "333"
+                - "401"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Apr 2026 06:21:35 GMT
+                - Mon, 24 Aug 2026 12:13:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -144,10 +144,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 83a33e24-e5da-4ed4-8a0e-638ef4116a30
+                - ad6a061c-bbdd-43e1-b6a5-a73e319ebb01
         status: 200 OK
         code: 200
-        duration: 36.509459ms
+        duration: 41.935112ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -163,8 +163,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops/f2e1cf2f-efec-4798-a959-767310ab30ae
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=TeleHouse+TH2&order_by=name_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -172,20 +172,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 336
+        content_length: 429
         uncompressed: false
-        body: '{"address":"29 Rue Edith Cavell","available_link_bandwidths_mbps":[50,100,200,500,1000,5000,10000],"city":"Vitry-sur-Seine","display_name":"Paris - OpCore DC2","hosting_provider_name":"OpCore","id":"f2e1cf2f-efec-4798-a959-767310ab30ae","logo_url":"https://app.opcore.com/web/image/website/1/logo/OPCORE","name":"DC2","region":"fr-par"}'
+        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"TeleHouse TH2","region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
-                - "336"
+                - "429"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Apr 2026 06:21:35 GMT
+                - Mon, 24 Aug 2026 12:13:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -193,10 +193,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 12fe38c1-221e-4eff-85ae-2f5872d83b83
+                - 1dbc7f86-4585-47af-8bef-a4418f1f007c
         status: 200 OK
         code: 200
-        duration: 33.522917ms
+        duration: 44.641507ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -212,8 +212,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=DC2&order_by=name_asc&page=1
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops/fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -221,20 +221,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 333
+        content_length: 401
         uncompressed: false
-        body: '{"pops":[{"address":"29 Rue Edith Cavell","available_link_bandwidths_mbps":[],"city":"Vitry-sur-Seine","display_name":"Paris - OpCore DC2","hosting_provider_name":"OpCore","id":"f2e1cf2f-efec-4798-a959-767310ab30ae","logo_url":"https://app.opcore.com/web/image/website/1/logo/OPCORE","name":"DC2","region":"fr-par"}],"total_count":1}'
+        body: '{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"TeleHouse TH2","region":"fr-par"}'
         headers:
             Content-Length:
-                - "333"
+                - "401"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Apr 2026 06:21:35 GMT
+                - Mon, 24 Aug 2026 12:13:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -242,10 +242,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8a8cfd08-a520-4962-9922-ffbe4a0db7b7
+                - 781c0fe6-369e-4945-b1f7-fb17b2de4aea
         status: 200 OK
         code: 200
-        duration: 98.903916ms
+        duration: 37.357428ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -261,8 +261,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops/f2e1cf2f-efec-4798-a959-767310ab30ae
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=TeleHouse+TH2&order_by=name_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -270,20 +270,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 336
+        content_length: 429
         uncompressed: false
-        body: '{"address":"29 Rue Edith Cavell","available_link_bandwidths_mbps":[50,100,200,500,1000,5000,10000],"city":"Vitry-sur-Seine","display_name":"Paris - OpCore DC2","hosting_provider_name":"OpCore","id":"f2e1cf2f-efec-4798-a959-767310ab30ae","logo_url":"https://app.opcore.com/web/image/website/1/logo/OPCORE","name":"DC2","region":"fr-par"}'
+        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"TeleHouse TH2","region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
-                - "336"
+                - "429"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Apr 2026 06:21:35 GMT
+                - Mon, 24 Aug 2026 12:13:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -291,7 +291,56 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3650186d-dab0-4991-8856-dbd8e07ba0f6
+                - 21d7a2e6-a548-47ae-8c47-1352a3252de1
         status: 200 OK
         code: 200
-        duration: 30.824209ms
+        duration: 51.256974ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops/fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 401
+        uncompressed: false
+        body: '{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"TeleHouse TH2","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "401"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 24 Aug 2026 12:13:39 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 40f6bdf4-3db5-4b33-9618-f16fecb51794
+        status: 200 OK
+        code: 200
+        duration: 48.363958ms

--- a/internal/services/interlink/testdata/data-source-interlink-pop-by-name.cassette.yaml
+++ b/internal/services/interlink/testdata/data-source-interlink-pop-by-name.cassette.yaml
@@ -16,8 +16,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=DC2&order_by=name_asc&page=1
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=TeleHouse+TH2&order_by=name_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -25,20 +25,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 333
+        content_length: 429
         uncompressed: false
-        body: '{"pops":[{"address":"29 Rue Edith Cavell","available_link_bandwidths_mbps":[],"city":"Vitry-sur-Seine","display_name":"Paris - OpCore DC2","hosting_provider_name":"OpCore","id":"f2e1cf2f-efec-4798-a959-767310ab30ae","logo_url":"https://app.opcore.com/web/image/website/1/logo/OPCORE","name":"DC2","region":"fr-par"}],"total_count":1}'
+        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"TeleHouse TH2","region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
-                - "333"
+                - "429"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Apr 2026 06:21:10 GMT
+                - Mon, 24 Aug 2026 12:13:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -46,10 +46,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 23a8b9ae-342c-4dbd-bf8a-53cc27b5795c
+                - c72c2488-0ee9-4aa4-9e1f-d253a2b8bf85
         status: 200 OK
         code: 200
-        duration: 151.208834ms
+        duration: 148.588519ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -65,8 +65,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=DC2&order_by=name_asc&page=1
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/metadata
         method: GET
       response:
         proto: HTTP/2.0
@@ -74,20 +74,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 333
+        content_length: 59
         uncompressed: false
-        body: '{"pops":[{"address":"29 Rue Edith Cavell","available_link_bandwidths_mbps":[],"city":"Vitry-sur-Seine","display_name":"Paris - OpCore DC2","hosting_provider_name":"OpCore","id":"f2e1cf2f-efec-4798-a959-767310ab30ae","logo_url":"https://app.opcore.com/web/image/website/1/logo/OPCORE","name":"DC2","region":"fr-par"}],"total_count":1}'
+        body: '{"domain":"scw.eu","partition":"scw","platform":"external"}'
         headers:
             Content-Length:
-                - "333"
+                - "59"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Apr 2026 06:21:11 GMT
+                - Mon, 24 Aug 2026 12:13:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -95,10 +95,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - af9f098e-cfd9-4e7c-aca7-4e9a4d56ad13
+                - be2eb1db-4310-4728-93c8-050b12601a34
         status: 200 OK
         code: 200
-        duration: 64.179166ms
+        duration: 27.995542ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -114,8 +114,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=DC2&order_by=name_asc&page=1
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=TeleHouse+TH2&order_by=name_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -123,20 +123,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 333
+        content_length: 429
         uncompressed: false
-        body: '{"pops":[{"address":"29 Rue Edith Cavell","available_link_bandwidths_mbps":[],"city":"Vitry-sur-Seine","display_name":"Paris - OpCore DC2","hosting_provider_name":"OpCore","id":"f2e1cf2f-efec-4798-a959-767310ab30ae","logo_url":"https://app.opcore.com/web/image/website/1/logo/OPCORE","name":"DC2","region":"fr-par"}],"total_count":1}'
+        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"TeleHouse TH2","region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
-                - "333"
+                - "429"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Apr 2026 06:21:11 GMT
+                - Mon, 24 Aug 2026 12:13:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -144,7 +144,56 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 520bd8d1-0463-4ca9-9707-821efd5d479d
+                - f867db0f-9523-46e8-851b-e8a516c97724
         status: 200 OK
         code: 200
-        duration: 59.647875ms
+        duration: 50.22139ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=TeleHouse+TH2&order_by=name_asc&page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 429
+        uncompressed: false
+        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"TeleHouse TH2","region":"fr-par"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "429"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 24 Aug 2026 12:13:39 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 609e3c91-0aad-49f7-93fa-f327cab531fe
+        status: 200 OK
+        code: 200
+        duration: 56.196741ms

--- a/internal/services/interlink/testdata/data-source-interlink-pops-basic.cassette.yaml
+++ b/internal/services/interlink/testdata/data-source-interlink-pops-basic.cassette.yaml
@@ -16,7 +16,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?order_by=name_asc
         method: GET
       response:
@@ -25,20 +25,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1875
+        content_length: 1974
         uncompressed: false
-        body: '{"pops":[{"address":"29 Rue Edith Cavell","available_link_bandwidths_mbps":[],"city":"Vitry-sur-Seine","display_name":"Paris - OpCore DC2","hosting_provider_name":"OpCore","id":"f2e1cf2f-efec-4798-a959-767310ab30ae","logo_url":"https://app.opcore.com/web/image/website/1/logo/OPCORE","name":"DC2","region":"fr-par"},{"address":"59 Rue Julian Grimau","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,20000,25000,50000,100000],"city":"Vitry-sur-Seine","display_name":"Paris - OpCore DC3","hosting_provider_name":"OpCore","id":"c1165d78-bd85-4574-9958-b068a6d191f9","logo_url":"https://app.opcore.com/web/image/website/1/logo/OPCORE","name":"DC3","region":"fr-par"},{"address":"27 Avenue de l Eguillette","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,20000,25000,50000,100000],"city":"Saint-Ouen-l-Aumône","display_name":"Paris - OpCore DC5","hosting_provider_name":"OpCore","id":"6c72a01d-6489-414c-aae6-863740b061c2","logo_url":"https://app.opcore.com/web/image/website/1/logo/OPCORE","name":"DC5","region":"fr-par"},{"address":"Chem. du Cap-Janet","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Marseille","display_name":"Marseille - Interxion MRS2","hosting_provider_name":"Interxion","id":"118e6439-6821-46be-92ca-fb558a46cf6f","logo_url":"https://res.cloudinary.com/digitalrealty/image/upload/f_auto,c_limit,w_640,q_auto/images/logo.png","name":"- Interxion MRS2","region":"fr-par"},{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"- Telehouse TH2","region":"fr-par"}],"total_count":5}'
+        body: '{"pops":[{"address":"Chem. du Cap-Janet","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Marseille","display_name":"Marseille - Interxion MRS2","hosting_provider_name":"Interxion","id":"118e6439-6821-46be-92ca-fb558a46cf6f","logo_url":"https://res.cloudinary.com/digitalrealty/image/upload/f_auto,c_limit,w_640,q_auto/images/logo.png","name":"Interxion MRS2","region":"fr-par"},{"address":"29 Rue Edith Cavell","available_link_bandwidths_mbps":[],"city":"Vitry-sur-Seine","display_name":"Paris - OpCore PAR2","hosting_provider_name":"OpCore","id":"f2e1cf2f-efec-4798-a959-767310ab30ae","logo_url":"https://app.opcore.com/web/image/website/1/logo/OPCORE","name":"OpCore PAR2","region":"fr-par"},{"address":"59 Rue Julian Grimau","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,20000,25000,50000,100000],"city":"Vitry-sur-Seine","display_name":"Paris - OpCore PAR3","hosting_provider_name":"OpCore","id":"c1165d78-bd85-4574-9958-b068a6d191f9","logo_url":"https://app.opcore.com/web/image/website/1/logo/OPCORE","name":"OpCore PAR3","region":"fr-par"},{"address":"27 Avenue de l Eguillette","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,20000,50000,100000],"city":"Saint-Ouen-l-Aumône","display_name":"Paris - OpCore PAR5","hosting_provider_name":"OpCore","id":"6c72a01d-6489-414c-aae6-863740b061c2","logo_url":"https://app.opcore.com/web/image/website/1/logo/OPCORE","name":"OpCore PAR5","region":"fr-par"},{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"TeleHouse TH2","region":"fr-par"}],"total_count":5}'
         headers:
             Content-Length:
-                - "1875"
+                - "1974"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Apr 2026 06:15:39 GMT
+                - Mon, 24 Aug 2026 12:13:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -46,10 +46,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 85258acb-812d-4828-b129-ede0a590242f
+                - 8a41adb4-92fd-43a5-88d9-f7cbe0239701
         status: 200 OK
         code: 200
-        duration: 173.704875ms
+        duration: 161.400934ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -65,8 +65,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?order_by=name_asc
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/metadata
         method: GET
       response:
         proto: HTTP/2.0
@@ -74,20 +74,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1875
+        content_length: 59
         uncompressed: false
-        body: '{"pops":[{"address":"29 Rue Edith Cavell","available_link_bandwidths_mbps":[],"city":"Vitry-sur-Seine","display_name":"Paris - OpCore DC2","hosting_provider_name":"OpCore","id":"f2e1cf2f-efec-4798-a959-767310ab30ae","logo_url":"https://app.opcore.com/web/image/website/1/logo/OPCORE","name":"DC2","region":"fr-par"},{"address":"59 Rue Julian Grimau","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,20000,25000,50000,100000],"city":"Vitry-sur-Seine","display_name":"Paris - OpCore DC3","hosting_provider_name":"OpCore","id":"c1165d78-bd85-4574-9958-b068a6d191f9","logo_url":"https://app.opcore.com/web/image/website/1/logo/OPCORE","name":"DC3","region":"fr-par"},{"address":"27 Avenue de l Eguillette","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,20000,25000,50000,100000],"city":"Saint-Ouen-l-Aumône","display_name":"Paris - OpCore DC5","hosting_provider_name":"OpCore","id":"6c72a01d-6489-414c-aae6-863740b061c2","logo_url":"https://app.opcore.com/web/image/website/1/logo/OPCORE","name":"DC5","region":"fr-par"},{"address":"Chem. du Cap-Janet","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Marseille","display_name":"Marseille - Interxion MRS2","hosting_provider_name":"Interxion","id":"118e6439-6821-46be-92ca-fb558a46cf6f","logo_url":"https://res.cloudinary.com/digitalrealty/image/upload/f_auto,c_limit,w_640,q_auto/images/logo.png","name":"- Interxion MRS2","region":"fr-par"},{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"- Telehouse TH2","region":"fr-par"}],"total_count":5}'
+        body: '{"domain":"scw.eu","partition":"scw","platform":"external"}'
         headers:
             Content-Length:
-                - "1875"
+                - "59"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Apr 2026 06:15:39 GMT
+                - Mon, 24 Aug 2026 12:13:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -95,10 +95,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a754317a-c5dd-4a51-8164-3ca3ae556355
+                - 3daf93fe-8b76-42af-a7c3-414ff7768288
         status: 200 OK
         code: 200
-        duration: 64.664875ms
+        duration: 22.587041ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -114,7 +114,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?order_by=name_asc
         method: GET
       response:
@@ -123,20 +123,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1875
+        content_length: 1974
         uncompressed: false
-        body: '{"pops":[{"address":"29 Rue Edith Cavell","available_link_bandwidths_mbps":[],"city":"Vitry-sur-Seine","display_name":"Paris - OpCore DC2","hosting_provider_name":"OpCore","id":"f2e1cf2f-efec-4798-a959-767310ab30ae","logo_url":"https://app.opcore.com/web/image/website/1/logo/OPCORE","name":"DC2","region":"fr-par"},{"address":"59 Rue Julian Grimau","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,20000,25000,50000,100000],"city":"Vitry-sur-Seine","display_name":"Paris - OpCore DC3","hosting_provider_name":"OpCore","id":"c1165d78-bd85-4574-9958-b068a6d191f9","logo_url":"https://app.opcore.com/web/image/website/1/logo/OPCORE","name":"DC3","region":"fr-par"},{"address":"27 Avenue de l Eguillette","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,20000,25000,50000,100000],"city":"Saint-Ouen-l-Aumône","display_name":"Paris - OpCore DC5","hosting_provider_name":"OpCore","id":"6c72a01d-6489-414c-aae6-863740b061c2","logo_url":"https://app.opcore.com/web/image/website/1/logo/OPCORE","name":"DC5","region":"fr-par"},{"address":"Chem. du Cap-Janet","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Marseille","display_name":"Marseille - Interxion MRS2","hosting_provider_name":"Interxion","id":"118e6439-6821-46be-92ca-fb558a46cf6f","logo_url":"https://res.cloudinary.com/digitalrealty/image/upload/f_auto,c_limit,w_640,q_auto/images/logo.png","name":"- Interxion MRS2","region":"fr-par"},{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"- Telehouse TH2","region":"fr-par"}],"total_count":5}'
+        body: '{"pops":[{"address":"Chem. du Cap-Janet","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Marseille","display_name":"Marseille - Interxion MRS2","hosting_provider_name":"Interxion","id":"118e6439-6821-46be-92ca-fb558a46cf6f","logo_url":"https://res.cloudinary.com/digitalrealty/image/upload/f_auto,c_limit,w_640,q_auto/images/logo.png","name":"Interxion MRS2","region":"fr-par"},{"address":"29 Rue Edith Cavell","available_link_bandwidths_mbps":[],"city":"Vitry-sur-Seine","display_name":"Paris - OpCore PAR2","hosting_provider_name":"OpCore","id":"f2e1cf2f-efec-4798-a959-767310ab30ae","logo_url":"https://app.opcore.com/web/image/website/1/logo/OPCORE","name":"OpCore PAR2","region":"fr-par"},{"address":"59 Rue Julian Grimau","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,20000,25000,50000,100000],"city":"Vitry-sur-Seine","display_name":"Paris - OpCore PAR3","hosting_provider_name":"OpCore","id":"c1165d78-bd85-4574-9958-b068a6d191f9","logo_url":"https://app.opcore.com/web/image/website/1/logo/OPCORE","name":"OpCore PAR3","region":"fr-par"},{"address":"27 Avenue de l Eguillette","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,20000,50000,100000],"city":"Saint-Ouen-l-Aumône","display_name":"Paris - OpCore PAR5","hosting_provider_name":"OpCore","id":"6c72a01d-6489-414c-aae6-863740b061c2","logo_url":"https://app.opcore.com/web/image/website/1/logo/OPCORE","name":"OpCore PAR5","region":"fr-par"},{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"TeleHouse TH2","region":"fr-par"}],"total_count":5}'
         headers:
             Content-Length:
-                - "1875"
+                - "1974"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Apr 2026 06:15:40 GMT
+                - Mon, 24 Aug 2026 12:13:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -144,7 +144,56 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 29d67fc4-11a4-4957-8259-cdb49081f280
+                - a85b3d22-2165-40bc-85c0-c1aa5d018ef2
         status: 200 OK
         code: 200
-        duration: 47.914417ms
+        duration: 48.702436ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?order_by=name_asc
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1974
+        uncompressed: false
+        body: '{"pops":[{"address":"Chem. du Cap-Janet","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Marseille","display_name":"Marseille - Interxion MRS2","hosting_provider_name":"Interxion","id":"118e6439-6821-46be-92ca-fb558a46cf6f","logo_url":"https://res.cloudinary.com/digitalrealty/image/upload/f_auto,c_limit,w_640,q_auto/images/logo.png","name":"Interxion MRS2","region":"fr-par"},{"address":"29 Rue Edith Cavell","available_link_bandwidths_mbps":[],"city":"Vitry-sur-Seine","display_name":"Paris - OpCore PAR2","hosting_provider_name":"OpCore","id":"f2e1cf2f-efec-4798-a959-767310ab30ae","logo_url":"https://app.opcore.com/web/image/website/1/logo/OPCORE","name":"OpCore PAR2","region":"fr-par"},{"address":"59 Rue Julian Grimau","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,20000,25000,50000,100000],"city":"Vitry-sur-Seine","display_name":"Paris - OpCore PAR3","hosting_provider_name":"OpCore","id":"c1165d78-bd85-4574-9958-b068a6d191f9","logo_url":"https://app.opcore.com/web/image/website/1/logo/OPCORE","name":"OpCore PAR3","region":"fr-par"},{"address":"27 Avenue de l Eguillette","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,20000,50000,100000],"city":"Saint-Ouen-l-Aumône","display_name":"Paris - OpCore PAR5","hosting_provider_name":"OpCore","id":"6c72a01d-6489-414c-aae6-863740b061c2","logo_url":"https://app.opcore.com/web/image/website/1/logo/OPCORE","name":"OpCore PAR5","region":"fr-par"},{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"TeleHouse TH2","region":"fr-par"}],"total_count":5}'
+        headers:
+            Content-Length:
+                - "1974"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 24 Aug 2026 12:13:39 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - aac7072e-30ef-4004-a7f1-35337bd07e8d
+        status: 200 OK
+        code: 200
+        duration: 58.120599ms

--- a/internal/services/interlink/testdata/data-source-interlink-pops-by-provider-name.cassette.yaml
+++ b/internal/services/interlink/testdata/data-source-interlink-pops-by-provider-name.cassette.yaml
@@ -16,7 +16,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?hosting_provider_name=OpCore&order_by=name_asc
         method: GET
       response:
@@ -25,20 +25,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1079
+        content_length: 1148
         uncompressed: false
-        body: '{"pops":[{"address":"29 Rue Edith Cavell","available_link_bandwidths_mbps":[],"city":"Vitry-sur-Seine","display_name":"Paris - OpCore DC2","hosting_provider_name":"OpCore","id":"f2e1cf2f-efec-4798-a959-767310ab30ae","logo_url":"https://app.opcore.com/web/image/website/1/logo/OPCORE","name":"DC2","region":"fr-par"},{"address":"59 Rue Julian Grimau","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,20000,25000,50000,100000],"city":"Vitry-sur-Seine","display_name":"Paris - OpCore DC3","hosting_provider_name":"OpCore","id":"c1165d78-bd85-4574-9958-b068a6d191f9","logo_url":"https://app.opcore.com/web/image/website/1/logo/OPCORE","name":"DC3","region":"fr-par"},{"address":"27 Avenue de l Eguillette","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,20000,25000,50000,100000],"city":"Saint-Ouen-l-Aumône","display_name":"Paris - OpCore DC5","hosting_provider_name":"OpCore","id":"6c72a01d-6489-414c-aae6-863740b061c2","logo_url":"https://app.opcore.com/web/image/website/1/logo/OPCORE","name":"DC5","region":"fr-par"}],"total_count":3}'
+        body: '{"pops":[{"address":"29 Rue Edith Cavell","available_link_bandwidths_mbps":[],"city":"Vitry-sur-Seine","display_name":"Paris - OpCore PAR2","hosting_provider_name":"OpCore","id":"f2e1cf2f-efec-4798-a959-767310ab30ae","logo_url":"https://app.opcore.com/web/image/website/1/logo/OPCORE","name":"OpCore PAR2","region":"fr-par"},{"address":"59 Rue Julian Grimau","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,20000,25000,50000,100000],"city":"Vitry-sur-Seine","display_name":"Paris - OpCore PAR3","hosting_provider_name":"OpCore","id":"c1165d78-bd85-4574-9958-b068a6d191f9","logo_url":"https://app.opcore.com/web/image/website/1/logo/OPCORE","name":"OpCore PAR3","region":"fr-par"},{"address":"27 Avenue de l Eguillette","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,20000,50000,100000],"city":"Saint-Ouen-l-Aumône","display_name":"Paris - OpCore PAR5","hosting_provider_name":"OpCore","id":"6c72a01d-6489-414c-aae6-863740b061c2","logo_url":"https://app.opcore.com/web/image/website/1/logo/OPCORE","name":"OpCore PAR5","region":"fr-par"}],"total_count":3}'
         headers:
             Content-Length:
-                - "1079"
+                - "1148"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Apr 2026 06:17:09 GMT
+                - Mon, 24 Aug 2026 12:13:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -46,10 +46,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 17578aec-8d8e-448f-8372-a17da52a31af
+                - e226c338-ed3c-4109-a726-c56d921ecc68
         status: 200 OK
         code: 200
-        duration: 235.580417ms
+        duration: 143.278604ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -65,8 +65,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?hosting_provider_name=OpCore&order_by=name_asc
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/metadata
         method: GET
       response:
         proto: HTTP/2.0
@@ -74,20 +74,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1079
+        content_length: 59
         uncompressed: false
-        body: '{"pops":[{"address":"29 Rue Edith Cavell","available_link_bandwidths_mbps":[],"city":"Vitry-sur-Seine","display_name":"Paris - OpCore DC2","hosting_provider_name":"OpCore","id":"f2e1cf2f-efec-4798-a959-767310ab30ae","logo_url":"https://app.opcore.com/web/image/website/1/logo/OPCORE","name":"DC2","region":"fr-par"},{"address":"59 Rue Julian Grimau","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,20000,25000,50000,100000],"city":"Vitry-sur-Seine","display_name":"Paris - OpCore DC3","hosting_provider_name":"OpCore","id":"c1165d78-bd85-4574-9958-b068a6d191f9","logo_url":"https://app.opcore.com/web/image/website/1/logo/OPCORE","name":"DC3","region":"fr-par"},{"address":"27 Avenue de l Eguillette","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,20000,25000,50000,100000],"city":"Saint-Ouen-l-Aumône","display_name":"Paris - OpCore DC5","hosting_provider_name":"OpCore","id":"6c72a01d-6489-414c-aae6-863740b061c2","logo_url":"https://app.opcore.com/web/image/website/1/logo/OPCORE","name":"DC5","region":"fr-par"}],"total_count":3}'
+        body: '{"domain":"scw.eu","partition":"scw","platform":"external"}'
         headers:
             Content-Length:
-                - "1079"
+                - "59"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Apr 2026 06:17:10 GMT
+                - Mon, 24 Aug 2026 12:13:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -95,10 +95,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 38040263-b5ed-4c93-a4f2-efcbb0ba1d53
+                - 6a7f2a10-f772-49f2-ad94-fe1a0737ce75
         status: 200 OK
         code: 200
-        duration: 40.556167ms
+        duration: 27.711826ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -114,7 +114,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?hosting_provider_name=OpCore&order_by=name_asc
         method: GET
       response:
@@ -123,20 +123,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1079
+        content_length: 1148
         uncompressed: false
-        body: '{"pops":[{"address":"29 Rue Edith Cavell","available_link_bandwidths_mbps":[],"city":"Vitry-sur-Seine","display_name":"Paris - OpCore DC2","hosting_provider_name":"OpCore","id":"f2e1cf2f-efec-4798-a959-767310ab30ae","logo_url":"https://app.opcore.com/web/image/website/1/logo/OPCORE","name":"DC2","region":"fr-par"},{"address":"59 Rue Julian Grimau","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,20000,25000,50000,100000],"city":"Vitry-sur-Seine","display_name":"Paris - OpCore DC3","hosting_provider_name":"OpCore","id":"c1165d78-bd85-4574-9958-b068a6d191f9","logo_url":"https://app.opcore.com/web/image/website/1/logo/OPCORE","name":"DC3","region":"fr-par"},{"address":"27 Avenue de l Eguillette","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,20000,25000,50000,100000],"city":"Saint-Ouen-l-Aumône","display_name":"Paris - OpCore DC5","hosting_provider_name":"OpCore","id":"6c72a01d-6489-414c-aae6-863740b061c2","logo_url":"https://app.opcore.com/web/image/website/1/logo/OPCORE","name":"DC5","region":"fr-par"}],"total_count":3}'
+        body: '{"pops":[{"address":"29 Rue Edith Cavell","available_link_bandwidths_mbps":[],"city":"Vitry-sur-Seine","display_name":"Paris - OpCore PAR2","hosting_provider_name":"OpCore","id":"f2e1cf2f-efec-4798-a959-767310ab30ae","logo_url":"https://app.opcore.com/web/image/website/1/logo/OPCORE","name":"OpCore PAR2","region":"fr-par"},{"address":"59 Rue Julian Grimau","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,20000,25000,50000,100000],"city":"Vitry-sur-Seine","display_name":"Paris - OpCore PAR3","hosting_provider_name":"OpCore","id":"c1165d78-bd85-4574-9958-b068a6d191f9","logo_url":"https://app.opcore.com/web/image/website/1/logo/OPCORE","name":"OpCore PAR3","region":"fr-par"},{"address":"27 Avenue de l Eguillette","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,20000,50000,100000],"city":"Saint-Ouen-l-Aumône","display_name":"Paris - OpCore PAR5","hosting_provider_name":"OpCore","id":"6c72a01d-6489-414c-aae6-863740b061c2","logo_url":"https://app.opcore.com/web/image/website/1/logo/OPCORE","name":"OpCore PAR5","region":"fr-par"}],"total_count":3}'
         headers:
             Content-Length:
-                - "1079"
+                - "1148"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 03 Apr 2026 06:17:10 GMT
+                - Mon, 24 Aug 2026 12:13:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -144,7 +144,56 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 55c1d965-7571-4099-bd93-c1e92436dc89
+                - c6e937cd-fd7d-403d-a9c0-77cbf9a70afe
         status: 200 OK
         code: 200
-        duration: 29.60375ms
+        duration: 51.261994ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?hosting_provider_name=OpCore&order_by=name_asc
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1148
+        uncompressed: false
+        body: '{"pops":[{"address":"29 Rue Edith Cavell","available_link_bandwidths_mbps":[],"city":"Vitry-sur-Seine","display_name":"Paris - OpCore PAR2","hosting_provider_name":"OpCore","id":"f2e1cf2f-efec-4798-a959-767310ab30ae","logo_url":"https://app.opcore.com/web/image/website/1/logo/OPCORE","name":"OpCore PAR2","region":"fr-par"},{"address":"59 Rue Julian Grimau","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,20000,25000,50000,100000],"city":"Vitry-sur-Seine","display_name":"Paris - OpCore PAR3","hosting_provider_name":"OpCore","id":"c1165d78-bd85-4574-9958-b068a6d191f9","logo_url":"https://app.opcore.com/web/image/website/1/logo/OPCORE","name":"OpCore PAR3","region":"fr-par"},{"address":"27 Avenue de l Eguillette","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,20000,50000,100000],"city":"Saint-Ouen-l-Aumône","display_name":"Paris - OpCore PAR5","hosting_provider_name":"OpCore","id":"6c72a01d-6489-414c-aae6-863740b061c2","logo_url":"https://app.opcore.com/web/image/website/1/logo/OPCORE","name":"OpCore PAR5","region":"fr-par"}],"total_count":3}'
+        headers:
+            Content-Length:
+                - "1148"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 24 Aug 2026 12:13:39 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4a4d3f9a-d4db-4f81-b9f8-b65f17ceb87a
+        status: 200 OK
+        code: 200
+        duration: 46.674571ms

--- a/internal/services/interlink/testdata/data-source-interlink-routing-policy-basic.cassette.yaml
+++ b/internal/services/interlink/testdata/data-source-interlink-routing-policy-basic.cassette.yaml
@@ -12,13 +12,13 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","name":"tf-test-interlink-routing-policy-ds","tags":[],"prefix_filter_in":["10.0.1.0/24"],"prefix_filter_out":["10.0.0.0/24"],"is_ipv6":false}'
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-interlink-routing-policy-ds","tags":[],"prefix_filter_in":["10.0.1.0/24"],"prefix_filter_out":["10.0.0.0/24"],"is_ipv6":false}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies
         method: POST
       response:
@@ -29,7 +29,7 @@ interactions:
         trailer: {}
         content_length: 410
         uncompressed: false
-        body: '{"created_at":"2026-04-13T05:59:45.226294Z","id":"76248157-5d63-4586-81a6-def157dc1c3a","is_ipv6":false,"name":"tf-test-interlink-routing-policy-ds","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","prefix_filter_in":["10.0.1.0/24"],"prefix_filter_out":["10.0.0.0/24"],"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","tags":[],"updated_at":"2026-04-13T05:59:45.226294Z"}'
+        body: '{"created_at":"2026-08-24T12:13:40.820526Z","id":"edc68dc4-b348-4a6c-8dda-5c4267d84e32","is_ipv6":false,"name":"tf-test-interlink-routing-policy-ds","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","prefix_filter_in":["10.0.1.0/24"],"prefix_filter_out":["10.0.0.0/24"],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":[],"updated_at":"2026-08-24T12:13:40.820526Z"}'
         headers:
             Content-Length:
                 - "410"
@@ -38,9 +38,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 13 Apr 2026 05:59:45 GMT
+                - Mon, 24 Aug 2026 12:13:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a7967136-8c80-4a74-95b0-f52a3cad4f56
+                - 2ee0fa0f-8fd2-4dc3-8b6f-e726aed956f7
         status: 200 OK
         code: 200
-        duration: 208.418916ms
+        duration: 217.686858ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,8 +67,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies/76248157-5d63-4586-81a6-def157dc1c3a
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/metadata
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 410
+        content_length: 59
         uncompressed: false
-        body: '{"created_at":"2026-04-13T05:59:45.226294Z","id":"76248157-5d63-4586-81a6-def157dc1c3a","is_ipv6":false,"name":"tf-test-interlink-routing-policy-ds","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","prefix_filter_in":["10.0.1.0/24"],"prefix_filter_out":["10.0.0.0/24"],"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","tags":[],"updated_at":"2026-04-13T05:59:45.226294Z"}'
+        body: '{"domain":"scw.eu","partition":"scw","platform":"external"}'
         headers:
             Content-Length:
-                - "410"
+                - "59"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 13 Apr 2026 05:59:45 GMT
+                - Mon, 24 Aug 2026 12:13:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c9607059-7bd8-4178-9b4d-52a0f49afec2
+                - 53d9d207-da49-4a93-9cb9-ea06749afc9f
         status: 200 OK
         code: 200
-        duration: 31.565375ms
+        duration: 19.099132ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -116,8 +116,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies/76248157-5d63-4586-81a6-def157dc1c3a
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies/edc68dc4-b348-4a6c-8dda-5c4267d84e32
         method: GET
       response:
         proto: HTTP/2.0
@@ -127,7 +127,7 @@ interactions:
         trailer: {}
         content_length: 410
         uncompressed: false
-        body: '{"created_at":"2026-04-13T05:59:45.226294Z","id":"76248157-5d63-4586-81a6-def157dc1c3a","is_ipv6":false,"name":"tf-test-interlink-routing-policy-ds","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","prefix_filter_in":["10.0.1.0/24"],"prefix_filter_out":["10.0.0.0/24"],"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","tags":[],"updated_at":"2026-04-13T05:59:45.226294Z"}'
+        body: '{"created_at":"2026-08-24T12:13:40.820526Z","id":"edc68dc4-b348-4a6c-8dda-5c4267d84e32","is_ipv6":false,"name":"tf-test-interlink-routing-policy-ds","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","prefix_filter_in":["10.0.1.0/24"],"prefix_filter_out":["10.0.0.0/24"],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":[],"updated_at":"2026-08-24T12:13:40.820526Z"}'
         headers:
             Content-Length:
                 - "410"
@@ -136,9 +136,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 13 Apr 2026 05:59:45 GMT
+                - Mon, 24 Aug 2026 12:13:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 06aaac6b-13bc-4528-8668-810898511227
+                - 0a1ecbc7-0070-46ae-b14e-d85007f9d477
         status: 200 OK
         code: 200
-        duration: 38.690917ms
+        duration: 34.614274ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -165,8 +165,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies/76248157-5d63-4586-81a6-def157dc1c3a
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies/edc68dc4-b348-4a6c-8dda-5c4267d84e32
         method: GET
       response:
         proto: HTTP/2.0
@@ -176,7 +176,7 @@ interactions:
         trailer: {}
         content_length: 410
         uncompressed: false
-        body: '{"created_at":"2026-04-13T05:59:45.226294Z","id":"76248157-5d63-4586-81a6-def157dc1c3a","is_ipv6":false,"name":"tf-test-interlink-routing-policy-ds","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","prefix_filter_in":["10.0.1.0/24"],"prefix_filter_out":["10.0.0.0/24"],"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","tags":[],"updated_at":"2026-04-13T05:59:45.226294Z"}'
+        body: '{"created_at":"2026-08-24T12:13:40.820526Z","id":"edc68dc4-b348-4a6c-8dda-5c4267d84e32","is_ipv6":false,"name":"tf-test-interlink-routing-policy-ds","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","prefix_filter_in":["10.0.1.0/24"],"prefix_filter_out":["10.0.0.0/24"],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":[],"updated_at":"2026-08-24T12:13:40.820526Z"}'
         headers:
             Content-Length:
                 - "410"
@@ -185,9 +185,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 13 Apr 2026 05:59:45 GMT
+                - Mon, 24 Aug 2026 12:13:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,10 +195,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4398c658-6ecb-4bef-97a2-a8c0b9640a37
+                - 04f5532a-2e25-4fbf-9be4-43472af941a1
         status: 200 OK
         code: 200
-        duration: 22.62325ms
+        duration: 31.734132ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -214,8 +214,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies/76248157-5d63-4586-81a6-def157dc1c3a
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies/edc68dc4-b348-4a6c-8dda-5c4267d84e32
         method: GET
       response:
         proto: HTTP/2.0
@@ -225,7 +225,7 @@ interactions:
         trailer: {}
         content_length: 410
         uncompressed: false
-        body: '{"created_at":"2026-04-13T05:59:45.226294Z","id":"76248157-5d63-4586-81a6-def157dc1c3a","is_ipv6":false,"name":"tf-test-interlink-routing-policy-ds","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","prefix_filter_in":["10.0.1.0/24"],"prefix_filter_out":["10.0.0.0/24"],"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","tags":[],"updated_at":"2026-04-13T05:59:45.226294Z"}'
+        body: '{"created_at":"2026-08-24T12:13:40.820526Z","id":"edc68dc4-b348-4a6c-8dda-5c4267d84e32","is_ipv6":false,"name":"tf-test-interlink-routing-policy-ds","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","prefix_filter_in":["10.0.1.0/24"],"prefix_filter_out":["10.0.0.0/24"],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":[],"updated_at":"2026-08-24T12:13:40.820526Z"}'
         headers:
             Content-Length:
                 - "410"
@@ -234,9 +234,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 13 Apr 2026 05:59:45 GMT
+                - Mon, 24 Aug 2026 12:13:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -244,10 +244,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c6ad602b-fc58-4f8c-a3b0-47d7c4a7dadd
+                - 065dbf40-6452-4166-be7b-9e052e0d23e4
         status: 200 OK
         code: 200
-        duration: 35.851417ms
+        duration: 34.565712ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -263,8 +263,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies?name=tf-test-interlink-routing-policy-ds&order_by=created_at_asc
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies/edc68dc4-b348-4a6c-8dda-5c4267d84e32
         method: GET
       response:
         proto: HTTP/2.0
@@ -272,20 +272,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 450
+        content_length: 410
         uncompressed: false
-        body: '{"routing_policies":[{"created_at":"2026-04-13T05:59:45.226294Z","id":"76248157-5d63-4586-81a6-def157dc1c3a","is_ipv6":false,"name":"tf-test-interlink-routing-policy-ds","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","prefix_filter_in":["10.0.1.0/24"],"prefix_filter_out":["10.0.0.0/24"],"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","tags":[],"updated_at":"2026-04-13T05:59:45.226294Z"}],"total_count":1}'
+        body: '{"created_at":"2026-08-24T12:13:40.820526Z","id":"edc68dc4-b348-4a6c-8dda-5c4267d84e32","is_ipv6":false,"name":"tf-test-interlink-routing-policy-ds","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","prefix_filter_in":["10.0.1.0/24"],"prefix_filter_out":["10.0.0.0/24"],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":[],"updated_at":"2026-08-24T12:13:40.820526Z"}'
         headers:
             Content-Length:
-                - "450"
+                - "410"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 13 Apr 2026 05:59:45 GMT
+                - Mon, 24 Aug 2026 12:13:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -293,10 +293,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 17eb72c0-475d-489b-a5f1-c3c1fba16b8d
+                - 119d6fb5-b7d0-4d4c-80a4-11c68bf99e75
         status: 200 OK
         code: 200
-        duration: 42.051667ms
+        duration: 39.159136ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -312,8 +312,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies/76248157-5d63-4586-81a6-def157dc1c3a
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies?name=tf-test-interlink-routing-policy-ds&order_by=created_at_asc
         method: GET
       response:
         proto: HTTP/2.0
@@ -321,20 +321,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 410
+        content_length: 450
         uncompressed: false
-        body: '{"created_at":"2026-04-13T05:59:45.226294Z","id":"76248157-5d63-4586-81a6-def157dc1c3a","is_ipv6":false,"name":"tf-test-interlink-routing-policy-ds","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","prefix_filter_in":["10.0.1.0/24"],"prefix_filter_out":["10.0.0.0/24"],"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","tags":[],"updated_at":"2026-04-13T05:59:45.226294Z"}'
+        body: '{"routing_policies":[{"created_at":"2026-08-24T12:13:40.820526Z","id":"edc68dc4-b348-4a6c-8dda-5c4267d84e32","is_ipv6":false,"name":"tf-test-interlink-routing-policy-ds","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","prefix_filter_in":["10.0.1.0/24"],"prefix_filter_out":["10.0.0.0/24"],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":[],"updated_at":"2026-08-24T12:13:40.820526Z"}],"total_count":1}'
         headers:
             Content-Length:
-                - "410"
+                - "450"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 13 Apr 2026 05:59:45 GMT
+                - Mon, 24 Aug 2026 12:13:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -342,10 +342,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d0418b22-8b9d-441a-a0e0-f7a8aff64519
+                - 6b9158e5-07c3-476b-beb7-e3e6adcf484e
         status: 200 OK
         code: 200
-        duration: 28.213333ms
+        duration: 116.12763ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -361,8 +361,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies/76248157-5d63-4586-81a6-def157dc1c3a
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies/edc68dc4-b348-4a6c-8dda-5c4267d84e32
         method: GET
       response:
         proto: HTTP/2.0
@@ -372,7 +372,7 @@ interactions:
         trailer: {}
         content_length: 410
         uncompressed: false
-        body: '{"created_at":"2026-04-13T05:59:45.226294Z","id":"76248157-5d63-4586-81a6-def157dc1c3a","is_ipv6":false,"name":"tf-test-interlink-routing-policy-ds","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","prefix_filter_in":["10.0.1.0/24"],"prefix_filter_out":["10.0.0.0/24"],"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","tags":[],"updated_at":"2026-04-13T05:59:45.226294Z"}'
+        body: '{"created_at":"2026-08-24T12:13:40.820526Z","id":"edc68dc4-b348-4a6c-8dda-5c4267d84e32","is_ipv6":false,"name":"tf-test-interlink-routing-policy-ds","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","prefix_filter_in":["10.0.1.0/24"],"prefix_filter_out":["10.0.0.0/24"],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":[],"updated_at":"2026-08-24T12:13:40.820526Z"}'
         headers:
             Content-Length:
                 - "410"
@@ -381,9 +381,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 13 Apr 2026 05:59:46 GMT
+                - Mon, 24 Aug 2026 12:13:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -391,10 +391,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ac4622bd-37eb-4684-8699-fd6d74b8f43d
+                - f3908fda-a91a-47e5-aba3-99315ba95280
         status: 200 OK
         code: 200
-        duration: 24.921959ms
+        duration: 33.183595ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -410,8 +410,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies/76248157-5d63-4586-81a6-def157dc1c3a
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies/edc68dc4-b348-4a6c-8dda-5c4267d84e32
         method: GET
       response:
         proto: HTTP/2.0
@@ -421,7 +421,7 @@ interactions:
         trailer: {}
         content_length: 410
         uncompressed: false
-        body: '{"created_at":"2026-04-13T05:59:45.226294Z","id":"76248157-5d63-4586-81a6-def157dc1c3a","is_ipv6":false,"name":"tf-test-interlink-routing-policy-ds","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","prefix_filter_in":["10.0.1.0/24"],"prefix_filter_out":["10.0.0.0/24"],"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","tags":[],"updated_at":"2026-04-13T05:59:45.226294Z"}'
+        body: '{"created_at":"2026-08-24T12:13:40.820526Z","id":"edc68dc4-b348-4a6c-8dda-5c4267d84e32","is_ipv6":false,"name":"tf-test-interlink-routing-policy-ds","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","prefix_filter_in":["10.0.1.0/24"],"prefix_filter_out":["10.0.0.0/24"],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":[],"updated_at":"2026-08-24T12:13:40.820526Z"}'
         headers:
             Content-Length:
                 - "410"
@@ -430,9 +430,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 13 Apr 2026 05:59:46 GMT
+                - Mon, 24 Aug 2026 12:13:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -440,10 +440,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8378adae-806f-45ad-83a9-e7efdf2cc79f
+                - 36754a0b-7da5-4410-8935-465ba41e3612
         status: 200 OK
         code: 200
-        duration: 28.186416ms
+        duration: 34.137214ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -459,8 +459,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies?name=tf-test-interlink-routing-policy-ds&order_by=created_at_asc
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies/edc68dc4-b348-4a6c-8dda-5c4267d84e32
         method: GET
       response:
         proto: HTTP/2.0
@@ -468,20 +468,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 450
+        content_length: 410
         uncompressed: false
-        body: '{"routing_policies":[{"created_at":"2026-04-13T05:59:45.226294Z","id":"76248157-5d63-4586-81a6-def157dc1c3a","is_ipv6":false,"name":"tf-test-interlink-routing-policy-ds","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","prefix_filter_in":["10.0.1.0/24"],"prefix_filter_out":["10.0.0.0/24"],"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","tags":[],"updated_at":"2026-04-13T05:59:45.226294Z"}],"total_count":1}'
+        body: '{"created_at":"2026-08-24T12:13:40.820526Z","id":"edc68dc4-b348-4a6c-8dda-5c4267d84e32","is_ipv6":false,"name":"tf-test-interlink-routing-policy-ds","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","prefix_filter_in":["10.0.1.0/24"],"prefix_filter_out":["10.0.0.0/24"],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":[],"updated_at":"2026-08-24T12:13:40.820526Z"}'
         headers:
             Content-Length:
-                - "450"
+                - "410"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 13 Apr 2026 05:59:46 GMT
+                - Mon, 24 Aug 2026 12:13:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -489,10 +489,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - abda9a25-49ce-4be1-a241-517261c4c03c
+                - d193b35b-9211-4101-b8c1-ca281c484cae
         status: 200 OK
         code: 200
-        duration: 68.485167ms
+        duration: 30.362344ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -508,8 +508,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies/76248157-5d63-4586-81a6-def157dc1c3a
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies?name=tf-test-interlink-routing-policy-ds&order_by=created_at_asc
         method: GET
       response:
         proto: HTTP/2.0
@@ -517,20 +517,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 410
+        content_length: 450
         uncompressed: false
-        body: '{"created_at":"2026-04-13T05:59:45.226294Z","id":"76248157-5d63-4586-81a6-def157dc1c3a","is_ipv6":false,"name":"tf-test-interlink-routing-policy-ds","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","prefix_filter_in":["10.0.1.0/24"],"prefix_filter_out":["10.0.0.0/24"],"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","tags":[],"updated_at":"2026-04-13T05:59:45.226294Z"}'
+        body: '{"routing_policies":[{"created_at":"2026-08-24T12:13:40.820526Z","id":"edc68dc4-b348-4a6c-8dda-5c4267d84e32","is_ipv6":false,"name":"tf-test-interlink-routing-policy-ds","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","prefix_filter_in":["10.0.1.0/24"],"prefix_filter_out":["10.0.0.0/24"],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":[],"updated_at":"2026-08-24T12:13:40.820526Z"}],"total_count":1}'
         headers:
             Content-Length:
-                - "410"
+                - "450"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 13 Apr 2026 05:59:46 GMT
+                - Mon, 24 Aug 2026 12:13:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -538,10 +538,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 28c8f3f7-e190-44c1-996a-760ff05636bb
+                - a8ecda0f-40bb-4dfe-a00b-0c5bc1841180
         status: 200 OK
         code: 200
-        duration: 28.25275ms
+        duration: 110.247509ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -557,8 +557,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies/76248157-5d63-4586-81a6-def157dc1c3a
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies/edc68dc4-b348-4a6c-8dda-5c4267d84e32
         method: GET
       response:
         proto: HTTP/2.0
@@ -568,7 +568,7 @@ interactions:
         trailer: {}
         content_length: 410
         uncompressed: false
-        body: '{"created_at":"2026-04-13T05:59:45.226294Z","id":"76248157-5d63-4586-81a6-def157dc1c3a","is_ipv6":false,"name":"tf-test-interlink-routing-policy-ds","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","prefix_filter_in":["10.0.1.0/24"],"prefix_filter_out":["10.0.0.0/24"],"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","tags":[],"updated_at":"2026-04-13T05:59:45.226294Z"}'
+        body: '{"created_at":"2026-08-24T12:13:40.820526Z","id":"edc68dc4-b348-4a6c-8dda-5c4267d84e32","is_ipv6":false,"name":"tf-test-interlink-routing-policy-ds","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","prefix_filter_in":["10.0.1.0/24"],"prefix_filter_out":["10.0.0.0/24"],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":[],"updated_at":"2026-08-24T12:13:40.820526Z"}'
         headers:
             Content-Length:
                 - "410"
@@ -577,9 +577,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 13 Apr 2026 05:59:46 GMT
+                - Mon, 24 Aug 2026 12:13:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -587,10 +587,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 07c0fe9a-d87c-40f6-b85a-bb57581d4305
+                - 62f385d8-f081-4258-81b5-25b1aa823bba
         status: 200 OK
         code: 200
-        duration: 24.609458ms
+        duration: 38.950372ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -606,8 +606,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies/76248157-5d63-4586-81a6-def157dc1c3a
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies/edc68dc4-b348-4a6c-8dda-5c4267d84e32
         method: GET
       response:
         proto: HTTP/2.0
@@ -617,7 +617,7 @@ interactions:
         trailer: {}
         content_length: 410
         uncompressed: false
-        body: '{"created_at":"2026-04-13T05:59:45.226294Z","id":"76248157-5d63-4586-81a6-def157dc1c3a","is_ipv6":false,"name":"tf-test-interlink-routing-policy-ds","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","prefix_filter_in":["10.0.1.0/24"],"prefix_filter_out":["10.0.0.0/24"],"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","tags":[],"updated_at":"2026-04-13T05:59:45.226294Z"}'
+        body: '{"created_at":"2026-08-24T12:13:40.820526Z","id":"edc68dc4-b348-4a6c-8dda-5c4267d84e32","is_ipv6":false,"name":"tf-test-interlink-routing-policy-ds","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","prefix_filter_in":["10.0.1.0/24"],"prefix_filter_out":["10.0.0.0/24"],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":[],"updated_at":"2026-08-24T12:13:40.820526Z"}'
         headers:
             Content-Length:
                 - "410"
@@ -626,9 +626,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 13 Apr 2026 05:59:46 GMT
+                - Mon, 24 Aug 2026 12:13:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -636,10 +636,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 77cdc8d8-a793-4c3c-b144-497ea951f05d
+                - ee36f704-74cc-482e-9deb-a651944f35e9
         status: 200 OK
         code: 200
-        duration: 28.240667ms
+        duration: 46.003724ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -655,8 +655,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies?name=tf-test-interlink-routing-policy-ds&order_by=created_at_asc
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies/edc68dc4-b348-4a6c-8dda-5c4267d84e32
         method: GET
       response:
         proto: HTTP/2.0
@@ -664,20 +664,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 450
+        content_length: 410
         uncompressed: false
-        body: '{"routing_policies":[{"created_at":"2026-04-13T05:59:45.226294Z","id":"76248157-5d63-4586-81a6-def157dc1c3a","is_ipv6":false,"name":"tf-test-interlink-routing-policy-ds","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","prefix_filter_in":["10.0.1.0/24"],"prefix_filter_out":["10.0.0.0/24"],"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","tags":[],"updated_at":"2026-04-13T05:59:45.226294Z"}],"total_count":1}'
+        body: '{"created_at":"2026-08-24T12:13:40.820526Z","id":"edc68dc4-b348-4a6c-8dda-5c4267d84e32","is_ipv6":false,"name":"tf-test-interlink-routing-policy-ds","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","prefix_filter_in":["10.0.1.0/24"],"prefix_filter_out":["10.0.0.0/24"],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":[],"updated_at":"2026-08-24T12:13:40.820526Z"}'
         headers:
             Content-Length:
-                - "450"
+                - "410"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 13 Apr 2026 05:59:46 GMT
+                - Mon, 24 Aug 2026 12:13:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -685,10 +685,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 08307cb4-d5ca-46f1-816e-3dbf9da61c0a
+                - ab44b4b5-8e9a-4843-b535-053c823c38b8
         status: 200 OK
         code: 200
-        duration: 46.558792ms
+        duration: 38.031338ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -704,8 +704,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies/76248157-5d63-4586-81a6-def157dc1c3a
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies?name=tf-test-interlink-routing-policy-ds&order_by=created_at_asc
         method: GET
       response:
         proto: HTTP/2.0
@@ -713,20 +713,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 410
+        content_length: 450
         uncompressed: false
-        body: '{"created_at":"2026-04-13T05:59:45.226294Z","id":"76248157-5d63-4586-81a6-def157dc1c3a","is_ipv6":false,"name":"tf-test-interlink-routing-policy-ds","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","prefix_filter_in":["10.0.1.0/24"],"prefix_filter_out":["10.0.0.0/24"],"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","tags":[],"updated_at":"2026-04-13T05:59:45.226294Z"}'
+        body: '{"routing_policies":[{"created_at":"2026-08-24T12:13:40.820526Z","id":"edc68dc4-b348-4a6c-8dda-5c4267d84e32","is_ipv6":false,"name":"tf-test-interlink-routing-policy-ds","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","prefix_filter_in":["10.0.1.0/24"],"prefix_filter_out":["10.0.0.0/24"],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":[],"updated_at":"2026-08-24T12:13:40.820526Z"}],"total_count":1}'
         headers:
             Content-Length:
-                - "410"
+                - "450"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 13 Apr 2026 05:59:46 GMT
+                - Mon, 24 Aug 2026 12:13:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -734,10 +734,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2335e70b-c35e-4201-842d-5d85d37ba433
+                - 42232118-a73c-4ca1-8716-ac00c4e966b9
         status: 200 OK
         code: 200
-        duration: 24.328041ms
+        duration: 141.149871ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -753,8 +753,57 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies/76248157-5d63-4586-81a6-def157dc1c3a
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies/edc68dc4-b348-4a6c-8dda-5c4267d84e32
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 410
+        uncompressed: false
+        body: '{"created_at":"2026-08-24T12:13:40.820526Z","id":"edc68dc4-b348-4a6c-8dda-5c4267d84e32","is_ipv6":false,"name":"tf-test-interlink-routing-policy-ds","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","prefix_filter_in":["10.0.1.0/24"],"prefix_filter_out":["10.0.0.0/24"],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":[],"updated_at":"2026-08-24T12:13:40.820526Z"}'
+        headers:
+            Content-Length:
+                - "410"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 24 Aug 2026 12:13:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d7dc8547-6fce-4bac-bde6-e2d74be399e3
+        status: 200 OK
+        code: 200
+        duration: 39.60713ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies/edc68dc4-b348-4a6c-8dda-5c4267d84e32
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -771,9 +820,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 13 Apr 2026 05:59:46 GMT
+                - Mon, 24 Aug 2026 12:13:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -781,59 +830,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 67ed9c08-1975-4b8c-a281-db211ddead5e
+                - 137b3d82-bc3a-4d24-a3af-f780ff4030f4
         status: 204 No Content
         code: 204
-        duration: 34.331333ms
-    - id: 16
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies/76248157-5d63-4586-81a6-def157dc1c3a
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 135
-        uncompressed: false
-        body: '{"message":"resource is not found","resource":"routing_policy","resource_id":"76248157-5d63-4586-81a6-def157dc1c3a","type":"not_found"}'
-        headers:
-            Content-Length:
-                - "135"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 13 Apr 2026 05:59:46 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 32d8ecbf-08da-46a1-a380-37dbb2d72eee
-        status: 404 Not Found
-        code: 404
-        duration: 25.085292ms
+        duration: 73.821739ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -849,8 +849,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies/76248157-5d63-4586-81a6-def157dc1c3a
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies/edc68dc4-b348-4a6c-8dda-5c4267d84e32
         method: GET
       response:
         proto: HTTP/2.0
@@ -860,7 +860,7 @@ interactions:
         trailer: {}
         content_length: 135
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"routing_policy","resource_id":"76248157-5d63-4586-81a6-def157dc1c3a","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"routing_policy","resource_id":"edc68dc4-b348-4a6c-8dda-5c4267d84e32","type":"not_found"}'
         headers:
             Content-Length:
                 - "135"
@@ -869,9 +869,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 13 Apr 2026 05:59:46 GMT
+                - Mon, 24 Aug 2026 12:13:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -879,10 +879,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6d146e3f-2cf7-419f-975f-10f36932ad5c
+                - d182a170-c76f-49cc-bd74-c803f1e5c922
         status: 404 Not Found
         code: 404
-        duration: 24.811042ms
+        duration: 47.475199ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -898,8 +898,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies/76248157-5d63-4586-81a6-def157dc1c3a
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies/edc68dc4-b348-4a6c-8dda-5c4267d84e32
         method: GET
       response:
         proto: HTTP/2.0
@@ -909,7 +909,7 @@ interactions:
         trailer: {}
         content_length: 135
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"routing_policy","resource_id":"76248157-5d63-4586-81a6-def157dc1c3a","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"routing_policy","resource_id":"edc68dc4-b348-4a6c-8dda-5c4267d84e32","type":"not_found"}'
         headers:
             Content-Length:
                 - "135"
@@ -918,9 +918,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 13 Apr 2026 05:59:46 GMT
+                - Mon, 24 Aug 2026 12:13:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -928,7 +928,56 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 499d1eb3-0a4e-4983-8875-f6ea4be0d4a8
+                - 45df745b-0e18-46ad-81fc-2c6ccc5c7042
         status: 404 Not Found
         code: 404
-        duration: 24.400917ms
+        duration: 41.38387ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies/edc68dc4-b348-4a6c-8dda-5c4267d84e32
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 135
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"routing_policy","resource_id":"edc68dc4-b348-4a6c-8dda-5c4267d84e32","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "135"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 24 Aug 2026 12:13:43 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f39f400d-3093-4bc4-ab64-d5b7b261470a
+        status: 404 Not Found
+        code: 404
+        duration: 34.815343ms

--- a/internal/services/interlink/testdata/interlink-link-basic.cassette.yaml
+++ b/internal/services/interlink/testdata/interlink-link-basic.cassette.yaml
@@ -16,7 +16,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
         method: GET
       response:
@@ -25,20 +25,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 708
+        content_length: 1158
         uncompressed: false
-        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","updated_at":"2024-11-28T08:45:33.852946Z"}],"total_count":2}'
+        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","l3_connectivity":true,"logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","region":"","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","l3_connectivity":true,"logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","region":"","updated_at":"2024-11-28T08:45:33.852946Z"},{"contact_email":"contact.experience-client@linkt.fr","created_at":"2026-04-21T14:31:08.285733Z","id":"4e0dcaaf-467c-432c-ad93-f28be5878df0","l3_connectivity":true,"logo_url":"https://www.linkt.fr/wp-content/themes/linkt/assets/img/svg/logo-linkt-sticky.svg","name":"Linkt","portal_url":"https://www.linkt.fr/","region":"","updated_at":"2026-07-07T11:57:51.706396Z"}],"total_count":3}'
         headers:
             Content-Length:
-                - "708"
+                - "1158"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 15:49:30 GMT
+                - Mon, 24 Aug 2026 12:13:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -46,10 +46,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5328537b-9d2f-4be9-abd6-53ae4531a3c7
+                - e82e872a-e23e-4841-be36-796e0bb38e3c
         status: 200 OK
         code: 200
-        duration: 206.40775ms
+        duration: 150.20623ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -65,8 +65,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=Telehouse+TH2&order_by=name_asc&page=1
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=TeleHouse+TH2&order_by=name_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -74,20 +74,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 431
+        content_length: 429
         uncompressed: false
-        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"- Telehouse TH2","region":"fr-par"}],"total_count":1}'
+        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"TeleHouse TH2","region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
-                - "431"
+                - "429"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 15:49:30 GMT
+                - Mon, 24 Aug 2026 12:13:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -95,50 +95,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 36b3eb14-190f-4e18-ba0f-0bd8cdfd20d6
+                - 2129e2b8-5915-47f3-a1a4-1955c8a160bb
         status: 200 OK
         code: 200
-        duration: 215.661416ms
+        duration: 157.651042ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 221
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","name":"tf-test-interlink-link","tags":["tag1"],"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","bandwidth_mbps":50,"partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links
-        method: POST
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/metadata
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 877
+        content_length: 59
         uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-15T15:49:30.752201Z","enable_route_propagation":false,"id":"c533d379-a8c5-43f4-a7cc-ef3d25d2a047","name":"tf-test-interlink-link","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"e1ed5670-30f0-4e5b-b5f2-a8d3d5e5477c","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.95/31","ipv6":"2001:1bc8:3812:fc60:1139:2efa:4387:d001/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.94/31","ipv6":"2001:1bc8:3812:fc60:1139:2efa:4387:d000/127"},"status":"requested","tags":["tag1"],"updated_at":"2026-04-15T15:49:30.752201Z","vlan":3295}'
+        body: '{"domain":"scw.eu","partition":"scw","platform":"external"}'
         headers:
             Content-Length:
-                - "877"
+                - "59"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 15:49:30 GMT
+                - Mon, 24 Aug 2026 12:13:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +144,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2a7eacb4-d51b-4879-b23b-bdc9ce126331
+                - faa93d51-e57b-436b-8c68-307881f462c7
         status: 200 OK
         code: 200
-        duration: 428.499917ms
+        duration: 19.827857ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -165,8 +163,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/c533d379-a8c5-43f4-a7cc-ef3d25d2a047
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/metadata
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,20 +172,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 877
+        content_length: 59
         uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-15T15:49:30.752201Z","enable_route_propagation":false,"id":"c533d379-a8c5-43f4-a7cc-ef3d25d2a047","name":"tf-test-interlink-link","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"e1ed5670-30f0-4e5b-b5f2-a8d3d5e5477c","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.95/31","ipv6":"2001:1bc8:3812:fc60:1139:2efa:4387:d001/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.94/31","ipv6":"2001:1bc8:3812:fc60:1139:2efa:4387:d000/127"},"status":"requested","tags":["tag1"],"updated_at":"2026-04-15T15:49:30.752201Z","vlan":3295}'
+        body: '{"domain":"scw.eu","partition":"scw","platform":"external"}'
         headers:
             Content-Length:
-                - "877"
+                - "59"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 15:49:30 GMT
+                - Mon, 24 Aug 2026 12:13:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,48 +193,50 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e1b1cd1e-e05b-415a-9134-42a97baba811
+                - 73048b82-9a13-4d8c-ae20-90841aff9db8
         status: 200 OK
         code: 200
-        duration: 60.885166ms
+        duration: 33.860213ms
     - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 221
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-interlink-link","tags":["tag1"],"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","bandwidth_mbps":50,"partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/c533d379-a8c5-43f4-a7cc-ef3d25d2a047
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 877
+        content_length: 899
         uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-15T15:49:30.752201Z","enable_route_propagation":false,"id":"c533d379-a8c5-43f4-a7cc-ef3d25d2a047","name":"tf-test-interlink-link","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"e1ed5670-30f0-4e5b-b5f2-a8d3d5e5477c","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.95/31","ipv6":"2001:1bc8:3812:fc60:1139:2efa:4387:d001/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.94/31","ipv6":"2001:1bc8:3812:fc60:1139:2efa:4387:d000/127"},"status":"requested","tags":["tag1"],"updated_at":"2026-04-15T15:49:30.752201Z","vlan":3295}'
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.343789Z","enable_route_propagation":false,"id":"bc0c63e7-1ce0-4e5c-9a2a-1988db4ff0de","name":"tf-test-interlink-link","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"f4490f6a-6855-40b9-b951-2a8b12d9a614","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.17/31","ipv6":"2001:1bc8:3812:fc60:4442:8556:623:6d01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.16/31","ipv6":"2001:1bc8:3812:fc60:4442:8556:623:6d00/127"},"status":"requested","tags":["tag1"],"updated_at":"2026-08-24T12:13:39.343789Z","vlan":1842}'
         headers:
             Content-Length:
-                - "877"
+                - "899"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 15:49:30 GMT
+                - Mon, 24 Aug 2026 12:13:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -244,10 +244,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0eaaf515-0142-4bfe-a7ea-08c945894ee7
+                - bd05eb09-e327-4237-80fc-5fd5c7531724
         status: 200 OK
         code: 200
-        duration: 59.683125ms
+        duration: 206.446301ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -263,8 +263,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/c533d379-a8c5-43f4-a7cc-ef3d25d2a047
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/bc0c63e7-1ce0-4e5c-9a2a-1988db4ff0de
         method: GET
       response:
         proto: HTTP/2.0
@@ -272,20 +272,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 877
+        content_length: 899
         uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-15T15:49:30.752201Z","enable_route_propagation":false,"id":"c533d379-a8c5-43f4-a7cc-ef3d25d2a047","name":"tf-test-interlink-link","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"e1ed5670-30f0-4e5b-b5f2-a8d3d5e5477c","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.95/31","ipv6":"2001:1bc8:3812:fc60:1139:2efa:4387:d001/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.94/31","ipv6":"2001:1bc8:3812:fc60:1139:2efa:4387:d000/127"},"status":"requested","tags":["tag1"],"updated_at":"2026-04-15T15:49:30.752201Z","vlan":3295}'
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.343789Z","enable_route_propagation":false,"id":"bc0c63e7-1ce0-4e5c-9a2a-1988db4ff0de","name":"tf-test-interlink-link","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"f4490f6a-6855-40b9-b951-2a8b12d9a614","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.17/31","ipv6":"2001:1bc8:3812:fc60:4442:8556:623:6d01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.16/31","ipv6":"2001:1bc8:3812:fc60:4442:8556:623:6d00/127"},"status":"requested","tags":["tag1"],"updated_at":"2026-08-24T12:13:39.343789Z","vlan":1842}'
         headers:
             Content-Length:
-                - "877"
+                - "899"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 15:49:31 GMT
+                - Mon, 24 Aug 2026 12:13:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -293,10 +293,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6de60126-a7bc-4ccd-abe6-a396ed725b5c
+                - ea93ff13-8812-4fc5-8292-22dfa93dab87
         status: 200 OK
         code: 200
-        duration: 61.156292ms
+        duration: 36.705418ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -312,8 +312,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/bc0c63e7-1ce0-4e5c-9a2a-1988db4ff0de
         method: GET
       response:
         proto: HTTP/2.0
@@ -321,20 +321,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 708
+        content_length: 899
         uncompressed: false
-        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","updated_at":"2024-11-28T08:45:33.852946Z"}],"total_count":2}'
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.343789Z","enable_route_propagation":false,"id":"bc0c63e7-1ce0-4e5c-9a2a-1988db4ff0de","name":"tf-test-interlink-link","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"f4490f6a-6855-40b9-b951-2a8b12d9a614","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.17/31","ipv6":"2001:1bc8:3812:fc60:4442:8556:623:6d01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.16/31","ipv6":"2001:1bc8:3812:fc60:4442:8556:623:6d00/127"},"status":"requested","tags":["tag1"],"updated_at":"2026-08-24T12:13:39.343789Z","vlan":1842}'
         headers:
             Content-Length:
-                - "708"
+                - "899"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 15:49:31 GMT
+                - Mon, 24 Aug 2026 12:13:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -342,10 +342,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 62963eb6-c38e-4fbc-9c0b-7ce02c38230e
+                - 1e55b964-f175-47df-b61f-5e2350c8bb2b
         status: 200 OK
         code: 200
-        duration: 34.769583ms
+        duration: 34.641987ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -361,8 +361,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=Telehouse+TH2&order_by=name_asc&page=1
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/bc0c63e7-1ce0-4e5c-9a2a-1988db4ff0de
         method: GET
       response:
         proto: HTTP/2.0
@@ -370,20 +370,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 431
+        content_length: 899
         uncompressed: false
-        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"- Telehouse TH2","region":"fr-par"}],"total_count":1}'
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.343789Z","enable_route_propagation":false,"id":"bc0c63e7-1ce0-4e5c-9a2a-1988db4ff0de","name":"tf-test-interlink-link","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"f4490f6a-6855-40b9-b951-2a8b12d9a614","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.17/31","ipv6":"2001:1bc8:3812:fc60:4442:8556:623:6d01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.16/31","ipv6":"2001:1bc8:3812:fc60:4442:8556:623:6d00/127"},"status":"requested","tags":["tag1"],"updated_at":"2026-08-24T12:13:39.343789Z","vlan":1842}'
         headers:
             Content-Length:
-                - "431"
+                - "899"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 15:49:31 GMT
+                - Mon, 24 Aug 2026 12:13:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -391,10 +391,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 08f00503-3adc-4043-8f5f-fc9eb0669520
+                - c908a75a-2df0-4482-a355-972ab285a08e
         status: 200 OK
         code: 200
-        duration: 52.534042ms
+        duration: 36.795469ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -410,7 +410,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
         method: GET
       response:
@@ -419,20 +419,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 708
+        content_length: 1158
         uncompressed: false
-        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","updated_at":"2024-11-28T08:45:33.852946Z"}],"total_count":2}'
+        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","l3_connectivity":true,"logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","region":"","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","l3_connectivity":true,"logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","region":"","updated_at":"2024-11-28T08:45:33.852946Z"},{"contact_email":"contact.experience-client@linkt.fr","created_at":"2026-04-21T14:31:08.285733Z","id":"4e0dcaaf-467c-432c-ad93-f28be5878df0","l3_connectivity":true,"logo_url":"https://www.linkt.fr/wp-content/themes/linkt/assets/img/svg/logo-linkt-sticky.svg","name":"Linkt","portal_url":"https://www.linkt.fr/","region":"","updated_at":"2026-07-07T11:57:51.706396Z"}],"total_count":3}'
         headers:
             Content-Length:
-                - "708"
+                - "1158"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 15:49:31 GMT
+                - Mon, 24 Aug 2026 12:13:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -440,10 +440,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6b91c758-9c52-4124-ad0a-56e00c16d763
+                - b4d5df9f-0e09-4dd8-b3a6-031fc921603a
         status: 200 OK
         code: 200
-        duration: 27.514458ms
+        duration: 43.314143ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -459,8 +459,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=Telehouse+TH2&order_by=name_asc&page=1
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=TeleHouse+TH2&order_by=name_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -468,20 +468,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 431
+        content_length: 429
         uncompressed: false
-        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"- Telehouse TH2","region":"fr-par"}],"total_count":1}'
+        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"TeleHouse TH2","region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
-                - "431"
+                - "429"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 15:49:31 GMT
+                - Mon, 24 Aug 2026 12:13:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -489,10 +489,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e94671da-5d39-48f4-b870-774b012278f8
+                - c474471c-e332-4d87-ad6b-35fe570c2665
         status: 200 OK
         code: 200
-        duration: 46.95125ms
+        duration: 44.706629ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -508,8 +508,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/c533d379-a8c5-43f4-a7cc-ef3d25d2a047
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -517,20 +517,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 877
+        content_length: 1158
         uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-15T15:49:30.752201Z","enable_route_propagation":false,"id":"c533d379-a8c5-43f4-a7cc-ef3d25d2a047","name":"tf-test-interlink-link","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"e1ed5670-30f0-4e5b-b5f2-a8d3d5e5477c","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.95/31","ipv6":"2001:1bc8:3812:fc60:1139:2efa:4387:d001/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.94/31","ipv6":"2001:1bc8:3812:fc60:1139:2efa:4387:d000/127"},"status":"requested","tags":["tag1"],"updated_at":"2026-04-15T15:49:30.752201Z","vlan":3295}'
+        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","l3_connectivity":true,"logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","region":"","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","l3_connectivity":true,"logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","region":"","updated_at":"2024-11-28T08:45:33.852946Z"},{"contact_email":"contact.experience-client@linkt.fr","created_at":"2026-04-21T14:31:08.285733Z","id":"4e0dcaaf-467c-432c-ad93-f28be5878df0","l3_connectivity":true,"logo_url":"https://www.linkt.fr/wp-content/themes/linkt/assets/img/svg/logo-linkt-sticky.svg","name":"Linkt","portal_url":"https://www.linkt.fr/","region":"","updated_at":"2026-07-07T11:57:51.706396Z"}],"total_count":3}'
         headers:
             Content-Length:
-                - "877"
+                - "1158"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 15:49:31 GMT
+                - Mon, 24 Aug 2026 12:13:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -538,10 +538,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d7ace1ac-17f0-42fe-9336-982e57f84943
+                - 3ed53bea-99ed-46c0-8509-0dc880d5d652
         status: 200 OK
         code: 200
-        duration: 32.215125ms
+        duration: 40.667421ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -557,8 +557,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=TeleHouse+TH2&order_by=name_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -566,20 +566,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 708
+        content_length: 429
         uncompressed: false
-        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","updated_at":"2024-11-28T08:45:33.852946Z"}],"total_count":2}'
+        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"TeleHouse TH2","region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
-                - "708"
+                - "429"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 15:49:31 GMT
+                - Mon, 24 Aug 2026 12:13:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -587,10 +587,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ccb79671-cfe4-4658-aae6-9707326c1a73
+                - 59bf764a-6467-4e8d-b49e-714dd120fc17
         status: 200 OK
         code: 200
-        duration: 34.089417ms
+        duration: 46.28221ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -606,8 +606,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=Telehouse+TH2&order_by=name_asc&page=1
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/bc0c63e7-1ce0-4e5c-9a2a-1988db4ff0de
         method: GET
       response:
         proto: HTTP/2.0
@@ -615,20 +615,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 431
+        content_length: 899
         uncompressed: false
-        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"- Telehouse TH2","region":"fr-par"}],"total_count":1}'
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.343789Z","enable_route_propagation":false,"id":"bc0c63e7-1ce0-4e5c-9a2a-1988db4ff0de","name":"tf-test-interlink-link","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"f4490f6a-6855-40b9-b951-2a8b12d9a614","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.17/31","ipv6":"2001:1bc8:3812:fc60:4442:8556:623:6d01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.16/31","ipv6":"2001:1bc8:3812:fc60:4442:8556:623:6d00/127"},"status":"requested","tags":["tag1"],"updated_at":"2026-08-24T12:13:39.343789Z","vlan":1842}'
         headers:
             Content-Length:
-                - "431"
+                - "899"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 15:49:31 GMT
+                - Mon, 24 Aug 2026 12:13:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -636,10 +636,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e135c4af-28ad-4f5c-a173-a0b7abba1624
+                - 0c7f480b-a08d-45d3-b11f-c15133eb1c2e
         status: 200 OK
         code: 200
-        duration: 46.495708ms
+        duration: 44.801468ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -655,8 +655,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/c533d379-a8c5-43f4-a7cc-ef3d25d2a047
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -664,20 +664,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 877
+        content_length: 1158
         uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-15T15:49:30.752201Z","enable_route_propagation":false,"id":"c533d379-a8c5-43f4-a7cc-ef3d25d2a047","name":"tf-test-interlink-link","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"e1ed5670-30f0-4e5b-b5f2-a8d3d5e5477c","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.95/31","ipv6":"2001:1bc8:3812:fc60:1139:2efa:4387:d001/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.94/31","ipv6":"2001:1bc8:3812:fc60:1139:2efa:4387:d000/127"},"status":"requested","tags":["tag1"],"updated_at":"2026-04-15T15:49:30.752201Z","vlan":3295}'
+        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","l3_connectivity":true,"logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","region":"","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","l3_connectivity":true,"logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","region":"","updated_at":"2024-11-28T08:45:33.852946Z"},{"contact_email":"contact.experience-client@linkt.fr","created_at":"2026-04-21T14:31:08.285733Z","id":"4e0dcaaf-467c-432c-ad93-f28be5878df0","l3_connectivity":true,"logo_url":"https://www.linkt.fr/wp-content/themes/linkt/assets/img/svg/logo-linkt-sticky.svg","name":"Linkt","portal_url":"https://www.linkt.fr/","region":"","updated_at":"2026-07-07T11:57:51.706396Z"}],"total_count":3}'
         headers:
             Content-Length:
-                - "877"
+                - "1158"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 15:49:31 GMT
+                - Mon, 24 Aug 2026 12:13:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -685,11 +685,109 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 613e5682-1126-4115-a679-74bce508a6ec
+                - e0b34cbc-7011-4f03-9f18-43f6282cc427
         status: 200 OK
         code: 200
-        duration: 26.16575ms
+        duration: 36.678077ms
     - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=TeleHouse+TH2&order_by=name_asc&page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 429
+        uncompressed: false
+        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"TeleHouse TH2","region":"fr-par"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "429"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 24 Aug 2026 12:13:40 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 54f102c7-5f88-48c7-8219-18de0df3c2a7
+        status: 200 OK
+        code: 200
+        duration: 44.998459ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/bc0c63e7-1ce0-4e5c-9a2a-1988db4ff0de
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 899
+        uncompressed: false
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.343789Z","enable_route_propagation":false,"id":"bc0c63e7-1ce0-4e5c-9a2a-1988db4ff0de","name":"tf-test-interlink-link","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"f4490f6a-6855-40b9-b951-2a8b12d9a614","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.17/31","ipv6":"2001:1bc8:3812:fc60:4442:8556:623:6d01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.16/31","ipv6":"2001:1bc8:3812:fc60:4442:8556:623:6d00/127"},"status":"requested","tags":["tag1"],"updated_at":"2026-08-24T12:13:39.343789Z","vlan":1842}'
+        headers:
+            Content-Length:
+                - "899"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 24 Aug 2026 12:13:40 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 90beea1f-181d-421e-9579-704a530e93e5
+        status: 200 OK
+        code: 200
+        duration: 51.066084ms
+    - id: 16
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -706,8 +804,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/c533d379-a8c5-43f4-a7cc-ef3d25d2a047
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/bc0c63e7-1ce0-4e5c-9a2a-1988db4ff0de
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -715,20 +813,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 893
+        content_length: 915
         uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-15T15:49:30.752201Z","enable_route_propagation":false,"id":"c533d379-a8c5-43f4-a7cc-ef3d25d2a047","name":"tf-test-interlink-link-updated","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"e1ed5670-30f0-4e5b-b5f2-a8d3d5e5477c","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.95/31","ipv6":"2001:1bc8:3812:fc60:1139:2efa:4387:d001/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.94/31","ipv6":"2001:1bc8:3812:fc60:1139:2efa:4387:d000/127"},"status":"requested","tags":["tag1","tag2"],"updated_at":"2026-04-15T15:49:31.966397Z","vlan":3295}'
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.343789Z","enable_route_propagation":false,"id":"bc0c63e7-1ce0-4e5c-9a2a-1988db4ff0de","name":"tf-test-interlink-link-updated","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"f4490f6a-6855-40b9-b951-2a8b12d9a614","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.17/31","ipv6":"2001:1bc8:3812:fc60:4442:8556:623:6d01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.16/31","ipv6":"2001:1bc8:3812:fc60:4442:8556:623:6d00/127"},"status":"requested","tags":["tag1","tag2"],"updated_at":"2026-08-24T12:13:41.084803Z","vlan":1842}'
         headers:
             Content-Length:
-                - "893"
+                - "915"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 15:49:31 GMT
+                - Mon, 24 Aug 2026 12:13:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -736,108 +834,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b0f395fd-abdf-4d65-9b19-4b15415b8869
+                - 6258811d-aec3-4def-9c33-7cfc5a79f2be
         status: 200 OK
         code: 200
-        duration: 83.488875ms
-    - id: 15
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/c533d379-a8c5-43f4-a7cc-ef3d25d2a047
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 893
-        uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-15T15:49:30.752201Z","enable_route_propagation":false,"id":"c533d379-a8c5-43f4-a7cc-ef3d25d2a047","name":"tf-test-interlink-link-updated","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"e1ed5670-30f0-4e5b-b5f2-a8d3d5e5477c","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.95/31","ipv6":"2001:1bc8:3812:fc60:1139:2efa:4387:d001/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.94/31","ipv6":"2001:1bc8:3812:fc60:1139:2efa:4387:d000/127"},"status":"requested","tags":["tag1","tag2"],"updated_at":"2026-04-15T15:49:31.966397Z","vlan":3295}'
-        headers:
-            Content-Length:
-                - "893"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 15 Apr 2026 15:49:32 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 4b70c93a-89ac-41a2-bedf-6715c55e4c0b
-        status: 200 OK
-        code: 200
-        duration: 32.170166ms
-    - id: 16
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/c533d379-a8c5-43f4-a7cc-ef3d25d2a047
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 893
-        uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-15T15:49:30.752201Z","enable_route_propagation":false,"id":"c533d379-a8c5-43f4-a7cc-ef3d25d2a047","name":"tf-test-interlink-link-updated","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"e1ed5670-30f0-4e5b-b5f2-a8d3d5e5477c","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.95/31","ipv6":"2001:1bc8:3812:fc60:1139:2efa:4387:d001/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.94/31","ipv6":"2001:1bc8:3812:fc60:1139:2efa:4387:d000/127"},"status":"requested","tags":["tag1","tag2"],"updated_at":"2026-04-15T15:49:31.966397Z","vlan":3295}'
-        headers:
-            Content-Length:
-                - "893"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 15 Apr 2026 15:49:32 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - f5941ac7-286f-4152-9811-40124f9bb66b
-        status: 200 OK
-        code: 200
-        duration: 37.64625ms
+        duration: 66.468041ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -853,8 +853,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/c533d379-a8c5-43f4-a7cc-ef3d25d2a047
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/bc0c63e7-1ce0-4e5c-9a2a-1988db4ff0de
         method: GET
       response:
         proto: HTTP/2.0
@@ -862,20 +862,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 893
+        content_length: 915
         uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-15T15:49:30.752201Z","enable_route_propagation":false,"id":"c533d379-a8c5-43f4-a7cc-ef3d25d2a047","name":"tf-test-interlink-link-updated","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"e1ed5670-30f0-4e5b-b5f2-a8d3d5e5477c","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.95/31","ipv6":"2001:1bc8:3812:fc60:1139:2efa:4387:d001/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.94/31","ipv6":"2001:1bc8:3812:fc60:1139:2efa:4387:d000/127"},"status":"requested","tags":["tag1","tag2"],"updated_at":"2026-04-15T15:49:31.966397Z","vlan":3295}'
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.343789Z","enable_route_propagation":false,"id":"bc0c63e7-1ce0-4e5c-9a2a-1988db4ff0de","name":"tf-test-interlink-link-updated","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"f4490f6a-6855-40b9-b951-2a8b12d9a614","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.17/31","ipv6":"2001:1bc8:3812:fc60:4442:8556:623:6d01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.16/31","ipv6":"2001:1bc8:3812:fc60:4442:8556:623:6d00/127"},"status":"requested","tags":["tag1","tag2"],"updated_at":"2026-08-24T12:13:41.084803Z","vlan":1842}'
         headers:
             Content-Length:
-                - "893"
+                - "915"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 15:49:32 GMT
+                - Mon, 24 Aug 2026 12:13:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -883,10 +883,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 60a0f90b-2810-4118-8e58-b8a7c7591de2
+                - c0a9f13f-e2a2-4184-b131-b5800677358d
         status: 200 OK
         code: 200
-        duration: 38.477709ms
+        duration: 33.226947ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -902,8 +902,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/bc0c63e7-1ce0-4e5c-9a2a-1988db4ff0de
         method: GET
       response:
         proto: HTTP/2.0
@@ -911,20 +911,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 708
+        content_length: 915
         uncompressed: false
-        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","updated_at":"2024-11-28T08:45:33.852946Z"}],"total_count":2}'
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.343789Z","enable_route_propagation":false,"id":"bc0c63e7-1ce0-4e5c-9a2a-1988db4ff0de","name":"tf-test-interlink-link-updated","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"f4490f6a-6855-40b9-b951-2a8b12d9a614","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.17/31","ipv6":"2001:1bc8:3812:fc60:4442:8556:623:6d01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.16/31","ipv6":"2001:1bc8:3812:fc60:4442:8556:623:6d00/127"},"status":"requested","tags":["tag1","tag2"],"updated_at":"2026-08-24T12:13:41.084803Z","vlan":1842}'
         headers:
             Content-Length:
-                - "708"
+                - "915"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 15:49:32 GMT
+                - Mon, 24 Aug 2026 12:13:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -932,10 +932,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d7848a59-6a91-4db1-af18-1f5de86d2ed4
+                - eba078d1-7f2d-4654-b35b-0ea5220b8a6e
         status: 200 OK
         code: 200
-        duration: 32.314917ms
+        duration: 35.507288ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -951,8 +951,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=Telehouse+TH2&order_by=name_asc&page=1
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/bc0c63e7-1ce0-4e5c-9a2a-1988db4ff0de
         method: GET
       response:
         proto: HTTP/2.0
@@ -960,20 +960,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 431
+        content_length: 915
         uncompressed: false
-        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"- Telehouse TH2","region":"fr-par"}],"total_count":1}'
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.343789Z","enable_route_propagation":false,"id":"bc0c63e7-1ce0-4e5c-9a2a-1988db4ff0de","name":"tf-test-interlink-link-updated","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"f4490f6a-6855-40b9-b951-2a8b12d9a614","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.17/31","ipv6":"2001:1bc8:3812:fc60:4442:8556:623:6d01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.16/31","ipv6":"2001:1bc8:3812:fc60:4442:8556:623:6d00/127"},"status":"requested","tags":["tag1","tag2"],"updated_at":"2026-08-24T12:13:41.084803Z","vlan":1842}'
         headers:
             Content-Length:
-                - "431"
+                - "915"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 15:49:32 GMT
+                - Mon, 24 Aug 2026 12:13:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -981,10 +981,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a2c8f62b-4b95-4737-80f0-f2e2f5a80d74
+                - c69f4514-48a1-48e6-9360-79864c6f92d5
         status: 200 OK
         code: 200
-        duration: 44.68925ms
+        duration: 37.583424ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1000,7 +1000,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
         method: GET
       response:
@@ -1009,20 +1009,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 708
+        content_length: 1158
         uncompressed: false
-        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","updated_at":"2024-11-28T08:45:33.852946Z"}],"total_count":2}'
+        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","l3_connectivity":true,"logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","region":"","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","l3_connectivity":true,"logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","region":"","updated_at":"2024-11-28T08:45:33.852946Z"},{"contact_email":"contact.experience-client@linkt.fr","created_at":"2026-04-21T14:31:08.285733Z","id":"4e0dcaaf-467c-432c-ad93-f28be5878df0","l3_connectivity":true,"logo_url":"https://www.linkt.fr/wp-content/themes/linkt/assets/img/svg/logo-linkt-sticky.svg","name":"Linkt","portal_url":"https://www.linkt.fr/","region":"","updated_at":"2026-07-07T11:57:51.706396Z"}],"total_count":3}'
         headers:
             Content-Length:
-                - "708"
+                - "1158"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 15:49:32 GMT
+                - Mon, 24 Aug 2026 12:13:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1030,10 +1030,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 98502798-6f8b-48d6-98be-f73fb642e8fc
+                - eb13fa25-0bf5-4c63-8eeb-f3b9283c3416
         status: 200 OK
         code: 200
-        duration: 29.283291ms
+        duration: 36.696451ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1049,8 +1049,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=Telehouse+TH2&order_by=name_asc&page=1
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=TeleHouse+TH2&order_by=name_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -1058,20 +1058,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 431
+        content_length: 429
         uncompressed: false
-        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"- Telehouse TH2","region":"fr-par"}],"total_count":1}'
+        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"TeleHouse TH2","region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
-                - "431"
+                - "429"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 15:49:32 GMT
+                - Mon, 24 Aug 2026 12:13:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1079,10 +1079,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1bc8eb69-dd2a-43ec-aaa4-f60ffed78173
+                - cc20b2a7-af4c-453c-a320-67a07c154fa3
         status: 200 OK
         code: 200
-        duration: 43.666042ms
+        duration: 42.128195ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1098,8 +1098,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/c533d379-a8c5-43f4-a7cc-ef3d25d2a047
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -1107,20 +1107,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 893
+        content_length: 1158
         uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-15T15:49:30.752201Z","enable_route_propagation":false,"id":"c533d379-a8c5-43f4-a7cc-ef3d25d2a047","name":"tf-test-interlink-link-updated","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"e1ed5670-30f0-4e5b-b5f2-a8d3d5e5477c","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.95/31","ipv6":"2001:1bc8:3812:fc60:1139:2efa:4387:d001/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.94/31","ipv6":"2001:1bc8:3812:fc60:1139:2efa:4387:d000/127"},"status":"requested","tags":["tag1","tag2"],"updated_at":"2026-04-15T15:49:31.966397Z","vlan":3295}'
+        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","l3_connectivity":true,"logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","region":"","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","l3_connectivity":true,"logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","region":"","updated_at":"2024-11-28T08:45:33.852946Z"},{"contact_email":"contact.experience-client@linkt.fr","created_at":"2026-04-21T14:31:08.285733Z","id":"4e0dcaaf-467c-432c-ad93-f28be5878df0","l3_connectivity":true,"logo_url":"https://www.linkt.fr/wp-content/themes/linkt/assets/img/svg/logo-linkt-sticky.svg","name":"Linkt","portal_url":"https://www.linkt.fr/","region":"","updated_at":"2026-07-07T11:57:51.706396Z"}],"total_count":3}'
         headers:
             Content-Length:
-                - "893"
+                - "1158"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 15:49:32 GMT
+                - Mon, 24 Aug 2026 12:13:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1128,10 +1128,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e9b0ac16-4695-4e57-9429-b05c964e33b8
+                - 88edf992-be32-49d8-b9aa-3901e0087a97
         status: 200 OK
         code: 200
-        duration: 33.294917ms
+        duration: 39.664369ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1147,8 +1147,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=TeleHouse+TH2&order_by=name_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -1156,20 +1156,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 708
+        content_length: 429
         uncompressed: false
-        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","updated_at":"2024-11-28T08:45:33.852946Z"}],"total_count":2}'
+        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"TeleHouse TH2","region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
-                - "708"
+                - "429"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 15:49:32 GMT
+                - Mon, 24 Aug 2026 12:13:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1177,10 +1177,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 009cf44a-d79a-473b-95e4-23f97c9c463e
+                - ff08e01d-9e6b-48b3-8ce9-ee5227114785
         status: 200 OK
         code: 200
-        duration: 35.413084ms
+        duration: 50.632324ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1196,8 +1196,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=Telehouse+TH2&order_by=name_asc&page=1
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/bc0c63e7-1ce0-4e5c-9a2a-1988db4ff0de
         method: GET
       response:
         proto: HTTP/2.0
@@ -1205,20 +1205,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 431
+        content_length: 915
         uncompressed: false
-        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"- Telehouse TH2","region":"fr-par"}],"total_count":1}'
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.343789Z","enable_route_propagation":false,"id":"bc0c63e7-1ce0-4e5c-9a2a-1988db4ff0de","name":"tf-test-interlink-link-updated","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"f4490f6a-6855-40b9-b951-2a8b12d9a614","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.17/31","ipv6":"2001:1bc8:3812:fc60:4442:8556:623:6d01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.16/31","ipv6":"2001:1bc8:3812:fc60:4442:8556:623:6d00/127"},"status":"requested","tags":["tag1","tag2"],"updated_at":"2026-08-24T12:13:41.084803Z","vlan":1842}'
         headers:
             Content-Length:
-                - "431"
+                - "915"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 15:49:32 GMT
+                - Mon, 24 Aug 2026 12:13:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1226,10 +1226,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ebbb4bc9-545b-49c2-a070-16fb1a36fb5f
+                - b18ffcae-7de7-4859-8325-b49772caefe3
         status: 200 OK
         code: 200
-        duration: 39.106708ms
+        duration: 48.535881ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1245,8 +1245,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/c533d379-a8c5-43f4-a7cc-ef3d25d2a047
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -1254,20 +1254,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 893
+        content_length: 1158
         uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-15T15:49:30.752201Z","enable_route_propagation":false,"id":"c533d379-a8c5-43f4-a7cc-ef3d25d2a047","name":"tf-test-interlink-link-updated","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"e1ed5670-30f0-4e5b-b5f2-a8d3d5e5477c","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.95/31","ipv6":"2001:1bc8:3812:fc60:1139:2efa:4387:d001/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.94/31","ipv6":"2001:1bc8:3812:fc60:1139:2efa:4387:d000/127"},"status":"requested","tags":["tag1","tag2"],"updated_at":"2026-04-15T15:49:31.966397Z","vlan":3295}'
+        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","l3_connectivity":true,"logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","region":"","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","l3_connectivity":true,"logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","region":"","updated_at":"2024-11-28T08:45:33.852946Z"},{"contact_email":"contact.experience-client@linkt.fr","created_at":"2026-04-21T14:31:08.285733Z","id":"4e0dcaaf-467c-432c-ad93-f28be5878df0","l3_connectivity":true,"logo_url":"https://www.linkt.fr/wp-content/themes/linkt/assets/img/svg/logo-linkt-sticky.svg","name":"Linkt","portal_url":"https://www.linkt.fr/","region":"","updated_at":"2026-07-07T11:57:51.706396Z"}],"total_count":3}'
         headers:
             Content-Length:
-                - "893"
+                - "1158"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 15:49:32 GMT
+                - Mon, 24 Aug 2026 12:13:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1275,10 +1275,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 045be023-59e9-421f-9fae-ae7b000fdc74
+                - c5f08bbc-fb2c-4455-a66b-872301de2e62
         status: 200 OK
         code: 200
-        duration: 29.471917ms
+        duration: 34.320769ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1294,29 +1294,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/c533d379-a8c5-43f4-a7cc-ef3d25d2a047
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=TeleHouse+TH2&order_by=name_asc&page=1
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 891
+        content_length: 429
         uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-15T15:49:30.752201Z","enable_route_propagation":false,"id":"c533d379-a8c5-43f4-a7cc-ef3d25d2a047","name":"tf-test-interlink-link-updated","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"e1ed5670-30f0-4e5b-b5f2-a8d3d5e5477c","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.95/31","ipv6":"2001:1bc8:3812:fc60:1139:2efa:4387:d001/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.94/31","ipv6":"2001:1bc8:3812:fc60:1139:2efa:4387:d000/127"},"status":"deleted","tags":["tag1","tag2"],"updated_at":"2026-04-15T15:49:31.966397Z","vlan":3295}'
+        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"TeleHouse TH2","region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
-                - "891"
+                - "429"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 15:49:33 GMT
+                - Mon, 24 Aug 2026 12:13:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1324,10 +1324,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6852dcb4-9336-4ba6-acaf-609c3c609a92
+                - 42ec1fdc-a75a-4fd6-934c-597bc332e362
         status: 200 OK
         code: 200
-        duration: 57.157208ms
+        duration: 47.782689ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1343,8 +1343,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/c533d379-a8c5-43f4-a7cc-ef3d25d2a047
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/bc0c63e7-1ce0-4e5c-9a2a-1988db4ff0de
         method: GET
       response:
         proto: HTTP/2.0
@@ -1352,20 +1352,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 125
+        content_length: 915
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"link","resource_id":"c533d379-a8c5-43f4-a7cc-ef3d25d2a047","type":"not_found"}'
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.343789Z","enable_route_propagation":false,"id":"bc0c63e7-1ce0-4e5c-9a2a-1988db4ff0de","name":"tf-test-interlink-link-updated","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"f4490f6a-6855-40b9-b951-2a8b12d9a614","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.17/31","ipv6":"2001:1bc8:3812:fc60:4442:8556:623:6d01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.16/31","ipv6":"2001:1bc8:3812:fc60:4442:8556:623:6d00/127"},"status":"requested","tags":["tag1","tag2"],"updated_at":"2026-08-24T12:13:41.084803Z","vlan":1842}'
         headers:
             Content-Length:
-                - "125"
+                - "915"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 15:49:33 GMT
+                - Mon, 24 Aug 2026 12:13:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1373,10 +1373,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 51efc306-7c63-453b-bb43-36a78e8be1bc
-        status: 404 Not Found
-        code: 404
-        duration: 29.430208ms
+                - 9b4cbfab-4e5f-4503-ac99-0d22a97685e3
+        status: 200 OK
+        code: 200
+        duration: 36.087482ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1392,8 +1392,57 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/c533d379-a8c5-43f4-a7cc-ef3d25d2a047
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/bc0c63e7-1ce0-4e5c-9a2a-1988db4ff0de
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 913
+        uncompressed: false
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.343789Z","enable_route_propagation":false,"id":"bc0c63e7-1ce0-4e5c-9a2a-1988db4ff0de","name":"tf-test-interlink-link-updated","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"f4490f6a-6855-40b9-b951-2a8b12d9a614","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.17/31","ipv6":"2001:1bc8:3812:fc60:4442:8556:623:6d01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.16/31","ipv6":"2001:1bc8:3812:fc60:4442:8556:623:6d00/127"},"status":"deleted","tags":["tag1","tag2"],"updated_at":"2026-08-24T12:13:41.084803Z","vlan":1842}'
+        headers:
+            Content-Length:
+                - "913"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 24 Aug 2026 12:13:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f4e280e2-23d7-49e4-99b3-6ac3bcf9acae
+        status: 200 OK
+        code: 200
+        duration: 51.056984ms
+    - id: 29
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/bc0c63e7-1ce0-4e5c-9a2a-1988db4ff0de
         method: GET
       response:
         proto: HTTP/2.0
@@ -1403,7 +1452,7 @@ interactions:
         trailer: {}
         content_length: 125
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"link","resource_id":"c533d379-a8c5-43f4-a7cc-ef3d25d2a047","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"link","resource_id":"bc0c63e7-1ce0-4e5c-9a2a-1988db4ff0de","type":"not_found"}'
         headers:
             Content-Length:
                 - "125"
@@ -1412,9 +1461,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 15 Apr 2026 15:49:33 GMT
+                - Mon, 24 Aug 2026 12:13:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1422,7 +1471,56 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 88cff8a6-5754-40cc-bed6-8f733b3b71a6
+                - ebf0f54a-73b6-4147-afcb-68f559287475
         status: 404 Not Found
         code: 404
-        duration: 24.202125ms
+        duration: 36.046825ms
+    - id: 30
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/bc0c63e7-1ce0-4e5c-9a2a-1988db4ff0de
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 125
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"link","resource_id":"bc0c63e7-1ce0-4e5c-9a2a-1988db4ff0de","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "125"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 24 Aug 2026 12:13:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 30540977-e98d-4b03-95b1-5fefddf485f5
+        status: 404 Not Found
+        code: 404
+        duration: 36.067154ms

--- a/internal/services/interlink/testdata/interlink-link-route-propagation.cassette.yaml
+++ b/internal/services/interlink/testdata/interlink-link-route-propagation.cassette.yaml
@@ -16,7 +16,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
         method: GET
       response:
@@ -25,18 +25,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 708
+        content_length: 1158
         uncompressed: false
-        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","updated_at":"2024-11-28T08:45:33.852946Z"}],"total_count":2}'
+        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","l3_connectivity":true,"logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","region":"","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","l3_connectivity":true,"logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","region":"","updated_at":"2024-11-28T08:45:33.852946Z"},{"contact_email":"contact.experience-client@linkt.fr","created_at":"2026-04-21T14:31:08.285733Z","id":"4e0dcaaf-467c-432c-ad93-f28be5878df0","l3_connectivity":true,"logo_url":"https://www.linkt.fr/wp-content/themes/linkt/assets/img/svg/logo-linkt-sticky.svg","name":"Linkt","portal_url":"https://www.linkt.fr/","region":"","updated_at":"2026-07-07T11:57:51.706396Z"}],"total_count":3}'
         headers:
             Content-Length:
-                - "708"
+                - "1158"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 20 Apr 2026 09:10:46 GMT
+                - Mon, 24 Aug 2026 12:13:38 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
@@ -46,10 +46,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0dc7829f-f31c-4aff-8a99-c562805a8466
+                - e56e130b-84b5-4a17-8ae0-af6805e1a62c
         status: 200 OK
         code: 200
-        duration: 202.165083ms
+        duration: 163.85352ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -65,8 +65,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=Telehouse+TH2&order_by=name_asc&page=1
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=TeleHouse+TH2&order_by=name_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -74,18 +74,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 431
+        content_length: 429
         uncompressed: false
-        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"- Telehouse TH2","region":"fr-par"}],"total_count":1}'
+        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"TeleHouse TH2","region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
-                - "431"
+                - "429"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 20 Apr 2026 09:10:46 GMT
+                - Mon, 24 Aug 2026 12:13:38 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
@@ -95,48 +95,46 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8663de9b-f4da-49af-92e3-e6b4f48bb1ed
+                - 8b297101-900d-4e83-96c7-b0f0890d751c
         status: 200 OK
         code: 200
-        duration: 212.292708ms
+        duration: 181.561919ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 218
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","name":"tf-test-interlink-link-rp","tags":[],"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","bandwidth_mbps":50,"partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links
-        method: POST
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/metadata
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 876
+        content_length: 59
         uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-20T09:10:46.809177Z","enable_route_propagation":false,"id":"49c5af40-8332-4757-ab8e-314176d25ddb","name":"tf-test-interlink-link-rp","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"cc4808c4-dedd-4f75-a8e3-7a6e95d47a07","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.101/31","ipv6":"2001:1bc8:3812:fc60:6d65:b2db:53c3:cc01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.100/31","ipv6":"2001:1bc8:3812:fc60:6d65:b2db:53c3:cc00/127"},"status":"requested","tags":[],"updated_at":"2026-04-20T09:10:46.809177Z","vlan":2386}'
+        body: '{"domain":"scw.eu","partition":"scw","platform":"external"}'
         headers:
             Content-Length:
-                - "876"
+                - "59"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 20 Apr 2026 09:10:46 GMT
+                - Mon, 24 Aug 2026 12:13:38 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
@@ -146,10 +144,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 529150dc-aae2-43f6-ad93-54e4d5e06bfa
+                - 19f5b005-5c2b-4527-ae97-292beb824906
         status: 200 OK
         code: 200
-        duration: 442.743209ms
+        duration: 21.671454ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -165,8 +163,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/49c5af40-8332-4757-ab8e-314176d25ddb
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/metadata
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,18 +172,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 876
+        content_length: 59
         uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-20T09:10:46.809177Z","enable_route_propagation":false,"id":"49c5af40-8332-4757-ab8e-314176d25ddb","name":"tf-test-interlink-link-rp","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"cc4808c4-dedd-4f75-a8e3-7a6e95d47a07","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.101/31","ipv6":"2001:1bc8:3812:fc60:6d65:b2db:53c3:cc01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.100/31","ipv6":"2001:1bc8:3812:fc60:6d65:b2db:53c3:cc00/127"},"status":"requested","tags":[],"updated_at":"2026-04-20T09:10:46.809177Z","vlan":2386}'
+        body: '{"domain":"scw.eu","partition":"scw","platform":"external"}'
         headers:
             Content-Length:
-                - "876"
+                - "59"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 20 Apr 2026 09:10:46 GMT
+                - Mon, 24 Aug 2026 12:13:38 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
@@ -195,29 +193,29 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2527837d-5c96-4af6-b42b-351ae4a10177
+                - f3e2be68-f9a8-433d-b34b-695ccf619ce0
         status: 200 OK
         code: 200
-        duration: 69.098458ms
+        duration: 22.509915ms
     - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 2
+        content_length: 218
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{}'
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-interlink-link-rp","tags":[],"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","bandwidth_mbps":50,"partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/49c5af40-8332-4757-ab8e-314176d25ddb/enable-route-propagation
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links
         method: POST
       response:
         proto: HTTP/2.0
@@ -225,18 +223,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 875
+        content_length: 898
         uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-20T09:10:46.809177Z","enable_route_propagation":true,"id":"49c5af40-8332-4757-ab8e-314176d25ddb","name":"tf-test-interlink-link-rp","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"cc4808c4-dedd-4f75-a8e3-7a6e95d47a07","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.101/31","ipv6":"2001:1bc8:3812:fc60:6d65:b2db:53c3:cc01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.100/31","ipv6":"2001:1bc8:3812:fc60:6d65:b2db:53c3:cc00/127"},"status":"requested","tags":[],"updated_at":"2026-04-20T09:10:47.002966Z","vlan":2386}'
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.352434Z","enable_route_propagation":false,"id":"40f409f7-30ca-47a7-83cc-338746837623","name":"tf-test-interlink-link-rp","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"6a104e5c-9bb5-4e42-9ef9-db299c42409f","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.91/31","ipv6":"2001:1bc8:3812:fc60:a998:7a19:86bb:da01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.90/31","ipv6":"2001:1bc8:3812:fc60:a998:7a19:86bb:da00/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:39.352434Z","vlan":3020}'
         headers:
             Content-Length:
-                - "875"
+                - "898"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 20 Apr 2026 09:10:47 GMT
+                - Mon, 24 Aug 2026 12:13:39 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
@@ -246,10 +244,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f12d9b44-3e8d-48a8-8e53-30aca04d32b5
+                - 0f5b62cf-7ea5-4571-985f-52fd364eec92
         status: 200 OK
         code: 200
-        duration: 74.296083ms
+        duration: 202.946009ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -265,8 +263,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/49c5af40-8332-4757-ab8e-314176d25ddb
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/40f409f7-30ca-47a7-83cc-338746837623
         method: GET
       response:
         proto: HTTP/2.0
@@ -274,18 +272,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 875
+        content_length: 898
         uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-20T09:10:46.809177Z","enable_route_propagation":true,"id":"49c5af40-8332-4757-ab8e-314176d25ddb","name":"tf-test-interlink-link-rp","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"cc4808c4-dedd-4f75-a8e3-7a6e95d47a07","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.101/31","ipv6":"2001:1bc8:3812:fc60:6d65:b2db:53c3:cc01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.100/31","ipv6":"2001:1bc8:3812:fc60:6d65:b2db:53c3:cc00/127"},"status":"requested","tags":[],"updated_at":"2026-04-20T09:10:47.002966Z","vlan":2386}'
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.352434Z","enable_route_propagation":false,"id":"40f409f7-30ca-47a7-83cc-338746837623","name":"tf-test-interlink-link-rp","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"6a104e5c-9bb5-4e42-9ef9-db299c42409f","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.91/31","ipv6":"2001:1bc8:3812:fc60:a998:7a19:86bb:da01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.90/31","ipv6":"2001:1bc8:3812:fc60:a998:7a19:86bb:da00/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:39.352434Z","vlan":3020}'
         headers:
             Content-Length:
-                - "875"
+                - "898"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 20 Apr 2026 09:10:47 GMT
+                - Mon, 24 Aug 2026 12:13:39 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
@@ -295,550 +293,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 60ec20ab-a46c-419e-ac3a-398356950a87
+                - b43bf2e1-fad2-4a1c-a4c1-3d95ff00a16b
         status: 200 OK
         code: 200
-        duration: 66.04575ms
+        duration: 36.842357ms
     - id: 6
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/49c5af40-8332-4757-ab8e-314176d25ddb
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 875
-        uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-20T09:10:46.809177Z","enable_route_propagation":true,"id":"49c5af40-8332-4757-ab8e-314176d25ddb","name":"tf-test-interlink-link-rp","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"cc4808c4-dedd-4f75-a8e3-7a6e95d47a07","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.101/31","ipv6":"2001:1bc8:3812:fc60:6d65:b2db:53c3:cc01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.100/31","ipv6":"2001:1bc8:3812:fc60:6d65:b2db:53c3:cc00/127"},"status":"requested","tags":[],"updated_at":"2026-04-20T09:10:47.002966Z","vlan":2386}'
-        headers:
-            Content-Length:
-                - "875"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 20 Apr 2026 09:10:47 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 32d5acae-5080-4981-940d-2964e6881bcc
-        status: 200 OK
-        code: 200
-        duration: 29.469792ms
-    - id: 7
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/49c5af40-8332-4757-ab8e-314176d25ddb
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 875
-        uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-20T09:10:46.809177Z","enable_route_propagation":true,"id":"49c5af40-8332-4757-ab8e-314176d25ddb","name":"tf-test-interlink-link-rp","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"cc4808c4-dedd-4f75-a8e3-7a6e95d47a07","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.101/31","ipv6":"2001:1bc8:3812:fc60:6d65:b2db:53c3:cc01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.100/31","ipv6":"2001:1bc8:3812:fc60:6d65:b2db:53c3:cc00/127"},"status":"requested","tags":[],"updated_at":"2026-04-20T09:10:47.002966Z","vlan":2386}'
-        headers:
-            Content-Length:
-                - "875"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 20 Apr 2026 09:10:47 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 404bc6e6-24bf-4c38-bb15-7e652fe96612
-        status: 200 OK
-        code: 200
-        duration: 55.589667ms
-    - id: 8
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 708
-        uncompressed: false
-        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","updated_at":"2024-11-28T08:45:33.852946Z"}],"total_count":2}'
-        headers:
-            Content-Length:
-                - "708"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 20 Apr 2026 09:10:47 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 9386cf5f-bfc5-4aaa-96a9-20d6f655bbdd
-        status: 200 OK
-        code: 200
-        duration: 29.397333ms
-    - id: 9
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=Telehouse+TH2&order_by=name_asc&page=1
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 431
-        uncompressed: false
-        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"- Telehouse TH2","region":"fr-par"}],"total_count":1}'
-        headers:
-            Content-Length:
-                - "431"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 20 Apr 2026 09:10:47 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - f1cd78f5-f2bd-4d6d-925b-456e3262d0f8
-        status: 200 OK
-        code: 200
-        duration: 46.511791ms
-    - id: 10
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 708
-        uncompressed: false
-        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","updated_at":"2024-11-28T08:45:33.852946Z"}],"total_count":2}'
-        headers:
-            Content-Length:
-                - "708"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 20 Apr 2026 09:10:47 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 18b60448-6ae1-47cf-9fce-576fd138f6c8
-        status: 200 OK
-        code: 200
-        duration: 31.47525ms
-    - id: 11
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=Telehouse+TH2&order_by=name_asc&page=1
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 431
-        uncompressed: false
-        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"- Telehouse TH2","region":"fr-par"}],"total_count":1}'
-        headers:
-            Content-Length:
-                - "431"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 20 Apr 2026 09:10:47 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 7d48e833-3e57-45db-bfea-f380c888caf2
-        status: 200 OK
-        code: 200
-        duration: 33.860292ms
-    - id: 12
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/49c5af40-8332-4757-ab8e-314176d25ddb
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 875
-        uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-20T09:10:46.809177Z","enable_route_propagation":true,"id":"49c5af40-8332-4757-ab8e-314176d25ddb","name":"tf-test-interlink-link-rp","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"cc4808c4-dedd-4f75-a8e3-7a6e95d47a07","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.101/31","ipv6":"2001:1bc8:3812:fc60:6d65:b2db:53c3:cc01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.100/31","ipv6":"2001:1bc8:3812:fc60:6d65:b2db:53c3:cc00/127"},"status":"requested","tags":[],"updated_at":"2026-04-20T09:10:47.002966Z","vlan":2386}'
-        headers:
-            Content-Length:
-                - "875"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 20 Apr 2026 09:10:47 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 588b0b5a-a93c-42ce-8875-879e176cf670
-        status: 200 OK
-        code: 200
-        duration: 22.6415ms
-    - id: 13
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 708
-        uncompressed: false
-        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","updated_at":"2024-11-28T08:45:33.852946Z"}],"total_count":2}'
-        headers:
-            Content-Length:
-                - "708"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 20 Apr 2026 09:10:47 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - a4151374-6861-43e3-a2a2-26e94979b73f
-        status: 200 OK
-        code: 200
-        duration: 24.746959ms
-    - id: 14
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=Telehouse+TH2&order_by=name_asc&page=1
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 431
-        uncompressed: false
-        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"- Telehouse TH2","region":"fr-par"}],"total_count":1}'
-        headers:
-            Content-Length:
-                - "431"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 20 Apr 2026 09:10:47 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 948f7146-0794-4a70-b261-d089dbd8cb26
-        status: 200 OK
-        code: 200
-        duration: 37.216417ms
-    - id: 15
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/49c5af40-8332-4757-ab8e-314176d25ddb
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 875
-        uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-20T09:10:46.809177Z","enable_route_propagation":true,"id":"49c5af40-8332-4757-ab8e-314176d25ddb","name":"tf-test-interlink-link-rp","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"cc4808c4-dedd-4f75-a8e3-7a6e95d47a07","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.101/31","ipv6":"2001:1bc8:3812:fc60:6d65:b2db:53c3:cc01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.100/31","ipv6":"2001:1bc8:3812:fc60:6d65:b2db:53c3:cc00/127"},"status":"requested","tags":[],"updated_at":"2026-04-20T09:10:47.002966Z","vlan":2386}'
-        headers:
-            Content-Length:
-                - "875"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 20 Apr 2026 09:10:47 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 0f378122-11a9-4498-9627-c98d1c42cffa
-        status: 200 OK
-        code: 200
-        duration: 21.25275ms
-    - id: 16
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/49c5af40-8332-4757-ab8e-314176d25ddb
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 875
-        uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-20T09:10:46.809177Z","enable_route_propagation":true,"id":"49c5af40-8332-4757-ab8e-314176d25ddb","name":"tf-test-interlink-link-rp","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"cc4808c4-dedd-4f75-a8e3-7a6e95d47a07","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.101/31","ipv6":"2001:1bc8:3812:fc60:6d65:b2db:53c3:cc01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.100/31","ipv6":"2001:1bc8:3812:fc60:6d65:b2db:53c3:cc00/127"},"status":"requested","tags":[],"updated_at":"2026-04-20T09:10:47.002966Z","vlan":2386}'
-        headers:
-            Content-Length:
-                - "875"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 20 Apr 2026 09:10:48 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - f59c223e-7453-47e3-93f0-cf0334e027af
-        status: 200 OK
-        code: 200
-        duration: 22.944583ms
-    - id: 17
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -855,8 +314,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/49c5af40-8332-4757-ab8e-314176d25ddb/disable-route-propagation
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/40f409f7-30ca-47a7-83cc-338746837623/enable-route-propagation
         method: POST
       response:
         proto: HTTP/2.0
@@ -864,18 +323,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 876
+        content_length: 897
         uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-20T09:10:46.809177Z","enable_route_propagation":false,"id":"49c5af40-8332-4757-ab8e-314176d25ddb","name":"tf-test-interlink-link-rp","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"cc4808c4-dedd-4f75-a8e3-7a6e95d47a07","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.101/31","ipv6":"2001:1bc8:3812:fc60:6d65:b2db:53c3:cc01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.100/31","ipv6":"2001:1bc8:3812:fc60:6d65:b2db:53c3:cc00/127"},"status":"requested","tags":[],"updated_at":"2026-04-20T09:10:48.069799Z","vlan":2386}'
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.352434Z","enable_route_propagation":true,"id":"40f409f7-30ca-47a7-83cc-338746837623","name":"tf-test-interlink-link-rp","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"6a104e5c-9bb5-4e42-9ef9-db299c42409f","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.91/31","ipv6":"2001:1bc8:3812:fc60:a998:7a19:86bb:da01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.90/31","ipv6":"2001:1bc8:3812:fc60:a998:7a19:86bb:da00/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:39.469241Z","vlan":3020}'
         headers:
             Content-Length:
-                - "876"
+                - "897"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 20 Apr 2026 09:10:48 GMT
+                - Mon, 24 Aug 2026 12:13:39 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
@@ -885,10 +344,549 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3f5e3a36-9b53-4dca-aeae-c37034425c8f
+                - 3924c774-c33b-418d-b7b4-a91cfe34364b
         status: 200 OK
         code: 200
-        duration: 45.304459ms
+        duration: 63.877476ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/40f409f7-30ca-47a7-83cc-338746837623
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 897
+        uncompressed: false
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.352434Z","enable_route_propagation":true,"id":"40f409f7-30ca-47a7-83cc-338746837623","name":"tf-test-interlink-link-rp","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"6a104e5c-9bb5-4e42-9ef9-db299c42409f","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.91/31","ipv6":"2001:1bc8:3812:fc60:a998:7a19:86bb:da01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.90/31","ipv6":"2001:1bc8:3812:fc60:a998:7a19:86bb:da00/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:39.469241Z","vlan":3020}'
+        headers:
+            Content-Length:
+                - "897"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 24 Aug 2026 12:13:39 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5f358dda-cadf-4ae4-8fe1-7dd45abc2873
+        status: 200 OK
+        code: 200
+        duration: 42.809902ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/40f409f7-30ca-47a7-83cc-338746837623
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 897
+        uncompressed: false
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.352434Z","enable_route_propagation":true,"id":"40f409f7-30ca-47a7-83cc-338746837623","name":"tf-test-interlink-link-rp","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"6a104e5c-9bb5-4e42-9ef9-db299c42409f","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.91/31","ipv6":"2001:1bc8:3812:fc60:a998:7a19:86bb:da01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.90/31","ipv6":"2001:1bc8:3812:fc60:a998:7a19:86bb:da00/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:39.469241Z","vlan":3020}'
+        headers:
+            Content-Length:
+                - "897"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 24 Aug 2026 12:13:39 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 98362c52-19f4-4378-9447-404d2fd22b9e
+        status: 200 OK
+        code: 200
+        duration: 41.289555ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/40f409f7-30ca-47a7-83cc-338746837623
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 897
+        uncompressed: false
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.352434Z","enable_route_propagation":true,"id":"40f409f7-30ca-47a7-83cc-338746837623","name":"tf-test-interlink-link-rp","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"6a104e5c-9bb5-4e42-9ef9-db299c42409f","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.91/31","ipv6":"2001:1bc8:3812:fc60:a998:7a19:86bb:da01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.90/31","ipv6":"2001:1bc8:3812:fc60:a998:7a19:86bb:da00/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:39.469241Z","vlan":3020}'
+        headers:
+            Content-Length:
+                - "897"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 24 Aug 2026 12:13:39 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a33856e9-9614-493e-bfcd-bd9737287798
+        status: 200 OK
+        code: 200
+        duration: 57.669829ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=TeleHouse+TH2&order_by=name_asc&page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 429
+        uncompressed: false
+        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"TeleHouse TH2","region":"fr-par"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "429"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 24 Aug 2026 12:13:40 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d1fac734-7447-4543-ae33-9f791a32d1e8
+        status: 200 OK
+        code: 200
+        duration: 43.278486ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1158
+        uncompressed: false
+        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","l3_connectivity":true,"logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","region":"","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","l3_connectivity":true,"logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","region":"","updated_at":"2024-11-28T08:45:33.852946Z"},{"contact_email":"contact.experience-client@linkt.fr","created_at":"2026-04-21T14:31:08.285733Z","id":"4e0dcaaf-467c-432c-ad93-f28be5878df0","l3_connectivity":true,"logo_url":"https://www.linkt.fr/wp-content/themes/linkt/assets/img/svg/logo-linkt-sticky.svg","name":"Linkt","portal_url":"https://www.linkt.fr/","region":"","updated_at":"2026-07-07T11:57:51.706396Z"}],"total_count":3}'
+        headers:
+            Content-Length:
+                - "1158"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 24 Aug 2026 12:13:40 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3ff97dc7-9049-4151-a103-2f7ebdc96cf6
+        status: 200 OK
+        code: 200
+        duration: 47.536186ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1158
+        uncompressed: false
+        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","l3_connectivity":true,"logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","region":"","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","l3_connectivity":true,"logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","region":"","updated_at":"2024-11-28T08:45:33.852946Z"},{"contact_email":"contact.experience-client@linkt.fr","created_at":"2026-04-21T14:31:08.285733Z","id":"4e0dcaaf-467c-432c-ad93-f28be5878df0","l3_connectivity":true,"logo_url":"https://www.linkt.fr/wp-content/themes/linkt/assets/img/svg/logo-linkt-sticky.svg","name":"Linkt","portal_url":"https://www.linkt.fr/","region":"","updated_at":"2026-07-07T11:57:51.706396Z"}],"total_count":3}'
+        headers:
+            Content-Length:
+                - "1158"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 24 Aug 2026 12:13:40 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - eed85250-7230-45da-8c92-90946eda6b06
+        status: 200 OK
+        code: 200
+        duration: 46.438736ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=TeleHouse+TH2&order_by=name_asc&page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 429
+        uncompressed: false
+        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"TeleHouse TH2","region":"fr-par"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "429"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 24 Aug 2026 12:13:40 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 13f94b25-4949-4339-879b-d9a280fa9bec
+        status: 200 OK
+        code: 200
+        duration: 46.397678ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/40f409f7-30ca-47a7-83cc-338746837623
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 897
+        uncompressed: false
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.352434Z","enable_route_propagation":true,"id":"40f409f7-30ca-47a7-83cc-338746837623","name":"tf-test-interlink-link-rp","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"6a104e5c-9bb5-4e42-9ef9-db299c42409f","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.91/31","ipv6":"2001:1bc8:3812:fc60:a998:7a19:86bb:da01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.90/31","ipv6":"2001:1bc8:3812:fc60:a998:7a19:86bb:da00/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:39.469241Z","vlan":3020}'
+        headers:
+            Content-Length:
+                - "897"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 24 Aug 2026 12:13:40 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 02daffa3-2dc6-46f9-ae3e-1859b03faec9
+        status: 200 OK
+        code: 200
+        duration: 33.495685ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=TeleHouse+TH2&order_by=name_asc&page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 429
+        uncompressed: false
+        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"TeleHouse TH2","region":"fr-par"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "429"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 24 Aug 2026 12:13:40 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5f334242-0744-4ec4-990f-b483d8ebbea8
+        status: 200 OK
+        code: 200
+        duration: 44.077492ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1158
+        uncompressed: false
+        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","l3_connectivity":true,"logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","region":"","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","l3_connectivity":true,"logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","region":"","updated_at":"2024-11-28T08:45:33.852946Z"},{"contact_email":"contact.experience-client@linkt.fr","created_at":"2026-04-21T14:31:08.285733Z","id":"4e0dcaaf-467c-432c-ad93-f28be5878df0","l3_connectivity":true,"logo_url":"https://www.linkt.fr/wp-content/themes/linkt/assets/img/svg/logo-linkt-sticky.svg","name":"Linkt","portal_url":"https://www.linkt.fr/","region":"","updated_at":"2026-07-07T11:57:51.706396Z"}],"total_count":3}'
+        headers:
+            Content-Length:
+                - "1158"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 24 Aug 2026 12:13:40 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3d0bf2dd-97b3-48be-86ac-04e8c245c34c
+        status: 200 OK
+        code: 200
+        duration: 44.923698ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/40f409f7-30ca-47a7-83cc-338746837623
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 897
+        uncompressed: false
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.352434Z","enable_route_propagation":true,"id":"40f409f7-30ca-47a7-83cc-338746837623","name":"tf-test-interlink-link-rp","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"6a104e5c-9bb5-4e42-9ef9-db299c42409f","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.91/31","ipv6":"2001:1bc8:3812:fc60:a998:7a19:86bb:da01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.90/31","ipv6":"2001:1bc8:3812:fc60:a998:7a19:86bb:da00/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:39.469241Z","vlan":3020}'
+        headers:
+            Content-Length:
+                - "897"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 24 Aug 2026 12:13:40 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f42b287b-6ed8-40ee-a234-71b38c574359
+        status: 200 OK
+        code: 200
+        duration: 35.566681ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -904,8 +902,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/49c5af40-8332-4757-ab8e-314176d25ddb
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/40f409f7-30ca-47a7-83cc-338746837623
         method: GET
       response:
         proto: HTTP/2.0
@@ -913,18 +911,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 876
+        content_length: 897
         uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-20T09:10:46.809177Z","enable_route_propagation":false,"id":"49c5af40-8332-4757-ab8e-314176d25ddb","name":"tf-test-interlink-link-rp","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"cc4808c4-dedd-4f75-a8e3-7a6e95d47a07","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.101/31","ipv6":"2001:1bc8:3812:fc60:6d65:b2db:53c3:cc01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.100/31","ipv6":"2001:1bc8:3812:fc60:6d65:b2db:53c3:cc00/127"},"status":"requested","tags":[],"updated_at":"2026-04-20T09:10:48.069799Z","vlan":2386}'
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.352434Z","enable_route_propagation":true,"id":"40f409f7-30ca-47a7-83cc-338746837623","name":"tf-test-interlink-link-rp","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"6a104e5c-9bb5-4e42-9ef9-db299c42409f","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.91/31","ipv6":"2001:1bc8:3812:fc60:a998:7a19:86bb:da01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.90/31","ipv6":"2001:1bc8:3812:fc60:a998:7a19:86bb:da00/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:39.469241Z","vlan":3020}'
         headers:
             Content-Length:
-                - "876"
+                - "897"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 20 Apr 2026 09:10:48 GMT
+                - Mon, 24 Aug 2026 12:13:41 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
@@ -934,46 +932,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 679ea764-9dff-4cc6-8b9c-7c6c42fbc6ff
+                - 64c68255-5b91-4108-88dc-b3f95390d055
         status: 200 OK
         code: 200
-        duration: 24.278084ms
+        duration: 36.216946ms
     - id: 19
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 2
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/49c5af40-8332-4757-ab8e-314176d25ddb
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/40f409f7-30ca-47a7-83cc-338746837623/disable-route-propagation
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 876
+        content_length: 898
         uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-20T09:10:46.809177Z","enable_route_propagation":false,"id":"49c5af40-8332-4757-ab8e-314176d25ddb","name":"tf-test-interlink-link-rp","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"cc4808c4-dedd-4f75-a8e3-7a6e95d47a07","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.101/31","ipv6":"2001:1bc8:3812:fc60:6d65:b2db:53c3:cc01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.100/31","ipv6":"2001:1bc8:3812:fc60:6d65:b2db:53c3:cc00/127"},"status":"requested","tags":[],"updated_at":"2026-04-20T09:10:48.069799Z","vlan":2386}'
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.352434Z","enable_route_propagation":false,"id":"40f409f7-30ca-47a7-83cc-338746837623","name":"tf-test-interlink-link-rp","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"6a104e5c-9bb5-4e42-9ef9-db299c42409f","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.91/31","ipv6":"2001:1bc8:3812:fc60:a998:7a19:86bb:da01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.90/31","ipv6":"2001:1bc8:3812:fc60:a998:7a19:86bb:da00/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:41.247528Z","vlan":3020}'
         headers:
             Content-Length:
-                - "876"
+                - "898"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 20 Apr 2026 09:10:48 GMT
+                - Mon, 24 Aug 2026 12:13:41 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
@@ -983,10 +983,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 37f5376a-9461-4220-9e60-f96ac00426e9
+                - 96bd1a80-e9d0-460e-b410-ab690e76e684
         status: 200 OK
         code: 200
-        duration: 25.984708ms
+        duration: 94.003855ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1002,8 +1002,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/49c5af40-8332-4757-ab8e-314176d25ddb
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/40f409f7-30ca-47a7-83cc-338746837623
         method: GET
       response:
         proto: HTTP/2.0
@@ -1011,18 +1011,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 876
+        content_length: 898
         uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-20T09:10:46.809177Z","enable_route_propagation":false,"id":"49c5af40-8332-4757-ab8e-314176d25ddb","name":"tf-test-interlink-link-rp","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"cc4808c4-dedd-4f75-a8e3-7a6e95d47a07","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.101/31","ipv6":"2001:1bc8:3812:fc60:6d65:b2db:53c3:cc01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.100/31","ipv6":"2001:1bc8:3812:fc60:6d65:b2db:53c3:cc00/127"},"status":"requested","tags":[],"updated_at":"2026-04-20T09:10:48.069799Z","vlan":2386}'
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.352434Z","enable_route_propagation":false,"id":"40f409f7-30ca-47a7-83cc-338746837623","name":"tf-test-interlink-link-rp","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"6a104e5c-9bb5-4e42-9ef9-db299c42409f","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.91/31","ipv6":"2001:1bc8:3812:fc60:a998:7a19:86bb:da01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.90/31","ipv6":"2001:1bc8:3812:fc60:a998:7a19:86bb:da00/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:41.247528Z","vlan":3020}'
         headers:
             Content-Length:
-                - "876"
+                - "898"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 20 Apr 2026 09:10:48 GMT
+                - Mon, 24 Aug 2026 12:13:41 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
@@ -1032,10 +1032,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3c554397-9bdd-42d0-a0e6-c71abaac2375
+                - 3cae6649-c2b3-4375-84b4-8d44948172ca
         status: 200 OK
         code: 200
-        duration: 34.44ms
+        duration: 36.847125ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1051,8 +1051,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/40f409f7-30ca-47a7-83cc-338746837623
         method: GET
       response:
         proto: HTTP/2.0
@@ -1060,18 +1060,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 708
+        content_length: 898
         uncompressed: false
-        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","updated_at":"2024-11-28T08:45:33.852946Z"}],"total_count":2}'
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.352434Z","enable_route_propagation":false,"id":"40f409f7-30ca-47a7-83cc-338746837623","name":"tf-test-interlink-link-rp","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"6a104e5c-9bb5-4e42-9ef9-db299c42409f","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.91/31","ipv6":"2001:1bc8:3812:fc60:a998:7a19:86bb:da01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.90/31","ipv6":"2001:1bc8:3812:fc60:a998:7a19:86bb:da00/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:41.247528Z","vlan":3020}'
         headers:
             Content-Length:
-                - "708"
+                - "898"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 20 Apr 2026 09:10:48 GMT
+                - Mon, 24 Aug 2026 12:13:41 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
@@ -1081,10 +1081,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 616680ca-9222-4f63-89f4-50bda784aafe
+                - 895b8a9f-65b6-42fc-a5b1-dc5960953edf
         status: 200 OK
         code: 200
-        duration: 144.783ms
+        duration: 40.546923ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1100,8 +1100,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=Telehouse+TH2&order_by=name_asc&page=1
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/40f409f7-30ca-47a7-83cc-338746837623
         method: GET
       response:
         proto: HTTP/2.0
@@ -1109,18 +1109,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 431
+        content_length: 898
         uncompressed: false
-        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"- Telehouse TH2","region":"fr-par"}],"total_count":1}'
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.352434Z","enable_route_propagation":false,"id":"40f409f7-30ca-47a7-83cc-338746837623","name":"tf-test-interlink-link-rp","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"6a104e5c-9bb5-4e42-9ef9-db299c42409f","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.91/31","ipv6":"2001:1bc8:3812:fc60:a998:7a19:86bb:da01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.90/31","ipv6":"2001:1bc8:3812:fc60:a998:7a19:86bb:da00/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:41.247528Z","vlan":3020}'
         headers:
             Content-Length:
-                - "431"
+                - "898"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 20 Apr 2026 09:10:48 GMT
+                - Mon, 24 Aug 2026 12:13:41 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
@@ -1130,10 +1130,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 239ab869-a533-4e5b-b061-518759206007
+                - 275ef536-d438-4ac2-9ccc-ea44d94dccd4
         status: 200 OK
         code: 200
-        duration: 144.733375ms
+        duration: 38.964348ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1149,8 +1149,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=Telehouse+TH2&order_by=name_asc&page=1
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -1158,18 +1158,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 431
+        content_length: 1158
         uncompressed: false
-        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"- Telehouse TH2","region":"fr-par"}],"total_count":1}'
+        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","l3_connectivity":true,"logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","region":"","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","l3_connectivity":true,"logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","region":"","updated_at":"2024-11-28T08:45:33.852946Z"},{"contact_email":"contact.experience-client@linkt.fr","created_at":"2026-04-21T14:31:08.285733Z","id":"4e0dcaaf-467c-432c-ad93-f28be5878df0","l3_connectivity":true,"logo_url":"https://www.linkt.fr/wp-content/themes/linkt/assets/img/svg/logo-linkt-sticky.svg","name":"Linkt","portal_url":"https://www.linkt.fr/","region":"","updated_at":"2026-07-07T11:57:51.706396Z"}],"total_count":3}'
         headers:
             Content-Length:
-                - "431"
+                - "1158"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 20 Apr 2026 09:10:48 GMT
+                - Mon, 24 Aug 2026 12:13:41 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
@@ -1179,10 +1179,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 900bfb5b-949b-4090-bfc0-1a69284d6af5
+                - 0025e59e-321d-440e-aa7d-e400c8e38614
         status: 200 OK
         code: 200
-        duration: 29.582375ms
+        duration: 40.005472ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1198,8 +1198,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=TeleHouse+TH2&order_by=name_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -1207,18 +1207,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 708
+        content_length: 429
         uncompressed: false
-        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","updated_at":"2024-11-28T08:45:33.852946Z"}],"total_count":2}'
+        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"TeleHouse TH2","region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
-                - "708"
+                - "429"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 20 Apr 2026 09:10:48 GMT
+                - Mon, 24 Aug 2026 12:13:41 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
@@ -1228,10 +1228,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e8ca668b-f661-4dfd-8148-a22691afd07f
+                - 2983f186-fb6b-4214-9348-fad816852a04
         status: 200 OK
         code: 200
-        duration: 29.530708ms
+        duration: 42.955165ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1247,8 +1247,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/49c5af40-8332-4757-ab8e-314176d25ddb
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=TeleHouse+TH2&order_by=name_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -1256,18 +1256,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 876
+        content_length: 429
         uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-20T09:10:46.809177Z","enable_route_propagation":false,"id":"49c5af40-8332-4757-ab8e-314176d25ddb","name":"tf-test-interlink-link-rp","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"cc4808c4-dedd-4f75-a8e3-7a6e95d47a07","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.101/31","ipv6":"2001:1bc8:3812:fc60:6d65:b2db:53c3:cc01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.100/31","ipv6":"2001:1bc8:3812:fc60:6d65:b2db:53c3:cc00/127"},"status":"requested","tags":[],"updated_at":"2026-04-20T09:10:48.069799Z","vlan":2386}'
+        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"TeleHouse TH2","region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
-                - "876"
+                - "429"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 20 Apr 2026 09:10:48 GMT
+                - Mon, 24 Aug 2026 12:13:42 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
@@ -1277,10 +1277,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a29f8fc0-fc1a-470a-97b6-e9188103bcb2
+                - 23e3d095-9456-4b50-a712-aaab18de251c
         status: 200 OK
         code: 200
-        duration: 29.732834ms
+        duration: 47.28973ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1296,7 +1296,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
         method: GET
       response:
@@ -1305,18 +1305,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 708
+        content_length: 1158
         uncompressed: false
-        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","updated_at":"2024-11-28T08:45:33.852946Z"}],"total_count":2}'
+        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","l3_connectivity":true,"logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","region":"","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","l3_connectivity":true,"logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","region":"","updated_at":"2024-11-28T08:45:33.852946Z"},{"contact_email":"contact.experience-client@linkt.fr","created_at":"2026-04-21T14:31:08.285733Z","id":"4e0dcaaf-467c-432c-ad93-f28be5878df0","l3_connectivity":true,"logo_url":"https://www.linkt.fr/wp-content/themes/linkt/assets/img/svg/logo-linkt-sticky.svg","name":"Linkt","portal_url":"https://www.linkt.fr/","region":"","updated_at":"2026-07-07T11:57:51.706396Z"}],"total_count":3}'
         headers:
             Content-Length:
-                - "708"
+                - "1158"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 20 Apr 2026 09:10:49 GMT
+                - Mon, 24 Aug 2026 12:13:42 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
@@ -1326,10 +1326,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b2677e85-fab5-4f28-a10d-950556485d04
+                - 68790b1c-c836-47ca-a094-071e5e76c0d2
         status: 200 OK
         code: 200
-        duration: 39.22575ms
+        duration: 58.598799ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1345,8 +1345,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=Telehouse+TH2&order_by=name_asc&page=1
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/40f409f7-30ca-47a7-83cc-338746837623
         method: GET
       response:
         proto: HTTP/2.0
@@ -1354,18 +1354,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 431
+        content_length: 898
         uncompressed: false
-        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"- Telehouse TH2","region":"fr-par"}],"total_count":1}'
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.352434Z","enable_route_propagation":false,"id":"40f409f7-30ca-47a7-83cc-338746837623","name":"tf-test-interlink-link-rp","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"6a104e5c-9bb5-4e42-9ef9-db299c42409f","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.91/31","ipv6":"2001:1bc8:3812:fc60:a998:7a19:86bb:da01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.90/31","ipv6":"2001:1bc8:3812:fc60:a998:7a19:86bb:da00/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:41.247528Z","vlan":3020}'
         headers:
             Content-Length:
-                - "431"
+                - "898"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 20 Apr 2026 09:10:49 GMT
+                - Mon, 24 Aug 2026 12:13:42 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
@@ -1375,10 +1375,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 031ecd11-c911-4659-b71d-a183cbacb609
+                - 68b55055-3633-4d28-8b26-ff5078127cd8
         status: 200 OK
         code: 200
-        duration: 47.346708ms
+        duration: 32.097877ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1394,8 +1394,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/49c5af40-8332-4757-ab8e-314176d25ddb
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -1403,18 +1403,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 876
+        content_length: 1158
         uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-20T09:10:46.809177Z","enable_route_propagation":false,"id":"49c5af40-8332-4757-ab8e-314176d25ddb","name":"tf-test-interlink-link-rp","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"cc4808c4-dedd-4f75-a8e3-7a6e95d47a07","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.101/31","ipv6":"2001:1bc8:3812:fc60:6d65:b2db:53c3:cc01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.100/31","ipv6":"2001:1bc8:3812:fc60:6d65:b2db:53c3:cc00/127"},"status":"requested","tags":[],"updated_at":"2026-04-20T09:10:48.069799Z","vlan":2386}'
+        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","l3_connectivity":true,"logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","region":"","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","l3_connectivity":true,"logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","region":"","updated_at":"2024-11-28T08:45:33.852946Z"},{"contact_email":"contact.experience-client@linkt.fr","created_at":"2026-04-21T14:31:08.285733Z","id":"4e0dcaaf-467c-432c-ad93-f28be5878df0","l3_connectivity":true,"logo_url":"https://www.linkt.fr/wp-content/themes/linkt/assets/img/svg/logo-linkt-sticky.svg","name":"Linkt","portal_url":"https://www.linkt.fr/","region":"","updated_at":"2026-07-07T11:57:51.706396Z"}],"total_count":3}'
         headers:
             Content-Length:
-                - "876"
+                - "1158"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 20 Apr 2026 09:10:49 GMT
+                - Mon, 24 Aug 2026 12:13:42 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
@@ -1424,10 +1424,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4cbe8e19-8fe9-4666-af01-a49e3da9030e
+                - 11c7ded6-ad0f-42f9-928d-cdd978949192
         status: 200 OK
         code: 200
-        duration: 29.369375ms
+        duration: 42.465612ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1443,27 +1443,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/49c5af40-8332-4757-ab8e-314176d25ddb
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=TeleHouse+TH2&order_by=name_asc&page=1
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 874
+        content_length: 429
         uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-20T09:10:46.809177Z","enable_route_propagation":false,"id":"49c5af40-8332-4757-ab8e-314176d25ddb","name":"tf-test-interlink-link-rp","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"cc4808c4-dedd-4f75-a8e3-7a6e95d47a07","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.101/31","ipv6":"2001:1bc8:3812:fc60:6d65:b2db:53c3:cc01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.100/31","ipv6":"2001:1bc8:3812:fc60:6d65:b2db:53c3:cc00/127"},"status":"deleted","tags":[],"updated_at":"2026-04-20T09:10:48.069799Z","vlan":2386}'
+        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"TeleHouse TH2","region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
-                - "874"
+                - "429"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 20 Apr 2026 09:10:49 GMT
+                - Mon, 24 Aug 2026 12:13:42 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
@@ -1473,10 +1473,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 763e7ca6-3792-48aa-815e-9439d34ad807
+                - 6555f0bf-7ca2-4175-83ae-e603e505a074
         status: 200 OK
         code: 200
-        duration: 62.074167ms
+        duration: 44.85646ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1492,8 +1492,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/49c5af40-8332-4757-ab8e-314176d25ddb
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/40f409f7-30ca-47a7-83cc-338746837623
         method: GET
       response:
         proto: HTTP/2.0
@@ -1501,18 +1501,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 125
+        content_length: 898
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"link","resource_id":"49c5af40-8332-4757-ab8e-314176d25ddb","type":"not_found"}'
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.352434Z","enable_route_propagation":false,"id":"40f409f7-30ca-47a7-83cc-338746837623","name":"tf-test-interlink-link-rp","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"6a104e5c-9bb5-4e42-9ef9-db299c42409f","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.91/31","ipv6":"2001:1bc8:3812:fc60:a998:7a19:86bb:da01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.90/31","ipv6":"2001:1bc8:3812:fc60:a998:7a19:86bb:da00/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:41.247528Z","vlan":3020}'
         headers:
             Content-Length:
-                - "125"
+                - "898"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 20 Apr 2026 09:10:49 GMT
+                - Mon, 24 Aug 2026 12:13:42 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
@@ -1522,10 +1522,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8fa29b2e-05ba-4b37-b213-3948320a2ba3
-        status: 404 Not Found
-        code: 404
-        duration: 24.212042ms
+                - cc91f227-a35d-419d-bcb5-aa8b02767853
+        status: 200 OK
+        code: 200
+        duration: 49.271547ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1541,27 +1541,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/49c5af40-8332-4757-ab8e-314176d25ddb
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/40f409f7-30ca-47a7-83cc-338746837623
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 125
+        content_length: 896
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"link","resource_id":"49c5af40-8332-4757-ab8e-314176d25ddb","type":"not_found"}'
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.352434Z","enable_route_propagation":false,"id":"40f409f7-30ca-47a7-83cc-338746837623","name":"tf-test-interlink-link-rp","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"6a104e5c-9bb5-4e42-9ef9-db299c42409f","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.91/31","ipv6":"2001:1bc8:3812:fc60:a998:7a19:86bb:da01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.90/31","ipv6":"2001:1bc8:3812:fc60:a998:7a19:86bb:da00/127"},"status":"deleted","tags":[],"updated_at":"2026-08-24T12:13:41.247528Z","vlan":3020}'
         headers:
             Content-Length:
-                - "125"
+                - "896"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 20 Apr 2026 09:10:49 GMT
+                - Mon, 24 Aug 2026 12:13:42 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
@@ -1571,7 +1571,105 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b05864ed-1269-4e0a-a9f5-e3844e007cfc
+                - 8220e659-2e87-4ec7-99e3-a4dff8e773cf
+        status: 200 OK
+        code: 200
+        duration: 60.867697ms
+    - id: 32
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/40f409f7-30ca-47a7-83cc-338746837623
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 125
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"link","resource_id":"40f409f7-30ca-47a7-83cc-338746837623","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "125"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 24 Aug 2026 12:13:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7e2b535f-963e-4dc6-b4f9-bc3a5438c6f1
         status: 404 Not Found
         code: 404
-        duration: 26.227208ms
+        duration: 38.862175ms
+    - id: 33
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/40f409f7-30ca-47a7-83cc-338746837623
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 125
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"link","resource_id":"40f409f7-30ca-47a7-83cc-338746837623","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "125"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 24 Aug 2026 12:13:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 05e299e7-fe7a-4ca4-92d4-0fe14af3e429
+        status: 404 Not Found
+        code: 404
+        duration: 45.288786ms

--- a/internal/services/interlink/testdata/interlink-link-with-vpc.cassette.yaml
+++ b/internal/services/interlink/testdata/interlink-link-with-vpc.cassette.yaml
@@ -16,7 +16,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
         method: GET
       response:
@@ -25,20 +25,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 708
+        content_length: 1158
         uncompressed: false
-        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","updated_at":"2024-11-28T08:45:33.852946Z"}],"total_count":2}'
+        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","l3_connectivity":true,"logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","region":"","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","l3_connectivity":true,"logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","region":"","updated_at":"2024-11-28T08:45:33.852946Z"},{"contact_email":"contact.experience-client@linkt.fr","created_at":"2026-04-21T14:31:08.285733Z","id":"4e0dcaaf-467c-432c-ad93-f28be5878df0","l3_connectivity":true,"logo_url":"https://www.linkt.fr/wp-content/themes/linkt/assets/img/svg/logo-linkt-sticky.svg","name":"Linkt","portal_url":"https://www.linkt.fr/","region":"","updated_at":"2026-07-07T11:57:51.706396Z"}],"total_count":3}'
         headers:
             Content-Length:
-                - "708"
+                - "1158"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Sun, 19 Apr 2026 20:29:50 GMT
+                - Mon, 24 Aug 2026 12:13:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -46,10 +46,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8638d0f5-e5a0-4ef1-abe0-b2690d34732f
+                - 94d76d71-f624-44a6-b313-bbf64f939c63
         status: 200 OK
         code: 200
-        duration: 327.313542ms
+        duration: 79.235855ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -65,8 +65,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=Telehouse+TH2&order_by=name_asc&page=1
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=TeleHouse+TH2&order_by=name_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -74,20 +74,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 431
+        content_length: 429
         uncompressed: false
-        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"- Telehouse TH2","region":"fr-par"}],"total_count":1}'
+        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"TeleHouse TH2","region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
-                - "431"
+                - "429"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Sun, 19 Apr 2026 20:29:50 GMT
+                - Mon, 24 Aug 2026 12:13:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -95,50 +95,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 92465d64-f574-42bc-92dc-a28794f6f941
+                - aeecc64d-a505-438f-94e1-fb10f37b39e6
         status: 200 OK
         code: 200
-        duration: 341.3395ms
+        duration: 94.449248ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 117
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-test-interlink-vpc","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","tags":[],"enable_routing":false}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs
-        method: POST
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/metadata
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 419
+        content_length: 59
         uncompressed: false
-        body: '{"created_at":"2026-04-19T20:29:51.212999Z","custom_routes_propagation_enabled":true,"id":"b189d7ca-53d8-4f3a-967c-25f90b09d22f","is_default":false,"name":"tf-test-interlink-vpc","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":0,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","routing_enabled":true,"tags":[],"updated_at":"2026-04-19T20:29:51.212999Z"}'
+        body: '{"domain":"scw.eu","partition":"scw","platform":"external"}'
         headers:
             Content-Length:
-                - "419"
+                - "59"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Sun, 19 Apr 2026 20:29:51 GMT
+                - Mon, 24 Aug 2026 12:13:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +144,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 12667fa6-646f-44f0-a29c-d50056376abf
+                - 76cc97a1-83a3-459d-9dce-0d02c7786aa9
         status: 200 OK
         code: 200
-        duration: 133.360583ms
+        duration: 22.97412ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -165,8 +163,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/b189d7ca-53d8-4f3a-967c-25f90b09d22f
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/metadata
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,20 +172,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 419
+        content_length: 59
         uncompressed: false
-        body: '{"created_at":"2026-04-19T20:29:51.212999Z","custom_routes_propagation_enabled":true,"id":"b189d7ca-53d8-4f3a-967c-25f90b09d22f","is_default":false,"name":"tf-test-interlink-vpc","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":0,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","routing_enabled":true,"tags":[],"updated_at":"2026-04-19T20:29:51.212999Z"}'
+        body: '{"domain":"scw.eu","partition":"scw","platform":"external"}'
         headers:
             Content-Length:
-                - "419"
+                - "59"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Sun, 19 Apr 2026 20:29:51 GMT
+                - Mon, 24 Aug 2026 12:13:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,29 +193,29 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6f7b0656-4b40-42a6-a22d-2d13aab11909
+                - bb201d0a-6e88-49bd-9105-49a1de91c9d1
         status: 200 OK
         code: 200
-        duration: 72.959458ms
+        duration: 22.136371ms
     - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 219
+        content_length: 145
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","name":"tf-test-interlink-link-vpc","tags":[],"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","bandwidth_mbps":50,"partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"}'
+        body: '{"name":"tf-test-interlink-vpc","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"enable_routing":false,"enable_transitivity":false}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs
         method: POST
       response:
         proto: HTTP/2.0
@@ -225,20 +223,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 875
+        content_length: 481
         uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-19T20:29:51.721706Z","enable_route_propagation":false,"id":"0bb8f7cf-88a6-43ff-ac07-ac0a705da1a8","name":"tf-test-interlink-link-vpc","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"222461a1-5b81-4ef4-86ba-e7612cc30e6b","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.99/31","ipv6":"2001:1bc8:3812:fc60:56de:818e:4e3f:5301/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.98/31","ipv6":"2001:1bc8:3812:fc60:56de:818e:4e3f:5300/127"},"status":"requested","tags":[],"updated_at":"2026-04-19T20:29:51.721706Z","vlan":1991}'
+        body: '{"created_at":"2026-08-24T12:13:39.264620Z","custom_routes_propagation_enabled":true,"id":"bec51601-1539-47e9-8d67-7ef3959cb5e2","is_default":false,"name":"tf-test-interlink-vpc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","routing_enabled":true,"s3_integration_enabled":false,"tags":[],"transitivity_enabled":false,"updated_at":"2026-08-24T12:13:39.264620Z"}'
         headers:
             Content-Length:
-                - "875"
+                - "481"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Sun, 19 Apr 2026 20:29:51 GMT
+                - Mon, 24 Aug 2026 12:13:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -246,10 +244,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4173e52b-7c87-42e8-94a6-82db82b53cce
+                - 6e8e9865-6070-44a1-879d-6a0a11b61131
         status: 200 OK
         code: 200
-        duration: 432.328125ms
+        duration: 99.674493ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -265,8 +263,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/0bb8f7cf-88a6-43ff-ac07-ac0a705da1a8
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/bec51601-1539-47e9-8d67-7ef3959cb5e2
         method: GET
       response:
         proto: HTTP/2.0
@@ -274,20 +272,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 875
+        content_length: 481
         uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-19T20:29:51.721706Z","enable_route_propagation":false,"id":"0bb8f7cf-88a6-43ff-ac07-ac0a705da1a8","name":"tf-test-interlink-link-vpc","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"222461a1-5b81-4ef4-86ba-e7612cc30e6b","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.99/31","ipv6":"2001:1bc8:3812:fc60:56de:818e:4e3f:5301/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.98/31","ipv6":"2001:1bc8:3812:fc60:56de:818e:4e3f:5300/127"},"status":"requested","tags":[],"updated_at":"2026-04-19T20:29:51.721706Z","vlan":1991}'
+        body: '{"created_at":"2026-08-24T12:13:39.264620Z","custom_routes_propagation_enabled":true,"id":"bec51601-1539-47e9-8d67-7ef3959cb5e2","is_default":false,"name":"tf-test-interlink-vpc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","routing_enabled":true,"s3_integration_enabled":false,"tags":[],"transitivity_enabled":false,"updated_at":"2026-08-24T12:13:39.264620Z"}'
         headers:
             Content-Length:
-                - "875"
+                - "481"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Sun, 19 Apr 2026 20:29:51 GMT
+                - Mon, 24 Aug 2026 12:13:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -295,29 +293,29 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7257aefb-49c5-4ca8-b89b-053166669cb4
+                - d1ac9192-20fe-4d87-b0d6-6c05380b1073
         status: 200 OK
         code: 200
-        duration: 76.05775ms
+        duration: 37.033388ms
     - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 49
+        content_length: 219
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"vpc_id":"b189d7ca-53d8-4f3a-967c-25f90b09d22f"}'
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-interlink-link-vpc","tags":[],"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","bandwidth_mbps":50,"partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/0bb8f7cf-88a6-43ff-ac07-ac0a705da1a8/attach-vpc
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links
         method: POST
       response:
         proto: HTTP/2.0
@@ -325,20 +323,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 924
+        content_length: 899
         uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-19T20:29:51.721706Z","enable_route_propagation":false,"id":"0bb8f7cf-88a6-43ff-ac07-ac0a705da1a8","name":"tf-test-interlink-link-vpc","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"222461a1-5b81-4ef4-86ba-e7612cc30e6b","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.99/31","ipv6":"2001:1bc8:3812:fc60:56de:818e:4e3f:5301/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.98/31","ipv6":"2001:1bc8:3812:fc60:56de:818e:4e3f:5300/127"},"status":"requested","tags":[],"updated_at":"2026-04-19T20:29:52.040637Z","vlan":1991,"vpc_id":"b189d7ca-53d8-4f3a-967c-25f90b09d22f"}'
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.478178Z","enable_route_propagation":false,"id":"5911eca8-0067-47b7-a482-33d5a3f50943","name":"tf-test-interlink-link-vpc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"efc7d57b-f59c-4709-b4c1-9c5a42123877","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.99/31","ipv6":"2001:1bc8:3812:fc60:c8cd:e863:1c58:ad01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.98/31","ipv6":"2001:1bc8:3812:fc60:c8cd:e863:1c58:ad00/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:39.478178Z","vlan":2575}'
         headers:
             Content-Length:
-                - "924"
+                - "899"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Sun, 19 Apr 2026 20:29:52 GMT
+                - Mon, 24 Aug 2026 12:13:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -346,10 +344,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b8112723-c816-4f7e-a487-a2f0ed083598
+                - 242eebd5-2793-4175-a97d-c1e3229e844b
         status: 200 OK
         code: 200
-        duration: 208.902167ms
+        duration: 182.050218ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -365,8 +363,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/0bb8f7cf-88a6-43ff-ac07-ac0a705da1a8
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/5911eca8-0067-47b7-a482-33d5a3f50943
         method: GET
       response:
         proto: HTTP/2.0
@@ -374,20 +372,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 924
+        content_length: 899
         uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-19T20:29:51.721706Z","enable_route_propagation":false,"id":"0bb8f7cf-88a6-43ff-ac07-ac0a705da1a8","name":"tf-test-interlink-link-vpc","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"222461a1-5b81-4ef4-86ba-e7612cc30e6b","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.99/31","ipv6":"2001:1bc8:3812:fc60:56de:818e:4e3f:5301/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.98/31","ipv6":"2001:1bc8:3812:fc60:56de:818e:4e3f:5300/127"},"status":"requested","tags":[],"updated_at":"2026-04-19T20:29:52.040637Z","vlan":1991,"vpc_id":"b189d7ca-53d8-4f3a-967c-25f90b09d22f"}'
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.478178Z","enable_route_propagation":false,"id":"5911eca8-0067-47b7-a482-33d5a3f50943","name":"tf-test-interlink-link-vpc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"efc7d57b-f59c-4709-b4c1-9c5a42123877","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.99/31","ipv6":"2001:1bc8:3812:fc60:c8cd:e863:1c58:ad01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.98/31","ipv6":"2001:1bc8:3812:fc60:c8cd:e863:1c58:ad00/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:39.478178Z","vlan":2575}'
         headers:
             Content-Length:
-                - "924"
+                - "899"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Sun, 19 Apr 2026 20:29:52 GMT
+                - Mon, 24 Aug 2026 12:13:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -395,48 +393,50 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 975dad84-bcb0-4e54-ba05-d7cbc5babf9a
+                - a16ee00a-0ba7-43d8-ab7e-6f2aaffaad66
         status: 200 OK
         code: 200
-        duration: 66.876667ms
+        duration: 34.748648ms
     - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 49
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"vpc_id":"bec51601-1539-47e9-8d67-7ef3959cb5e2"}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/0bb8f7cf-88a6-43ff-ac07-ac0a705da1a8
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/5911eca8-0067-47b7-a482-33d5a3f50943/attach-vpc
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 924
+        content_length: 948
         uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-19T20:29:51.721706Z","enable_route_propagation":false,"id":"0bb8f7cf-88a6-43ff-ac07-ac0a705da1a8","name":"tf-test-interlink-link-vpc","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"222461a1-5b81-4ef4-86ba-e7612cc30e6b","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.99/31","ipv6":"2001:1bc8:3812:fc60:56de:818e:4e3f:5301/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.98/31","ipv6":"2001:1bc8:3812:fc60:56de:818e:4e3f:5300/127"},"status":"requested","tags":[],"updated_at":"2026-04-19T20:29:52.040637Z","vlan":1991,"vpc_id":"b189d7ca-53d8-4f3a-967c-25f90b09d22f"}'
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.478178Z","enable_route_propagation":false,"id":"5911eca8-0067-47b7-a482-33d5a3f50943","name":"tf-test-interlink-link-vpc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"efc7d57b-f59c-4709-b4c1-9c5a42123877","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.99/31","ipv6":"2001:1bc8:3812:fc60:c8cd:e863:1c58:ad01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.98/31","ipv6":"2001:1bc8:3812:fc60:c8cd:e863:1c58:ad00/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:39.734401Z","vlan":2575,"vpc_id":"bec51601-1539-47e9-8d67-7ef3959cb5e2"}'
         headers:
             Content-Length:
-                - "924"
+                - "948"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Sun, 19 Apr 2026 20:29:52 GMT
+                - Mon, 24 Aug 2026 12:13:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -444,10 +444,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 58314cdd-2397-4c56-abf8-03f3ac7926f0
+                - 8fc6546f-02f9-4b4e-9f59-f197b662a08d
         status: 200 OK
         code: 200
-        duration: 77.498959ms
+        duration: 202.491572ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -463,8 +463,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/0bb8f7cf-88a6-43ff-ac07-ac0a705da1a8
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/5911eca8-0067-47b7-a482-33d5a3f50943
         method: GET
       response:
         proto: HTTP/2.0
@@ -472,20 +472,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 924
+        content_length: 948
         uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-19T20:29:51.721706Z","enable_route_propagation":false,"id":"0bb8f7cf-88a6-43ff-ac07-ac0a705da1a8","name":"tf-test-interlink-link-vpc","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"222461a1-5b81-4ef4-86ba-e7612cc30e6b","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.99/31","ipv6":"2001:1bc8:3812:fc60:56de:818e:4e3f:5301/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.98/31","ipv6":"2001:1bc8:3812:fc60:56de:818e:4e3f:5300/127"},"status":"requested","tags":[],"updated_at":"2026-04-19T20:29:52.040637Z","vlan":1991,"vpc_id":"b189d7ca-53d8-4f3a-967c-25f90b09d22f"}'
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.478178Z","enable_route_propagation":false,"id":"5911eca8-0067-47b7-a482-33d5a3f50943","name":"tf-test-interlink-link-vpc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"efc7d57b-f59c-4709-b4c1-9c5a42123877","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.99/31","ipv6":"2001:1bc8:3812:fc60:c8cd:e863:1c58:ad01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.98/31","ipv6":"2001:1bc8:3812:fc60:c8cd:e863:1c58:ad00/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:39.734401Z","vlan":2575,"vpc_id":"bec51601-1539-47e9-8d67-7ef3959cb5e2"}'
         headers:
             Content-Length:
-                - "924"
+                - "948"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Sun, 19 Apr 2026 20:29:52 GMT
+                - Mon, 24 Aug 2026 12:13:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -493,10 +493,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9083bfa2-972b-42e8-b17e-0af06edf3a77
+                - cdb212ea-55a6-4374-a9ec-eeb2af56055f
         status: 200 OK
         code: 200
-        duration: 69.324583ms
+        duration: 39.255659ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -512,8 +512,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/5911eca8-0067-47b7-a482-33d5a3f50943
         method: GET
       response:
         proto: HTTP/2.0
@@ -521,20 +521,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 708
+        content_length: 948
         uncompressed: false
-        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","updated_at":"2024-11-28T08:45:33.852946Z"}],"total_count":2}'
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.478178Z","enable_route_propagation":false,"id":"5911eca8-0067-47b7-a482-33d5a3f50943","name":"tf-test-interlink-link-vpc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"efc7d57b-f59c-4709-b4c1-9c5a42123877","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.99/31","ipv6":"2001:1bc8:3812:fc60:c8cd:e863:1c58:ad01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.98/31","ipv6":"2001:1bc8:3812:fc60:c8cd:e863:1c58:ad00/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:39.734401Z","vlan":2575,"vpc_id":"bec51601-1539-47e9-8d67-7ef3959cb5e2"}'
         headers:
             Content-Length:
-                - "708"
+                - "948"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Sun, 19 Apr 2026 20:29:52 GMT
+                - Mon, 24 Aug 2026 12:13:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -542,10 +542,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 782b5cec-0fbb-4c07-9135-1fad7ffe5b1d
+                - c0b18fe6-863e-4c02-a7e5-1df08d7b4a6a
         status: 200 OK
         code: 200
-        duration: 69.913875ms
+        duration: 40.935167ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -561,8 +561,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=Telehouse+TH2&order_by=name_asc&page=1
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/5911eca8-0067-47b7-a482-33d5a3f50943
         method: GET
       response:
         proto: HTTP/2.0
@@ -570,20 +570,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 431
+        content_length: 948
         uncompressed: false
-        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"- Telehouse TH2","region":"fr-par"}],"total_count":1}'
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.478178Z","enable_route_propagation":false,"id":"5911eca8-0067-47b7-a482-33d5a3f50943","name":"tf-test-interlink-link-vpc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"efc7d57b-f59c-4709-b4c1-9c5a42123877","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.99/31","ipv6":"2001:1bc8:3812:fc60:c8cd:e863:1c58:ad01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.98/31","ipv6":"2001:1bc8:3812:fc60:c8cd:e863:1c58:ad00/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:39.734401Z","vlan":2575,"vpc_id":"bec51601-1539-47e9-8d67-7ef3959cb5e2"}'
         headers:
             Content-Length:
-                - "431"
+                - "948"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Sun, 19 Apr 2026 20:29:52 GMT
+                - Mon, 24 Aug 2026 12:13:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -591,10 +591,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c885da1b-74ef-430b-8bca-f7a210a6ff13
+                - 40f760f1-c956-436b-8fe7-496f548d04eb
         status: 200 OK
         code: 200
-        duration: 85.031292ms
+        duration: 35.60354ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -610,8 +610,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/b189d7ca-53d8-4f3a-967c-25f90b09d22f
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -619,20 +619,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 419
+        content_length: 1158
         uncompressed: false
-        body: '{"created_at":"2026-04-19T20:29:51.212999Z","custom_routes_propagation_enabled":true,"id":"b189d7ca-53d8-4f3a-967c-25f90b09d22f","is_default":false,"name":"tf-test-interlink-vpc","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":0,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","routing_enabled":true,"tags":[],"updated_at":"2026-04-19T20:29:51.212999Z"}'
+        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","l3_connectivity":true,"logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","region":"","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","l3_connectivity":true,"logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","region":"","updated_at":"2024-11-28T08:45:33.852946Z"},{"contact_email":"contact.experience-client@linkt.fr","created_at":"2026-04-21T14:31:08.285733Z","id":"4e0dcaaf-467c-432c-ad93-f28be5878df0","l3_connectivity":true,"logo_url":"https://www.linkt.fr/wp-content/themes/linkt/assets/img/svg/logo-linkt-sticky.svg","name":"Linkt","portal_url":"https://www.linkt.fr/","region":"","updated_at":"2026-07-07T11:57:51.706396Z"}],"total_count":3}'
         headers:
             Content-Length:
-                - "419"
+                - "1158"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Sun, 19 Apr 2026 20:29:52 GMT
+                - Mon, 24 Aug 2026 12:13:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -640,10 +640,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - df946be4-053f-49ea-8ac3-372b5a99e3fa
+                - 01de851d-4fc5-41b8-b776-be65e9f1a76e
         status: 200 OK
         code: 200
-        duration: 68.4765ms
+        duration: 32.10421ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -659,8 +659,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=TeleHouse+TH2&order_by=name_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -668,20 +668,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 708
+        content_length: 429
         uncompressed: false
-        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","updated_at":"2024-11-28T08:45:33.852946Z"}],"total_count":2}'
+        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"TeleHouse TH2","region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
-                - "708"
+                - "429"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Sun, 19 Apr 2026 20:29:52 GMT
+                - Mon, 24 Aug 2026 12:13:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -689,10 +689,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c50d96f6-e3a6-47a3-bad4-0271c45c9812
+                - 1245c05b-4022-4559-9ef3-57070b5320d1
         status: 200 OK
         code: 200
-        duration: 68.502042ms
+        duration: 34.340067ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -708,8 +708,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=Telehouse+TH2&order_by=name_asc&page=1
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=TeleHouse+TH2&order_by=name_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -717,20 +717,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 431
+        content_length: 429
         uncompressed: false
-        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"- Telehouse TH2","region":"fr-par"}],"total_count":1}'
+        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"TeleHouse TH2","region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
-                - "431"
+                - "429"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Sun, 19 Apr 2026 20:29:52 GMT
+                - Mon, 24 Aug 2026 12:13:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -738,10 +738,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5e520022-8c8e-4117-ac0e-e536c87a8656
+                - b1d05222-6eb0-4a45-a75c-7d5d69494e30
         status: 200 OK
         code: 200
-        duration: 77.680209ms
+        duration: 34.83491ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -757,8 +757,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/0bb8f7cf-88a6-43ff-ac07-ac0a705da1a8
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -766,20 +766,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 924
+        content_length: 1158
         uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-19T20:29:51.721706Z","enable_route_propagation":false,"id":"0bb8f7cf-88a6-43ff-ac07-ac0a705da1a8","name":"tf-test-interlink-link-vpc","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"222461a1-5b81-4ef4-86ba-e7612cc30e6b","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.99/31","ipv6":"2001:1bc8:3812:fc60:56de:818e:4e3f:5301/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.98/31","ipv6":"2001:1bc8:3812:fc60:56de:818e:4e3f:5300/127"},"status":"requested","tags":[],"updated_at":"2026-04-19T20:29:52.040637Z","vlan":1991,"vpc_id":"b189d7ca-53d8-4f3a-967c-25f90b09d22f"}'
+        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","l3_connectivity":true,"logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","region":"","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","l3_connectivity":true,"logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","region":"","updated_at":"2024-11-28T08:45:33.852946Z"},{"contact_email":"contact.experience-client@linkt.fr","created_at":"2026-04-21T14:31:08.285733Z","id":"4e0dcaaf-467c-432c-ad93-f28be5878df0","l3_connectivity":true,"logo_url":"https://www.linkt.fr/wp-content/themes/linkt/assets/img/svg/logo-linkt-sticky.svg","name":"Linkt","portal_url":"https://www.linkt.fr/","region":"","updated_at":"2026-07-07T11:57:51.706396Z"}],"total_count":3}'
         headers:
             Content-Length:
-                - "924"
+                - "1158"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Sun, 19 Apr 2026 20:29:52 GMT
+                - Mon, 24 Aug 2026 12:13:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -787,10 +787,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7c44cd0c-d589-409c-9d58-8288ec0499c1
+                - 78172d02-8fe5-402d-bac6-18f588f6585a
         status: 200 OK
         code: 200
-        duration: 61.758125ms
+        duration: 41.810186ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -806,8 +806,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/bec51601-1539-47e9-8d67-7ef3959cb5e2
         method: GET
       response:
         proto: HTTP/2.0
@@ -815,20 +815,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 708
+        content_length: 481
         uncompressed: false
-        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","updated_at":"2024-11-28T08:45:33.852946Z"}],"total_count":2}'
+        body: '{"created_at":"2026-08-24T12:13:39.264620Z","custom_routes_propagation_enabled":true,"id":"bec51601-1539-47e9-8d67-7ef3959cb5e2","is_default":false,"name":"tf-test-interlink-vpc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","routing_enabled":true,"s3_integration_enabled":false,"tags":[],"transitivity_enabled":false,"updated_at":"2026-08-24T12:13:39.264620Z"}'
         headers:
             Content-Length:
-                - "708"
+                - "481"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Sun, 19 Apr 2026 20:29:53 GMT
+                - Mon, 24 Aug 2026 12:13:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -836,10 +836,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9e87b938-f927-4aeb-b054-566138456ed0
+                - b65d1a08-314c-4b6f-b568-c482b601d310
         status: 200 OK
         code: 200
-        duration: 71.864959ms
+        duration: 187.142159ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -855,8 +855,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/b189d7ca-53d8-4f3a-967c-25f90b09d22f
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/5911eca8-0067-47b7-a482-33d5a3f50943
         method: GET
       response:
         proto: HTTP/2.0
@@ -864,20 +864,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 419
+        content_length: 948
         uncompressed: false
-        body: '{"created_at":"2026-04-19T20:29:51.212999Z","custom_routes_propagation_enabled":true,"id":"b189d7ca-53d8-4f3a-967c-25f90b09d22f","is_default":false,"name":"tf-test-interlink-vpc","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":0,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","routing_enabled":true,"tags":[],"updated_at":"2026-04-19T20:29:51.212999Z"}'
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.478178Z","enable_route_propagation":false,"id":"5911eca8-0067-47b7-a482-33d5a3f50943","name":"tf-test-interlink-link-vpc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"efc7d57b-f59c-4709-b4c1-9c5a42123877","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.99/31","ipv6":"2001:1bc8:3812:fc60:c8cd:e863:1c58:ad01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.98/31","ipv6":"2001:1bc8:3812:fc60:c8cd:e863:1c58:ad00/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:39.734401Z","vlan":2575,"vpc_id":"bec51601-1539-47e9-8d67-7ef3959cb5e2"}'
         headers:
             Content-Length:
-                - "419"
+                - "948"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Sun, 19 Apr 2026 20:29:53 GMT
+                - Mon, 24 Aug 2026 12:13:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -885,10 +885,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1b352b85-f901-42ae-b50d-b1e04222a6aa
+                - a682c457-d9fe-4fa0-b67e-40b36156a6c2
         status: 200 OK
         code: 200
-        duration: 86.244458ms
+        duration: 34.775849ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -904,8 +904,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=Telehouse+TH2&order_by=name_asc&page=1
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -913,20 +913,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 431
+        content_length: 1158
         uncompressed: false
-        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"- Telehouse TH2","region":"fr-par"}],"total_count":1}'
+        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","l3_connectivity":true,"logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","region":"","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","l3_connectivity":true,"logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","region":"","updated_at":"2024-11-28T08:45:33.852946Z"},{"contact_email":"contact.experience-client@linkt.fr","created_at":"2026-04-21T14:31:08.285733Z","id":"4e0dcaaf-467c-432c-ad93-f28be5878df0","l3_connectivity":true,"logo_url":"https://www.linkt.fr/wp-content/themes/linkt/assets/img/svg/logo-linkt-sticky.svg","name":"Linkt","portal_url":"https://www.linkt.fr/","region":"","updated_at":"2026-07-07T11:57:51.706396Z"}],"total_count":3}'
         headers:
             Content-Length:
-                - "431"
+                - "1158"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Sun, 19 Apr 2026 20:29:53 GMT
+                - Mon, 24 Aug 2026 12:13:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -934,10 +934,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0dd570bc-6345-4bc2-a75f-ba1415088a86
+                - 4da8e867-8e9a-45dd-823e-1c1d0379689d
         status: 200 OK
         code: 200
-        duration: 86.621458ms
+        duration: 33.642661ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -953,8 +953,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/0bb8f7cf-88a6-43ff-ac07-ac0a705da1a8
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=TeleHouse+TH2&order_by=name_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -962,20 +962,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 924
+        content_length: 429
         uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-19T20:29:51.721706Z","enable_route_propagation":false,"id":"0bb8f7cf-88a6-43ff-ac07-ac0a705da1a8","name":"tf-test-interlink-link-vpc","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"222461a1-5b81-4ef4-86ba-e7612cc30e6b","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.99/31","ipv6":"2001:1bc8:3812:fc60:56de:818e:4e3f:5301/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.98/31","ipv6":"2001:1bc8:3812:fc60:56de:818e:4e3f:5300/127"},"status":"requested","tags":[],"updated_at":"2026-04-19T20:29:52.040637Z","vlan":1991,"vpc_id":"b189d7ca-53d8-4f3a-967c-25f90b09d22f"}'
+        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"TeleHouse TH2","region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
-                - "924"
+                - "429"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Sun, 19 Apr 2026 20:29:53 GMT
+                - Mon, 24 Aug 2026 12:13:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -983,50 +983,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9d72db4f-84f2-4372-a57b-80ee414ad5be
+                - 217fa456-fc29-4200-a0b2-ecc75ca7e32f
         status: 200 OK
         code: 200
-        duration: 75.773125ms
+        duration: 39.589197ms
     - id: 20
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 125
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-test-interlink-swap-target","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","tags":[],"enable_routing":false}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs
-        method: POST
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/bec51601-1539-47e9-8d67-7ef3959cb5e2
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 427
+        content_length: 481
         uncompressed: false
-        body: '{"created_at":"2026-04-19T20:29:53.514364Z","custom_routes_propagation_enabled":true,"id":"1f0cc61a-ab4d-4b30-a00a-78d647cb1b8e","is_default":false,"name":"tf-test-interlink-swap-target","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":0,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","routing_enabled":true,"tags":[],"updated_at":"2026-04-19T20:29:53.514364Z"}'
+        body: '{"created_at":"2026-08-24T12:13:39.264620Z","custom_routes_propagation_enabled":true,"id":"bec51601-1539-47e9-8d67-7ef3959cb5e2","is_default":false,"name":"tf-test-interlink-vpc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","routing_enabled":true,"s3_integration_enabled":false,"tags":[],"transitivity_enabled":false,"updated_at":"2026-08-24T12:13:39.264620Z"}'
         headers:
             Content-Length:
-                - "427"
+                - "481"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Sun, 19 Apr 2026 20:29:53 GMT
+                - Mon, 24 Aug 2026 12:13:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1034,10 +1032,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c9713dc4-f4b0-4a25-91a5-988f7e034e9c
+                - bf9768fb-81cd-4e44-8414-d6335d688e06
         status: 200 OK
         code: 200
-        duration: 126.907542ms
+        duration: 42.250697ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1053,8 +1051,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/1f0cc61a-ab4d-4b30-a00a-78d647cb1b8e
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/5911eca8-0067-47b7-a482-33d5a3f50943
         method: GET
       response:
         proto: HTTP/2.0
@@ -1062,20 +1060,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 427
+        content_length: 948
         uncompressed: false
-        body: '{"created_at":"2026-04-19T20:29:53.514364Z","custom_routes_propagation_enabled":true,"id":"1f0cc61a-ab4d-4b30-a00a-78d647cb1b8e","is_default":false,"name":"tf-test-interlink-swap-target","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":0,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","routing_enabled":true,"tags":[],"updated_at":"2026-04-19T20:29:53.514364Z"}'
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.478178Z","enable_route_propagation":false,"id":"5911eca8-0067-47b7-a482-33d5a3f50943","name":"tf-test-interlink-link-vpc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"efc7d57b-f59c-4709-b4c1-9c5a42123877","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.99/31","ipv6":"2001:1bc8:3812:fc60:c8cd:e863:1c58:ad01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.98/31","ipv6":"2001:1bc8:3812:fc60:c8cd:e863:1c58:ad00/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:39.734401Z","vlan":2575,"vpc_id":"bec51601-1539-47e9-8d67-7ef3959cb5e2"}'
         headers:
             Content-Length:
-                - "427"
+                - "948"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Sun, 19 Apr 2026 20:29:53 GMT
+                - Mon, 24 Aug 2026 12:13:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1083,11 +1081,62 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 380ee9f2-d91c-4509-ad30-c6f8bc766b9c
+                - fab7b28d-c661-4b46-b4c8-7535ee99baa4
         status: 200 OK
         code: 200
-        duration: 116.410542ms
+        duration: 31.928148ms
     - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 153
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"tf-test-interlink-swap-target","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"enable_routing":false,"enable_transitivity":false}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 489
+        uncompressed: false
+        body: '{"created_at":"2026-08-24T12:13:41.624515Z","custom_routes_propagation_enabled":true,"id":"8ecc9971-0ebb-4f06-8ef7-ba07c00329da","is_default":false,"name":"tf-test-interlink-swap-target","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","routing_enabled":true,"s3_integration_enabled":false,"tags":[],"transitivity_enabled":false,"updated_at":"2026-08-24T12:13:41.624515Z"}'
+        headers:
+            Content-Length:
+                - "489"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 24 Aug 2026 12:13:41 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 1a9ed18e-da40-4099-ad78-219426b63f16
+        status: 200 OK
+        code: 200
+        duration: 114.839201ms
+    - id: 23
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1102,8 +1151,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/0bb8f7cf-88a6-43ff-ac07-ac0a705da1a8
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/8ecc9971-0ebb-4f06-8ef7-ba07c00329da
         method: GET
       response:
         proto: HTTP/2.0
@@ -1111,20 +1160,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 924
+        content_length: 489
         uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-19T20:29:51.721706Z","enable_route_propagation":false,"id":"0bb8f7cf-88a6-43ff-ac07-ac0a705da1a8","name":"tf-test-interlink-link-vpc","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"222461a1-5b81-4ef4-86ba-e7612cc30e6b","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.99/31","ipv6":"2001:1bc8:3812:fc60:56de:818e:4e3f:5301/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.98/31","ipv6":"2001:1bc8:3812:fc60:56de:818e:4e3f:5300/127"},"status":"requested","tags":[],"updated_at":"2026-04-19T20:29:52.040637Z","vlan":1991,"vpc_id":"b189d7ca-53d8-4f3a-967c-25f90b09d22f"}'
+        body: '{"created_at":"2026-08-24T12:13:41.624515Z","custom_routes_propagation_enabled":true,"id":"8ecc9971-0ebb-4f06-8ef7-ba07c00329da","is_default":false,"name":"tf-test-interlink-swap-target","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","routing_enabled":true,"s3_integration_enabled":false,"tags":[],"transitivity_enabled":false,"updated_at":"2026-08-24T12:13:41.624515Z"}'
         headers:
             Content-Length:
-                - "924"
+                - "489"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Sun, 19 Apr 2026 20:29:53 GMT
+                - Mon, 24 Aug 2026 12:13:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1132,61 +1181,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5bcbe55b-2fb2-49e5-b803-264e50139a60
+                - 2c42b5a4-4d24-4e3a-a399-6f956a688092
         status: 200 OK
         code: 200
-        duration: 68.873334ms
-    - id: 23
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 2
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/0bb8f7cf-88a6-43ff-ac07-ac0a705da1a8/detach-vpc
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 875
-        uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-19T20:29:51.721706Z","enable_route_propagation":false,"id":"0bb8f7cf-88a6-43ff-ac07-ac0a705da1a8","name":"tf-test-interlink-link-vpc","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"222461a1-5b81-4ef4-86ba-e7612cc30e6b","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.99/31","ipv6":"2001:1bc8:3812:fc60:56de:818e:4e3f:5301/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.98/31","ipv6":"2001:1bc8:3812:fc60:56de:818e:4e3f:5300/127"},"status":"requested","tags":[],"updated_at":"2026-04-19T20:29:53.858108Z","vlan":1991}'
-        headers:
-            Content-Length:
-                - "875"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Sun, 19 Apr 2026 20:29:53 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - ec14d1ce-4d58-4609-b8fd-e06370d4a816
-        status: 200 OK
-        code: 200
-        duration: 129.907834ms
+        duration: 38.273655ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1202,8 +1200,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/0bb8f7cf-88a6-43ff-ac07-ac0a705da1a8
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/5911eca8-0067-47b7-a482-33d5a3f50943
         method: GET
       response:
         proto: HTTP/2.0
@@ -1211,20 +1209,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 875
+        content_length: 948
         uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-19T20:29:51.721706Z","enable_route_propagation":false,"id":"0bb8f7cf-88a6-43ff-ac07-ac0a705da1a8","name":"tf-test-interlink-link-vpc","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"222461a1-5b81-4ef4-86ba-e7612cc30e6b","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.99/31","ipv6":"2001:1bc8:3812:fc60:56de:818e:4e3f:5301/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.98/31","ipv6":"2001:1bc8:3812:fc60:56de:818e:4e3f:5300/127"},"status":"requested","tags":[],"updated_at":"2026-04-19T20:29:53.858108Z","vlan":1991}'
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.478178Z","enable_route_propagation":false,"id":"5911eca8-0067-47b7-a482-33d5a3f50943","name":"tf-test-interlink-link-vpc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"efc7d57b-f59c-4709-b4c1-9c5a42123877","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.99/31","ipv6":"2001:1bc8:3812:fc60:c8cd:e863:1c58:ad01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.98/31","ipv6":"2001:1bc8:3812:fc60:c8cd:e863:1c58:ad00/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:39.734401Z","vlan":2575,"vpc_id":"bec51601-1539-47e9-8d67-7ef3959cb5e2"}'
         headers:
             Content-Length:
-                - "875"
+                - "948"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Sun, 19 Apr 2026 20:29:53 GMT
+                - Mon, 24 Aug 2026 12:13:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1232,846 +1230,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9bb9c1c4-228e-4902-b4f6-2a29e6160052
+                - 3ea9b51f-5b06-42a7-bedf-791a97e1a828
         status: 200 OK
         code: 200
-        duration: 76.911916ms
+        duration: 43.366761ms
     - id: 25
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 49
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"vpc_id":"1f0cc61a-ab4d-4b30-a00a-78d647cb1b8e"}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/0bb8f7cf-88a6-43ff-ac07-ac0a705da1a8/attach-vpc
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 924
-        uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-19T20:29:51.721706Z","enable_route_propagation":false,"id":"0bb8f7cf-88a6-43ff-ac07-ac0a705da1a8","name":"tf-test-interlink-link-vpc","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"222461a1-5b81-4ef4-86ba-e7612cc30e6b","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.99/31","ipv6":"2001:1bc8:3812:fc60:56de:818e:4e3f:5301/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.98/31","ipv6":"2001:1bc8:3812:fc60:56de:818e:4e3f:5300/127"},"status":"requested","tags":[],"updated_at":"2026-04-19T20:29:54.157546Z","vlan":1991,"vpc_id":"1f0cc61a-ab4d-4b30-a00a-78d647cb1b8e"}'
-        headers:
-            Content-Length:
-                - "924"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Sun, 19 Apr 2026 20:29:54 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 2bdda42f-68a4-4f2e-a948-8f8acc92d5f7
-        status: 200 OK
-        code: 200
-        duration: 215.229542ms
-    - id: 26
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/0bb8f7cf-88a6-43ff-ac07-ac0a705da1a8
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 924
-        uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-19T20:29:51.721706Z","enable_route_propagation":false,"id":"0bb8f7cf-88a6-43ff-ac07-ac0a705da1a8","name":"tf-test-interlink-link-vpc","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"222461a1-5b81-4ef4-86ba-e7612cc30e6b","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.99/31","ipv6":"2001:1bc8:3812:fc60:56de:818e:4e3f:5301/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.98/31","ipv6":"2001:1bc8:3812:fc60:56de:818e:4e3f:5300/127"},"status":"requested","tags":[],"updated_at":"2026-04-19T20:29:54.157546Z","vlan":1991,"vpc_id":"1f0cc61a-ab4d-4b30-a00a-78d647cb1b8e"}'
-        headers:
-            Content-Length:
-                - "924"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Sun, 19 Apr 2026 20:29:54 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - be08a3fa-09a8-475e-97ca-6856a0a28632
-        status: 200 OK
-        code: 200
-        duration: 63.502959ms
-    - id: 27
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/0bb8f7cf-88a6-43ff-ac07-ac0a705da1a8
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 924
-        uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-19T20:29:51.721706Z","enable_route_propagation":false,"id":"0bb8f7cf-88a6-43ff-ac07-ac0a705da1a8","name":"tf-test-interlink-link-vpc","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"222461a1-5b81-4ef4-86ba-e7612cc30e6b","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.99/31","ipv6":"2001:1bc8:3812:fc60:56de:818e:4e3f:5301/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.98/31","ipv6":"2001:1bc8:3812:fc60:56de:818e:4e3f:5300/127"},"status":"requested","tags":[],"updated_at":"2026-04-19T20:29:54.157546Z","vlan":1991,"vpc_id":"1f0cc61a-ab4d-4b30-a00a-78d647cb1b8e"}'
-        headers:
-            Content-Length:
-                - "924"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Sun, 19 Apr 2026 20:29:54 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - cc7e88f9-d242-4887-92a6-9c583913f751
-        status: 200 OK
-        code: 200
-        duration: 68.490333ms
-    - id: 28
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/0bb8f7cf-88a6-43ff-ac07-ac0a705da1a8
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 924
-        uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-19T20:29:51.721706Z","enable_route_propagation":false,"id":"0bb8f7cf-88a6-43ff-ac07-ac0a705da1a8","name":"tf-test-interlink-link-vpc","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"222461a1-5b81-4ef4-86ba-e7612cc30e6b","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.99/31","ipv6":"2001:1bc8:3812:fc60:56de:818e:4e3f:5301/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.98/31","ipv6":"2001:1bc8:3812:fc60:56de:818e:4e3f:5300/127"},"status":"requested","tags":[],"updated_at":"2026-04-19T20:29:54.157546Z","vlan":1991,"vpc_id":"1f0cc61a-ab4d-4b30-a00a-78d647cb1b8e"}'
-        headers:
-            Content-Length:
-                - "924"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Sun, 19 Apr 2026 20:29:54 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 6151d2c4-59fa-4c4f-b2f6-ddd0d5fc9842
-        status: 200 OK
-        code: 200
-        duration: 69.669542ms
-    - id: 29
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 708
-        uncompressed: false
-        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","updated_at":"2024-11-28T08:45:33.852946Z"}],"total_count":2}'
-        headers:
-            Content-Length:
-                - "708"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Sun, 19 Apr 2026 20:29:54 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 879c27a7-d23b-4d3a-acff-d24240d0340f
-        status: 200 OK
-        code: 200
-        duration: 79.711417ms
-    - id: 30
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=Telehouse+TH2&order_by=name_asc&page=1
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 431
-        uncompressed: false
-        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"- Telehouse TH2","region":"fr-par"}],"total_count":1}'
-        headers:
-            Content-Length:
-                - "431"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Sun, 19 Apr 2026 20:29:54 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 0ade29b2-01fa-427f-b456-71a5b6879422
-        status: 200 OK
-        code: 200
-        duration: 101.037667ms
-    - id: 31
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 708
-        uncompressed: false
-        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","updated_at":"2024-11-28T08:45:33.852946Z"}],"total_count":2}'
-        headers:
-            Content-Length:
-                - "708"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Sun, 19 Apr 2026 20:29:54 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - abdb9ba6-bd1f-4cc6-9302-87580790b7b3
-        status: 200 OK
-        code: 200
-        duration: 66.696208ms
-    - id: 32
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/b189d7ca-53d8-4f3a-967c-25f90b09d22f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 419
-        uncompressed: false
-        body: '{"created_at":"2026-04-19T20:29:51.212999Z","custom_routes_propagation_enabled":true,"id":"b189d7ca-53d8-4f3a-967c-25f90b09d22f","is_default":false,"name":"tf-test-interlink-vpc","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":0,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","routing_enabled":true,"tags":[],"updated_at":"2026-04-19T20:29:51.212999Z"}'
-        headers:
-            Content-Length:
-                - "419"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Sun, 19 Apr 2026 20:29:54 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - e3f805f8-61c8-4a78-8103-c1f7f440bdd2
-        status: 200 OK
-        code: 200
-        duration: 75.920916ms
-    - id: 33
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=Telehouse+TH2&order_by=name_asc&page=1
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 431
-        uncompressed: false
-        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"- Telehouse TH2","region":"fr-par"}],"total_count":1}'
-        headers:
-            Content-Length:
-                - "431"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Sun, 19 Apr 2026 20:29:54 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 417afede-266a-47ce-b182-2c3310026b47
-        status: 200 OK
-        code: 200
-        duration: 77.210125ms
-    - id: 34
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/1f0cc61a-ab4d-4b30-a00a-78d647cb1b8e
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 427
-        uncompressed: false
-        body: '{"created_at":"2026-04-19T20:29:53.514364Z","custom_routes_propagation_enabled":true,"id":"1f0cc61a-ab4d-4b30-a00a-78d647cb1b8e","is_default":false,"name":"tf-test-interlink-swap-target","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":0,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","routing_enabled":true,"tags":[],"updated_at":"2026-04-19T20:29:53.514364Z"}'
-        headers:
-            Content-Length:
-                - "427"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Sun, 19 Apr 2026 20:29:54 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 6fa3e7e9-7ea7-4a5f-878a-810f13da64d4
-        status: 200 OK
-        code: 200
-        duration: 80.918417ms
-    - id: 35
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/0bb8f7cf-88a6-43ff-ac07-ac0a705da1a8
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 924
-        uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-19T20:29:51.721706Z","enable_route_propagation":false,"id":"0bb8f7cf-88a6-43ff-ac07-ac0a705da1a8","name":"tf-test-interlink-link-vpc","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"222461a1-5b81-4ef4-86ba-e7612cc30e6b","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.99/31","ipv6":"2001:1bc8:3812:fc60:56de:818e:4e3f:5301/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.98/31","ipv6":"2001:1bc8:3812:fc60:56de:818e:4e3f:5300/127"},"status":"requested","tags":[],"updated_at":"2026-04-19T20:29:54.157546Z","vlan":1991,"vpc_id":"1f0cc61a-ab4d-4b30-a00a-78d647cb1b8e"}'
-        headers:
-            Content-Length:
-                - "924"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Sun, 19 Apr 2026 20:29:54 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - dea1ef09-ab84-4932-a9b5-11539b8a0845
-        status: 200 OK
-        code: 200
-        duration: 67.03725ms
-    - id: 36
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/b189d7ca-53d8-4f3a-967c-25f90b09d22f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 419
-        uncompressed: false
-        body: '{"created_at":"2026-04-19T20:29:51.212999Z","custom_routes_propagation_enabled":true,"id":"b189d7ca-53d8-4f3a-967c-25f90b09d22f","is_default":false,"name":"tf-test-interlink-vpc","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":0,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","routing_enabled":true,"tags":[],"updated_at":"2026-04-19T20:29:51.212999Z"}'
-        headers:
-            Content-Length:
-                - "419"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Sun, 19 Apr 2026 20:29:55 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 2dc4ce6b-a770-4f84-9709-3c14cdf23735
-        status: 200 OK
-        code: 200
-        duration: 65.452125ms
-    - id: 37
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/1f0cc61a-ab4d-4b30-a00a-78d647cb1b8e
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 427
-        uncompressed: false
-        body: '{"created_at":"2026-04-19T20:29:53.514364Z","custom_routes_propagation_enabled":true,"id":"1f0cc61a-ab4d-4b30-a00a-78d647cb1b8e","is_default":false,"name":"tf-test-interlink-swap-target","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":0,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","routing_enabled":true,"tags":[],"updated_at":"2026-04-19T20:29:53.514364Z"}'
-        headers:
-            Content-Length:
-                - "427"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Sun, 19 Apr 2026 20:29:55 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 5d21e37f-aaf2-4131-bdb1-f6eb254e6455
-        status: 200 OK
-        code: 200
-        duration: 70.066209ms
-    - id: 38
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=Telehouse+TH2&order_by=name_asc&page=1
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 431
-        uncompressed: false
-        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"- Telehouse TH2","region":"fr-par"}],"total_count":1}'
-        headers:
-            Content-Length:
-                - "431"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Sun, 19 Apr 2026 20:29:55 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 4373890e-cdb1-42c6-836d-63bb0b23a52c
-        status: 200 OK
-        code: 200
-        duration: 70.703958ms
-    - id: 39
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 708
-        uncompressed: false
-        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","updated_at":"2024-11-28T08:45:33.852946Z"}],"total_count":2}'
-        headers:
-            Content-Length:
-                - "708"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Sun, 19 Apr 2026 20:29:55 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 350dfa47-805f-47d5-9f60-0467714a2a9c
-        status: 200 OK
-        code: 200
-        duration: 82.14725ms
-    - id: 40
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/0bb8f7cf-88a6-43ff-ac07-ac0a705da1a8
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 924
-        uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-19T20:29:51.721706Z","enable_route_propagation":false,"id":"0bb8f7cf-88a6-43ff-ac07-ac0a705da1a8","name":"tf-test-interlink-link-vpc","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"222461a1-5b81-4ef4-86ba-e7612cc30e6b","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.99/31","ipv6":"2001:1bc8:3812:fc60:56de:818e:4e3f:5301/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.98/31","ipv6":"2001:1bc8:3812:fc60:56de:818e:4e3f:5300/127"},"status":"requested","tags":[],"updated_at":"2026-04-19T20:29:54.157546Z","vlan":1991,"vpc_id":"1f0cc61a-ab4d-4b30-a00a-78d647cb1b8e"}'
-        headers:
-            Content-Length:
-                - "924"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Sun, 19 Apr 2026 20:29:55 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - b3e05779-e711-4fa6-b412-a2f07718657a
-        status: 200 OK
-        code: 200
-        duration: 63.056792ms
-    - id: 41
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/0bb8f7cf-88a6-43ff-ac07-ac0a705da1a8
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 924
-        uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-19T20:29:51.721706Z","enable_route_propagation":false,"id":"0bb8f7cf-88a6-43ff-ac07-ac0a705da1a8","name":"tf-test-interlink-link-vpc","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"222461a1-5b81-4ef4-86ba-e7612cc30e6b","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.99/31","ipv6":"2001:1bc8:3812:fc60:56de:818e:4e3f:5301/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.98/31","ipv6":"2001:1bc8:3812:fc60:56de:818e:4e3f:5300/127"},"status":"requested","tags":[],"updated_at":"2026-04-19T20:29:54.157546Z","vlan":1991,"vpc_id":"1f0cc61a-ab4d-4b30-a00a-78d647cb1b8e"}'
-        headers:
-            Content-Length:
-                - "924"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Sun, 19 Apr 2026 20:29:55 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 50e3178e-ca2c-4805-ad4d-79f3a7d53374
-        status: 200 OK
-        code: 200
-        duration: 69.32825ms
-    - id: 42
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2088,8 +1251,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/0bb8f7cf-88a6-43ff-ac07-ac0a705da1a8/detach-vpc
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/5911eca8-0067-47b7-a482-33d5a3f50943/detach-vpc
         method: POST
       response:
         proto: HTTP/2.0
@@ -2097,20 +1260,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 875
+        content_length: 899
         uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-19T20:29:51.721706Z","enable_route_propagation":false,"id":"0bb8f7cf-88a6-43ff-ac07-ac0a705da1a8","name":"tf-test-interlink-link-vpc","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"222461a1-5b81-4ef4-86ba-e7612cc30e6b","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.99/31","ipv6":"2001:1bc8:3812:fc60:56de:818e:4e3f:5301/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.98/31","ipv6":"2001:1bc8:3812:fc60:56de:818e:4e3f:5300/127"},"status":"requested","tags":[],"updated_at":"2026-04-19T20:29:55.684157Z","vlan":1991}'
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.478178Z","enable_route_propagation":false,"id":"5911eca8-0067-47b7-a482-33d5a3f50943","name":"tf-test-interlink-link-vpc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"efc7d57b-f59c-4709-b4c1-9c5a42123877","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.99/31","ipv6":"2001:1bc8:3812:fc60:c8cd:e863:1c58:ad01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.98/31","ipv6":"2001:1bc8:3812:fc60:c8cd:e863:1c58:ad00/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:41.823075Z","vlan":2575}'
         headers:
             Content-Length:
-                - "875"
+                - "899"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Sun, 19 Apr 2026 20:29:55 GMT
+                - Mon, 24 Aug 2026 12:13:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2118,10 +1281,845 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2d0b9cb1-d525-4db5-9b10-261fb5f41284
+                - 24df3e8b-2736-4a7c-aa52-c6b84f83ff2b
         status: 200 OK
         code: 200
-        duration: 126.100209ms
+        duration: 95.223175ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/5911eca8-0067-47b7-a482-33d5a3f50943
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 899
+        uncompressed: false
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.478178Z","enable_route_propagation":false,"id":"5911eca8-0067-47b7-a482-33d5a3f50943","name":"tf-test-interlink-link-vpc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"efc7d57b-f59c-4709-b4c1-9c5a42123877","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.99/31","ipv6":"2001:1bc8:3812:fc60:c8cd:e863:1c58:ad01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.98/31","ipv6":"2001:1bc8:3812:fc60:c8cd:e863:1c58:ad00/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:41.823075Z","vlan":2575}'
+        headers:
+            Content-Length:
+                - "899"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 24 Aug 2026 12:13:41 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0ccf440c-2575-4ee0-a3d3-14df860f282b
+        status: 200 OK
+        code: 200
+        duration: 38.125756ms
+    - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 49
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"vpc_id":"8ecc9971-0ebb-4f06-8ef7-ba07c00329da"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/5911eca8-0067-47b7-a482-33d5a3f50943/attach-vpc
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 948
+        uncompressed: false
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.478178Z","enable_route_propagation":false,"id":"5911eca8-0067-47b7-a482-33d5a3f50943","name":"tf-test-interlink-link-vpc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"efc7d57b-f59c-4709-b4c1-9c5a42123877","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.99/31","ipv6":"2001:1bc8:3812:fc60:c8cd:e863:1c58:ad01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.98/31","ipv6":"2001:1bc8:3812:fc60:c8cd:e863:1c58:ad00/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:42.040579Z","vlan":2575,"vpc_id":"8ecc9971-0ebb-4f06-8ef7-ba07c00329da"}'
+        headers:
+            Content-Length:
+                - "948"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 24 Aug 2026 12:13:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 19b87bb8-cc66-449b-b434-d7c573bd4733
+        status: 200 OK
+        code: 200
+        duration: 171.584224ms
+    - id: 28
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/5911eca8-0067-47b7-a482-33d5a3f50943
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 948
+        uncompressed: false
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.478178Z","enable_route_propagation":false,"id":"5911eca8-0067-47b7-a482-33d5a3f50943","name":"tf-test-interlink-link-vpc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"efc7d57b-f59c-4709-b4c1-9c5a42123877","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.99/31","ipv6":"2001:1bc8:3812:fc60:c8cd:e863:1c58:ad01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.98/31","ipv6":"2001:1bc8:3812:fc60:c8cd:e863:1c58:ad00/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:42.040579Z","vlan":2575,"vpc_id":"8ecc9971-0ebb-4f06-8ef7-ba07c00329da"}'
+        headers:
+            Content-Length:
+                - "948"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 24 Aug 2026 12:13:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ed8153e3-2d0e-4096-8dbc-0a86f5a7d02a
+        status: 200 OK
+        code: 200
+        duration: 36.44704ms
+    - id: 29
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/5911eca8-0067-47b7-a482-33d5a3f50943
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 948
+        uncompressed: false
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.478178Z","enable_route_propagation":false,"id":"5911eca8-0067-47b7-a482-33d5a3f50943","name":"tf-test-interlink-link-vpc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"efc7d57b-f59c-4709-b4c1-9c5a42123877","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.99/31","ipv6":"2001:1bc8:3812:fc60:c8cd:e863:1c58:ad01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.98/31","ipv6":"2001:1bc8:3812:fc60:c8cd:e863:1c58:ad00/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:42.040579Z","vlan":2575,"vpc_id":"8ecc9971-0ebb-4f06-8ef7-ba07c00329da"}'
+        headers:
+            Content-Length:
+                - "948"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 24 Aug 2026 12:13:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 1727930c-e8d9-4ffb-96c9-6ab76c84d8e6
+        status: 200 OK
+        code: 200
+        duration: 34.71826ms
+    - id: 30
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/5911eca8-0067-47b7-a482-33d5a3f50943
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 948
+        uncompressed: false
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.478178Z","enable_route_propagation":false,"id":"5911eca8-0067-47b7-a482-33d5a3f50943","name":"tf-test-interlink-link-vpc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"efc7d57b-f59c-4709-b4c1-9c5a42123877","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.99/31","ipv6":"2001:1bc8:3812:fc60:c8cd:e863:1c58:ad01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.98/31","ipv6":"2001:1bc8:3812:fc60:c8cd:e863:1c58:ad00/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:42.040579Z","vlan":2575,"vpc_id":"8ecc9971-0ebb-4f06-8ef7-ba07c00329da"}'
+        headers:
+            Content-Length:
+                - "948"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 24 Aug 2026 12:13:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 1242a8a4-be9c-47fd-b88d-0157423dee9d
+        status: 200 OK
+        code: 200
+        duration: 40.090171ms
+    - id: 31
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1158
+        uncompressed: false
+        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","l3_connectivity":true,"logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","region":"","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","l3_connectivity":true,"logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","region":"","updated_at":"2024-11-28T08:45:33.852946Z"},{"contact_email":"contact.experience-client@linkt.fr","created_at":"2026-04-21T14:31:08.285733Z","id":"4e0dcaaf-467c-432c-ad93-f28be5878df0","l3_connectivity":true,"logo_url":"https://www.linkt.fr/wp-content/themes/linkt/assets/img/svg/logo-linkt-sticky.svg","name":"Linkt","portal_url":"https://www.linkt.fr/","region":"","updated_at":"2026-07-07T11:57:51.706396Z"}],"total_count":3}'
+        headers:
+            Content-Length:
+                - "1158"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 24 Aug 2026 12:13:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 1c60af39-5f6d-49e6-82c6-b8f475ccc490
+        status: 200 OK
+        code: 200
+        duration: 35.251064ms
+    - id: 32
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=TeleHouse+TH2&order_by=name_asc&page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 429
+        uncompressed: false
+        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"TeleHouse TH2","region":"fr-par"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "429"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 24 Aug 2026 12:13:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a478131d-632d-461e-ae6c-f5031ec30fce
+        status: 200 OK
+        code: 200
+        duration: 42.754906ms
+    - id: 33
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1158
+        uncompressed: false
+        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","l3_connectivity":true,"logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","region":"","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","l3_connectivity":true,"logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","region":"","updated_at":"2024-11-28T08:45:33.852946Z"},{"contact_email":"contact.experience-client@linkt.fr","created_at":"2026-04-21T14:31:08.285733Z","id":"4e0dcaaf-467c-432c-ad93-f28be5878df0","l3_connectivity":true,"logo_url":"https://www.linkt.fr/wp-content/themes/linkt/assets/img/svg/logo-linkt-sticky.svg","name":"Linkt","portal_url":"https://www.linkt.fr/","region":"","updated_at":"2026-07-07T11:57:51.706396Z"}],"total_count":3}'
+        headers:
+            Content-Length:
+                - "1158"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 24 Aug 2026 12:13:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 710db130-8abb-4ede-b8a7-40df88722f31
+        status: 200 OK
+        code: 200
+        duration: 36.975026ms
+    - id: 34
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/8ecc9971-0ebb-4f06-8ef7-ba07c00329da
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 489
+        uncompressed: false
+        body: '{"created_at":"2026-08-24T12:13:41.624515Z","custom_routes_propagation_enabled":true,"id":"8ecc9971-0ebb-4f06-8ef7-ba07c00329da","is_default":false,"name":"tf-test-interlink-swap-target","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","routing_enabled":true,"s3_integration_enabled":false,"tags":[],"transitivity_enabled":false,"updated_at":"2026-08-24T12:13:41.624515Z"}'
+        headers:
+            Content-Length:
+                - "489"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 24 Aug 2026 12:13:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 8e0485b7-8664-4d25-9610-e7a2745e76bf
+        status: 200 OK
+        code: 200
+        duration: 40.086464ms
+    - id: 35
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/bec51601-1539-47e9-8d67-7ef3959cb5e2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 481
+        uncompressed: false
+        body: '{"created_at":"2026-08-24T12:13:39.264620Z","custom_routes_propagation_enabled":true,"id":"bec51601-1539-47e9-8d67-7ef3959cb5e2","is_default":false,"name":"tf-test-interlink-vpc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","routing_enabled":true,"s3_integration_enabled":false,"tags":[],"transitivity_enabled":false,"updated_at":"2026-08-24T12:13:39.264620Z"}'
+        headers:
+            Content-Length:
+                - "481"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 24 Aug 2026 12:13:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a9908e78-1b5d-4a2f-8058-a82a50824b9e
+        status: 200 OK
+        code: 200
+        duration: 41.102821ms
+    - id: 36
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=TeleHouse+TH2&order_by=name_asc&page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 429
+        uncompressed: false
+        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"TeleHouse TH2","region":"fr-par"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "429"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 24 Aug 2026 12:13:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 83d5ec4b-273e-4b0b-9fce-2ce4e5dc2696
+        status: 200 OK
+        code: 200
+        duration: 52.575809ms
+    - id: 37
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/5911eca8-0067-47b7-a482-33d5a3f50943
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 948
+        uncompressed: false
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.478178Z","enable_route_propagation":false,"id":"5911eca8-0067-47b7-a482-33d5a3f50943","name":"tf-test-interlink-link-vpc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"efc7d57b-f59c-4709-b4c1-9c5a42123877","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.99/31","ipv6":"2001:1bc8:3812:fc60:c8cd:e863:1c58:ad01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.98/31","ipv6":"2001:1bc8:3812:fc60:c8cd:e863:1c58:ad00/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:42.040579Z","vlan":2575,"vpc_id":"8ecc9971-0ebb-4f06-8ef7-ba07c00329da"}'
+        headers:
+            Content-Length:
+                - "948"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 24 Aug 2026 12:13:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 35b4816c-1a8e-47a6-b562-a011961eef9c
+        status: 200 OK
+        code: 200
+        duration: 40.813314ms
+    - id: 38
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/8ecc9971-0ebb-4f06-8ef7-ba07c00329da
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 489
+        uncompressed: false
+        body: '{"created_at":"2026-08-24T12:13:41.624515Z","custom_routes_propagation_enabled":true,"id":"8ecc9971-0ebb-4f06-8ef7-ba07c00329da","is_default":false,"name":"tf-test-interlink-swap-target","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","routing_enabled":true,"s3_integration_enabled":false,"tags":[],"transitivity_enabled":false,"updated_at":"2026-08-24T12:13:41.624515Z"}'
+        headers:
+            Content-Length:
+                - "489"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 24 Aug 2026 12:13:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a845b80d-75fe-4009-ae1c-e37fa783db73
+        status: 200 OK
+        code: 200
+        duration: 40.02081ms
+    - id: 39
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1158
+        uncompressed: false
+        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","l3_connectivity":true,"logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","region":"","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","l3_connectivity":true,"logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","region":"","updated_at":"2024-11-28T08:45:33.852946Z"},{"contact_email":"contact.experience-client@linkt.fr","created_at":"2026-04-21T14:31:08.285733Z","id":"4e0dcaaf-467c-432c-ad93-f28be5878df0","l3_connectivity":true,"logo_url":"https://www.linkt.fr/wp-content/themes/linkt/assets/img/svg/logo-linkt-sticky.svg","name":"Linkt","portal_url":"https://www.linkt.fr/","region":"","updated_at":"2026-07-07T11:57:51.706396Z"}],"total_count":3}'
+        headers:
+            Content-Length:
+                - "1158"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 24 Aug 2026 12:13:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - cd546936-e658-4462-9ef0-d174773598d1
+        status: 200 OK
+        code: 200
+        duration: 48.423939ms
+    - id: 40
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=TeleHouse+TH2&order_by=name_asc&page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 429
+        uncompressed: false
+        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"TeleHouse TH2","region":"fr-par"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "429"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 24 Aug 2026 12:13:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 462d44fe-c78d-474b-b609-62420bb22820
+        status: 200 OK
+        code: 200
+        duration: 48.433427ms
+    - id: 41
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/bec51601-1539-47e9-8d67-7ef3959cb5e2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 481
+        uncompressed: false
+        body: '{"created_at":"2026-08-24T12:13:39.264620Z","custom_routes_propagation_enabled":true,"id":"bec51601-1539-47e9-8d67-7ef3959cb5e2","is_default":false,"name":"tf-test-interlink-vpc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","routing_enabled":true,"s3_integration_enabled":false,"tags":[],"transitivity_enabled":false,"updated_at":"2026-08-24T12:13:39.264620Z"}'
+        headers:
+            Content-Length:
+                - "481"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 24 Aug 2026 12:13:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4c41601d-aa3f-4bfc-b16a-fed934542339
+        status: 200 OK
+        code: 200
+        duration: 55.383355ms
+    - id: 42
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/5911eca8-0067-47b7-a482-33d5a3f50943
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 948
+        uncompressed: false
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.478178Z","enable_route_propagation":false,"id":"5911eca8-0067-47b7-a482-33d5a3f50943","name":"tf-test-interlink-link-vpc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"efc7d57b-f59c-4709-b4c1-9c5a42123877","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.99/31","ipv6":"2001:1bc8:3812:fc60:c8cd:e863:1c58:ad01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.98/31","ipv6":"2001:1bc8:3812:fc60:c8cd:e863:1c58:ad00/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:42.040579Z","vlan":2575,"vpc_id":"8ecc9971-0ebb-4f06-8ef7-ba07c00329da"}'
+        headers:
+            Content-Length:
+                - "948"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 24 Aug 2026 12:13:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 99d7e6b3-c912-4ec6-a9a1-5fd60ff096e3
+        status: 200 OK
+        code: 200
+        duration: 41.908861ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -2137,8 +2135,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/0bb8f7cf-88a6-43ff-ac07-ac0a705da1a8
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/5911eca8-0067-47b7-a482-33d5a3f50943
         method: GET
       response:
         proto: HTTP/2.0
@@ -2146,20 +2144,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 875
+        content_length: 948
         uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-19T20:29:51.721706Z","enable_route_propagation":false,"id":"0bb8f7cf-88a6-43ff-ac07-ac0a705da1a8","name":"tf-test-interlink-link-vpc","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"222461a1-5b81-4ef4-86ba-e7612cc30e6b","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.99/31","ipv6":"2001:1bc8:3812:fc60:56de:818e:4e3f:5301/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.98/31","ipv6":"2001:1bc8:3812:fc60:56de:818e:4e3f:5300/127"},"status":"requested","tags":[],"updated_at":"2026-04-19T20:29:55.684157Z","vlan":1991}'
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.478178Z","enable_route_propagation":false,"id":"5911eca8-0067-47b7-a482-33d5a3f50943","name":"tf-test-interlink-link-vpc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"efc7d57b-f59c-4709-b4c1-9c5a42123877","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.99/31","ipv6":"2001:1bc8:3812:fc60:c8cd:e863:1c58:ad01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.98/31","ipv6":"2001:1bc8:3812:fc60:c8cd:e863:1c58:ad00/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:42.040579Z","vlan":2575,"vpc_id":"8ecc9971-0ebb-4f06-8ef7-ba07c00329da"}'
         headers:
             Content-Length:
-                - "875"
+                - "948"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Sun, 19 Apr 2026 20:29:55 GMT
+                - Mon, 24 Aug 2026 12:13:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2167,48 +2165,50 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 954cee2a-e63d-4032-b359-17f0cf9881e9
+                - 55898d1e-de88-4d7c-8d08-979a06bc7564
         status: 200 OK
         code: 200
-        duration: 75.402875ms
+        duration: 47.660318ms
     - id: 44
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 2
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/0bb8f7cf-88a6-43ff-ac07-ac0a705da1a8
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/5911eca8-0067-47b7-a482-33d5a3f50943/detach-vpc
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 875
+        content_length: 899
         uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-19T20:29:51.721706Z","enable_route_propagation":false,"id":"0bb8f7cf-88a6-43ff-ac07-ac0a705da1a8","name":"tf-test-interlink-link-vpc","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"222461a1-5b81-4ef4-86ba-e7612cc30e6b","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.99/31","ipv6":"2001:1bc8:3812:fc60:56de:818e:4e3f:5301/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.98/31","ipv6":"2001:1bc8:3812:fc60:56de:818e:4e3f:5300/127"},"status":"requested","tags":[],"updated_at":"2026-04-19T20:29:55.684157Z","vlan":1991}'
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.478178Z","enable_route_propagation":false,"id":"5911eca8-0067-47b7-a482-33d5a3f50943","name":"tf-test-interlink-link-vpc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"efc7d57b-f59c-4709-b4c1-9c5a42123877","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.99/31","ipv6":"2001:1bc8:3812:fc60:c8cd:e863:1c58:ad01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.98/31","ipv6":"2001:1bc8:3812:fc60:c8cd:e863:1c58:ad00/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:43.204208Z","vlan":2575}'
         headers:
             Content-Length:
-                - "875"
+                - "899"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Sun, 19 Apr 2026 20:29:55 GMT
+                - Mon, 24 Aug 2026 12:13:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2216,10 +2216,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dfb957b6-5394-4a4c-bdb1-928eb90f305b
+                - d248d308-00a8-49d9-84f2-69714d34b803
         status: 200 OK
         code: 200
-        duration: 63.60225ms
+        duration: 98.719386ms
     - id: 45
       request:
         proto: HTTP/1.1
@@ -2235,8 +2235,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/0bb8f7cf-88a6-43ff-ac07-ac0a705da1a8
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/5911eca8-0067-47b7-a482-33d5a3f50943
         method: GET
       response:
         proto: HTTP/2.0
@@ -2244,20 +2244,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 875
+        content_length: 899
         uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-19T20:29:51.721706Z","enable_route_propagation":false,"id":"0bb8f7cf-88a6-43ff-ac07-ac0a705da1a8","name":"tf-test-interlink-link-vpc","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"222461a1-5b81-4ef4-86ba-e7612cc30e6b","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.99/31","ipv6":"2001:1bc8:3812:fc60:56de:818e:4e3f:5301/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.98/31","ipv6":"2001:1bc8:3812:fc60:56de:818e:4e3f:5300/127"},"status":"requested","tags":[],"updated_at":"2026-04-19T20:29:55.684157Z","vlan":1991}'
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.478178Z","enable_route_propagation":false,"id":"5911eca8-0067-47b7-a482-33d5a3f50943","name":"tf-test-interlink-link-vpc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"efc7d57b-f59c-4709-b4c1-9c5a42123877","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.99/31","ipv6":"2001:1bc8:3812:fc60:c8cd:e863:1c58:ad01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.98/31","ipv6":"2001:1bc8:3812:fc60:c8cd:e863:1c58:ad00/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:43.204208Z","vlan":2575}'
         headers:
             Content-Length:
-                - "875"
+                - "899"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Sun, 19 Apr 2026 20:29:55 GMT
+                - Mon, 24 Aug 2026 12:13:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2265,10 +2265,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 203cde36-aad1-46d4-9418-dffcc17f59a4
+                - b824eed7-759b-409c-8151-0f01c34355b4
         status: 200 OK
         code: 200
-        duration: 64.80575ms
+        duration: 40.156345ms
     - id: 46
       request:
         proto: HTTP/1.1
@@ -2284,8 +2284,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/5911eca8-0067-47b7-a482-33d5a3f50943
         method: GET
       response:
         proto: HTTP/2.0
@@ -2293,20 +2293,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 708
+        content_length: 899
         uncompressed: false
-        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","updated_at":"2024-11-28T08:45:33.852946Z"}],"total_count":2}'
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.478178Z","enable_route_propagation":false,"id":"5911eca8-0067-47b7-a482-33d5a3f50943","name":"tf-test-interlink-link-vpc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"efc7d57b-f59c-4709-b4c1-9c5a42123877","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.99/31","ipv6":"2001:1bc8:3812:fc60:c8cd:e863:1c58:ad01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.98/31","ipv6":"2001:1bc8:3812:fc60:c8cd:e863:1c58:ad00/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:43.204208Z","vlan":2575}'
         headers:
             Content-Length:
-                - "708"
+                - "899"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Sun, 19 Apr 2026 20:29:56 GMT
+                - Mon, 24 Aug 2026 12:13:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2314,10 +2314,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d5a4ba75-d6c2-49ac-9945-dfddd72365e8
+                - c45c32ee-731e-48de-a622-19c6c51f41e3
         status: 200 OK
         code: 200
-        duration: 70.743875ms
+        duration: 38.41982ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -2333,8 +2333,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=Telehouse+TH2&order_by=name_asc&page=1
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/5911eca8-0067-47b7-a482-33d5a3f50943
         method: GET
       response:
         proto: HTTP/2.0
@@ -2342,20 +2342,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 431
+        content_length: 899
         uncompressed: false
-        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"- Telehouse TH2","region":"fr-par"}],"total_count":1}'
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.478178Z","enable_route_propagation":false,"id":"5911eca8-0067-47b7-a482-33d5a3f50943","name":"tf-test-interlink-link-vpc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"efc7d57b-f59c-4709-b4c1-9c5a42123877","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.99/31","ipv6":"2001:1bc8:3812:fc60:c8cd:e863:1c58:ad01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.98/31","ipv6":"2001:1bc8:3812:fc60:c8cd:e863:1c58:ad00/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:43.204208Z","vlan":2575}'
         headers:
             Content-Length:
-                - "431"
+                - "899"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Sun, 19 Apr 2026 20:29:56 GMT
+                - Mon, 24 Aug 2026 12:13:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2363,10 +2363,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8088b199-2844-4d87-b47f-3f09f707a79b
+                - e3887a33-398c-4acd-93e8-7de44c6e8cfa
         status: 200 OK
         code: 200
-        duration: 89.401292ms
+        duration: 44.111755ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -2382,8 +2382,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/1f0cc61a-ab4d-4b30-a00a-78d647cb1b8e
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=TeleHouse+TH2&order_by=name_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -2391,20 +2391,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 427
+        content_length: 429
         uncompressed: false
-        body: '{"created_at":"2026-04-19T20:29:53.514364Z","custom_routes_propagation_enabled":true,"id":"1f0cc61a-ab4d-4b30-a00a-78d647cb1b8e","is_default":false,"name":"tf-test-interlink-swap-target","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":0,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","routing_enabled":true,"tags":[],"updated_at":"2026-04-19T20:29:53.514364Z"}'
+        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"TeleHouse TH2","region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
-                - "427"
+                - "429"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Sun, 19 Apr 2026 20:29:56 GMT
+                - Mon, 24 Aug 2026 12:13:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2412,10 +2412,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e00f1c0d-cf7d-4bc8-b248-4ff075abde23
+                - 20388722-bf0c-44fc-a245-053c3b44226f
         status: 200 OK
         code: 200
-        duration: 69.805125ms
+        duration: 42.408141ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -2431,8 +2431,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/b189d7ca-53d8-4f3a-967c-25f90b09d22f
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -2440,20 +2440,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 419
+        content_length: 1158
         uncompressed: false
-        body: '{"created_at":"2026-04-19T20:29:51.212999Z","custom_routes_propagation_enabled":true,"id":"b189d7ca-53d8-4f3a-967c-25f90b09d22f","is_default":false,"name":"tf-test-interlink-vpc","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":0,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","routing_enabled":true,"tags":[],"updated_at":"2026-04-19T20:29:51.212999Z"}'
+        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","l3_connectivity":true,"logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","region":"","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","l3_connectivity":true,"logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","region":"","updated_at":"2024-11-28T08:45:33.852946Z"},{"contact_email":"contact.experience-client@linkt.fr","created_at":"2026-04-21T14:31:08.285733Z","id":"4e0dcaaf-467c-432c-ad93-f28be5878df0","l3_connectivity":true,"logo_url":"https://www.linkt.fr/wp-content/themes/linkt/assets/img/svg/logo-linkt-sticky.svg","name":"Linkt","portal_url":"https://www.linkt.fr/","region":"","updated_at":"2026-07-07T11:57:51.706396Z"}],"total_count":3}'
         headers:
             Content-Length:
-                - "419"
+                - "1158"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Sun, 19 Apr 2026 20:29:56 GMT
+                - Mon, 24 Aug 2026 12:13:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2461,10 +2461,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 385d3c32-4260-4acb-bf42-6be17e69bc79
+                - 3d9b4113-2065-43e6-a447-5be3c19e6a28
         status: 200 OK
         code: 200
-        duration: 70.159417ms
+        duration: 42.320657ms
     - id: 50
       request:
         proto: HTTP/1.1
@@ -2480,7 +2480,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
         method: GET
       response:
@@ -2489,20 +2489,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 708
+        content_length: 1158
         uncompressed: false
-        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","updated_at":"2024-11-28T08:45:33.852946Z"}],"total_count":2}'
+        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","l3_connectivity":true,"logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","region":"","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","l3_connectivity":true,"logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","region":"","updated_at":"2024-11-28T08:45:33.852946Z"},{"contact_email":"contact.experience-client@linkt.fr","created_at":"2026-04-21T14:31:08.285733Z","id":"4e0dcaaf-467c-432c-ad93-f28be5878df0","l3_connectivity":true,"logo_url":"https://www.linkt.fr/wp-content/themes/linkt/assets/img/svg/logo-linkt-sticky.svg","name":"Linkt","portal_url":"https://www.linkt.fr/","region":"","updated_at":"2026-07-07T11:57:51.706396Z"}],"total_count":3}'
         headers:
             Content-Length:
-                - "708"
+                - "1158"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Sun, 19 Apr 2026 20:29:56 GMT
+                - Mon, 24 Aug 2026 12:13:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2510,10 +2510,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 83efd4c1-1568-4f65-8609-a8c13d7cb338
+                - 7107b495-84f7-4beb-92e1-c6c35538b29e
         status: 200 OK
         code: 200
-        duration: 69.94825ms
+        duration: 30.92259ms
     - id: 51
       request:
         proto: HTTP/1.1
@@ -2529,8 +2529,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=Telehouse+TH2&order_by=name_asc&page=1
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/8ecc9971-0ebb-4f06-8ef7-ba07c00329da
         method: GET
       response:
         proto: HTTP/2.0
@@ -2538,20 +2538,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 431
+        content_length: 489
         uncompressed: false
-        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"- Telehouse TH2","region":"fr-par"}],"total_count":1}'
+        body: '{"created_at":"2026-08-24T12:13:41.624515Z","custom_routes_propagation_enabled":true,"id":"8ecc9971-0ebb-4f06-8ef7-ba07c00329da","is_default":false,"name":"tf-test-interlink-swap-target","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","routing_enabled":true,"s3_integration_enabled":false,"tags":[],"transitivity_enabled":false,"updated_at":"2026-08-24T12:13:41.624515Z"}'
         headers:
             Content-Length:
-                - "431"
+                - "489"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Sun, 19 Apr 2026 20:29:56 GMT
+                - Mon, 24 Aug 2026 12:13:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2559,10 +2559,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - aecfe906-2017-44dd-bab7-a00e0f68e372
+                - 9be8cb6e-7732-456a-b751-75334b0274b0
         status: 200 OK
         code: 200
-        duration: 77.470792ms
+        duration: 37.275021ms
     - id: 52
       request:
         proto: HTTP/1.1
@@ -2578,8 +2578,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/0bb8f7cf-88a6-43ff-ac07-ac0a705da1a8
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/bec51601-1539-47e9-8d67-7ef3959cb5e2
         method: GET
       response:
         proto: HTTP/2.0
@@ -2587,20 +2587,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 875
+        content_length: 481
         uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-19T20:29:51.721706Z","enable_route_propagation":false,"id":"0bb8f7cf-88a6-43ff-ac07-ac0a705da1a8","name":"tf-test-interlink-link-vpc","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"222461a1-5b81-4ef4-86ba-e7612cc30e6b","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.99/31","ipv6":"2001:1bc8:3812:fc60:56de:818e:4e3f:5301/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.98/31","ipv6":"2001:1bc8:3812:fc60:56de:818e:4e3f:5300/127"},"status":"requested","tags":[],"updated_at":"2026-04-19T20:29:55.684157Z","vlan":1991}'
+        body: '{"created_at":"2026-08-24T12:13:39.264620Z","custom_routes_propagation_enabled":true,"id":"bec51601-1539-47e9-8d67-7ef3959cb5e2","is_default":false,"name":"tf-test-interlink-vpc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","routing_enabled":true,"s3_integration_enabled":false,"tags":[],"transitivity_enabled":false,"updated_at":"2026-08-24T12:13:39.264620Z"}'
         headers:
             Content-Length:
-                - "875"
+                - "481"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Sun, 19 Apr 2026 20:29:56 GMT
+                - Mon, 24 Aug 2026 12:13:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2608,10 +2608,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b13b5c44-2dad-4e1c-9f2c-ab0bcb1cc5a5
+                - d80d3471-db6d-445f-ab24-411cc68ecc20
         status: 200 OK
         code: 200
-        duration: 61.784334ms
+        duration: 38.795107ms
     - id: 53
       request:
         proto: HTTP/1.1
@@ -2627,8 +2627,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=Telehouse+TH2&order_by=name_asc&page=1
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=TeleHouse+TH2&order_by=name_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -2636,20 +2636,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 431
+        content_length: 429
         uncompressed: false
-        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"- Telehouse TH2","region":"fr-par"}],"total_count":1}'
+        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"TeleHouse TH2","region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
-                - "431"
+                - "429"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Sun, 19 Apr 2026 20:29:56 GMT
+                - Mon, 24 Aug 2026 12:13:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2657,10 +2657,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 204d2ed1-eef4-415f-af88-b63a131eb8ea
+                - f8057e7f-e9f3-4075-9065-689a5c88473e
         status: 200 OK
         code: 200
-        duration: 69.201875ms
+        duration: 48.521021ms
     - id: 54
       request:
         proto: HTTP/1.1
@@ -2676,8 +2676,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/5911eca8-0067-47b7-a482-33d5a3f50943
         method: GET
       response:
         proto: HTTP/2.0
@@ -2685,20 +2685,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 708
+        content_length: 899
         uncompressed: false
-        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","updated_at":"2024-11-28T08:45:33.852946Z"}],"total_count":2}'
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.478178Z","enable_route_propagation":false,"id":"5911eca8-0067-47b7-a482-33d5a3f50943","name":"tf-test-interlink-link-vpc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"efc7d57b-f59c-4709-b4c1-9c5a42123877","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.99/31","ipv6":"2001:1bc8:3812:fc60:c8cd:e863:1c58:ad01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.98/31","ipv6":"2001:1bc8:3812:fc60:c8cd:e863:1c58:ad00/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:43.204208Z","vlan":2575}'
         headers:
             Content-Length:
-                - "708"
+                - "899"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Sun, 19 Apr 2026 20:29:56 GMT
+                - Mon, 24 Aug 2026 12:13:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2706,10 +2706,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 876cfc11-ef84-4c73-9485-c375e4448858
+                - 6fbef320-1107-48e2-afc2-ba890a358484
         status: 200 OK
         code: 200
-        duration: 69.260084ms
+        duration: 35.481499ms
     - id: 55
       request:
         proto: HTTP/1.1
@@ -2725,8 +2725,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/0bb8f7cf-88a6-43ff-ac07-ac0a705da1a8
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/partners?order_by=name_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -2734,20 +2734,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 875
+        content_length: 1158
         uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-19T20:29:51.721706Z","enable_route_propagation":false,"id":"0bb8f7cf-88a6-43ff-ac07-ac0a705da1a8","name":"tf-test-interlink-link-vpc","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"222461a1-5b81-4ef4-86ba-e7612cc30e6b","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.99/31","ipv6":"2001:1bc8:3812:fc60:56de:818e:4e3f:5301/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.98/31","ipv6":"2001:1bc8:3812:fc60:56de:818e:4e3f:5300/127"},"status":"requested","tags":[],"updated_at":"2026-04-19T20:29:55.684157Z","vlan":1991}'
+        body: '{"partners":[{"contact_email":"l2-support@franceix.net","created_at":"2025-04-08T16:09:15.661184Z","id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5","l3_connectivity":true,"logo_url":"https://www.franceix.net/static/django_franceix/images/navbar-logo.svg","name":"FranceIX","portal_url":"https://www.franceix.net/en/services/cloud/cloud-access/","region":"","updated_at":"2025-06-26T09:14:51.368612Z"},{"contact_email":"engineering@freepro.com","created_at":"2024-09-25T06:44:33.475845Z","id":"930ebb71-7fb2-4ea7-a8d1-7f4cc3177c05","l3_connectivity":true,"logo_url":"https://pro.free.fr/assets/img/brand/free-pro.svg","name":"FreePro","portal_url":"https://pro.free.fr/espace-client/connexion/#/","region":"","updated_at":"2024-11-28T08:45:33.852946Z"},{"contact_email":"contact.experience-client@linkt.fr","created_at":"2026-04-21T14:31:08.285733Z","id":"4e0dcaaf-467c-432c-ad93-f28be5878df0","l3_connectivity":true,"logo_url":"https://www.linkt.fr/wp-content/themes/linkt/assets/img/svg/logo-linkt-sticky.svg","name":"Linkt","portal_url":"https://www.linkt.fr/","region":"","updated_at":"2026-07-07T11:57:51.706396Z"}],"total_count":3}'
         headers:
             Content-Length:
-                - "875"
+                - "1158"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Sun, 19 Apr 2026 20:29:56 GMT
+                - Mon, 24 Aug 2026 12:13:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2755,10 +2755,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a76b58f4-2e3f-493b-97f9-2313e737774b
+                - 4e4b78b3-c3f6-4820-a5ab-c423ea083465
         status: 200 OK
         code: 200
-        duration: 63.732542ms
+        duration: 37.246016ms
     - id: 56
       request:
         proto: HTTP/1.1
@@ -2774,29 +2774,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/0bb8f7cf-88a6-43ff-ac07-ac0a705da1a8
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/pops?name=TeleHouse+TH2&order_by=name_asc&page=1
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 873
+        content_length: 429
         uncompressed: false
-        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-04-19T20:29:51.721706Z","enable_route_propagation":false,"id":"0bb8f7cf-88a6-43ff-ac07-ac0a705da1a8","name":"tf-test-interlink-link-vpc","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","partner":{"disapproved_reason":"","pairing_key":"222461a1-5b81-4ef4-86ba-e7612cc30e6b","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.99/31","ipv6":"2001:1bc8:3812:fc60:56de:818e:4e3f:5301/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.98/31","ipv6":"2001:1bc8:3812:fc60:56de:818e:4e3f:5300/127"},"status":"deleted","tags":[],"updated_at":"2026-04-19T20:29:55.684157Z","vlan":1991}'
+        body: '{"pops":[{"address":"137 Boulevard Voltaire","available_link_bandwidths_mbps":[50,100,200,500,1000,2000,5000,10000,25000],"city":"Paris","display_name":"Paris - TeleHouse TH2","hosting_provider_name":"TeleHouse","id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","logo_url":"https://www.telehouse.fr/wp-content/uploads/2020/03/telehouse-vector-white-logo.svg","name":"TeleHouse TH2","region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
-                - "873"
+                - "429"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Sun, 19 Apr 2026 20:29:57 GMT
+                - Mon, 24 Aug 2026 12:13:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2804,10 +2804,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bd4a4148-c154-47e0-a42e-fcc6b734eb21
+                - 5264492f-d8a9-41b5-926b-b71a43d8b56c
         status: 200 OK
         code: 200
-        duration: 105.694875ms
+        duration: 42.099069ms
     - id: 57
       request:
         proto: HTTP/1.1
@@ -2823,8 +2823,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/0bb8f7cf-88a6-43ff-ac07-ac0a705da1a8
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/5911eca8-0067-47b7-a482-33d5a3f50943
         method: GET
       response:
         proto: HTTP/2.0
@@ -2832,20 +2832,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 125
+        content_length: 899
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"link","resource_id":"0bb8f7cf-88a6-43ff-ac07-ac0a705da1a8","type":"not_found"}'
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.478178Z","enable_route_propagation":false,"id":"5911eca8-0067-47b7-a482-33d5a3f50943","name":"tf-test-interlink-link-vpc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"efc7d57b-f59c-4709-b4c1-9c5a42123877","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.99/31","ipv6":"2001:1bc8:3812:fc60:c8cd:e863:1c58:ad01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.98/31","ipv6":"2001:1bc8:3812:fc60:c8cd:e863:1c58:ad00/127"},"status":"requested","tags":[],"updated_at":"2026-08-24T12:13:43.204208Z","vlan":2575}'
         headers:
             Content-Length:
-                - "125"
+                - "899"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Sun, 19 Apr 2026 20:29:57 GMT
+                - Mon, 24 Aug 2026 12:13:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2853,10 +2853,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - efe790ca-a446-47c1-bfbc-8dd525da9897
-        status: 404 Not Found
-        code: 404
-        duration: 61.971834ms
+                - f902c9bd-19eb-48d7-8aa9-3250e88201d6
+        status: 200 OK
+        code: 200
+        duration: 32.677249ms
     - id: 58
       request:
         proto: HTTP/1.1
@@ -2872,8 +2872,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/b189d7ca-53d8-4f3a-967c-25f90b09d22f
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/5911eca8-0067-47b7-a482-33d5a3f50943
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2881,18 +2881,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 897
         uncompressed: false
-        body: ""
+        body: '{"bandwidth_mbps":50,"bgp_v4_status":"disabled","bgp_v6_status":"disabled","created_at":"2026-08-24T12:13:39.478178Z","enable_route_propagation":false,"id":"5911eca8-0067-47b7-a482-33d5a3f50943","name":"tf-test-interlink-link-vpc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","partner":{"disapproved_reason":"","l3_connectivity":true,"pairing_key":"efc7d57b-f59c-4709-b4c1-9c5a42123877","partner_id":"89d00734-eddb-4192-8b16-bc16f0b0f5a5"},"peer_bgp_config":{"asn":39801,"ipv4":"169.254.0.99/31","ipv6":"2001:1bc8:3812:fc60:c8cd:e863:1c58:ad01/127"},"pop_id":"fd046cc9-d9bf-4a87-9c32-d299fe4bf4d7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","scw_bgp_config":{"asn":12876,"ipv4":"169.254.0.98/31","ipv6":"2001:1bc8:3812:fc60:c8cd:e863:1c58:ad00/127"},"status":"deleted","tags":[],"updated_at":"2026-08-24T12:13:43.204208Z","vlan":2575}'
         headers:
+            Content-Length:
+                - "897"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Sun, 19 Apr 2026 20:29:57 GMT
+                - Mon, 24 Aug 2026 12:13:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2900,10 +2902,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8240aada-4c92-4308-b2b5-52d5be082ea5
-        status: 204 No Content
-        code: 204
-        duration: 444.205625ms
+                - a347a29e-87b9-4dfe-9d01-e98cd9107b95
+        status: 200 OK
+        code: 200
+        duration: 88.084426ms
     - id: 59
       request:
         proto: HTTP/1.1
@@ -2919,8 +2921,57 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/1f0cc61a-ab4d-4b30-a00a-78d647cb1b8e
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/5911eca8-0067-47b7-a482-33d5a3f50943
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 125
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"link","resource_id":"5911eca8-0067-47b7-a482-33d5a3f50943","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "125"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 24 Aug 2026 12:13:44 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3e2c0e30-f8e7-41f3-8747-557109574d15
+        status: 404 Not Found
+        code: 404
+        duration: 37.166537ms
+    - id: 60
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/bec51601-1539-47e9-8d67-7ef3959cb5e2
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2937,9 +2988,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Sun, 19 Apr 2026 20:29:57 GMT
+                - Mon, 24 Aug 2026 12:13:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2947,11 +2998,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ce4b7c13-60dd-474a-840d-19f1087841f3
+                - 2593b84c-89bd-425e-a924-779dfa5ccdd2
         status: 204 No Content
         code: 204
-        duration: 457.620625ms
-    - id: 60
+        duration: 665.562597ms
+    - id: 61
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2966,8 +3017,55 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/0bb8f7cf-88a6-43ff-ac07-ac0a705da1a8
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/8ecc9971-0ebb-4f06-8ef7-ba07c00329da
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 24 Aug 2026 12:13:44 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5cae33af-2855-4ea7-aa19-dfa0efe732ad
+        status: 204 No Content
+        code: 204
+        duration: 665.507053ms
+    - id: 62
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/links/5911eca8-0067-47b7-a482-33d5a3f50943
         method: GET
       response:
         proto: HTTP/2.0
@@ -2977,7 +3075,7 @@ interactions:
         trailer: {}
         content_length: 125
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"link","resource_id":"0bb8f7cf-88a6-43ff-ac07-ac0a705da1a8","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"link","resource_id":"5911eca8-0067-47b7-a482-33d5a3f50943","type":"not_found"}'
         headers:
             Content-Length:
                 - "125"
@@ -2986,9 +3084,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Sun, 19 Apr 2026 20:29:57 GMT
+                - Mon, 24 Aug 2026 12:13:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2996,7 +3094,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 57aefbd4-a810-4cdf-9fb1-1a15a5dd65d1
+                - 488be492-6b90-4d2d-9074-605b3082a0ca
         status: 404 Not Found
         code: 404
-        duration: 65.214917ms
+        duration: 41.614464ms

--- a/internal/services/interlink/testdata/interlink-routing-policy-basic.cassette.yaml
+++ b/internal/services/interlink/testdata/interlink-routing-policy-basic.cassette.yaml
@@ -12,13 +12,13 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","name":"tf-test-interlink-routing-policy","tags":["tf_tests"],"prefix_filter_in":["10.0.1.0/24"],"prefix_filter_out":["10.0.2.0/24"],"is_ipv6":false}'
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-interlink-routing-policy","tags":["tf_tests"],"prefix_filter_in":["10.0.1.0/24"],"prefix_filter_out":["10.0.2.0/24"],"is_ipv6":false}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies
         method: POST
       response:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 407
+        content_length: 417
         uncompressed: false
-        body: '{"created_at":"2026-04-13T12:29:58.857390Z","id":"837bcaf6-0c7e-4ce5-8cdf-6a1216124db4","is_ipv6":false,"name":"tf-test-interlink-routing-policy","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","prefix_filter_in":["10.0.1.0/24"],"prefix_filter_out":["10.0.2.0/24"],"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","tags":["tf_tests"],"updated_at":"2026-04-13T12:29:58.857390Z"}'
+        body: '{"created_at":"2026-08-24T12:13:38.853432Z","id":"ad42c642-9aed-4bf8-a409-63e6e3ca9621","is_ipv6":false,"name":"tf-test-interlink-routing-policy","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","prefix_filter_in":["10.0.1.0/24"],"prefix_filter_out":["10.0.2.0/24"],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":["tf_tests"],"updated_at":"2026-08-24T12:13:38.853432Z"}'
         headers:
             Content-Length:
-                - "407"
+                - "417"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 13 Apr 2026 12:29:58 GMT
+                - Mon, 24 Aug 2026 12:13:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bc1549df-28d6-44ad-a1ce-0a0650f20bf9
+                - d6b16a64-315b-4db1-a396-d168420e4c53
         status: 200 OK
         code: 200
-        duration: 188.124458ms
+        duration: 156.89144ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,8 +67,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies/837bcaf6-0c7e-4ce5-8cdf-6a1216124db4
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/metadata
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 407
+        content_length: 59
         uncompressed: false
-        body: '{"created_at":"2026-04-13T12:29:58.857390Z","id":"837bcaf6-0c7e-4ce5-8cdf-6a1216124db4","is_ipv6":false,"name":"tf-test-interlink-routing-policy","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","prefix_filter_in":["10.0.1.0/24"],"prefix_filter_out":["10.0.2.0/24"],"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","tags":["tf_tests"],"updated_at":"2026-04-13T12:29:58.857390Z"}'
+        body: '{"domain":"scw.eu","partition":"scw","platform":"external"}'
         headers:
             Content-Length:
-                - "407"
+                - "59"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 13 Apr 2026 12:29:58 GMT
+                - Mon, 24 Aug 2026 12:13:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f7d6c731-18f6-4b05-a53b-ccf330d03d15
+                - c5668c9f-b80b-4c4a-934a-09c3e443ae95
         status: 200 OK
         code: 200
-        duration: 61.388042ms
+        duration: 28.653593ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -116,8 +116,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies/837bcaf6-0c7e-4ce5-8cdf-6a1216124db4
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies/ad42c642-9aed-4bf8-a409-63e6e3ca9621
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,20 +125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 407
+        content_length: 417
         uncompressed: false
-        body: '{"created_at":"2026-04-13T12:29:58.857390Z","id":"837bcaf6-0c7e-4ce5-8cdf-6a1216124db4","is_ipv6":false,"name":"tf-test-interlink-routing-policy","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","prefix_filter_in":["10.0.1.0/24"],"prefix_filter_out":["10.0.2.0/24"],"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","tags":["tf_tests"],"updated_at":"2026-04-13T12:29:58.857390Z"}'
+        body: '{"created_at":"2026-08-24T12:13:38.853432Z","id":"ad42c642-9aed-4bf8-a409-63e6e3ca9621","is_ipv6":false,"name":"tf-test-interlink-routing-policy","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","prefix_filter_in":["10.0.1.0/24"],"prefix_filter_out":["10.0.2.0/24"],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":["tf_tests"],"updated_at":"2026-08-24T12:13:38.853432Z"}'
         headers:
             Content-Length:
-                - "407"
+                - "417"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 13 Apr 2026 12:29:59 GMT
+                - Mon, 24 Aug 2026 12:13:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5dbb0d11-a584-4518-a51c-2797e2152f8a
+                - 451a064f-07fa-46af-b0ee-c11d7660194b
         status: 200 OK
         code: 200
-        duration: 22.439958ms
+        duration: 38.231166ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -165,8 +165,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies/837bcaf6-0c7e-4ce5-8cdf-6a1216124db4
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies/ad42c642-9aed-4bf8-a409-63e6e3ca9621
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,20 +174,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 407
+        content_length: 417
         uncompressed: false
-        body: '{"created_at":"2026-04-13T12:29:58.857390Z","id":"837bcaf6-0c7e-4ce5-8cdf-6a1216124db4","is_ipv6":false,"name":"tf-test-interlink-routing-policy","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","prefix_filter_in":["10.0.1.0/24"],"prefix_filter_out":["10.0.2.0/24"],"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","tags":["tf_tests"],"updated_at":"2026-04-13T12:29:58.857390Z"}'
+        body: '{"created_at":"2026-08-24T12:13:38.853432Z","id":"ad42c642-9aed-4bf8-a409-63e6e3ca9621","is_ipv6":false,"name":"tf-test-interlink-routing-policy","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","prefix_filter_in":["10.0.1.0/24"],"prefix_filter_out":["10.0.2.0/24"],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":["tf_tests"],"updated_at":"2026-08-24T12:13:38.853432Z"}'
         headers:
             Content-Length:
-                - "407"
+                - "417"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 13 Apr 2026 12:29:59 GMT
+                - Mon, 24 Aug 2026 12:13:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,10 +195,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 117cd29b-4d91-4f08-a652-0c7dffbb1742
+                - c50404a6-216c-4642-aac1-a7acea43ac93
         status: 200 OK
         code: 200
-        duration: 23.070917ms
+        duration: 51.206609ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -214,8 +214,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies/837bcaf6-0c7e-4ce5-8cdf-6a1216124db4
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies/ad42c642-9aed-4bf8-a409-63e6e3ca9621
         method: GET
       response:
         proto: HTTP/2.0
@@ -223,20 +223,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 407
+        content_length: 417
         uncompressed: false
-        body: '{"created_at":"2026-04-13T12:29:58.857390Z","id":"837bcaf6-0c7e-4ce5-8cdf-6a1216124db4","is_ipv6":false,"name":"tf-test-interlink-routing-policy","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","prefix_filter_in":["10.0.1.0/24"],"prefix_filter_out":["10.0.2.0/24"],"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","tags":["tf_tests"],"updated_at":"2026-04-13T12:29:58.857390Z"}'
+        body: '{"created_at":"2026-08-24T12:13:38.853432Z","id":"ad42c642-9aed-4bf8-a409-63e6e3ca9621","is_ipv6":false,"name":"tf-test-interlink-routing-policy","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","prefix_filter_in":["10.0.1.0/24"],"prefix_filter_out":["10.0.2.0/24"],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":["tf_tests"],"updated_at":"2026-08-24T12:13:38.853432Z"}'
         headers:
             Content-Length:
-                - "407"
+                - "417"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 13 Apr 2026 12:29:59 GMT
+                - Mon, 24 Aug 2026 12:13:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -244,11 +244,60 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dbe14a36-ca23-483f-862f-35651862e52b
+                - 93042bca-cd49-4d26-94bd-9803bce7dcd9
         status: 200 OK
         code: 200
-        duration: 25.983375ms
+        duration: 34.826746ms
     - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies/ad42c642-9aed-4bf8-a409-63e6e3ca9621
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 417
+        uncompressed: false
+        body: '{"created_at":"2026-08-24T12:13:38.853432Z","id":"ad42c642-9aed-4bf8-a409-63e6e3ca9621","is_ipv6":false,"name":"tf-test-interlink-routing-policy","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","prefix_filter_in":["10.0.1.0/24"],"prefix_filter_out":["10.0.2.0/24"],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":["tf_tests"],"updated_at":"2026-08-24T12:13:38.853432Z"}'
+        headers:
+            Content-Length:
+                - "417"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 24 Aug 2026 12:13:40 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 422dd911-9800-4458-8e44-d0c107412d2b
+        status: 200 OK
+        code: 200
+        duration: 40.849153ms
+    - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -265,8 +314,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies/837bcaf6-0c7e-4ce5-8cdf-6a1216124db4
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies/ad42c642-9aed-4bf8-a409-63e6e3ca9621
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -274,20 +323,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 439
+        content_length: 451
         uncompressed: false
-        body: '{"created_at":"2026-04-13T12:29:58.857390Z","id":"837bcaf6-0c7e-4ce5-8cdf-6a1216124db4","is_ipv6":false,"name":"tf-test-interlink-routing-policy-updated","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","prefix_filter_in":["10.0.1.0/24","10.0.3.0/24"],"prefix_filter_out":["10.0.4.0/24"],"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","tags":["tf_tests","updated"],"updated_at":"2026-04-13T12:29:59.674913Z"}'
+        body: '{"created_at":"2026-08-24T12:13:38.853432Z","id":"ad42c642-9aed-4bf8-a409-63e6e3ca9621","is_ipv6":false,"name":"tf-test-interlink-routing-policy-updated","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","prefix_filter_in":["10.0.1.0/24","10.0.3.0/24"],"prefix_filter_out":["10.0.4.0/24"],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":["tf_tests","updated"],"updated_at":"2026-08-24T12:13:40.510118Z"}'
         headers:
             Content-Length:
-                - "439"
+                - "451"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 13 Apr 2026 12:29:59 GMT
+                - Mon, 24 Aug 2026 12:13:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -295,59 +344,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 673114ac-8b7a-4262-9c1f-2e97ee80cc86
+                - eb70bdbe-482a-4782-9742-2c5eb214dde1
         status: 200 OK
         code: 200
-        duration: 73.440042ms
-    - id: 6
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies/837bcaf6-0c7e-4ce5-8cdf-6a1216124db4
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 439
-        uncompressed: false
-        body: '{"created_at":"2026-04-13T12:29:58.857390Z","id":"837bcaf6-0c7e-4ce5-8cdf-6a1216124db4","is_ipv6":false,"name":"tf-test-interlink-routing-policy-updated","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","prefix_filter_in":["10.0.1.0/24","10.0.3.0/24"],"prefix_filter_out":["10.0.4.0/24"],"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","tags":["tf_tests","updated"],"updated_at":"2026-04-13T12:29:59.674913Z"}'
-        headers:
-            Content-Length:
-                - "439"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 13 Apr 2026 12:29:59 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 141e7bc7-0c81-4d96-9d04-1d333b6b5a0a
-        status: 200 OK
-        code: 200
-        duration: 30.388542ms
+        duration: 64.01226ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -363,8 +363,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies/837bcaf6-0c7e-4ce5-8cdf-6a1216124db4
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies/ad42c642-9aed-4bf8-a409-63e6e3ca9621
         method: GET
       response:
         proto: HTTP/2.0
@@ -372,20 +372,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 439
+        content_length: 451
         uncompressed: false
-        body: '{"created_at":"2026-04-13T12:29:58.857390Z","id":"837bcaf6-0c7e-4ce5-8cdf-6a1216124db4","is_ipv6":false,"name":"tf-test-interlink-routing-policy-updated","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","prefix_filter_in":["10.0.1.0/24","10.0.3.0/24"],"prefix_filter_out":["10.0.4.0/24"],"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","tags":["tf_tests","updated"],"updated_at":"2026-04-13T12:29:59.674913Z"}'
+        body: '{"created_at":"2026-08-24T12:13:38.853432Z","id":"ad42c642-9aed-4bf8-a409-63e6e3ca9621","is_ipv6":false,"name":"tf-test-interlink-routing-policy-updated","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","prefix_filter_in":["10.0.1.0/24","10.0.3.0/24"],"prefix_filter_out":["10.0.4.0/24"],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":["tf_tests","updated"],"updated_at":"2026-08-24T12:13:40.510118Z"}'
         headers:
             Content-Length:
-                - "439"
+                - "451"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 13 Apr 2026 12:29:59 GMT
+                - Mon, 24 Aug 2026 12:13:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -393,10 +393,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0abd6894-04d0-4e46-b328-b66fadbb5d46
+                - 8930979d-55d1-4729-a0d9-0d22cb38c926
         status: 200 OK
         code: 200
-        duration: 21.83075ms
+        duration: 37.228434ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -412,8 +412,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies/837bcaf6-0c7e-4ce5-8cdf-6a1216124db4
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies/ad42c642-9aed-4bf8-a409-63e6e3ca9621
         method: GET
       response:
         proto: HTTP/2.0
@@ -421,20 +421,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 439
+        content_length: 451
         uncompressed: false
-        body: '{"created_at":"2026-04-13T12:29:58.857390Z","id":"837bcaf6-0c7e-4ce5-8cdf-6a1216124db4","is_ipv6":false,"name":"tf-test-interlink-routing-policy-updated","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","prefix_filter_in":["10.0.1.0/24","10.0.3.0/24"],"prefix_filter_out":["10.0.4.0/24"],"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","tags":["tf_tests","updated"],"updated_at":"2026-04-13T12:29:59.674913Z"}'
+        body: '{"created_at":"2026-08-24T12:13:38.853432Z","id":"ad42c642-9aed-4bf8-a409-63e6e3ca9621","is_ipv6":false,"name":"tf-test-interlink-routing-policy-updated","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","prefix_filter_in":["10.0.1.0/24","10.0.3.0/24"],"prefix_filter_out":["10.0.4.0/24"],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":["tf_tests","updated"],"updated_at":"2026-08-24T12:13:40.510118Z"}'
         headers:
             Content-Length:
-                - "439"
+                - "451"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 13 Apr 2026 12:30:00 GMT
+                - Mon, 24 Aug 2026 12:13:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -442,10 +442,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5995776e-0fc5-4b63-bd5c-87d0804b8578
+                - 428d2065-cd3a-4ac3-8ec2-a7f66b9edd35
         status: 200 OK
         code: 200
-        duration: 32.0045ms
+        duration: 33.856385ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -461,8 +461,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies/837bcaf6-0c7e-4ce5-8cdf-6a1216124db4
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies/ad42c642-9aed-4bf8-a409-63e6e3ca9621
         method: GET
       response:
         proto: HTTP/2.0
@@ -470,20 +470,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 439
+        content_length: 451
         uncompressed: false
-        body: '{"created_at":"2026-04-13T12:29:58.857390Z","id":"837bcaf6-0c7e-4ce5-8cdf-6a1216124db4","is_ipv6":false,"name":"tf-test-interlink-routing-policy-updated","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","prefix_filter_in":["10.0.1.0/24","10.0.3.0/24"],"prefix_filter_out":["10.0.4.0/24"],"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","tags":["tf_tests","updated"],"updated_at":"2026-04-13T12:29:59.674913Z"}'
+        body: '{"created_at":"2026-08-24T12:13:38.853432Z","id":"ad42c642-9aed-4bf8-a409-63e6e3ca9621","is_ipv6":false,"name":"tf-test-interlink-routing-policy-updated","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","prefix_filter_in":["10.0.1.0/24","10.0.3.0/24"],"prefix_filter_out":["10.0.4.0/24"],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":["tf_tests","updated"],"updated_at":"2026-08-24T12:13:40.510118Z"}'
         headers:
             Content-Length:
-                - "439"
+                - "451"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 13 Apr 2026 12:30:00 GMT
+                - Mon, 24 Aug 2026 12:13:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -491,10 +491,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 32f03506-6c56-45e1-a5bc-ac58591d3039
+                - 2d849aeb-675a-4296-8d30-6f83fe5dd0ea
         status: 200 OK
         code: 200
-        duration: 26.4735ms
+        duration: 47.09879ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -510,8 +510,57 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies/837bcaf6-0c7e-4ce5-8cdf-6a1216124db4
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies/ad42c642-9aed-4bf8-a409-63e6e3ca9621
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 451
+        uncompressed: false
+        body: '{"created_at":"2026-08-24T12:13:38.853432Z","id":"ad42c642-9aed-4bf8-a409-63e6e3ca9621","is_ipv6":false,"name":"tf-test-interlink-routing-policy-updated","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","prefix_filter_in":["10.0.1.0/24","10.0.3.0/24"],"prefix_filter_out":["10.0.4.0/24"],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":["tf_tests","updated"],"updated_at":"2026-08-24T12:13:40.510118Z"}'
+        headers:
+            Content-Length:
+                - "451"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 24 Aug 2026 12:13:41 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 84f8a116-8a58-4bd9-9615-a5b9c9b40867
+        status: 200 OK
+        code: 200
+        duration: 41.107992ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies/ad42c642-9aed-4bf8-a409-63e6e3ca9621
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -528,9 +577,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 13 Apr 2026 12:30:00 GMT
+                - Mon, 24 Aug 2026 12:13:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -538,11 +587,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0c7d931b-474a-415e-9db3-a662bb939a55
+                - afb5a88b-8004-479c-bd6a-003e2162384a
         status: 204 No Content
         code: 204
-        duration: 56.510916ms
-    - id: 11
+        duration: 62.355183ms
+    - id: 12
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -557,8 +606,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies/837bcaf6-0c7e-4ce5-8cdf-6a1216124db4
+                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/interlink/v1beta1/regions/fr-par/routing-policies/ad42c642-9aed-4bf8-a409-63e6e3ca9621
         method: GET
       response:
         proto: HTTP/2.0
@@ -568,7 +617,7 @@ interactions:
         trailer: {}
         content_length: 135
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"routing_policy","resource_id":"837bcaf6-0c7e-4ce5-8cdf-6a1216124db4","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"routing_policy","resource_id":"ad42c642-9aed-4bf8-a409-63e6e3ca9621","type":"not_found"}'
         headers:
             Content-Length:
                 - "135"
@@ -577,9 +626,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 13 Apr 2026 12:30:00 GMT
+                - Mon, 24 Aug 2026 12:13:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -587,7 +636,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5b370806-8fdd-4ca1-beae-3f0e6d51535b
+                - 1a25de48-0b16-485f-8298-621d92bad29e
         status: 404 Not Found
         code: 404
-        duration: 23.742917ms
+        duration: 39.382005ms


### PR DESCRIPTION
had to rerecord tests for https://github.com/scaleway/terraform-provider-scaleway/pull/4283 but got stuck because the datasources pointed to missing pops.