### PR TITLE
docs: mark SCW_DEFAULT_ORGANIZATION_ID mandatory

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -217,7 +217,7 @@ In addition to [generic provider arguments](https://www.terraform.io/docs/config
 | `access_key`      | `SCW_ACCESS_KEY`                                | [Scaleway access key](https://console.scaleway.com/project/credentials)                                                                         | ✅        |
 | `secret_key`      | `SCW_SECRET_KEY`                                | [Scaleway secret key](https://console.scaleway.com/project/credentials)                                                                         | ✅        |
 | `project_id`      | `SCW_DEFAULT_PROJECT_ID`                        | The [project ID](https://console.scaleway.com/project/settings) that will be used as default value for project-scoped resources.                | ✅        |
-| `organization_id` | `SCW_DEFAULT_ORGANIZATION_ID`                   | The [organization ID](https://console.scaleway.com/organization/settings) that will be used as default value for organization-scoped resources. |           |
+| `organization_id` | `SCW_DEFAULT_ORGANIZATION_ID`                   | The [organization ID](https://console.scaleway.com/organization/settings) that will be used as default value for organization-scoped resources. | ✅        |
 | `region`          | `SCW_DEFAULT_REGION`                            | The [region](./guides/regions_and_zones.md#regions)  that will be used as default value for all resources. (`fr-par` if none specified)         |           |
 | `zone`            | `SCW_DEFAULT_ZONE`                              | The [zone](./guides/regions_and_zones.md#zones) that will be used as default value for all resources. (`fr-par-1` if none specified)            |           |
 

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -217,7 +217,7 @@ In addition to [generic provider arguments](https://www.terraform.io/docs/config
 | `access_key`      | `SCW_ACCESS_KEY`                                | [Scaleway access key](https://console.scaleway.com/project/credentials)                                                                         | ✅        |
 | `secret_key`      | `SCW_SECRET_KEY`                                | [Scaleway secret key](https://console.scaleway.com/project/credentials)                                                                         | ✅        |
 | `project_id`      | `SCW_DEFAULT_PROJECT_ID`                        | The [project ID](https://console.scaleway.com/project/settings) that will be used as default value for project-scoped resources.                | ✅        |
-| `organization_id` | `SCW_DEFAULT_ORGANIZATION_ID`                   | The [organization ID](https://console.scaleway.com/organization/settings) that will be used as default value for organization-scoped resources. |           |
+| `organization_id` | `SCW_DEFAULT_ORGANIZATION_ID`                   | The [organization ID](https://console.scaleway.com/organization/settings) that will be used as default value for organization-scoped resources. | ✅        |
 | `region`          | `SCW_DEFAULT_REGION`                            | The [region](./guides/regions_and_zones.md#regions)  that will be used as default value for all resources. (`fr-par` if none specified)         |           |
 | `zone`            | `SCW_DEFAULT_ZONE`                              | The [zone](./guides/regions_and_zones.md#zones) that will be used as default value for all resources. (`fr-par-1` if none specified)            |           |
 


### PR DESCRIPTION
related to https://github.com/scaleway/terraform-provider-scaleway/pull/4325

While working on defaults in tests, I realized our documentation indicated `SCW_DEFAULT_ORGANIZATION_ID` as optional. For core namespaces (billing, iam, annotations...), this is definitely incoherent: organization_id is explicitely required in a number of calls, for which on provider side we allow resorting to default (and if default is missing, an error is triggered). This is why I believe `SCW_DEFAULT_ORGANIZATION_ID` should rather be marked as `mandatory`.