### PR TITLE
chore(ci): rework workflow concurrency

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -19,8 +19,9 @@ on:
   schedule:
     - cron: '0 7 * * 2'
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+concurrency:  
+  # Only cancel previous concurrent runs in one PR (not on main)
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -3,7 +3,7 @@ on:
   - pull_request_target
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,10 +8,6 @@ on:
     # Will run at 00:00 every day
     - cron: "0 0 * * *"
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   nightly:
     strategy:


### PR DESCRIPTION
Fix workflow concurrency issues introduced by my previous commit:
- fix labeler concurrency: since it runs on pull_request_target, `github.ref` was `main`, so there was concurrency between separate PRs
- fix codeql: keep cancelling concurrent workflows on runs within one PR, but remove concurrency for runs on branch main
- remove non-relevant nightly concurrency cancelling