### PR TITLE
chore(lint): ignore console link 403 in markdown lint

### DIFF
--- a/.markdownlinkcheck.json
+++ b/.markdownlinkcheck.json
@@ -11,6 +11,9 @@
     },
     {
       "pattern": "^https://sqs.mnq.fr-par.scaleway.com"
+    },
+    {
+      "pattern": "^https://console\\.scaleway\\.com/"
     }
   ],
   "replacementPatterns": [


### PR DESCRIPTION
Markdown linter raises because of [403 errors on console links](https://github.com/scaleway/terraform-provider-scaleway/actions/runs/32854313371/job/97822444664) (which is expected since the linter ci is not logged in)