### PR TITLE
fix(file): crash on file size update

### DIFF
--- a/internal/services/file/filesystem.go
+++ b/internal/services/file/filesystem.go
@@ -197,7 +197,7 @@ func ResourceFileSystemUpdate(ctx context.Context, d *schema.ResourceData, m any
 
 	if d.HasChange("size_in_gb") {
 		sizeInGB := uint64(d.Get("size_in_gb").(int)) * uint64(scw.GB)
-		req.Size = types.ExpandUint64Ptr(sizeInGB)
+		req.Size = &sizeInGB
 	}
 
 	if d.HasChange("tags") {

--- a/internal/services/file/filesystem_test.go
+++ b/internal/services/file/filesystem_test.go
@@ -21,6 +21,7 @@ func TestAccFileSystem_Basic(t *testing.T) {
 	fileSystemName := "TestAccFileSystem_Basic"
 	fileSystemNameUpdated := "TestAccFileSystem_BasicUpdate"
 	sizeInGB := 100
+	sizeInGBUpdated := 200
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: tt.ProviderFactories,
@@ -50,6 +51,18 @@ func TestAccFileSystem_Basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFileSystemExists(tt, "scaleway_file_filesystem.fs"),
 					resource.TestCheckResourceAttr("scaleway_file_filesystem.fs", "size_in_gb", strconv.Itoa(sizeInGB)),
+				),
+			},
+			{
+				Config: fmt.Sprintf(`
+					resource "scaleway_file_filesystem" "fs" {
+						name = "%s"
+						size_in_gb = %d
+					}
+				`, fileSystemNameUpdated, sizeInGBUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFileSystemExists(tt, "scaleway_file_filesystem.fs"),
+					resource.TestCheckResourceAttr("scaleway_file_filesystem.fs", "size_in_gb", strconv.Itoa(sizeInGBUpdated)),
 				),
 			},
 			{

--- a/internal/services/file/testdata/file-system-basic.cassette.yaml
+++ b/internal/services/file/testdata/file-system-basic.cassette.yaml
@@ -18,7 +18,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.7; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/file/v1alpha1/regions/fr-par/filesystems
         method: POST
       response:
@@ -27,31 +27,37 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 402
+        content_length: 391
         uncompressed: false
-        body: '{"created_at":"2026-08-24T14:02:27.705751Z","filesystem_type_id":"","id":"d939c753-377c-4adf-a709-75097ee7b308","name":"TestAccFileSystem_Basic","number_of_attachments":0,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":100000000000,"status":"creating","tags":[],"updated_at":"2026-08-24T14:02:27.705751Z"}'
+        body: '{"created_at":"2026-09-02T07:24:48.672188Z","filesystem_type_id":"","id":"e6e13f04-d486-45a9-8036-84e02f78d353","name":"TestAccFileSystem_Basic","number_of_attachments":0,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":100000000000,"status":"creating","tags":[],"updated_at":"2026-09-02T07:24:48.672188Z"}'
         headers:
             Content-Length:
-                - "402"
+                - "391"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 24 Aug 2026 14:02:27 GMT
+                - Wed, 02 Sep 2026 07:24:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
                 - nosniff
             X-Frame-Options:
                 - DENY
+            X-Ratelimit-Limit:
+                - 50, 50;w=1
+            X-Ratelimit-Remaining:
+                - "49"
+            X-Ratelimit-Reset:
+                - "1"
             X-Request-Id:
-                - e4504a70-49be-4787-95d7-b9cbe111a2ca
+                - 54eefd99-cb4a-4c7b-ba7d-3b659b1cfe81
         status: 200 OK
         code: 200
-        duration: 452.948661ms
+        duration: 276.20175ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,7 +73,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.7; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/metadata
         method: GET
       response:
@@ -87,20 +93,26 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 24 Aug 2026 14:02:27 GMT
+                - Wed, 02 Sep 2026 07:24:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
                 - nosniff
             X-Frame-Options:
                 - DENY
+            X-Ratelimit-Limit:
+                - 50, 50;w=1
+            X-Ratelimit-Remaining:
+                - "48"
+            X-Ratelimit-Reset:
+                - "1"
             X-Request-Id:
-                - 8b9c7309-7394-492d-a407-672252ebd1a3
+                - 59df8d98-01ae-4196-9238-2d759009759c
         status: 200 OK
         code: 200
-        duration: 22.236555ms
+        duration: 23.597208ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -116,8 +128,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/file/v1alpha1/regions/fr-par/filesystems/d939c753-377c-4adf-a709-75097ee7b308
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.7; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/file/v1alpha1/regions/fr-par/filesystems/e6e13f04-d486-45a9-8036-84e02f78d353
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,31 +137,37 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 402
+        content_length: 391
         uncompressed: false
-        body: '{"created_at":"2026-08-24T14:02:27.705751Z","filesystem_type_id":"","id":"d939c753-377c-4adf-a709-75097ee7b308","name":"TestAccFileSystem_Basic","number_of_attachments":0,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":100000000000,"status":"creating","tags":[],"updated_at":"2026-08-24T14:02:27.705751Z"}'
+        body: '{"created_at":"2026-09-02T07:24:48.672188Z","filesystem_type_id":"","id":"e6e13f04-d486-45a9-8036-84e02f78d353","name":"TestAccFileSystem_Basic","number_of_attachments":0,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":100000000000,"status":"creating","tags":[],"updated_at":"2026-09-02T07:24:48.672188Z"}'
         headers:
             Content-Length:
-                - "402"
+                - "391"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 24 Aug 2026 14:02:28 GMT
+                - Wed, 02 Sep 2026 07:24:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
                 - nosniff
             X-Frame-Options:
                 - DENY
+            X-Ratelimit-Limit:
+                - 50, 50;w=1
+            X-Ratelimit-Remaining:
+                - "49"
+            X-Ratelimit-Reset:
+                - "1"
             X-Request-Id:
-                - 6e896909-9e4a-4950-8668-6d378d3e3d63
+                - 9b9031db-6427-4758-8242-caaf139ef361
         status: 200 OK
         code: 200
-        duration: 116.48838ms
+        duration: 75.033208ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -165,8 +183,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/file/v1alpha1/regions/fr-par/filesystems/d939c753-377c-4adf-a709-75097ee7b308
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.7; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/file/v1alpha1/regions/fr-par/filesystems/e6e13f04-d486-45a9-8036-84e02f78d353
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,31 +192,37 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 403
+        content_length: 392
         uncompressed: false
-        body: '{"created_at":"2026-08-24T14:02:27.705751Z","filesystem_type_id":"","id":"d939c753-377c-4adf-a709-75097ee7b308","name":"TestAccFileSystem_Basic","number_of_attachments":0,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":100000000000,"status":"available","tags":[],"updated_at":"2026-08-24T14:02:27.902725Z"}'
+        body: '{"created_at":"2026-09-02T07:24:48.672188Z","filesystem_type_id":"","id":"e6e13f04-d486-45a9-8036-84e02f78d353","name":"TestAccFileSystem_Basic","number_of_attachments":0,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":100000000000,"status":"available","tags":[],"updated_at":"2026-09-02T07:24:48.777243Z"}'
         headers:
             Content-Length:
-                - "403"
+                - "392"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 24 Aug 2026 14:02:33 GMT
+                - Wed, 02 Sep 2026 07:24:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
                 - nosniff
             X-Frame-Options:
                 - DENY
+            X-Ratelimit-Limit:
+                - 50, 50;w=1
+            X-Ratelimit-Remaining:
+                - "49"
+            X-Ratelimit-Reset:
+                - "1"
             X-Request-Id:
-                - 670c2627-26a4-4c0b-8ba8-ca3ac14c5ff0
+                - c75f46b2-f7a0-4a35-9403-e43559b1aa2c
         status: 200 OK
         code: 200
-        duration: 138.847846ms
+        duration: 67.30525ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -214,8 +238,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/file/v1alpha1/regions/fr-par/filesystems/d939c753-377c-4adf-a709-75097ee7b308
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.7; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/file/v1alpha1/regions/fr-par/filesystems/e6e13f04-d486-45a9-8036-84e02f78d353
         method: GET
       response:
         proto: HTTP/2.0
@@ -223,31 +247,37 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 403
+        content_length: 392
         uncompressed: false
-        body: '{"created_at":"2026-08-24T14:02:27.705751Z","filesystem_type_id":"","id":"d939c753-377c-4adf-a709-75097ee7b308","name":"TestAccFileSystem_Basic","number_of_attachments":0,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":100000000000,"status":"available","tags":[],"updated_at":"2026-08-24T14:02:27.902725Z"}'
+        body: '{"created_at":"2026-09-02T07:24:48.672188Z","filesystem_type_id":"","id":"e6e13f04-d486-45a9-8036-84e02f78d353","name":"TestAccFileSystem_Basic","number_of_attachments":0,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":100000000000,"status":"available","tags":[],"updated_at":"2026-09-02T07:24:48.777243Z"}'
         headers:
             Content-Length:
-                - "403"
+                - "392"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 24 Aug 2026 14:02:33 GMT
+                - Wed, 02 Sep 2026 07:24:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
                 - nosniff
             X-Frame-Options:
                 - DENY
+            X-Ratelimit-Limit:
+                - 50, 50;w=1
+            X-Ratelimit-Remaining:
+                - "48"
+            X-Ratelimit-Reset:
+                - "1"
             X-Request-Id:
-                - 9144e187-87e5-429c-9984-23b103103896
+                - 4fab2aee-9319-49a1-822a-6efb66181e5a
         status: 200 OK
         code: 200
-        duration: 147.396843ms
+        duration: 49.678083ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -263,8 +293,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/file/v1alpha1/regions/fr-par/filesystems/d939c753-377c-4adf-a709-75097ee7b308
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.7; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/file/v1alpha1/regions/fr-par/filesystems/e6e13f04-d486-45a9-8036-84e02f78d353
         method: GET
       response:
         proto: HTTP/2.0
@@ -272,31 +302,37 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 403
+        content_length: 392
         uncompressed: false
-        body: '{"created_at":"2026-08-24T14:02:27.705751Z","filesystem_type_id":"","id":"d939c753-377c-4adf-a709-75097ee7b308","name":"TestAccFileSystem_Basic","number_of_attachments":0,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":100000000000,"status":"available","tags":[],"updated_at":"2026-08-24T14:02:27.902725Z"}'
+        body: '{"created_at":"2026-09-02T07:24:48.672188Z","filesystem_type_id":"","id":"e6e13f04-d486-45a9-8036-84e02f78d353","name":"TestAccFileSystem_Basic","number_of_attachments":0,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":100000000000,"status":"available","tags":[],"updated_at":"2026-09-02T07:24:48.777243Z"}'
         headers:
             Content-Length:
-                - "403"
+                - "392"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 24 Aug 2026 14:02:33 GMT
+                - Wed, 02 Sep 2026 07:24:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
                 - nosniff
             X-Frame-Options:
                 - DENY
+            X-Ratelimit-Limit:
+                - 50, 50;w=1
+            X-Ratelimit-Remaining:
+                - "49"
+            X-Ratelimit-Reset:
+                - "1"
             X-Request-Id:
-                - 09d57811-5b05-446d-ac59-4659e7747e66
+                - 4a80dcc2-1159-459d-8624-5c9b5410634d
         status: 200 OK
         code: 200
-        duration: 139.696482ms
+        duration: 118.925166ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -312,8 +348,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/file/v1alpha1/regions/fr-par/filesystems/d939c753-377c-4adf-a709-75097ee7b308
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.7; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/file/v1alpha1/regions/fr-par/filesystems/e6e13f04-d486-45a9-8036-84e02f78d353
         method: GET
       response:
         proto: HTTP/2.0
@@ -321,31 +357,37 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 403
+        content_length: 392
         uncompressed: false
-        body: '{"created_at":"2026-08-24T14:02:27.705751Z","filesystem_type_id":"","id":"d939c753-377c-4adf-a709-75097ee7b308","name":"TestAccFileSystem_Basic","number_of_attachments":0,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":100000000000,"status":"available","tags":[],"updated_at":"2026-08-24T14:02:27.902725Z"}'
+        body: '{"created_at":"2026-09-02T07:24:48.672188Z","filesystem_type_id":"","id":"e6e13f04-d486-45a9-8036-84e02f78d353","name":"TestAccFileSystem_Basic","number_of_attachments":0,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":100000000000,"status":"available","tags":[],"updated_at":"2026-09-02T07:24:48.777243Z"}'
         headers:
             Content-Length:
-                - "403"
+                - "392"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 24 Aug 2026 14:02:34 GMT
+                - Wed, 02 Sep 2026 07:24:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
                 - nosniff
             X-Frame-Options:
                 - DENY
+            X-Ratelimit-Limit:
+                - 50, 50;w=1
+            X-Ratelimit-Remaining:
+                - "48"
+            X-Ratelimit-Reset:
+                - "1"
             X-Request-Id:
-                - 77837f5d-e629-4c73-bfa1-fa085956b769
+                - 12a546db-70eb-4e2f-8d44-8139a0213a2e
         status: 200 OK
         code: 200
-        duration: 196.244776ms
+        duration: 59.452833ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -361,8 +403,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/file/v1alpha1/regions/fr-par/filesystems/d939c753-377c-4adf-a709-75097ee7b308
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.7; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/file/v1alpha1/regions/fr-par/filesystems/e6e13f04-d486-45a9-8036-84e02f78d353
         method: GET
       response:
         proto: HTTP/2.0
@@ -370,31 +412,37 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 403
+        content_length: 392
         uncompressed: false
-        body: '{"created_at":"2026-08-24T14:02:27.705751Z","filesystem_type_id":"","id":"d939c753-377c-4adf-a709-75097ee7b308","name":"TestAccFileSystem_Basic","number_of_attachments":0,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":100000000000,"status":"available","tags":[],"updated_at":"2026-08-24T14:02:27.902725Z"}'
+        body: '{"created_at":"2026-09-02T07:24:48.672188Z","filesystem_type_id":"","id":"e6e13f04-d486-45a9-8036-84e02f78d353","name":"TestAccFileSystem_Basic","number_of_attachments":0,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":100000000000,"status":"available","tags":[],"updated_at":"2026-09-02T07:24:48.777243Z"}'
         headers:
             Content-Length:
-                - "403"
+                - "392"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 24 Aug 2026 14:02:34 GMT
+                - Wed, 02 Sep 2026 07:24:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
                 - nosniff
             X-Frame-Options:
                 - DENY
+            X-Ratelimit-Limit:
+                - 50, 50;w=1
+            X-Ratelimit-Remaining:
+                - "47"
+            X-Ratelimit-Reset:
+                - "1"
             X-Request-Id:
-                - 72dafcae-d49b-4f4d-8b35-5e7f467a1d14
+                - 82b33970-be45-4542-a743-d38cbd03f2a8
         status: 200 OK
         code: 200
-        duration: 148.193903ms
+        duration: 63.597209ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -410,8 +458,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/file/v1alpha1/regions/fr-par/filesystems/d939c753-377c-4adf-a709-75097ee7b308
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.7; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/file/v1alpha1/regions/fr-par/filesystems/e6e13f04-d486-45a9-8036-84e02f78d353
         method: GET
       response:
         proto: HTTP/2.0
@@ -419,31 +467,37 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 403
+        content_length: 392
         uncompressed: false
-        body: '{"created_at":"2026-08-24T14:02:27.705751Z","filesystem_type_id":"","id":"d939c753-377c-4adf-a709-75097ee7b308","name":"TestAccFileSystem_Basic","number_of_attachments":0,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":100000000000,"status":"available","tags":[],"updated_at":"2026-08-24T14:02:27.902725Z"}'
+        body: '{"created_at":"2026-09-02T07:24:48.672188Z","filesystem_type_id":"","id":"e6e13f04-d486-45a9-8036-84e02f78d353","name":"TestAccFileSystem_Basic","number_of_attachments":0,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":100000000000,"status":"available","tags":[],"updated_at":"2026-09-02T07:24:48.777243Z"}'
         headers:
             Content-Length:
-                - "403"
+                - "392"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 24 Aug 2026 14:02:34 GMT
+                - Wed, 02 Sep 2026 07:24:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
                 - nosniff
             X-Frame-Options:
                 - DENY
+            X-Ratelimit-Limit:
+                - 50, 50;w=1
+            X-Ratelimit-Remaining:
+                - "46"
+            X-Ratelimit-Reset:
+                - "1"
             X-Request-Id:
-                - 4c8220d1-80e5-494b-9e88-580f7b85c439
+                - 3737b616-49d2-4957-82a8-5cb0ae4a8b48
         status: 200 OK
         code: 200
-        duration: 58.494295ms
+        duration: 47.411875ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -461,8 +515,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/file/v1alpha1/regions/fr-par/filesystems/d939c753-377c-4adf-a709-75097ee7b308
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.7; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/file/v1alpha1/regions/fr-par/filesystems/e6e13f04-d486-45a9-8036-84e02f78d353
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -470,31 +524,37 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 409
+        content_length: 398
         uncompressed: false
-        body: '{"created_at":"2026-08-24T14:02:27.705751Z","filesystem_type_id":"","id":"d939c753-377c-4adf-a709-75097ee7b308","name":"TestAccFileSystem_BasicUpdate","number_of_attachments":0,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":100000000000,"status":"available","tags":[],"updated_at":"2026-08-24T14:02:34.973110Z"}'
+        body: '{"created_at":"2026-09-02T07:24:48.672188Z","filesystem_type_id":"","id":"e6e13f04-d486-45a9-8036-84e02f78d353","name":"TestAccFileSystem_BasicUpdate","number_of_attachments":0,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":100000000000,"status":"available","tags":[],"updated_at":"2026-09-02T07:24:54.946090Z"}'
         headers:
             Content-Length:
-                - "409"
+                - "398"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 24 Aug 2026 14:02:35 GMT
+                - Wed, 02 Sep 2026 07:24:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
                 - nosniff
             X-Frame-Options:
                 - DENY
+            X-Ratelimit-Limit:
+                - 50, 50;w=1
+            X-Ratelimit-Remaining:
+                - "45"
+            X-Ratelimit-Reset:
+                - "1"
             X-Request-Id:
-                - 7fcf2728-ae0d-49a6-8ff0-1b8f85ec2642
+                - 3af7ef32-7a73-4849-9567-25a6502200c4
         status: 200 OK
         code: 200
-        duration: 183.707663ms
+        duration: 94.78725ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -510,8 +570,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/file/v1alpha1/regions/fr-par/filesystems/d939c753-377c-4adf-a709-75097ee7b308
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.7; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/file/v1alpha1/regions/fr-par/filesystems/e6e13f04-d486-45a9-8036-84e02f78d353
         method: GET
       response:
         proto: HTTP/2.0
@@ -519,31 +579,37 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 409
+        content_length: 398
         uncompressed: false
-        body: '{"created_at":"2026-08-24T14:02:27.705751Z","filesystem_type_id":"","id":"d939c753-377c-4adf-a709-75097ee7b308","name":"TestAccFileSystem_BasicUpdate","number_of_attachments":0,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":100000000000,"status":"available","tags":[],"updated_at":"2026-08-24T14:02:34.973110Z"}'
+        body: '{"created_at":"2026-09-02T07:24:48.672188Z","filesystem_type_id":"","id":"e6e13f04-d486-45a9-8036-84e02f78d353","name":"TestAccFileSystem_BasicUpdate","number_of_attachments":0,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":100000000000,"status":"available","tags":[],"updated_at":"2026-09-02T07:24:54.946090Z"}'
         headers:
             Content-Length:
-                - "409"
+                - "398"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 24 Aug 2026 14:02:35 GMT
+                - Wed, 02 Sep 2026 07:24:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
                 - nosniff
             X-Frame-Options:
                 - DENY
+            X-Ratelimit-Limit:
+                - 50, 50;w=1
+            X-Ratelimit-Remaining:
+                - "47"
+            X-Ratelimit-Reset:
+                - "1"
             X-Request-Id:
-                - be3cbc56-5cc5-409e-8c7f-d664ebe95ac1
+                - 9378f5d4-d7af-45f6-a552-4120f92224da
         status: 200 OK
         code: 200
-        duration: 134.731779ms
+        duration: 53.650708ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -559,8 +625,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/file/v1alpha1/regions/fr-par/filesystems/d939c753-377c-4adf-a709-75097ee7b308
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.7; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/file/v1alpha1/regions/fr-par/filesystems/e6e13f04-d486-45a9-8036-84e02f78d353
         method: GET
       response:
         proto: HTTP/2.0
@@ -568,31 +634,37 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 409
+        content_length: 398
         uncompressed: false
-        body: '{"created_at":"2026-08-24T14:02:27.705751Z","filesystem_type_id":"","id":"d939c753-377c-4adf-a709-75097ee7b308","name":"TestAccFileSystem_BasicUpdate","number_of_attachments":0,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":100000000000,"status":"available","tags":[],"updated_at":"2026-08-24T14:02:34.973110Z"}'
+        body: '{"created_at":"2026-09-02T07:24:48.672188Z","filesystem_type_id":"","id":"e6e13f04-d486-45a9-8036-84e02f78d353","name":"TestAccFileSystem_BasicUpdate","number_of_attachments":0,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":100000000000,"status":"available","tags":[],"updated_at":"2026-09-02T07:24:54.946090Z"}'
         headers:
             Content-Length:
-                - "409"
+                - "398"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 24 Aug 2026 14:02:35 GMT
+                - Wed, 02 Sep 2026 07:24:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
                 - nosniff
             X-Frame-Options:
                 - DENY
+            X-Ratelimit-Limit:
+                - 50, 50;w=1
+            X-Ratelimit-Remaining:
+                - "49"
+            X-Ratelimit-Reset:
+                - "1"
             X-Request-Id:
-                - de9fe819-c6bf-4450-b74e-7dd83f00d5eb
+                - 4c55b92b-5ab9-475e-99c8-56e6f04f7655
         status: 200 OK
         code: 200
-        duration: 51.252066ms
+        duration: 58.175ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -608,8 +680,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/file/v1alpha1/regions/fr-par/filesystems/d939c753-377c-4adf-a709-75097ee7b308
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.7; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/file/v1alpha1/regions/fr-par/filesystems/e6e13f04-d486-45a9-8036-84e02f78d353
         method: GET
       response:
         proto: HTTP/2.0
@@ -617,31 +689,37 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 409
+        content_length: 398
         uncompressed: false
-        body: '{"created_at":"2026-08-24T14:02:27.705751Z","filesystem_type_id":"","id":"d939c753-377c-4adf-a709-75097ee7b308","name":"TestAccFileSystem_BasicUpdate","number_of_attachments":0,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":100000000000,"status":"available","tags":[],"updated_at":"2026-08-24T14:02:34.973110Z"}'
+        body: '{"created_at":"2026-09-02T07:24:48.672188Z","filesystem_type_id":"","id":"e6e13f04-d486-45a9-8036-84e02f78d353","name":"TestAccFileSystem_BasicUpdate","number_of_attachments":0,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":100000000000,"status":"available","tags":[],"updated_at":"2026-09-02T07:24:54.946090Z"}'
         headers:
             Content-Length:
-                - "409"
+                - "398"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 24 Aug 2026 14:02:35 GMT
+                - Wed, 02 Sep 2026 07:24:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
                 - nosniff
             X-Frame-Options:
                 - DENY
+            X-Ratelimit-Limit:
+                - 50, 50;w=1
+            X-Ratelimit-Remaining:
+                - "49"
+            X-Ratelimit-Reset:
+                - "1"
             X-Request-Id:
-                - 3a4e2ffc-e037-4323-880d-06007b33e9e7
+                - 2a2f58e4-a3a1-4d80-87a4-f1850536604c
         status: 200 OK
         code: 200
-        duration: 140.590244ms
+        duration: 56.155083ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -657,8 +735,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/file/v1alpha1/regions/fr-par/filesystems/d939c753-377c-4adf-a709-75097ee7b308
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.7; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/file/v1alpha1/regions/fr-par/filesystems/e6e13f04-d486-45a9-8036-84e02f78d353
         method: GET
       response:
         proto: HTTP/2.0
@@ -666,31 +744,37 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 409
+        content_length: 398
         uncompressed: false
-        body: '{"created_at":"2026-08-24T14:02:27.705751Z","filesystem_type_id":"","id":"d939c753-377c-4adf-a709-75097ee7b308","name":"TestAccFileSystem_BasicUpdate","number_of_attachments":0,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":100000000000,"status":"available","tags":[],"updated_at":"2026-08-24T14:02:34.973110Z"}'
+        body: '{"created_at":"2026-09-02T07:24:48.672188Z","filesystem_type_id":"","id":"e6e13f04-d486-45a9-8036-84e02f78d353","name":"TestAccFileSystem_BasicUpdate","number_of_attachments":0,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":100000000000,"status":"available","tags":[],"updated_at":"2026-09-02T07:24:54.946090Z"}'
         headers:
             Content-Length:
-                - "409"
+                - "398"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 24 Aug 2026 14:02:36 GMT
+                - Wed, 02 Sep 2026 07:24:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
                 - nosniff
             X-Frame-Options:
                 - DENY
+            X-Ratelimit-Limit:
+                - 50, 50;w=1
+            X-Ratelimit-Remaining:
+                - "48"
+            X-Ratelimit-Reset:
+                - "1"
             X-Request-Id:
-                - 1ea432b2-a399-4392-93bb-b5d99fd136b5
+                - 53f8f3db-3e2c-4f89-8d76-be171dbfa077
         status: 200 OK
         code: 200
-        duration: 154.357612ms
+        duration: 59.56275ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -706,8 +790,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/file/v1alpha1/regions/fr-par/filesystems/d939c753-377c-4adf-a709-75097ee7b308
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.7; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/file/v1alpha1/regions/fr-par/filesystems/e6e13f04-d486-45a9-8036-84e02f78d353
         method: GET
       response:
         proto: HTTP/2.0
@@ -715,32 +799,95 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 409
+        content_length: 398
         uncompressed: false
-        body: '{"created_at":"2026-08-24T14:02:27.705751Z","filesystem_type_id":"","id":"d939c753-377c-4adf-a709-75097ee7b308","name":"TestAccFileSystem_BasicUpdate","number_of_attachments":0,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":100000000000,"status":"available","tags":[],"updated_at":"2026-08-24T14:02:34.973110Z"}'
+        body: '{"created_at":"2026-09-02T07:24:48.672188Z","filesystem_type_id":"","id":"e6e13f04-d486-45a9-8036-84e02f78d353","name":"TestAccFileSystem_BasicUpdate","number_of_attachments":0,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":100000000000,"status":"available","tags":[],"updated_at":"2026-09-02T07:24:54.946090Z"}'
         headers:
             Content-Length:
-                - "409"
+                - "398"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 24 Aug 2026 14:02:36 GMT
+                - Wed, 02 Sep 2026 07:24:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
                 - nosniff
             X-Frame-Options:
                 - DENY
+            X-Ratelimit-Limit:
+                - 50, 50;w=1
+            X-Ratelimit-Remaining:
+                - "49"
+            X-Ratelimit-Reset:
+                - "1"
             X-Request-Id:
-                - 3268dd1f-527a-4517-8397-b2a5aa469676
+                - 999a055f-701d-4723-9460-381e74f3a137
         status: 200 OK
         code: 200
-        duration: 113.883537ms
+        duration: 48.794042ms
     - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 21
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"size":200000000000}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.7; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/file/v1alpha1/regions/fr-par/filesystems/e6e13f04-d486-45a9-8036-84e02f78d353
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 397
+        uncompressed: false
+        body: '{"created_at":"2026-09-02T07:24:48.672188Z","filesystem_type_id":"","id":"e6e13f04-d486-45a9-8036-84e02f78d353","name":"TestAccFileSystem_BasicUpdate","number_of_attachments":0,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":100000000000,"status":"updating","tags":[],"updated_at":"2026-09-02T07:24:55.865630Z"}'
+        headers:
+            Content-Length:
+                - "397"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 02 Sep 2026 07:24:55 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Ratelimit-Limit:
+                - 50, 50;w=1
+            X-Ratelimit-Remaining:
+                - "48"
+            X-Ratelimit-Reset:
+                - "1"
+            X-Request-Id:
+                - 145b782a-a07a-4db6-b355-b1b957f70d89
+        status: 200 OK
+        code: 200
+        duration: 164.821125ms
+    - id: 16
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -755,8 +902,338 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/file/v1alpha1/regions/fr-par/filesystems/d939c753-377c-4adf-a709-75097ee7b308
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.7; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/file/v1alpha1/regions/fr-par/filesystems/e6e13f04-d486-45a9-8036-84e02f78d353
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 397
+        uncompressed: false
+        body: '{"created_at":"2026-09-02T07:24:48.672188Z","filesystem_type_id":"","id":"e6e13f04-d486-45a9-8036-84e02f78d353","name":"TestAccFileSystem_BasicUpdate","number_of_attachments":0,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":100000000000,"status":"updating","tags":[],"updated_at":"2026-09-02T07:24:55.865630Z"}'
+        headers:
+            Content-Length:
+                - "397"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 02 Sep 2026 07:24:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Ratelimit-Limit:
+                - 50, 50;w=1
+            X-Ratelimit-Remaining:
+                - "47"
+            X-Ratelimit-Reset:
+                - "1"
+            X-Request-Id:
+                - e0e4d2a9-0c4f-442b-8d88-619d3563dcba
+        status: 200 OK
+        code: 200
+        duration: 57.809334ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.7; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/file/v1alpha1/regions/fr-par/filesystems/e6e13f04-d486-45a9-8036-84e02f78d353
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 398
+        uncompressed: false
+        body: '{"created_at":"2026-09-02T07:24:48.672188Z","filesystem_type_id":"","id":"e6e13f04-d486-45a9-8036-84e02f78d353","name":"TestAccFileSystem_BasicUpdate","number_of_attachments":0,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":200000000000,"status":"available","tags":[],"updated_at":"2026-09-02T07:24:55.952304Z"}'
+        headers:
+            Content-Length:
+                - "398"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 02 Sep 2026 07:25:01 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Ratelimit-Limit:
+                - 50, 50;w=1
+            X-Ratelimit-Remaining:
+                - "49"
+            X-Ratelimit-Reset:
+                - "1"
+            X-Request-Id:
+                - bde97689-ac0d-45a9-b7f0-ae1721939b0b
+        status: 200 OK
+        code: 200
+        duration: 144.785708ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.7; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/file/v1alpha1/regions/fr-par/filesystems/e6e13f04-d486-45a9-8036-84e02f78d353
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 398
+        uncompressed: false
+        body: '{"created_at":"2026-09-02T07:24:48.672188Z","filesystem_type_id":"","id":"e6e13f04-d486-45a9-8036-84e02f78d353","name":"TestAccFileSystem_BasicUpdate","number_of_attachments":0,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":200000000000,"status":"available","tags":[],"updated_at":"2026-09-02T07:24:55.952304Z"}'
+        headers:
+            Content-Length:
+                - "398"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 02 Sep 2026 07:25:01 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Ratelimit-Limit:
+                - 50, 50;w=1
+            X-Ratelimit-Remaining:
+                - "48"
+            X-Ratelimit-Reset:
+                - "1"
+            X-Request-Id:
+                - 279bddea-0eaf-4f1a-9c52-559dbc766d33
+        status: 200 OK
+        code: 200
+        duration: 48.418917ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.7; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/file/v1alpha1/regions/fr-par/filesystems/e6e13f04-d486-45a9-8036-84e02f78d353
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 398
+        uncompressed: false
+        body: '{"created_at":"2026-09-02T07:24:48.672188Z","filesystem_type_id":"","id":"e6e13f04-d486-45a9-8036-84e02f78d353","name":"TestAccFileSystem_BasicUpdate","number_of_attachments":0,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":200000000000,"status":"available","tags":[],"updated_at":"2026-09-02T07:24:55.952304Z"}'
+        headers:
+            Content-Length:
+                - "398"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 02 Sep 2026 07:25:01 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Ratelimit-Limit:
+                - 50, 50;w=1
+            X-Ratelimit-Remaining:
+                - "48"
+            X-Ratelimit-Reset:
+                - "1"
+            X-Request-Id:
+                - 74917614-644d-43ac-beb0-7d7c81f6e6f1
+        status: 200 OK
+        code: 200
+        duration: 59.855834ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.7; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/file/v1alpha1/regions/fr-par/filesystems/e6e13f04-d486-45a9-8036-84e02f78d353
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 398
+        uncompressed: false
+        body: '{"created_at":"2026-09-02T07:24:48.672188Z","filesystem_type_id":"","id":"e6e13f04-d486-45a9-8036-84e02f78d353","name":"TestAccFileSystem_BasicUpdate","number_of_attachments":0,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":200000000000,"status":"available","tags":[],"updated_at":"2026-09-02T07:24:55.952304Z"}'
+        headers:
+            Content-Length:
+                - "398"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 02 Sep 2026 07:25:01 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Ratelimit-Limit:
+                - 50, 50;w=1
+            X-Ratelimit-Remaining:
+                - "47"
+            X-Ratelimit-Reset:
+                - "1"
+            X-Request-Id:
+                - 49db805e-c639-49f2-b099-68dbd9a60fa7
+        status: 200 OK
+        code: 200
+        duration: 51.677459ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.7; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/file/v1alpha1/regions/fr-par/filesystems/e6e13f04-d486-45a9-8036-84e02f78d353
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 398
+        uncompressed: false
+        body: '{"created_at":"2026-09-02T07:24:48.672188Z","filesystem_type_id":"","id":"e6e13f04-d486-45a9-8036-84e02f78d353","name":"TestAccFileSystem_BasicUpdate","number_of_attachments":0,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","size":200000000000,"status":"available","tags":[],"updated_at":"2026-09-02T07:24:55.952304Z"}'
+        headers:
+            Content-Length:
+                - "398"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 02 Sep 2026 07:25:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Ratelimit-Limit:
+                - 50, 50;w=1
+            X-Ratelimit-Remaining:
+                - "49"
+            X-Ratelimit-Reset:
+                - "1"
+            X-Request-Id:
+                - 88446349-3a10-4b1a-a653-e277726dc582
+        status: 200 OK
+        code: 200
+        duration: 62.028709ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.7; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/file/v1alpha1/regions/fr-par/filesystems/e6e13f04-d486-45a9-8036-84e02f78d353
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -773,21 +1250,27 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 24 Aug 2026 14:02:36 GMT
+                - Wed, 02 Sep 2026 07:25:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
                 - nosniff
             X-Frame-Options:
                 - DENY
+            X-Ratelimit-Limit:
+                - 50, 50;w=1
+            X-Ratelimit-Remaining:
+                - "49"
+            X-Ratelimit-Reset:
+                - "1"
             X-Request-Id:
-                - 062ee667-b0ce-4308-bad4-ca69cc8350fe
+                - b08305a9-9662-413e-8009-691120e3d7c2
         status: 204 No Content
         code: 204
-        duration: 160.700868ms
-    - id: 16
+        duration: 152.786333ms
+    - id: 23
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -802,8 +1285,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/file/v1alpha1/regions/fr-par/filesystems/d939c753-377c-4adf-a709-75097ee7b308
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.7; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/file/v1alpha1/regions/fr-par/filesystems/e6e13f04-d486-45a9-8036-84e02f78d353
         method: GET
       response:
         proto: HTTP/2.0
@@ -813,7 +1296,7 @@ interactions:
         trailer: {}
         content_length: 131
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"filesystem","resource_id":"d939c753-377c-4adf-a709-75097ee7b308","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"filesystem","resource_id":"e6e13f04-d486-45a9-8036-84e02f78d353","type":"not_found"}'
         headers:
             Content-Length:
                 - "131"
@@ -822,21 +1305,27 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 24 Aug 2026 14:02:36 GMT
+                - Wed, 02 Sep 2026 07:25:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
                 - nosniff
             X-Frame-Options:
                 - DENY
+            X-Ratelimit-Limit:
+                - 50, 50;w=1
+            X-Ratelimit-Remaining:
+                - "47"
+            X-Ratelimit-Reset:
+                - "1"
             X-Request-Id:
-                - bbd252e8-b7f6-4a82-b16c-049f322b2b0b
+                - 6edf92fb-88cc-40a1-bc7e-f4643f2841d5
         status: 404 Not Found
         code: 404
-        duration: 47.791254ms
-    - id: 17
+        duration: 44.414083ms
+    - id: 24
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -851,8 +1340,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.37.0.20260820161448-2c5cd81b0528 (go1.27.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/file/v1alpha1/regions/fr-par/filesystems/d939c753-377c-4adf-a709-75097ee7b308
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.7; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/file/v1alpha1/regions/fr-par/filesystems/e6e13f04-d486-45a9-8036-84e02f78d353
         method: GET
       response:
         proto: HTTP/2.0
@@ -862,7 +1351,7 @@ interactions:
         trailer: {}
         content_length: 131
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"filesystem","resource_id":"d939c753-377c-4adf-a709-75097ee7b308","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"filesystem","resource_id":"e6e13f04-d486-45a9-8036-84e02f78d353","type":"not_found"}'
         headers:
             Content-Length:
                 - "131"
@@ -871,17 +1360,23 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 24 Aug 2026 14:02:37 GMT
+                - Wed, 02 Sep 2026 07:25:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-1;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
                 - nosniff
             X-Frame-Options:
                 - DENY
+            X-Ratelimit-Limit:
+                - 50, 50;w=1
+            X-Ratelimit-Remaining:
+                - "48"
+            X-Ratelimit-Reset:
+                - "1"
             X-Request-Id:
-                - ac4d816c-ae64-4b7c-b3d0-603cedd97171
+                - 49244d52-9d78-42e7-88f8-b0c809f65f2d
         status: 404 Not Found
         code: 404
-        duration: 44.158618ms
+        duration: 43.227375ms


### PR DESCRIPTION
This PR fixes a crash on filesystem size update and adds a regression test for it.

Resize of a filesystem on latest tag or main would cause:
```
panic: interface conversion: interface {} is uint64, not int

github.com/scaleway/terraform-provider-scaleway/v2/internal/types.ExpandUint64Ptr
 internal/types/number.go:40
github.com/scaleway/terraform-provider-scaleway/v2/internal/services/file.ResourceFileSystemUpdate
 internal/services/file/filesystem.go:200
 ```
 
 I regenerated the cassette and manually swapped my organization id for yours