### PR TITLE
fix(object): unset lifecycle_rule.expiration fields when empty in config

### DIFF
--- a/internal/services/object/bucket.go
+++ b/internal/services/object/bucket.go
@@ -485,30 +485,30 @@ func resourceBucketLifecycleUpdate(ctx context.Context, conn *s3.Client, d *sche
 		// Expiration
 		expiration := d.Get(fmt.Sprintf("lifecycle_rule.%d.expiration", i)).([]any)
 		if len(expiration) > 0 && expiration[0] != nil {
-			e := expiration[0].(map[string]any)
-			i := &s3Types.LifecycleExpiration{}
+			expirationMap := expiration[0].(map[string]any)
+			expirationS3 := &s3Types.LifecycleExpiration{}
 
-			if val, ok := e["days"].(int); ok && val > 0 {
+			if val, ok := expirationMap["days"].(int); ok && val > 0 {
 				days := int32(val)
-				i.Days = aws.Int32(days)
+				expirationS3.Days = aws.Int32(days)
 			}
 
-			if val, ok := e["date"].(string); ok && val != "" {
+			if val, ok := expirationMap["date"].(string); ok && val != "" {
 				date, err := time.Parse("2006-01-02", val)
 				if err != nil {
 					return fmt.Errorf("error while parsing expiration date '%s': %w", val, err)
 				}
 
-				i.Date = aws.Time(date)
+				expirationS3.Date = aws.Time(date)
 			}
 
 			if val, ok := meta.GetRawConfigForKey(
 				d, fmt.Sprintf("lifecycle_rule.%d.expiration.0.expired_object_delete_marker", i), cty.Bool,
 			); ok {
-				i.ExpiredObjectDeleteMarker = aws.Bool(val.(bool))
+				expirationS3.ExpiredObjectDeleteMarker = aws.Bool(val.(bool))
 			}
 
-			rule.Expiration = i
+			rule.Expiration = expirationS3
 		}
 
 		// Transitions

--- a/internal/services/object/bucket.go
+++ b/internal/services/object/bucket.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3Types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
@@ -18,6 +19,7 @@ import (
 	"github.com/scaleway/scaleway-sdk-go/scw"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/identity"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/locality/regional"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/meta"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/services/account"
 )
 
@@ -1163,7 +1165,7 @@ func validateLifecycleExpiration(diff *schema.ResourceDiff, i int) error {
 
 	_, daysOk := diff.GetOk(prefix + "days")
 	_, dateOk := diff.GetOk(prefix + "date")
-	_, markerOk := diff.GetOk(prefix + "expired_object_delete_marker")
+	_, markerOk := meta.GetRawConfigForKey(diff, prefix+"expired_object_delete_marker", cty.Bool)
 
 	// Implement "ExactlyOneOf"
 	count := 0

--- a/internal/services/object/bucket.go
+++ b/internal/services/object/bucket.go
@@ -502,8 +502,10 @@ func resourceBucketLifecycleUpdate(ctx context.Context, conn *s3.Client, d *sche
 				i.Date = aws.Time(date)
 			}
 
-			if val, ok := e["expired_object_delete_marker"].(bool); ok {
-				i.ExpiredObjectDeleteMarker = aws.Bool(val)
+			if val, ok := meta.GetRawConfigForKey(
+				d, fmt.Sprintf("lifecycle_rule.%d.expiration.0.expired_object_delete_marker", i), cty.Bool,
+			); ok {
+				i.ExpiredObjectDeleteMarker = aws.Bool(val.(bool))
 			}
 
 			rule.Expiration = i

--- a/internal/services/object/bucket_test.go
+++ b/internal/services/object/bucket_test.go
@@ -438,6 +438,24 @@ func TestAccObjectBucket_Lifecycle(t *testing.T) {
 			},
 			{
 				Config: fmt.Sprintf(`
+						resource "scaleway_object_bucket" "main-bucket-lifecycle" {
+							name           		= "%s"
+							region 				= "%s"
+							object_lock_enabled = true
+
+							lifecycle_rule {
+								enabled = true
+								prefix  = ""
+								expiration {
+									days = 2
+									expired_object_delete_marker = false
+								}
+							}
+						}`, bucketLifecycle, objectTestsMainRegion),
+				ExpectError: regexp.MustCompile("lifecycle_rule.0.expiration: 'days', 'date', 'expired_object_delete_marker' are mutually exclusive"),
+			},
+			{
+				Config: fmt.Sprintf(`
 					resource "scaleway_object_bucket" "main-bucket-lifecycle" {
 					name = "%s"
 					region = "%s"

--- a/internal/services/object/testdata/object-bucket-lifecycle.cassette.yaml
+++ b/internal/services/object/testdata/object-bucket-lifecycle.cassette.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -18,7 +18,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 683f4075-36b2-4330-b565-31f1f6cf0c40
+                - 2e8bac36-64a7-4b99-81ee-671ee8e36ff1
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -26,8 +26,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133706Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/
+                - 20260908T144828Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/
         method: PUT
       response:
         proto: HTTP/2.0
@@ -42,16 +42,16 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 08 Sep 2026 13:37:06 GMT
+                - Tue, 08 Sep 2026 14:48:28 GMT
             Location:
-                - /tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797
+                - /tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016
             X-Amz-Id-2:
-                - txg1cb3d1073d894c83ab91-006aa00f82
+                - txgcf89e9b476d64e3399c5-006aa0203c
             X-Amz-Request-Id:
-                - txg1cb3d1073d894c83ab91-006aa00f82
+                - txgcf89e9b476d64e3399c5-006aa0203c
         status: 200 OK
         code: 200
-        duration: 4.906836417s
+        duration: 1.449670417s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -60,7 +60,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -69,7 +69,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 186350e3-2b4c-461f-8798-c050bfd28a19
+                - 564a98dd-d638-4d97-b01d-fefc11ce621c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -81,8 +81,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133711Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T144829Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?acl=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -97,14 +97,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 08 Sep 2026 13:37:11 GMT
+                - Tue, 08 Sep 2026 14:48:29 GMT
             X-Amz-Id-2:
-                - txg3574c212df5c462b8791-006aa00f87
+                - txg88e2072b27394ada82c8-006aa0203d
             X-Amz-Request-Id:
-                - txg3574c212df5c462b8791-006aa00f87
+                - txg88e2072b27394ada82c8-006aa0203d
         status: 200 OK
         code: 200
-        duration: 307.025958ms
+        duration: 357.667666ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -113,7 +113,7 @@ interactions:
         content_length: 303
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></LifecycleConfiguration>
@@ -122,7 +122,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6874ecea-635d-4bd3-b1e6-afb6fad25275
+                - e899efe9-9284-433e-b38b-0c7f44098fbd
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -134,8 +134,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - 13feec03c398f242f302d24e62c26ce8c47f46e3921d2bf7a84ca9914cd3488a
             X-Amz-Date:
-                - 20260908T133711Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T144829Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -150,14 +150,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 08 Sep 2026 13:37:11 GMT
+                - Tue, 08 Sep 2026 14:48:29 GMT
             X-Amz-Id-2:
-                - txg3b15c62872dd4b82ab07-006aa00f87
+                - txga0065be16fa641e88795-006aa0203d
             X-Amz-Request-Id:
-                - txg3b15c62872dd4b82ab07-006aa00f87
+                - txga0065be16fa641e88795-006aa0203d
         status: 200 OK
         code: 200
-        duration: 199.228375ms
+        duration: 312.304875ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -166,7 +166,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -175,7 +175,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f96262ec-df68-4eae-8a78-59c75373cc1f
+                - 3a1f1198-6e81-4937-8a7a-04ba6fbcef73
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -183,8 +183,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133711Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T144830Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -203,14 +203,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:11 GMT
+                - Tue, 08 Sep 2026 14:48:30 GMT
             X-Amz-Id-2:
-                - txga74b251f7e6843e2a20a-006aa00f87
+                - txg0ceb316085194f5f86cb-006aa0203e
             X-Amz-Request-Id:
-                - txga74b251f7e6843e2a20a-006aa00f87
+                - txg0ceb316085194f5f86cb-006aa0203e
         status: 200 OK
         code: 200
-        duration: 194.503041ms
+        duration: 241.861333ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -219,7 +219,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -228,7 +228,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7f8e18b1-5276-4b9b-961c-ba765c26d677
+                - 665f63db-5432-465f-a432-94861b5e3aaa
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -236,8 +236,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133711Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T144830Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -247,21 +247,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgfb1f759c53e64f038ab6-006aa00f87</RequestId><HostId>txgfb1f759c53e64f038ab6-006aa00f87</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgee73045f14de4cd38f9d-006aa0203e</RequestId><HostId>txgee73045f14de4cd38f9d-006aa0203e</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:11 GMT
+                - Tue, 08 Sep 2026 14:48:30 GMT
             X-Amz-Id-2:
-                - txgfb1f759c53e64f038ab6-006aa00f87
+                - txgee73045f14de4cd38f9d-006aa0203e
             X-Amz-Request-Id:
-                - txgfb1f759c53e64f038ab6-006aa00f87
+                - txgee73045f14de4cd38f9d-006aa0203e
         status: 404 Not Found
         code: 404
-        duration: 123.692458ms
+        duration: 158.009125ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -270,7 +270,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -279,7 +279,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5a9c9c6c-1fbe-4606-b433-9819749e8b63
+                - 83805c7a-0a29-4f10-b317-f266dc1da6a9
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -287,8 +287,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133711Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/
+                - 20260908T144830Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -300,21 +300,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:12 GMT
+                - Tue, 08 Sep 2026 14:48:30 GMT
             X-Amz-Id-2:
-                - txgbf0fc20791d44259af84-006aa00f88
+                - txg4676da4642b34eebae1c-006aa0203e
             X-Amz-Request-Id:
-                - txgbf0fc20791d44259af84-006aa00f88
+                - txg4676da4642b34eebae1c-006aa0203e
         status: 200 OK
         code: 200
-        duration: 309.889292ms
+        duration: 264.994667ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -323,7 +323,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -332,7 +332,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 15663e5d-d428-4d7b-b676-c52fab19a5b4
+                - 3d5640c7-d179-4f3c-a5e3-2e1d3706b921
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -340,8 +340,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133712Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T144830Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -351,21 +351,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg1f6c32f4b69c46169aff-006aa00f88</RequestId><HostId>txg1f6c32f4b69c46169aff-006aa00f88</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg61f0bb4ed46c47b99caa-006aa0203e</RequestId><HostId>txg61f0bb4ed46c47b99caa-006aa0203e</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:12 GMT
+                - Tue, 08 Sep 2026 14:48:30 GMT
             X-Amz-Id-2:
-                - txg1f6c32f4b69c46169aff-006aa00f88
+                - txg61f0bb4ed46c47b99caa-006aa0203e
             X-Amz-Request-Id:
-                - txg1f6c32f4b69c46169aff-006aa00f88
+                - txg61f0bb4ed46c47b99caa-006aa0203e
         status: 404 Not Found
         code: 404
-        duration: 91.519833ms
+        duration: 207.342959ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -374,7 +374,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -383,7 +383,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9a5f685c-514d-45b8-ae18-6fd86a87c831
+                - 4138a78f-9be9-4959-9278-5c938a050d9e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -391,8 +391,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133712Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T144830Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -402,21 +402,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg42f5d026907e4d2a8bdf-006aa00f88</RequestId><HostId>txg42f5d026907e4d2a8bdf-006aa00f88</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg667592c24d69481fbd40-006aa0203f</RequestId><HostId>txg667592c24d69481fbd40-006aa0203f</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:12 GMT
+                - Tue, 08 Sep 2026 14:48:31 GMT
             X-Amz-Id-2:
-                - txg42f5d026907e4d2a8bdf-006aa00f88
+                - txg667592c24d69481fbd40-006aa0203f
             X-Amz-Request-Id:
-                - txg42f5d026907e4d2a8bdf-006aa00f88
+                - txg667592c24d69481fbd40-006aa0203f
         status: 404 Not Found
         code: 404
-        duration: 106.539ms
+        duration: 319.98375ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -425,7 +425,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -434,7 +434,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 985d03fd-0794-4a5c-b630-9b731629913b
+                - 7d05bbb5-3879-4346-9aa6-d870b0b44a7d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -442,8 +442,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133712Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T144831Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -462,14 +462,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:12 GMT
+                - Tue, 08 Sep 2026 14:48:31 GMT
             X-Amz-Id-2:
-                - txg6140163fe45d41ee8700-006aa00f88
+                - txgafe64695ae6c4dbaba2f-006aa0203f
             X-Amz-Request-Id:
-                - txg6140163fe45d41ee8700-006aa00f88
+                - txgafe64695ae6c4dbaba2f-006aa0203f
         status: 200 OK
         code: 200
-        duration: 376.971ms
+        duration: 271.021958ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -478,7 +478,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -487,7 +487,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 79cebb40-dcb9-4077-b8dd-f0d33e401637
+                - 3d736a7f-266e-4c19-8f01-ba3159499b0b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -495,8 +495,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133712Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T144831Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -515,14 +515,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:12 GMT
+                - Tue, 08 Sep 2026 14:48:31 GMT
             X-Amz-Id-2:
-                - txga069a23832f140369e1e-006aa00f88
+                - txge4e5384792284c2394da-006aa0203f
             X-Amz-Request-Id:
-                - txga069a23832f140369e1e-006aa00f88
+                - txge4e5384792284c2394da-006aa0203f
         status: 200 OK
         code: 200
-        duration: 132.898917ms
+        duration: 186.611083ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -531,7 +531,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -540,7 +540,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6783d199-692a-4b83-9b4a-5926b946b9ae
+                - dc370772-a9a9-421f-97f5-dee4321f1790
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -548,8 +548,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133713Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/
+                - 20260908T144831Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -564,16 +564,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:13 GMT
+                - Tue, 08 Sep 2026 14:48:31 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txge120d07ab462469eb692-006aa00f89
+                - txgbbbeb20497374f078b53-006aa0203f
             X-Amz-Request-Id:
-                - txge120d07ab462469eb692-006aa00f89
+                - txgbbbeb20497374f078b53-006aa0203f
         status: 200 OK
         code: 200
-        duration: 98.823875ms
+        duration: 292.2495ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -582,7 +582,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -591,7 +591,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 790a745b-8656-4596-b21d-3d2389e8c8b3
+                - ef6b9141-13db-4be2-870e-ddf0e5403c19
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -599,8 +599,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133713Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T144832Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -619,14 +619,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:13 GMT
+                - Tue, 08 Sep 2026 14:48:32 GMT
             X-Amz-Id-2:
-                - txgf943fb4444c14eb9af58-006aa00f89
+                - txgcbf34744189e48cfb0a5-006aa02040
             X-Amz-Request-Id:
-                - txgf943fb4444c14eb9af58-006aa00f89
+                - txgcbf34744189e48cfb0a5-006aa02040
         status: 200 OK
         code: 200
-        duration: 94.698625ms
+        duration: 219.543625ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -635,7 +635,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -644,7 +644,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9d77be8a-5c17-48d6-96f1-6d5b2fbb7a2a
+                - d734edc5-3654-4a1b-8f68-984fb1c2eb88
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -652,8 +652,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133713Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T144832Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -672,14 +672,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:13 GMT
+                - Tue, 08 Sep 2026 14:48:32 GMT
             X-Amz-Id-2:
-                - txg4c986f9aab854bcaa464-006aa00f89
+                - txg5302e2f4ef9648858589-006aa02040
             X-Amz-Request-Id:
-                - txg4c986f9aab854bcaa464-006aa00f89
+                - txg5302e2f4ef9648858589-006aa02040
         status: 200 OK
         code: 200
-        duration: 1.417191209s
+        duration: 315.111375ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -688,7 +688,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -697,7 +697,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0733f9bd-4099-4489-8946-be23747f94d0
+                - f887589d-d8c1-474c-99b2-aedbc510b12f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -705,8 +705,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133713Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T144832Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -716,21 +716,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg5e293ff6b2834b2facc2-006aa00f8b</RequestId><HostId>txg5e293ff6b2834b2facc2-006aa00f8b</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgc343efc1fd5f413b92c8-006aa02041</RequestId><HostId>txgc343efc1fd5f413b92c8-006aa02041</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:15 GMT
+                - Tue, 08 Sep 2026 14:48:33 GMT
             X-Amz-Id-2:
-                - txg5e293ff6b2834b2facc2-006aa00f8b
+                - txgc343efc1fd5f413b92c8-006aa02041
             X-Amz-Request-Id:
-                - txg5e293ff6b2834b2facc2-006aa00f8b
+                - txgc343efc1fd5f413b92c8-006aa02041
         status: 404 Not Found
         code: 404
-        duration: 95.644333ms
+        duration: 408.422166ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -739,7 +739,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -748,7 +748,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - dc15c76f-c134-4ead-bc90-84842877b3d4
+                - 84b8879c-466a-4b83-9926-44b8561dba47
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -756,8 +756,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133715Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/
+                - 20260908T144833Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -769,21 +769,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:15 GMT
+                - Tue, 08 Sep 2026 14:48:33 GMT
             X-Amz-Id-2:
-                - txgdb97160fce6b4109b310-006aa00f8b
+                - txg24d6f213808144538bc8-006aa02041
             X-Amz-Request-Id:
-                - txgdb97160fce6b4109b310-006aa00f8b
+                - txg24d6f213808144538bc8-006aa02041
         status: 200 OK
         code: 200
-        duration: 340.541916ms
+        duration: 402.492792ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -792,7 +792,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -801,7 +801,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ccf00b14-31a3-40be-b515-9379caa37474
+                - aa2e7d5a-0125-4287-8f9c-803414a97d84
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -809,8 +809,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133715Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T144833Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -820,21 +820,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg96c5d53d9706449ba361-006aa00f8b</RequestId><HostId>txg96c5d53d9706449ba361-006aa00f8b</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgd8e026cbb8c24d1d9075-006aa02041</RequestId><HostId>txgd8e026cbb8c24d1d9075-006aa02041</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:15 GMT
+                - Tue, 08 Sep 2026 14:48:33 GMT
             X-Amz-Id-2:
-                - txg96c5d53d9706449ba361-006aa00f8b
+                - txgd8e026cbb8c24d1d9075-006aa02041
             X-Amz-Request-Id:
-                - txg96c5d53d9706449ba361-006aa00f8b
+                - txgd8e026cbb8c24d1d9075-006aa02041
         status: 404 Not Found
         code: 404
-        duration: 93.498291ms
+        duration: 168.600958ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -843,7 +843,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -852,7 +852,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ed1e8a95-5e47-426d-8c93-fb5ba5a82323
+                - 2658b856-8d04-4eba-b605-35dd49a349ad
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -860,8 +860,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133715Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T144833Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -871,21 +871,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgb43b107941d64a13acc9-006aa00f8b</RequestId><HostId>txgb43b107941d64a13acc9-006aa00f8b</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg793ddc95054b43b4bb94-006aa02042</RequestId><HostId>txg793ddc95054b43b4bb94-006aa02042</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:15 GMT
+                - Tue, 08 Sep 2026 14:48:34 GMT
             X-Amz-Id-2:
-                - txgb43b107941d64a13acc9-006aa00f8b
+                - txg793ddc95054b43b4bb94-006aa02042
             X-Amz-Request-Id:
-                - txgb43b107941d64a13acc9-006aa00f8b
+                - txg793ddc95054b43b4bb94-006aa02042
         status: 404 Not Found
         code: 404
-        duration: 88.028708ms
+        duration: 231.313292ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -894,7 +894,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -903,7 +903,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6d5d3924-ec16-4114-b897-38f2e135ab6b
+                - fd2c124e-b22b-423f-8093-b4a8f1ee39e4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -911,8 +911,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133715Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T144834Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -931,14 +931,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:15 GMT
+                - Tue, 08 Sep 2026 14:48:34 GMT
             X-Amz-Id-2:
-                - txga13c90986436420792da-006aa00f8b
+                - txg9e449b9bc5c241778332-006aa02042
             X-Amz-Request-Id:
-                - txga13c90986436420792da-006aa00f8b
+                - txg9e449b9bc5c241778332-006aa02042
         status: 200 OK
         code: 200
-        duration: 89.615958ms
+        duration: 211.695833ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -947,7 +947,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -956,7 +956,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5c910f41-7c9a-4897-934e-6c64e34f112c
+                - 50eee1b4-ab6f-4696-8805-1cfa6892556f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -964,8 +964,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133715Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T144834Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -984,14 +984,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:15 GMT
+                - Tue, 08 Sep 2026 14:48:34 GMT
             X-Amz-Id-2:
-                - txg9cfd988996ab4bf18be1-006aa00f8b
+                - txge74210e231854e32a12d-006aa02042
             X-Amz-Request-Id:
-                - txg9cfd988996ab4bf18be1-006aa00f8b
+                - txge74210e231854e32a12d-006aa02042
         status: 200 OK
         code: 200
-        duration: 109.02575ms
+        duration: 145.7685ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -1000,7 +1000,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1009,7 +1009,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 2f98c709-0e9d-472a-8d35-60b5be653f94
+                - 6db9dc81-3489-4b63-8fa5-deaddc8e43d5
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1017,8 +1017,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133715Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T144834Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1037,14 +1037,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:16 GMT
+                - Tue, 08 Sep 2026 14:48:34 GMT
             X-Amz-Id-2:
-                - txg459efc7af828451cb373-006aa00f8c
+                - txg175497be9b9b4c909fca-006aa02042
             X-Amz-Request-Id:
-                - txg459efc7af828451cb373-006aa00f8c
+                - txg175497be9b9b4c909fca-006aa02042
         status: 200 OK
         code: 200
-        duration: 38.607959ms
+        duration: 570.28075ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1053,7 +1053,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1062,7 +1062,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7ea39e66-93c8-471c-aec0-53310ae04a9d
+                - fa45abd0-03a4-42ca-9a64-e2d65a8710ad
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1070,8 +1070,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133716Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T144834Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1081,21 +1081,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txga740aa51d41d46f3b8a3-006aa00f8c</RequestId><HostId>txga740aa51d41d46f3b8a3-006aa00f8c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg0b08ffeed2ea44468594-006aa02043</RequestId><HostId>txg0b08ffeed2ea44468594-006aa02043</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:16 GMT
+                - Tue, 08 Sep 2026 14:48:35 GMT
             X-Amz-Id-2:
-                - txga740aa51d41d46f3b8a3-006aa00f8c
+                - txg0b08ffeed2ea44468594-006aa02043
             X-Amz-Request-Id:
-                - txga740aa51d41d46f3b8a3-006aa00f8c
+                - txg0b08ffeed2ea44468594-006aa02043
         status: 404 Not Found
         code: 404
-        duration: 94.861875ms
+        duration: 347.869041ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1104,7 +1104,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1113,7 +1113,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 2885a0e9-089c-4569-84ee-aac0fe3e6e85
+                - dd165c50-154a-463f-ba41-177c8ff43b0d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1121,8 +1121,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133716Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/
+                - 20260908T144835Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -1134,21 +1134,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:16 GMT
+                - Tue, 08 Sep 2026 14:48:35 GMT
             X-Amz-Id-2:
-                - txgcff11d4aa482425c8ee1-006aa00f8c
+                - txg7f9be1a1e55644d6be45-006aa02043
             X-Amz-Request-Id:
-                - txgcff11d4aa482425c8ee1-006aa00f8c
+                - txg7f9be1a1e55644d6be45-006aa02043
         status: 200 OK
         code: 200
-        duration: 184.201042ms
+        duration: 243.630666ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1157,7 +1157,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1166,7 +1166,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - dff9e37d-a2b3-4ee2-a16f-8e816bc76c38
+                - 48a85791-f6c0-4336-b199-d0bde26e70c2
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1174,8 +1174,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133716Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T144835Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1185,21 +1185,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgaf25435a48df412190c2-006aa00f8c</RequestId><HostId>txgaf25435a48df412190c2-006aa00f8c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgf04a32bcbcf84ef1ab33-006aa02044</RequestId><HostId>txgf04a32bcbcf84ef1ab33-006aa02044</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:16 GMT
+                - Tue, 08 Sep 2026 14:48:36 GMT
             X-Amz-Id-2:
-                - txgaf25435a48df412190c2-006aa00f8c
+                - txgf04a32bcbcf84ef1ab33-006aa02044
             X-Amz-Request-Id:
-                - txgaf25435a48df412190c2-006aa00f8c
+                - txgf04a32bcbcf84ef1ab33-006aa02044
         status: 404 Not Found
         code: 404
-        duration: 29.233083ms
+        duration: 283.644042ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1208,7 +1208,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1217,7 +1217,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4ee9e9da-7675-4170-b0e9-6bd78086b7b1
+                - 995a94ec-346a-466a-a6eb-eac79ee1860c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1225,8 +1225,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133716Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T144836Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1236,21 +1236,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg6fa95486f8a943de80c9-006aa00f8c</RequestId><HostId>txg6fa95486f8a943de80c9-006aa00f8c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg1fd76f19ccd84f70a099-006aa02044</RequestId><HostId>txg1fd76f19ccd84f70a099-006aa02044</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:16 GMT
+                - Tue, 08 Sep 2026 14:48:36 GMT
             X-Amz-Id-2:
-                - txg6fa95486f8a943de80c9-006aa00f8c
+                - txg1fd76f19ccd84f70a099-006aa02044
             X-Amz-Request-Id:
-                - txg6fa95486f8a943de80c9-006aa00f8c
+                - txg1fd76f19ccd84f70a099-006aa02044
         status: 404 Not Found
         code: 404
-        duration: 108.289542ms
+        duration: 126.765458ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1259,7 +1259,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1268,7 +1268,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 42273f05-6ffa-4acd-823f-248259039aaa
+                - ca1365ff-3e20-4d54-ba80-4a709f98eb02
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1276,8 +1276,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133716Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T144836Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1296,14 +1296,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:16 GMT
+                - Tue, 08 Sep 2026 14:48:36 GMT
             X-Amz-Id-2:
-                - txg2fa5a02952a64ce0a24a-006aa00f8c
+                - txg8f87abdc86844e00bdd6-006aa02044
             X-Amz-Request-Id:
-                - txg2fa5a02952a64ce0a24a-006aa00f8c
+                - txg8f87abdc86844e00bdd6-006aa02044
         status: 200 OK
         code: 200
-        duration: 99.087042ms
+        duration: 295.030458ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1312,7 +1312,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1321,7 +1321,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 70fba48c-5c48-442b-ba2c-1754f3d4461d
+                - 43c75725-64cb-4900-a480-fcae4fff38b2
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1329,8 +1329,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133716Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T144836Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1349,14 +1349,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:16 GMT
+                - Tue, 08 Sep 2026 14:48:36 GMT
             X-Amz-Id-2:
-                - txg0e6c7375579f464580db-006aa00f8c
+                - txg6f9fe4b5c74946dc9326-006aa02044
             X-Amz-Request-Id:
-                - txg0e6c7375579f464580db-006aa00f8c
+                - txg6f9fe4b5c74946dc9326-006aa02044
         status: 200 OK
         code: 200
-        duration: 128.684875ms
+        duration: 336.143459ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1365,7 +1365,7 @@ interactions:
         content_length: 306
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition></Rule></LifecycleConfiguration>
@@ -1374,7 +1374,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 68747362-50c4-475c-b3d7-5bf285bcb493
+                - 27e951bc-9c28-4681-a131-01b49d09798a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -1386,8 +1386,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - de1418e62a2680330e07a11a092b47b671d4ed12fe9fe6d9780b095b8f45d69c
             X-Amz-Date:
-                - 20260908T133716Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T144837Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -1402,14 +1402,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 08 Sep 2026 13:37:16 GMT
+                - Tue, 08 Sep 2026 14:48:37 GMT
             X-Amz-Id-2:
-                - txg32bce155a1534af59643-006aa00f8c
+                - txg8f8dedbad95341cd8dca-006aa02045
             X-Amz-Request-Id:
-                - txg32bce155a1534af59643-006aa00f8c
+                - txg8f8dedbad95341cd8dca-006aa02045
         status: 200 OK
         code: 200
-        duration: 462.33625ms
+        duration: 189.82075ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1418,7 +1418,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1427,7 +1427,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d1903ff8-5e4d-4252-8a17-11d3bb102601
+                - a9f46662-a02f-420d-984b-ce13abe88dab
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1435,8 +1435,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133717Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T144837Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1455,14 +1455,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:17 GMT
+                - Tue, 08 Sep 2026 14:48:37 GMT
             X-Amz-Id-2:
-                - txg86a41f55ae7a4f118a73-006aa00f8d
+                - txgf4a16be8f1174cffb478-006aa02045
             X-Amz-Request-Id:
-                - txg86a41f55ae7a4f118a73-006aa00f8d
+                - txgf4a16be8f1174cffb478-006aa02045
         status: 200 OK
         code: 200
-        duration: 182.54425ms
+        duration: 109.540625ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1471,7 +1471,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1480,7 +1480,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 2566460f-18b7-4e20-a189-d916b2d8c0a3
+                - 3971ed52-c4d6-4f7b-a716-2a4fe812a5c6
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1488,8 +1488,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133717Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T144837Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1499,21 +1499,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgef316cdc7a824f069f61-006aa00f8d</RequestId><HostId>txgef316cdc7a824f069f61-006aa00f8d</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg6be8415c43554feda673-006aa02045</RequestId><HostId>txg6be8415c43554feda673-006aa02045</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:17 GMT
+                - Tue, 08 Sep 2026 14:48:37 GMT
             X-Amz-Id-2:
-                - txgef316cdc7a824f069f61-006aa00f8d
+                - txg6be8415c43554feda673-006aa02045
             X-Amz-Request-Id:
-                - txgef316cdc7a824f069f61-006aa00f8d
+                - txg6be8415c43554feda673-006aa02045
         status: 404 Not Found
         code: 404
-        duration: 180.051417ms
+        duration: 291.008667ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1522,7 +1522,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1531,7 +1531,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - feeaae05-2e4e-4087-b18c-8701c3883cc9
+                - 9ce8d32c-cc53-4637-826b-2b53a8cfbae1
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1539,8 +1539,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133717Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/
+                - 20260908T144837Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -1552,21 +1552,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:17 GMT
+                - Tue, 08 Sep 2026 14:48:37 GMT
             X-Amz-Id-2:
-                - txg0982a68eb68f4841926f-006aa00f8d
+                - txge7af721498c24d27b932-006aa02045
             X-Amz-Request-Id:
-                - txg0982a68eb68f4841926f-006aa00f8d
+                - txge7af721498c24d27b932-006aa02045
         status: 200 OK
         code: 200
-        duration: 216.821459ms
+        duration: 119.932792ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1575,7 +1575,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1584,7 +1584,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 041f484d-c0c4-4ce4-aaf7-c34279edab10
+                - 0c628f69-e842-4fba-8cc1-ad4a02c2a39a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1592,8 +1592,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133717Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T144837Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1603,21 +1603,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg56a2debae3224280af5a-006aa00f8d</RequestId><HostId>txg56a2debae3224280af5a-006aa00f8d</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txge16536e1388b429cba65-006aa02046</RequestId><HostId>txge16536e1388b429cba65-006aa02046</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:17 GMT
+                - Tue, 08 Sep 2026 14:48:38 GMT
             X-Amz-Id-2:
-                - txg56a2debae3224280af5a-006aa00f8d
+                - txge16536e1388b429cba65-006aa02046
             X-Amz-Request-Id:
-                - txg56a2debae3224280af5a-006aa00f8d
+                - txge16536e1388b429cba65-006aa02046
         status: 404 Not Found
         code: 404
-        duration: 294.874667ms
+        duration: 197.483875ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1626,7 +1626,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1635,7 +1635,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d8851b97-f2ce-483f-9a6c-4a0aa6334df0
+                - fac0e342-ab47-4ca4-8dc1-f21ca4e17416
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1643,8 +1643,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133717Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T144838Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1654,21 +1654,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg5e2d169c5ee241d4bf05-006aa00f8e</RequestId><HostId>txg5e2d169c5ee241d4bf05-006aa00f8e</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txga042f18a45d74ad0b496-006aa02046</RequestId><HostId>txga042f18a45d74ad0b496-006aa02046</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:18 GMT
+                - Tue, 08 Sep 2026 14:48:38 GMT
             X-Amz-Id-2:
-                - txg5e2d169c5ee241d4bf05-006aa00f8e
+                - txga042f18a45d74ad0b496-006aa02046
             X-Amz-Request-Id:
-                - txg5e2d169c5ee241d4bf05-006aa00f8e
+                - txga042f18a45d74ad0b496-006aa02046
         status: 404 Not Found
         code: 404
-        duration: 25.572333ms
+        duration: 312.516459ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1677,7 +1677,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1686,7 +1686,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a0d12aa3-778f-4c44-983c-c15bebae2b94
+                - e0fda03a-7523-4b1e-872f-d9d2c7ece63e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1694,8 +1694,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133718Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T144838Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1714,14 +1714,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:18 GMT
+                - Tue, 08 Sep 2026 14:48:38 GMT
             X-Amz-Id-2:
-                - txgb4c5a802f0b04a6c8bd2-006aa00f8e
+                - txg6e3058c877284836b2d4-006aa02046
             X-Amz-Request-Id:
-                - txgb4c5a802f0b04a6c8bd2-006aa00f8e
+                - txg6e3058c877284836b2d4-006aa02046
         status: 200 OK
         code: 200
-        duration: 179.778625ms
+        duration: 264.110417ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1730,7 +1730,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1739,7 +1739,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c4e57d56-0a81-4012-a623-7c476788ced2
+                - 0187260f-c418-4aaa-838d-d96d1a1e2228
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1747,8 +1747,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133718Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T144838Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1767,14 +1767,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:18 GMT
+                - Tue, 08 Sep 2026 14:48:38 GMT
             X-Amz-Id-2:
-                - txg5911dc0ed3da42d7b823-006aa00f8e
+                - txge93d69b86eb644bc97c3-006aa02046
             X-Amz-Request-Id:
-                - txg5911dc0ed3da42d7b823-006aa00f8e
+                - txge93d69b86eb644bc97c3-006aa02046
         status: 200 OK
         code: 200
-        duration: 322.596875ms
+        duration: 125.180833ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1783,7 +1783,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1792,7 +1792,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 68f80bf1-6f10-4fb6-bf74-6cccd2abf649
+                - 802aeb17-d309-43ba-94fa-f56c3c31440d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1800,8 +1800,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133718Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/
+                - 20260908T144838Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -1816,16 +1816,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:18 GMT
+                - Tue, 08 Sep 2026 14:48:39 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txge9277a7b1f9a467f9c72-006aa00f8e
+                - txg39c8520ea56d4483ad70-006aa02047
             X-Amz-Request-Id:
-                - txge9277a7b1f9a467f9c72-006aa00f8e
+                - txg39c8520ea56d4483ad70-006aa02047
         status: 200 OK
         code: 200
-        duration: 106.319417ms
+        duration: 85.566667ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1834,7 +1834,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1843,7 +1843,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 60fa0dcf-185c-4643-a607-28e9b531e09d
+                - 0f9578a3-4261-4e66-bc7c-5cf9a969546e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1851,8 +1851,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133718Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T144839Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1871,14 +1871,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:18 GMT
+                - Tue, 08 Sep 2026 14:48:39 GMT
             X-Amz-Id-2:
-                - txge1408719618a4fa880a8-006aa00f8e
+                - txg29dcf6275ad445c6bff9-006aa02047
             X-Amz-Request-Id:
-                - txge1408719618a4fa880a8-006aa00f8e
+                - txg29dcf6275ad445c6bff9-006aa02047
         status: 200 OK
         code: 200
-        duration: 190.389583ms
+        duration: 293.571958ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1887,7 +1887,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1896,7 +1896,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d8a7833d-b88b-4a2c-9047-723bfd678e38
+                - 7c736554-0242-46e3-8f8e-739e7460e404
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1904,8 +1904,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133719Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T144839Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1924,14 +1924,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:19 GMT
+                - Tue, 08 Sep 2026 14:48:39 GMT
             X-Amz-Id-2:
-                - txg35d45c6233c14222bed3-006aa00f8f
+                - txgc1373f2231a9490dbb30-006aa02047
             X-Amz-Request-Id:
-                - txg35d45c6233c14222bed3-006aa00f8f
+                - txgc1373f2231a9490dbb30-006aa02047
         status: 200 OK
         code: 200
-        duration: 93.345708ms
+        duration: 2.073409833s
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1940,7 +1940,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1949,7 +1949,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6ed2a4da-9c17-47eb-9109-79c7c77a4fdd
+                - 6025f7bd-90e4-48ce-a449-0c5686bcfbb7
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1957,8 +1957,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133719Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T144840Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1968,21 +1968,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg9ae1414fea2245598d76-006aa00f8f</RequestId><HostId>txg9ae1414fea2245598d76-006aa00f8f</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg2d03e07cee104d0eb949-006aa02049</RequestId><HostId>txg2d03e07cee104d0eb949-006aa02049</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:19 GMT
+                - Tue, 08 Sep 2026 14:48:41 GMT
             X-Amz-Id-2:
-                - txg9ae1414fea2245598d76-006aa00f8f
+                - txg2d03e07cee104d0eb949-006aa02049
             X-Amz-Request-Id:
-                - txg9ae1414fea2245598d76-006aa00f8f
+                - txg2d03e07cee104d0eb949-006aa02049
         status: 404 Not Found
         code: 404
-        duration: 26.067667ms
+        duration: 1.258405042s
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1991,7 +1991,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2000,7 +2000,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 42b95634-6258-4b9b-ae9e-70c43f91ee97
+                - 152b07ca-f2cd-40e1-9db0-ff678a4112cc
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2008,8 +2008,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133719Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/
+                - 20260908T144841Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -2021,21 +2021,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:19 GMT
+                - Tue, 08 Sep 2026 14:48:43 GMT
             X-Amz-Id-2:
-                - txgd37836b67e684ef8bbea-006aa00f8f
+                - txg789bae66d3f04271b85f-006aa0204b
             X-Amz-Request-Id:
-                - txgd37836b67e684ef8bbea-006aa00f8f
+                - txg789bae66d3f04271b85f-006aa0204b
         status: 200 OK
         code: 200
-        duration: 90.474542ms
+        duration: 421.945333ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -2044,7 +2044,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2053,7 +2053,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 81ccca10-5c2a-4fbd-a942-0b5d16a2d68c
+                - 273b7ac1-1ac1-4883-bd45-379cecf51b4f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2061,8 +2061,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133719Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T144843Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2072,21 +2072,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgc3bdcffd91974a36b08b-006aa00f8f</RequestId><HostId>txgc3bdcffd91974a36b08b-006aa00f8f</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgda289b440b0746569cc1-006aa0204b</RequestId><HostId>txgda289b440b0746569cc1-006aa0204b</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:19 GMT
+                - Tue, 08 Sep 2026 14:48:43 GMT
             X-Amz-Id-2:
-                - txgc3bdcffd91974a36b08b-006aa00f8f
+                - txgda289b440b0746569cc1-006aa0204b
             X-Amz-Request-Id:
-                - txgc3bdcffd91974a36b08b-006aa00f8f
+                - txgda289b440b0746569cc1-006aa0204b
         status: 404 Not Found
         code: 404
-        duration: 91.935209ms
+        duration: 1.138129667s
     - id: 40
       request:
         proto: HTTP/1.1
@@ -2095,7 +2095,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2104,7 +2104,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - fdc18b1d-b07e-408a-9bac-9e66be732df5
+                - 99f70a8d-f04e-46d1-95b6-8e529872794b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2112,8 +2112,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133719Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T144843Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2123,21 +2123,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txga92410989f834798a34d-006aa00f8f</RequestId><HostId>txga92410989f834798a34d-006aa00f8f</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg5174a3fcbd23475f96da-006aa0204c</RequestId><HostId>txg5174a3fcbd23475f96da-006aa0204c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:19 GMT
+                - Tue, 08 Sep 2026 14:48:44 GMT
             X-Amz-Id-2:
-                - txga92410989f834798a34d-006aa00f8f
+                - txg5174a3fcbd23475f96da-006aa0204c
             X-Amz-Request-Id:
-                - txga92410989f834798a34d-006aa00f8f
+                - txg5174a3fcbd23475f96da-006aa0204c
         status: 404 Not Found
         code: 404
-        duration: 93.539875ms
+        duration: 517.828041ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2146,7 +2146,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2155,7 +2155,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 2a0dd427-b9fc-48bc-8388-d8bcc0c8119b
+                - 1d7dc96c-9322-45bb-aa81-e28b843b2c53
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2163,8 +2163,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133719Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T144844Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2183,14 +2183,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:19 GMT
+                - Tue, 08 Sep 2026 14:48:45 GMT
             X-Amz-Id-2:
-                - txg60c08668e7d345d8a983-006aa00f8f
+                - txgfee855d2f7234793b09a-006aa0204d
             X-Amz-Request-Id:
-                - txg60c08668e7d345d8a983-006aa00f8f
+                - txgfee855d2f7234793b09a-006aa0204d
         status: 200 OK
         code: 200
-        duration: 104.030666ms
+        duration: 3.294629083s
     - id: 42
       request:
         proto: HTTP/1.1
@@ -2199,7 +2199,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2208,7 +2208,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 8b2502a6-5803-4c6d-9e82-05fbf50fc73a
+                - 2d2a1097-7ac9-4428-ac2a-2f305e4daded
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2216,8 +2216,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133719Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T144846Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2236,14 +2236,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:19 GMT
+                - Tue, 08 Sep 2026 14:48:48 GMT
             X-Amz-Id-2:
-                - txg86ab79a1c0ee4b43a85b-006aa00f8f
+                - txga90de5596d5347bcafd4-006aa02050
             X-Amz-Request-Id:
-                - txg86ab79a1c0ee4b43a85b-006aa00f8f
+                - txga90de5596d5347bcafd4-006aa02050
         status: 200 OK
         code: 200
-        duration: 205.015542ms
+        duration: 657.877667ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -2252,7 +2252,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2261,7 +2261,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3bf02d37-2de2-48de-9311-0737e377bac7
+                - e7e38e27-d181-4266-8ecf-180753cbd359
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2269,8 +2269,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133720Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T144849Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2289,14 +2289,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:20 GMT
+                - Tue, 08 Sep 2026 14:48:49 GMT
             X-Amz-Id-2:
-                - txg29fdf679deb0423daf0e-006aa00f90
+                - txg6f5ee57f05c640049dc9-006aa02051
             X-Amz-Request-Id:
-                - txg29fdf679deb0423daf0e-006aa00f90
+                - txg6f5ee57f05c640049dc9-006aa02051
         status: 200 OK
         code: 200
-        duration: 140.370584ms
+        duration: 901.299791ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -2305,7 +2305,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2314,7 +2314,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - de24fd1c-2ea1-400a-a70b-0bd2fbf1f939
+                - a7d5bf97-758a-4c92-8814-0c154030858b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2322,8 +2322,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133720Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T144849Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2333,21 +2333,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg47faf48d7329462e9972-006aa00f90</RequestId><HostId>txg47faf48d7329462e9972-006aa00f90</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg6dc43cc7b371418fba25-006aa02052</RequestId><HostId>txg6dc43cc7b371418fba25-006aa02052</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:20 GMT
+                - Tue, 08 Sep 2026 14:48:50 GMT
             X-Amz-Id-2:
-                - txg47faf48d7329462e9972-006aa00f90
+                - txg6dc43cc7b371418fba25-006aa02052
             X-Amz-Request-Id:
-                - txg47faf48d7329462e9972-006aa00f90
+                - txg6dc43cc7b371418fba25-006aa02052
         status: 404 Not Found
         code: 404
-        duration: 24.348667ms
+        duration: 1.019419791s
     - id: 45
       request:
         proto: HTTP/1.1
@@ -2356,7 +2356,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2365,7 +2365,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ee19b2fd-5599-4b0b-89d9-0b614c960011
+                - cdc68c55-0593-4754-8adf-0a769ee7f72e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2373,8 +2373,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133720Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/
+                - 20260908T144850Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -2386,21 +2386,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:20 GMT
+                - Tue, 08 Sep 2026 14:48:51 GMT
             X-Amz-Id-2:
-                - txg16c36952c9c0468f9cbd-006aa00f90
+                - txg4a74c15e1f354ceeae61-006aa02053
             X-Amz-Request-Id:
-                - txg16c36952c9c0468f9cbd-006aa00f90
+                - txg4a74c15e1f354ceeae61-006aa02053
         status: 200 OK
         code: 200
-        duration: 92.80325ms
+        duration: 509.507167ms
     - id: 46
       request:
         proto: HTTP/1.1
@@ -2409,7 +2409,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2418,7 +2418,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e896d5ef-9713-4b01-936b-f5756f2e4512
+                - 47c6e1ba-71ff-4d7b-ae32-078c33fb9b84
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2426,8 +2426,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133720Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T144851Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2437,21 +2437,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg9183c70ea2c84daea85c-006aa00f90</RequestId><HostId>txg9183c70ea2c84daea85c-006aa00f90</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg803f2ebb72d84b9a98e8-006aa02053</RequestId><HostId>txg803f2ebb72d84b9a98e8-006aa02053</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:20 GMT
+                - Tue, 08 Sep 2026 14:48:51 GMT
             X-Amz-Id-2:
-                - txg9183c70ea2c84daea85c-006aa00f90
+                - txg803f2ebb72d84b9a98e8-006aa02053
             X-Amz-Request-Id:
-                - txg9183c70ea2c84daea85c-006aa00f90
+                - txg803f2ebb72d84b9a98e8-006aa02053
         status: 404 Not Found
         code: 404
-        duration: 21.581959ms
+        duration: 599.53825ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -2460,7 +2460,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2469,7 +2469,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - eaa45c27-fb18-47e1-9966-182463a961b5
+                - d58ad2f1-c3ab-497c-bd19-8f1a8783d1cb
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2477,8 +2477,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133720Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T144851Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2488,21 +2488,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgd9fc00589c3e49eabec2-006aa00f90</RequestId><HostId>txgd9fc00589c3e49eabec2-006aa00f90</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgfebb23a4333541e3aa25-006aa02054</RequestId><HostId>txgfebb23a4333541e3aa25-006aa02054</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:20 GMT
+                - Tue, 08 Sep 2026 14:48:52 GMT
             X-Amz-Id-2:
-                - txgd9fc00589c3e49eabec2-006aa00f90
+                - txgfebb23a4333541e3aa25-006aa02054
             X-Amz-Request-Id:
-                - txgd9fc00589c3e49eabec2-006aa00f90
+                - txgfebb23a4333541e3aa25-006aa02054
         status: 404 Not Found
         code: 404
-        duration: 58.066584ms
+        duration: 431.340834ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -2511,7 +2511,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2520,7 +2520,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5cc9ae91-4f36-417f-9196-6f3c4faf5f9b
+                - afdfed12-a7bb-4894-8bab-918c2026bc03
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2528,8 +2528,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133720Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T144852Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2548,14 +2548,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:20 GMT
+                - Tue, 08 Sep 2026 14:48:52 GMT
             X-Amz-Id-2:
-                - txg460919d7ef4a4e1d9e84-006aa00f90
+                - txgbc44aafe2a8f4e748a05-006aa02054
             X-Amz-Request-Id:
-                - txg460919d7ef4a4e1d9e84-006aa00f90
+                - txgbc44aafe2a8f4e748a05-006aa02054
         status: 200 OK
         code: 200
-        duration: 21.335958ms
+        duration: 207.031875ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -2564,7 +2564,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2573,7 +2573,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - bdec7b49-1d34-4b98-bed9-19a709eb132f
+                - 26b5ff2e-f92c-4ec5-8526-c7091366d5a0
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2581,8 +2581,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133720Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T144852Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2601,14 +2601,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:20 GMT
+                - Tue, 08 Sep 2026 14:48:52 GMT
             X-Amz-Id-2:
-                - txg26e9f8e71dfd433f9f7f-006aa00f90
+                - txg4063b428073a47059fcf-006aa02054
             X-Amz-Request-Id:
-                - txg26e9f8e71dfd433f9f7f-006aa00f90
+                - txg4063b428073a47059fcf-006aa02054
         status: 200 OK
         code: 200
-        duration: 90.269ms
+        duration: 2.642149625s
     - id: 50
       request:
         proto: HTTP/1.1
@@ -2617,16 +2617,16 @@ interactions:
         content_length: 1132
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
-        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></LifecycleConfiguration>
+        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></LifecycleConfiguration>
         form: {}
         headers:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - cedffbe7-55c7-4cb5-8d10-0b4633dd5a33
+                - fd3867ba-779d-48d9-8489-352e1db07b51
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -2634,12 +2634,12 @@ interactions:
             User-Agent:
                 - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,Z,e
             X-Amz-Checksum-Crc32:
-                - Zsh9Ug==
+                - evq8rg==
             X-Amz-Content-Sha256:
-                - 5f9243f4f931bea9c2119f4e79c617a5c5220b643a54f2c4e442edaf30ca867a
+                - 902f25c8abe3b6d458899c1f9aef3919d185ece32edd99225c5045962328b4c7
             X-Amz-Date:
-                - 20260908T133720Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T144855Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -2654,14 +2654,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 08 Sep 2026 13:37:20 GMT
+                - Tue, 08 Sep 2026 14:48:55 GMT
             X-Amz-Id-2:
-                - txg7075495f4ef147749613-006aa00f90
+                - txg5a9774ee430e4a02b55a-006aa02057
             X-Amz-Request-Id:
-                - txg7075495f4ef147749613-006aa00f90
+                - txg5a9774ee430e4a02b55a-006aa02057
         status: 200 OK
         code: 200
-        duration: 144.447ms
+        duration: 2.66013s
     - id: 51
       request:
         proto: HTTP/1.1
@@ -2670,7 +2670,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2679,7 +2679,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e1e5ef64-c9eb-4d76-873d-f2ee3fa8cd1a
+                - 6b62cae1-860b-45a6-9479-3ecee473bb82
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2687,8 +2687,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133720Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T144858Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2707,14 +2707,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:20 GMT
+                - Tue, 08 Sep 2026 14:48:58 GMT
             X-Amz-Id-2:
-                - txgb85307bd1a0b4217a6d8-006aa00f90
+                - txg2779cbc31cdf43458c07-006aa0205a
             X-Amz-Request-Id:
-                - txgb85307bd1a0b4217a6d8-006aa00f90
+                - txg2779cbc31cdf43458c07-006aa0205a
         status: 200 OK
         code: 200
-        duration: 136.619292ms
+        duration: 204.743416ms
     - id: 52
       request:
         proto: HTTP/1.1
@@ -2723,7 +2723,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2732,7 +2732,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9daa5437-fb2f-4501-819a-26a0a614fd0b
+                - 77291d1c-d754-4eb6-8219-69711faa6d9d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2740,8 +2740,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133720Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T144858Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2751,21 +2751,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgca6eb843bae84f618e3d-006aa00f91</RequestId><HostId>txgca6eb843bae84f618e3d-006aa00f91</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg4fb0f197942c4bccb9e5-006aa0205a</RequestId><HostId>txg4fb0f197942c4bccb9e5-006aa0205a</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:21 GMT
+                - Tue, 08 Sep 2026 14:48:58 GMT
             X-Amz-Id-2:
-                - txgca6eb843bae84f618e3d-006aa00f91
+                - txg4fb0f197942c4bccb9e5-006aa0205a
             X-Amz-Request-Id:
-                - txgca6eb843bae84f618e3d-006aa00f91
+                - txg4fb0f197942c4bccb9e5-006aa0205a
         status: 404 Not Found
         code: 404
-        duration: 92.520167ms
+        duration: 217.249709ms
     - id: 53
       request:
         proto: HTTP/1.1
@@ -2774,7 +2774,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2783,7 +2783,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - bb3e4e5b-ab03-42f4-a46e-5a7d73977635
+                - 89724514-ff46-46c5-b265-e1ba97c42d2d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2791,8 +2791,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133721Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/
+                - 20260908T144858Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -2804,21 +2804,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:21 GMT
+                - Tue, 08 Sep 2026 14:48:58 GMT
             X-Amz-Id-2:
-                - txg512036d4b42c4962a652-006aa00f91
+                - txg469f62f2e72148ecb5d8-006aa0205a
             X-Amz-Request-Id:
-                - txg512036d4b42c4962a652-006aa00f91
+                - txg469f62f2e72148ecb5d8-006aa0205a
         status: 200 OK
         code: 200
-        duration: 92.6075ms
+        duration: 304.336083ms
     - id: 54
       request:
         proto: HTTP/1.1
@@ -2827,7 +2827,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2836,7 +2836,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5a718076-8f9f-47de-93e4-81797c450dbe
+                - c278c2ec-3156-4bcb-b521-83927714dbf1
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2844,8 +2844,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133721Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T144858Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2855,21 +2855,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg3a2ed2e9151a4114a5f9-006aa00f91</RequestId><HostId>txg3a2ed2e9151a4114a5f9-006aa00f91</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg3586262db3934e25bd7d-006aa0205b</RequestId><HostId>txg3586262db3934e25bd7d-006aa0205b</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:21 GMT
+                - Tue, 08 Sep 2026 14:48:59 GMT
             X-Amz-Id-2:
-                - txg3a2ed2e9151a4114a5f9-006aa00f91
+                - txg3586262db3934e25bd7d-006aa0205b
             X-Amz-Request-Id:
-                - txg3a2ed2e9151a4114a5f9-006aa00f91
+                - txg3586262db3934e25bd7d-006aa0205b
         status: 404 Not Found
         code: 404
-        duration: 89.927375ms
+        duration: 205.999958ms
     - id: 55
       request:
         proto: HTTP/1.1
@@ -2878,7 +2878,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2887,7 +2887,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7427f4ed-8c71-4736-9c10-05e4f99be6b7
+                - cf0bbcca-7675-4ddf-b3c2-459eeeff3005
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2895,8 +2895,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133721Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T144859Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2906,21 +2906,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg03998f4f54fa4cacbbeb-006aa00f91</RequestId><HostId>txg03998f4f54fa4cacbbeb-006aa00f91</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg04fda752b5b7498fb617-006aa0205b</RequestId><HostId>txg04fda752b5b7498fb617-006aa0205b</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:21 GMT
+                - Tue, 08 Sep 2026 14:48:59 GMT
             X-Amz-Id-2:
-                - txg03998f4f54fa4cacbbeb-006aa00f91
+                - txg04fda752b5b7498fb617-006aa0205b
             X-Amz-Request-Id:
-                - txg03998f4f54fa4cacbbeb-006aa00f91
+                - txg04fda752b5b7498fb617-006aa0205b
         status: 404 Not Found
         code: 404
-        duration: 99.486667ms
+        duration: 281.463875ms
     - id: 56
       request:
         proto: HTTP/1.1
@@ -2929,7 +2929,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2938,7 +2938,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b2068bad-e624-41b7-9ccc-b0a4255a99be
+                - 57c9f4e8-e68e-4510-8da7-d471a82d49b2
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2946,8 +2946,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133721Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T144859Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2966,14 +2966,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:21 GMT
+                - Tue, 08 Sep 2026 14:48:59 GMT
             X-Amz-Id-2:
-                - txg5cce0179684d402b9b82-006aa00f91
+                - txg8f588ac4dca24b5fa13a-006aa0205b
             X-Amz-Request-Id:
-                - txg5cce0179684d402b9b82-006aa00f91
+                - txg8f588ac4dca24b5fa13a-006aa0205b
         status: 200 OK
         code: 200
-        duration: 20.3645ms
+        duration: 126.02875ms
     - id: 57
       request:
         proto: HTTP/1.1
@@ -2982,7 +2982,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2991,7 +2991,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a3e0524d-1701-4e35-9056-833aca4d9e40
+                - 921101ea-5ee2-4686-999d-6997f25dd86e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2999,8 +2999,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133721Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T144859Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3012,21 +3012,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
                 - "1105"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:21 GMT
+                - Tue, 08 Sep 2026 14:48:59 GMT
             X-Amz-Id-2:
-                - txg96db46e4c29f4de0800c-006aa00f91
+                - txg6e83225b9ee649e88849-006aa0205b
             X-Amz-Request-Id:
-                - txg96db46e4c29f4de0800c-006aa00f91
+                - txg6e83225b9ee649e88849-006aa0205b
         status: 200 OK
         code: 200
-        duration: 75.463ms
+        duration: 196.054583ms
     - id: 58
       request:
         proto: HTTP/1.1
@@ -3035,7 +3035,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3044,7 +3044,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c517402c-a1d1-413e-80e9-b24478ea3f35
+                - d6ba033f-a2b0-466b-96fa-83c58c1c4dae
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3052,8 +3052,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133721Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/
+                - 20260908T144900Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -3068,16 +3068,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:21 GMT
+                - Tue, 08 Sep 2026 14:49:00 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txg7e0269353a7244169d20-006aa00f91
+                - txgb4dfedfd4b8842ba89fc-006aa0205c
             X-Amz-Request-Id:
-                - txg7e0269353a7244169d20-006aa00f91
+                - txgb4dfedfd4b8842ba89fc-006aa0205c
         status: 200 OK
         code: 200
-        duration: 24.686167ms
+        duration: 181.832542ms
     - id: 59
       request:
         proto: HTTP/1.1
@@ -3086,7 +3086,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3095,7 +3095,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 41c00c2a-2900-461c-a90d-224bef66b032
+                - 7cd56052-f86d-48de-be02-abe2217cdfad
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3103,8 +3103,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133721Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T144900Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3116,21 +3116,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
                 - "1105"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:21 GMT
+                - Tue, 08 Sep 2026 14:49:00 GMT
             X-Amz-Id-2:
-                - txgadc0f47cd2054d1496e1-006aa00f91
+                - txg435659cd02e44bd19a22-006aa0205c
             X-Amz-Request-Id:
-                - txgadc0f47cd2054d1496e1-006aa00f91
+                - txg435659cd02e44bd19a22-006aa0205c
         status: 200 OK
         code: 200
-        duration: 99.741125ms
+        duration: 303.885958ms
     - id: 60
       request:
         proto: HTTP/1.1
@@ -3139,7 +3139,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3148,7 +3148,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 53ab7584-376c-429e-889b-3f94aa2212b1
+                - 37e05a58-ad9e-413d-9b3f-0c06c8a05246
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3156,8 +3156,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133721Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T144900Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3176,14 +3176,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:22 GMT
+                - Tue, 08 Sep 2026 14:49:00 GMT
             X-Amz-Id-2:
-                - txg142d310e7f4840eb884a-006aa00f92
+                - txgbf3030fac4894e7ba223-006aa0205c
             X-Amz-Request-Id:
-                - txg142d310e7f4840eb884a-006aa00f92
+                - txgbf3030fac4894e7ba223-006aa0205c
         status: 200 OK
         code: 200
-        duration: 30.643625ms
+        duration: 313.890625ms
     - id: 61
       request:
         proto: HTTP/1.1
@@ -3192,7 +3192,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3201,16 +3201,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 2392a705-6035-41c8-a196-23cb7931ab87
+                - d108ed8e-0345-459e-8849-72d63cb53d0d
             Amz-Sdk-Request:
-                - attempt=1; max=3; ttl=20260908T154721Z
+                - attempt=1; max=3
             User-Agent:
                 - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133722Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T144900Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3220,21 +3220,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg909b7e01d5f04adaad9d-006aa00f92</RequestId><HostId>txg909b7e01d5f04adaad9d-006aa00f92</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg77d012f934f54a78bc3f-006aa0205d</RequestId><HostId>txg77d012f934f54a78bc3f-006aa0205d</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:22 GMT
+                - Tue, 08 Sep 2026 14:49:01 GMT
             X-Amz-Id-2:
-                - txg909b7e01d5f04adaad9d-006aa00f92
+                - txg77d012f934f54a78bc3f-006aa0205d
             X-Amz-Request-Id:
-                - txg909b7e01d5f04adaad9d-006aa00f92
+                - txg77d012f934f54a78bc3f-006aa0205d
         status: 404 Not Found
         code: 404
-        duration: 162.242125ms
+        duration: 99.270167ms
     - id: 62
       request:
         proto: HTTP/1.1
@@ -3243,7 +3243,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3252,7 +3252,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c2aea7f8-9596-4dbc-a55d-f69f8360d846
+                - 7cb26d31-8b5e-44c7-9c57-194cf9de4d9c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3260,8 +3260,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133722Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/
+                - 20260908T144901Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -3273,21 +3273,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:22 GMT
+                - Tue, 08 Sep 2026 14:49:01 GMT
             X-Amz-Id-2:
-                - txga2798a353e2a40349b3f-006aa00f92
+                - txg831ef7c5babd47039373-006aa0205d
             X-Amz-Request-Id:
-                - txga2798a353e2a40349b3f-006aa00f92
+                - txg831ef7c5babd47039373-006aa0205d
         status: 200 OK
         code: 200
-        duration: 307.907125ms
+        duration: 302.016833ms
     - id: 63
       request:
         proto: HTTP/1.1
@@ -3296,7 +3296,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3305,7 +3305,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5639df73-0470-434d-a38e-9b3c7a6e48a4
+                - 40771aab-11d3-4ac8-8051-004549756a58
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3313,8 +3313,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133722Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T144901Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3324,21 +3324,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg55fe6dd866c14ea480e1-006aa00f92</RequestId><HostId>txg55fe6dd866c14ea480e1-006aa00f92</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg1d951cbc16f44f9b9343-006aa0205d</RequestId><HostId>txg1d951cbc16f44f9b9343-006aa0205d</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:22 GMT
+                - Tue, 08 Sep 2026 14:49:01 GMT
             X-Amz-Id-2:
-                - txg55fe6dd866c14ea480e1-006aa00f92
+                - txg1d951cbc16f44f9b9343-006aa0205d
             X-Amz-Request-Id:
-                - txg55fe6dd866c14ea480e1-006aa00f92
+                - txg1d951cbc16f44f9b9343-006aa0205d
         status: 404 Not Found
         code: 404
-        duration: 22.374958ms
+        duration: 200.877959ms
     - id: 64
       request:
         proto: HTTP/1.1
@@ -3347,7 +3347,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3356,7 +3356,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9be25433-c765-4a9e-93ab-c5195d303cca
+                - 750b946c-46d0-4b88-9a73-f2e310b279a3
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3364,8 +3364,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133722Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T144901Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3375,21 +3375,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg75df0de8bef7430fbabf-006aa00f92</RequestId><HostId>txg75df0de8bef7430fbabf-006aa00f92</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg42c59bb4bc7f4836b87b-006aa0205d</RequestId><HostId>txg42c59bb4bc7f4836b87b-006aa0205d</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:22 GMT
+                - Tue, 08 Sep 2026 14:49:01 GMT
             X-Amz-Id-2:
-                - txg75df0de8bef7430fbabf-006aa00f92
+                - txg42c59bb4bc7f4836b87b-006aa0205d
             X-Amz-Request-Id:
-                - txg75df0de8bef7430fbabf-006aa00f92
+                - txg42c59bb4bc7f4836b87b-006aa0205d
         status: 404 Not Found
         code: 404
-        duration: 92.178625ms
+        duration: 212.479875ms
     - id: 65
       request:
         proto: HTTP/1.1
@@ -3398,7 +3398,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3407,7 +3407,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 14bc1a3b-ddec-4768-a954-7b39fe7b4bf5
+                - 02f63b1b-e8b6-495d-ab9a-4916c79e1a2c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3415,8 +3415,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133722Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T144901Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3435,14 +3435,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:22 GMT
+                - Tue, 08 Sep 2026 14:49:02 GMT
             X-Amz-Id-2:
-                - txg968e482d700f4b21a6a4-006aa00f92
+                - txg54b108fc95be4380885a-006aa0205e
             X-Amz-Request-Id:
-                - txg968e482d700f4b21a6a4-006aa00f92
+                - txg54b108fc95be4380885a-006aa0205e
         status: 200 OK
         code: 200
-        duration: 97.305541ms
+        duration: 206.602458ms
     - id: 66
       request:
         proto: HTTP/1.1
@@ -3451,7 +3451,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3460,7 +3460,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b3ad1705-9aac-4951-87d2-1b895f021be7
+                - 7a2b6d68-0417-4e1d-862d-c3c4cdf480e7
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3468,8 +3468,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133722Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T144902Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3481,21 +3481,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
                 - "1105"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:22 GMT
+                - Tue, 08 Sep 2026 14:49:02 GMT
             X-Amz-Id-2:
-                - txg8a471ca39895443dae00-006aa00f92
+                - txg562dcfe4e412431d89e8-006aa0205e
             X-Amz-Request-Id:
-                - txg8a471ca39895443dae00-006aa00f92
+                - txg562dcfe4e412431d89e8-006aa0205e
         status: 200 OK
         code: 200
-        duration: 95.012208ms
+        duration: 100.578791ms
     - id: 67
       request:
         proto: HTTP/1.1
@@ -3504,7 +3504,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3513,7 +3513,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b1bab7d1-8370-4b40-bf56-52f0bac07532
+                - f0cc6189-3c40-4c80-beec-d8bb4116ca93
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3521,8 +3521,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133722Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T144902Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3541,14 +3541,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:22 GMT
+                - Tue, 08 Sep 2026 14:49:02 GMT
             X-Amz-Id-2:
-                - txgbe9a3f318f86424c8d92-006aa00f92
+                - txgc539b89b644c4da886b6-006aa0205e
             X-Amz-Request-Id:
-                - txgbe9a3f318f86424c8d92-006aa00f92
+                - txgc539b89b644c4da886b6-006aa0205e
         status: 200 OK
         code: 200
-        duration: 129.969167ms
+        duration: 305.669708ms
     - id: 68
       request:
         proto: HTTP/1.1
@@ -3557,7 +3557,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3566,7 +3566,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - af3d6aaa-2960-469f-8958-5269aebbdeab
+                - 61e81b26-004e-4977-b3f8-2e2f0be771b7
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3574,8 +3574,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133722Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T144902Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3585,21 +3585,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg9235a186dc6d41ebb098-006aa00f93</RequestId><HostId>txg9235a186dc6d41ebb098-006aa00f93</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgd997a3f438ff40a68f4d-006aa0205e</RequestId><HostId>txgd997a3f438ff40a68f4d-006aa0205e</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:23 GMT
+                - Tue, 08 Sep 2026 14:49:02 GMT
             X-Amz-Id-2:
-                - txg9235a186dc6d41ebb098-006aa00f93
+                - txgd997a3f438ff40a68f4d-006aa0205e
             X-Amz-Request-Id:
-                - txg9235a186dc6d41ebb098-006aa00f93
+                - txgd997a3f438ff40a68f4d-006aa0205e
         status: 404 Not Found
         code: 404
-        duration: 23.047833ms
+        duration: 371.123625ms
     - id: 69
       request:
         proto: HTTP/1.1
@@ -3608,7 +3608,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3617,7 +3617,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b6e2bbfe-74f8-4ac3-8657-43ab343f0c2e
+                - 11a50085-5b78-454b-9cf8-da7526ec2b6c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3625,8 +3625,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133723Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/
+                - 20260908T144902Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -3638,21 +3638,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:23 GMT
+                - Tue, 08 Sep 2026 14:49:03 GMT
             X-Amz-Id-2:
-                - txg814820601ae44315b8de-006aa00f93
+                - txgb1d14f5a5fbf41119b14-006aa0205f
             X-Amz-Request-Id:
-                - txg814820601ae44315b8de-006aa00f93
+                - txgb1d14f5a5fbf41119b14-006aa0205f
         status: 200 OK
         code: 200
-        duration: 299.353667ms
+        duration: 200.323166ms
     - id: 70
       request:
         proto: HTTP/1.1
@@ -3661,7 +3661,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3670,7 +3670,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f068fc8a-a26f-4942-a574-1afe1792cba0
+                - 161375d3-f751-46ed-8671-77aaa013c06c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3678,8 +3678,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133723Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T144903Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3689,21 +3689,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgacc66817bbd64064b0bf-006aa00f93</RequestId><HostId>txgacc66817bbd64064b0bf-006aa00f93</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg48b91857029d4de29094-006aa0205f</RequestId><HostId>txg48b91857029d4de29094-006aa0205f</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:23 GMT
+                - Tue, 08 Sep 2026 14:49:03 GMT
             X-Amz-Id-2:
-                - txgacc66817bbd64064b0bf-006aa00f93
+                - txg48b91857029d4de29094-006aa0205f
             X-Amz-Request-Id:
-                - txgacc66817bbd64064b0bf-006aa00f93
+                - txg48b91857029d4de29094-006aa0205f
         status: 404 Not Found
         code: 404
-        duration: 21.909ms
+        duration: 311.9215ms
     - id: 71
       request:
         proto: HTTP/1.1
@@ -3712,7 +3712,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3721,7 +3721,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ebd5b441-3d1f-467a-aca7-b69d80eb16bc
+                - d6ecafcc-7395-4bd3-a285-1730a2015e0d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3729,8 +3729,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133723Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T144903Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3740,21 +3740,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgfc637a4655724d8c9ba7-006aa00f93</RequestId><HostId>txgfc637a4655724d8c9ba7-006aa00f93</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgf6c97835b2d847968dbc-006aa0205f</RequestId><HostId>txgf6c97835b2d847968dbc-006aa0205f</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:23 GMT
+                - Tue, 08 Sep 2026 14:49:03 GMT
             X-Amz-Id-2:
-                - txgfc637a4655724d8c9ba7-006aa00f93
+                - txgf6c97835b2d847968dbc-006aa0205f
             X-Amz-Request-Id:
-                - txgfc637a4655724d8c9ba7-006aa00f93
+                - txgf6c97835b2d847968dbc-006aa0205f
         status: 404 Not Found
         code: 404
-        duration: 46.69825ms
+        duration: 320.091625ms
     - id: 72
       request:
         proto: HTTP/1.1
@@ -3763,7 +3763,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3772,7 +3772,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 09dab68d-7856-43be-ab89-75fedf811c73
+                - 755a6302-f270-48ea-b5fe-adab0198a00b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3780,8 +3780,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133723Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T144903Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3800,14 +3800,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:23 GMT
+                - Tue, 08 Sep 2026 14:49:04 GMT
             X-Amz-Id-2:
-                - txga0fbf31f3fa54832bf49-006aa00f93
+                - txg41d260bccd8248a29dd8-006aa02060
             X-Amz-Request-Id:
-                - txga0fbf31f3fa54832bf49-006aa00f93
+                - txg41d260bccd8248a29dd8-006aa02060
         status: 200 OK
         code: 200
-        duration: 138.631875ms
+        duration: 305.233125ms
     - id: 73
       request:
         proto: HTTP/1.1
@@ -3816,7 +3816,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3825,7 +3825,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6724c247-1fe4-483d-bae1-85a20bf24344
+                - 7407c769-e089-48cd-a0d5-4de3b37f540a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3833,8 +3833,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133723Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T144904Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3846,21 +3846,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
                 - "1105"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:23 GMT
+                - Tue, 08 Sep 2026 14:49:04 GMT
             X-Amz-Id-2:
-                - txg0ab0a94117cc45de90ec-006aa00f93
+                - txg18e0ed82cb864e82b831-006aa02060
             X-Amz-Request-Id:
-                - txg0ab0a94117cc45de90ec-006aa00f93
+                - txg18e0ed82cb864e82b831-006aa02060
         status: 200 OK
         code: 200
-        duration: 86.92025ms
+        duration: 183.07175ms
     - id: 74
       request:
         proto: HTTP/1.1
@@ -3869,7 +3869,7 @@ interactions:
         content_length: 296
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
@@ -3878,7 +3878,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d79debe7-a8a7-4743-8a31-123fd42c1b10
+                - 8d847a5a-3478-4eb0-b329-359ec31a06dd
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -3890,8 +3890,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - 7756d51b786b61edff20b7957d22346417f85f71d19eeca0d6d28d6df7b15bbc
             X-Amz-Date:
-                - 20260908T133723Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T144904Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -3906,14 +3906,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 08 Sep 2026 13:37:23 GMT
+                - Tue, 08 Sep 2026 14:49:04 GMT
             X-Amz-Id-2:
-                - txg16539269a8914edfaa23-006aa00f93
+                - txg5cdfded855914b0388c3-006aa02060
             X-Amz-Request-Id:
-                - txg16539269a8914edfaa23-006aa00f93
+                - txg5cdfded855914b0388c3-006aa02060
         status: 200 OK
         code: 200
-        duration: 333.218667ms
+        duration: 342.503792ms
     - id: 75
       request:
         proto: HTTP/1.1
@@ -3922,7 +3922,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3931,7 +3931,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f55ba422-a633-4a11-9384-f37a075c9444
+                - a235d925-6230-4773-90e7-a21fc2554023
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3939,8 +3939,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133724Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T144905Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3959,14 +3959,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:24 GMT
+                - Tue, 08 Sep 2026 14:49:05 GMT
             X-Amz-Id-2:
-                - txg1d44c83cc3c344f89af0-006aa00f94
+                - txgb87d1dbd739e441b8185-006aa02061
             X-Amz-Request-Id:
-                - txg1d44c83cc3c344f89af0-006aa00f94
+                - txgb87d1dbd739e441b8185-006aa02061
         status: 200 OK
         code: 200
-        duration: 215.892209ms
+        duration: 292.920292ms
     - id: 76
       request:
         proto: HTTP/1.1
@@ -3975,7 +3975,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3984,7 +3984,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - cdaf03b3-3bbe-4e0b-a116-317cb4d368df
+                - 6a467635-bf0c-4bd2-8d7e-0327a7d57749
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3992,8 +3992,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133724Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T144905Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4003,21 +4003,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg2fea404498164de9b8de-006aa00f94</RequestId><HostId>txg2fea404498164de9b8de-006aa00f94</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg37fa7f1e641b4d7f9095-006aa02061</RequestId><HostId>txg37fa7f1e641b4d7f9095-006aa02061</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:24 GMT
+                - Tue, 08 Sep 2026 14:49:05 GMT
             X-Amz-Id-2:
-                - txg2fea404498164de9b8de-006aa00f94
+                - txg37fa7f1e641b4d7f9095-006aa02061
             X-Amz-Request-Id:
-                - txg2fea404498164de9b8de-006aa00f94
+                - txg37fa7f1e641b4d7f9095-006aa02061
         status: 404 Not Found
         code: 404
-        duration: 105.748084ms
+        duration: 190.644791ms
     - id: 77
       request:
         proto: HTTP/1.1
@@ -4026,7 +4026,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4035,7 +4035,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e00fe846-10a8-417c-8a8c-cde6e4bc7aa6
+                - ad45c2c6-f9c6-4cde-9e6c-412dbcc24773
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4043,8 +4043,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133724Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/
+                - 20260908T144905Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -4056,21 +4056,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:24 GMT
+                - Tue, 08 Sep 2026 14:49:05 GMT
             X-Amz-Id-2:
-                - txgea4bf3cbb5d14917bf44-006aa00f94
+                - txg8f9c07ad687b4335949c-006aa02061
             X-Amz-Request-Id:
-                - txgea4bf3cbb5d14917bf44-006aa00f94
+                - txg8f9c07ad687b4335949c-006aa02061
         status: 200 OK
         code: 200
-        duration: 28.744459ms
+        duration: 211.725ms
     - id: 78
       request:
         proto: HTTP/1.1
@@ -4079,7 +4079,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4088,7 +4088,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 752f9008-19b2-48e6-b35d-0cb8b994128d
+                - 19e3962c-9f26-4c86-970a-eb3cf92babc7
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4096,8 +4096,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133724Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T144905Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4107,21 +4107,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg6aec08799f5748628594-006aa00f94</RequestId><HostId>txg6aec08799f5748628594-006aa00f94</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgc7d48512432b4094bae3-006aa02061</RequestId><HostId>txgc7d48512432b4094bae3-006aa02061</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:24 GMT
+                - Tue, 08 Sep 2026 14:49:05 GMT
             X-Amz-Id-2:
-                - txg6aec08799f5748628594-006aa00f94
+                - txgc7d48512432b4094bae3-006aa02061
             X-Amz-Request-Id:
-                - txg6aec08799f5748628594-006aa00f94
+                - txgc7d48512432b4094bae3-006aa02061
         status: 404 Not Found
         code: 404
-        duration: 108.174833ms
+        duration: 121.103541ms
     - id: 79
       request:
         proto: HTTP/1.1
@@ -4130,7 +4130,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4139,7 +4139,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 93d4183e-5793-41e2-bd7a-649ddf0a6e04
+                - 01c5e1c6-f745-462a-aac6-bf83137b40fe
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4147,8 +4147,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133724Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T144905Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4158,21 +4158,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg7d5698ce49c44e528d94-006aa00f94</RequestId><HostId>txg7d5698ce49c44e528d94-006aa00f94</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgf41543bffc904797982c-006aa02061</RequestId><HostId>txgf41543bffc904797982c-006aa02061</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:24 GMT
+                - Tue, 08 Sep 2026 14:49:05 GMT
             X-Amz-Id-2:
-                - txg7d5698ce49c44e528d94-006aa00f94
+                - txgf41543bffc904797982c-006aa02061
             X-Amz-Request-Id:
-                - txg7d5698ce49c44e528d94-006aa00f94
+                - txgf41543bffc904797982c-006aa02061
         status: 404 Not Found
         code: 404
-        duration: 267.753125ms
+        duration: 301.677875ms
     - id: 80
       request:
         proto: HTTP/1.1
@@ -4181,7 +4181,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4190,7 +4190,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e90ae00e-cda5-401c-9d75-5d6e4145cbea
+                - eac0d5a5-1ccf-4097-8ea4-1a60f02ee56f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4198,8 +4198,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133724Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T144905Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4218,14 +4218,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:24 GMT
+                - Tue, 08 Sep 2026 14:49:06 GMT
             X-Amz-Id-2:
-                - txga3aebbd604ef4b02a36e-006aa00f94
+                - txga65d6b3abffe4620aa41-006aa02062
             X-Amz-Request-Id:
-                - txga3aebbd604ef4b02a36e-006aa00f94
+                - txga65d6b3abffe4620aa41-006aa02062
         status: 200 OK
         code: 200
-        duration: 198.777166ms
+        duration: 407.053291ms
     - id: 81
       request:
         proto: HTTP/1.1
@@ -4234,7 +4234,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4243,7 +4243,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4a03e01b-ad69-474f-8379-c1d5e46da7ea
+                - 3a962f37-eafe-42df-a011-2cdc16d6e46f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4251,8 +4251,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133724Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T144906Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4271,14 +4271,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:25 GMT
+                - Tue, 08 Sep 2026 14:49:06 GMT
             X-Amz-Id-2:
-                - txgc19da5116aa84acdab02-006aa00f95
+                - txg4e1dd4e1e52b423eb06c-006aa02062
             X-Amz-Request-Id:
-                - txgc19da5116aa84acdab02-006aa00f95
+                - txg4e1dd4e1e52b423eb06c-006aa02062
         status: 200 OK
         code: 200
-        duration: 21.749792ms
+        duration: 199.786583ms
     - id: 82
       request:
         proto: HTTP/1.1
@@ -4287,7 +4287,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4296,7 +4296,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 917eacc4-4127-49aa-8ec9-38178f3b70a6
+                - c8a31bb0-b832-4aff-863d-a718b5cb58fb
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4304,8 +4304,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133725Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/
+                - 20260908T144907Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -4320,16 +4320,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:25 GMT
+                - Tue, 08 Sep 2026 14:49:07 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txga5eb42e6e98448d88604-006aa00f95
+                - txg7e7dd799f82b4c118287-006aa02063
             X-Amz-Request-Id:
-                - txga5eb42e6e98448d88604-006aa00f95
+                - txg7e7dd799f82b4c118287-006aa02063
         status: 200 OK
         code: 200
-        duration: 127.748625ms
+        duration: 33.014916ms
     - id: 83
       request:
         proto: HTTP/1.1
@@ -4338,7 +4338,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4347,7 +4347,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - dfb162d8-9ccf-49e4-8ebb-80e72618012c
+                - 7f4c3948-71cc-45c5-9e65-f96bffa9a1fb
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4355,8 +4355,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133725Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T144907Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4375,14 +4375,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:25 GMT
+                - Tue, 08 Sep 2026 14:49:07 GMT
             X-Amz-Id-2:
-                - txgb6574441f6054ee4a3f9-006aa00f95
+                - txgc6667282fb1c41b793bd-006aa02063
             X-Amz-Request-Id:
-                - txgb6574441f6054ee4a3f9-006aa00f95
+                - txgc6667282fb1c41b793bd-006aa02063
         status: 200 OK
         code: 200
-        duration: 308.163875ms
+        duration: 92.782791ms
     - id: 84
       request:
         proto: HTTP/1.1
@@ -4391,7 +4391,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4400,7 +4400,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7eb80c58-7df3-4e75-a746-0869b5724b4f
+                - 7abc4aae-b251-4212-9c84-4de414844c5c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4408,8 +4408,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133725Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T144907Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4428,14 +4428,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:25 GMT
+                - Tue, 08 Sep 2026 14:49:07 GMT
             X-Amz-Id-2:
-                - txga7921fa6fc104eb09dc7-006aa00f95
+                - txge71d4b89a9404652a3a4-006aa02063
             X-Amz-Request-Id:
-                - txga7921fa6fc104eb09dc7-006aa00f95
+                - txge71d4b89a9404652a3a4-006aa02063
         status: 200 OK
         code: 200
-        duration: 270.726541ms
+        duration: 129.15375ms
     - id: 85
       request:
         proto: HTTP/1.1
@@ -4444,7 +4444,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4453,7 +4453,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 25cd31de-13dd-4fba-9ff8-6565a596c948
+                - e139d283-7063-4fa1-9bf3-784bbc879f43
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4461,8 +4461,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133725Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T144907Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4472,21 +4472,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgc5f6c74b03ab4911bcb1-006aa00f96</RequestId><HostId>txgc5f6c74b03ab4911bcb1-006aa00f96</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg9daadd2b8d66418fb246-006aa02063</RequestId><HostId>txg9daadd2b8d66418fb246-006aa02063</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:26 GMT
+                - Tue, 08 Sep 2026 14:49:07 GMT
             X-Amz-Id-2:
-                - txgc5f6c74b03ab4911bcb1-006aa00f96
+                - txg9daadd2b8d66418fb246-006aa02063
             X-Amz-Request-Id:
-                - txgc5f6c74b03ab4911bcb1-006aa00f96
+                - txg9daadd2b8d66418fb246-006aa02063
         status: 404 Not Found
         code: 404
-        duration: 98.960834ms
+        duration: 185.271542ms
     - id: 86
       request:
         proto: HTTP/1.1
@@ -4495,7 +4495,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4504,7 +4504,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f592e29f-a396-4289-9056-ecbfc5e3be83
+                - 97233846-c19b-48db-883b-976c86ecb668
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4512,8 +4512,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133726Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/
+                - 20260908T144907Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -4525,21 +4525,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:26 GMT
+                - Tue, 08 Sep 2026 14:49:07 GMT
             X-Amz-Id-2:
-                - txgddd141aabfa043528cdd-006aa00f96
+                - txg5584a28c209741668936-006aa02063
             X-Amz-Request-Id:
-                - txgddd141aabfa043528cdd-006aa00f96
+                - txg5584a28c209741668936-006aa02063
         status: 200 OK
         code: 200
-        duration: 210.199833ms
+        duration: 323.068208ms
     - id: 87
       request:
         proto: HTTP/1.1
@@ -4548,7 +4548,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4557,7 +4557,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 488e8365-ecd9-4851-9978-8d6a690c0136
+                - 3bb52edd-3c21-4b55-90c2-17aa12f8e43c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4565,8 +4565,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133726Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T144907Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4576,21 +4576,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg919a58b528364882a85e-006aa00f96</RequestId><HostId>txg919a58b528364882a85e-006aa00f96</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgbe2cd7b7b75c48228069-006aa02064</RequestId><HostId>txgbe2cd7b7b75c48228069-006aa02064</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:26 GMT
+                - Tue, 08 Sep 2026 14:49:08 GMT
             X-Amz-Id-2:
-                - txg919a58b528364882a85e-006aa00f96
+                - txgbe2cd7b7b75c48228069-006aa02064
             X-Amz-Request-Id:
-                - txg919a58b528364882a85e-006aa00f96
+                - txgbe2cd7b7b75c48228069-006aa02064
         status: 404 Not Found
         code: 404
-        duration: 26.50775ms
+        duration: 101.211709ms
     - id: 88
       request:
         proto: HTTP/1.1
@@ -4599,7 +4599,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4608,7 +4608,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c0500857-517f-4521-8aec-08b4d733faad
+                - 4bb40c98-2f04-47ee-bfc0-3edb35a750ca
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4616,8 +4616,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133726Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T144908Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4627,21 +4627,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg9aeaa306b4114a4b8554-006aa00f96</RequestId><HostId>txg9aeaa306b4114a4b8554-006aa00f96</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgeabc094ff6da442da4b7-006aa02064</RequestId><HostId>txgeabc094ff6da442da4b7-006aa02064</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:26 GMT
+                - Tue, 08 Sep 2026 14:49:08 GMT
             X-Amz-Id-2:
-                - txg9aeaa306b4114a4b8554-006aa00f96
+                - txgeabc094ff6da442da4b7-006aa02064
             X-Amz-Request-Id:
-                - txg9aeaa306b4114a4b8554-006aa00f96
+                - txgeabc094ff6da442da4b7-006aa02064
         status: 404 Not Found
         code: 404
-        duration: 65.192542ms
+        duration: 104.460208ms
     - id: 89
       request:
         proto: HTTP/1.1
@@ -4650,7 +4650,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4659,7 +4659,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - db5e1943-ed77-44ef-a76d-ab0f305559c0
+                - 0777d430-40f8-4f98-8288-55ba9bcb9e2b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4667,8 +4667,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133726Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T144908Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4687,14 +4687,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:26 GMT
+                - Tue, 08 Sep 2026 14:49:08 GMT
             X-Amz-Id-2:
-                - txge0d6a58f792842cea9df-006aa00f96
+                - txg6f7db2e2a1f944e59b51-006aa02064
             X-Amz-Request-Id:
-                - txge0d6a58f792842cea9df-006aa00f96
+                - txg6f7db2e2a1f944e59b51-006aa02064
         status: 200 OK
         code: 200
-        duration: 95.940375ms
+        duration: 301.531542ms
     - id: 90
       request:
         proto: HTTP/1.1
@@ -4703,7 +4703,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4712,7 +4712,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - dafb5a63-47b1-46de-8073-c0773a2d3fcf
+                - 91ebae49-9530-40a9-9e36-f70310cf0abb
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4720,8 +4720,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133726Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T144908Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4740,14 +4740,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:26 GMT
+                - Tue, 08 Sep 2026 14:49:08 GMT
             X-Amz-Id-2:
-                - txg96161ab4a44348dabc9b-006aa00f96
+                - txg6ac4a65123344c008dc0-006aa02064
             X-Amz-Request-Id:
-                - txg96161ab4a44348dabc9b-006aa00f96
+                - txg6ac4a65123344c008dc0-006aa02064
         status: 200 OK
         code: 200
-        duration: 21.991666ms
+        duration: 373.580875ms
     - id: 91
       request:
         proto: HTTP/1.1
@@ -4756,7 +4756,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4765,7 +4765,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 077303f0-7824-4b12-8a25-6043a9df611d
+                - 5796b123-62ed-4336-8974-936fe52b4fdc
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4773,8 +4773,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133726Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T144909Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4793,14 +4793,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:26 GMT
+                - Tue, 08 Sep 2026 14:49:09 GMT
             X-Amz-Id-2:
-                - txg0d0775bac92d45478481-006aa00f96
+                - txg761f8dd837044f55b59c-006aa02065
             X-Amz-Request-Id:
-                - txg0d0775bac92d45478481-006aa00f96
+                - txg761f8dd837044f55b59c-006aa02065
         status: 200 OK
         code: 200
-        duration: 155.03275ms
+        duration: 218.711667ms
     - id: 92
       request:
         proto: HTTP/1.1
@@ -4809,7 +4809,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4818,7 +4818,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 960ce9af-af5f-4e38-8e99-3a5dfcc54927
+                - 99813316-0c17-4183-816c-9d547a537a6c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4826,8 +4826,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133726Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T144909Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4837,21 +4837,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg0f2b09c5639f45b9be04-006aa00f97</RequestId><HostId>txg0f2b09c5639f45b9be04-006aa00f97</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgfd50a954418448d2aca5-006aa02065</RequestId><HostId>txgfd50a954418448d2aca5-006aa02065</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:27 GMT
+                - Tue, 08 Sep 2026 14:49:09 GMT
             X-Amz-Id-2:
-                - txg0f2b09c5639f45b9be04-006aa00f97
+                - txgfd50a954418448d2aca5-006aa02065
             X-Amz-Request-Id:
-                - txg0f2b09c5639f45b9be04-006aa00f97
+                - txgfd50a954418448d2aca5-006aa02065
         status: 404 Not Found
         code: 404
-        duration: 269.177083ms
+        duration: 101.400792ms
     - id: 93
       request:
         proto: HTTP/1.1
@@ -4860,7 +4860,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4869,7 +4869,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b9059741-85f0-4cee-ad62-abe36d15176b
+                - e2dc2702-70a1-4f65-a650-de4e1db0fd85
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4877,8 +4877,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133727Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/
+                - 20260908T144909Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -4890,21 +4890,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:27 GMT
+                - Tue, 08 Sep 2026 14:49:09 GMT
             X-Amz-Id-2:
-                - txg64caeb369b494c1eb376-006aa00f97
+                - txgf6a221196cd14eac877e-006aa02065
             X-Amz-Request-Id:
-                - txg64caeb369b494c1eb376-006aa00f97
+                - txgf6a221196cd14eac877e-006aa02065
         status: 200 OK
         code: 200
-        duration: 126.718042ms
+        duration: 317.691709ms
     - id: 94
       request:
         proto: HTTP/1.1
@@ -4913,7 +4913,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4922,7 +4922,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 83c72c35-ce69-4907-bb95-b544d467a90a
+                - 68ab7aa5-9f80-4067-8ff7-03dc1e243785
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4930,8 +4930,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133727Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T144909Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4941,21 +4941,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg2f825edfcf9f4dd3a26b-006aa00f97</RequestId><HostId>txg2f825edfcf9f4dd3a26b-006aa00f97</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg1f1eabaa3c524d6083b5-006aa02065</RequestId><HostId>txg1f1eabaa3c524d6083b5-006aa02065</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:27 GMT
+                - Tue, 08 Sep 2026 14:49:09 GMT
             X-Amz-Id-2:
-                - txg2f825edfcf9f4dd3a26b-006aa00f97
+                - txg1f1eabaa3c524d6083b5-006aa02065
             X-Amz-Request-Id:
-                - txg2f825edfcf9f4dd3a26b-006aa00f97
+                - txg1f1eabaa3c524d6083b5-006aa02065
         status: 404 Not Found
         code: 404
-        duration: 108.724625ms
+        duration: 204.151167ms
     - id: 95
       request:
         proto: HTTP/1.1
@@ -4964,7 +4964,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4973,7 +4973,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 80d64306-b8e3-457d-91b1-cfed8795dc40
+                - fb63af27-25ca-4bda-8865-8dd737fcf407
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4981,8 +4981,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133727Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T144909Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4992,21 +4992,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgc110fdf9d0b7444e88f2-006aa00f97</RequestId><HostId>txgc110fdf9d0b7444e88f2-006aa00f97</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgb15ea7860aff4d9fb1c1-006aa02066</RequestId><HostId>txgb15ea7860aff4d9fb1c1-006aa02066</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:27 GMT
+                - Tue, 08 Sep 2026 14:49:10 GMT
             X-Amz-Id-2:
-                - txgc110fdf9d0b7444e88f2-006aa00f97
+                - txgb15ea7860aff4d9fb1c1-006aa02066
             X-Amz-Request-Id:
-                - txgc110fdf9d0b7444e88f2-006aa00f97
+                - txgb15ea7860aff4d9fb1c1-006aa02066
         status: 404 Not Found
         code: 404
-        duration: 92.619375ms
+        duration: 304.85775ms
     - id: 96
       request:
         proto: HTTP/1.1
@@ -5015,7 +5015,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5024,7 +5024,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4620e04a-24b9-4e08-bb4f-14480b19a6fe
+                - ee6cd61a-2123-4722-9d1e-20fc981cd33e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5032,8 +5032,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133727Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T144910Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5052,14 +5052,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:27 GMT
+                - Tue, 08 Sep 2026 14:49:10 GMT
             X-Amz-Id-2:
-                - txgd0e56b79716c41099c2c-006aa00f97
+                - txge37f47b9f03542d3a98f-006aa02066
             X-Amz-Request-Id:
-                - txgd0e56b79716c41099c2c-006aa00f97
+                - txge37f47b9f03542d3a98f-006aa02066
         status: 200 OK
         code: 200
-        duration: 610.871667ms
+        duration: 101.389791ms
     - id: 97
       request:
         proto: HTTP/1.1
@@ -5068,7 +5068,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5077,7 +5077,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 001b2810-103a-4f83-a948-34d4aab448bb
+                - 9e3a1aa7-5299-414f-b0ef-029a68b786de
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5085,8 +5085,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133727Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T144910Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5105,14 +5105,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:28 GMT
+                - Tue, 08 Sep 2026 14:49:10 GMT
             X-Amz-Id-2:
-                - txgee39ee8c86a340eba7c9-006aa00f98
+                - txg9d157d728c444208b957-006aa02066
             X-Amz-Request-Id:
-                - txgee39ee8c86a340eba7c9-006aa00f98
+                - txg9d157d728c444208b957-006aa02066
         status: 200 OK
         code: 200
-        duration: 88.144ms
+        duration: 409.727833ms
     - id: 98
       request:
         proto: HTTP/1.1
@@ -5121,7 +5121,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5130,7 +5130,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0856c37d-82f9-43c0-9c07-4ac6bc451c05
+                - 59133cd2-0aab-44ba-ac61-56284767d74c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5138,8 +5138,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133728Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/
+                - 20260908T144911Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -5154,16 +5154,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:28 GMT
+                - Tue, 08 Sep 2026 14:49:11 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txgbb01b253e0b24335a454-006aa00f98
+                - txg308c81a2188b4037a79e-006aa02067
             X-Amz-Request-Id:
-                - txgbb01b253e0b24335a454-006aa00f98
+                - txg308c81a2188b4037a79e-006aa02067
         status: 200 OK
         code: 200
-        duration: 233.534875ms
+        duration: 89.458ms
     - id: 99
       request:
         proto: HTTP/1.1
@@ -5172,7 +5172,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5181,7 +5181,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 25683e34-2394-4358-bab0-f5040cae0a57
+                - 80885edb-d292-4cd4-be79-5fa9e810eb58
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5189,8 +5189,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133728Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T144911Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5209,14 +5209,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:28 GMT
+                - Tue, 08 Sep 2026 14:49:11 GMT
             X-Amz-Id-2:
-                - txg93c94d8d8de74ee8a748-006aa00f98
+                - txg86ece6abeddc43789a7c-006aa02067
             X-Amz-Request-Id:
-                - txg93c94d8d8de74ee8a748-006aa00f98
+                - txg86ece6abeddc43789a7c-006aa02067
         status: 200 OK
         code: 200
-        duration: 26.876625ms
+        duration: 176.189833ms
     - id: 100
       request:
         proto: HTTP/1.1
@@ -5225,7 +5225,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5234,7 +5234,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9b6e0cf1-f116-44a5-a1ba-3ee235d3269a
+                - d6332ccf-3db2-4efa-9141-7260a6bf8c8f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5242,8 +5242,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133728Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T144911Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5262,14 +5262,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:29 GMT
+                - Tue, 08 Sep 2026 14:49:11 GMT
             X-Amz-Id-2:
-                - txg93ed1c694b0d435480b4-006aa00f99
+                - txg9a9f73c374264cb3991a-006aa02067
             X-Amz-Request-Id:
-                - txg93ed1c694b0d435480b4-006aa00f99
+                - txg9a9f73c374264cb3991a-006aa02067
         status: 200 OK
         code: 200
-        duration: 71.810875ms
+        duration: 126.110584ms
     - id: 101
       request:
         proto: HTTP/1.1
@@ -5278,7 +5278,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5287,7 +5287,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5e9c9ac7-bcaa-4125-b54e-fdf8f3855dca
+                - 1d62cc07-cc31-412b-98f7-314f3148d17d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5295,8 +5295,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133729Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T144911Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5306,21 +5306,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg32986a0181cb45a2a24a-006aa00f99</RequestId><HostId>txg32986a0181cb45a2a24a-006aa00f99</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg1cafebb7caa94f8a9f91-006aa02067</RequestId><HostId>txg1cafebb7caa94f8a9f91-006aa02067</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:29 GMT
+                - Tue, 08 Sep 2026 14:49:11 GMT
             X-Amz-Id-2:
-                - txg32986a0181cb45a2a24a-006aa00f99
+                - txg1cafebb7caa94f8a9f91-006aa02067
             X-Amz-Request-Id:
-                - txg32986a0181cb45a2a24a-006aa00f99
+                - txg1cafebb7caa94f8a9f91-006aa02067
         status: 404 Not Found
         code: 404
-        duration: 20.644791ms
+        duration: 212.159542ms
     - id: 102
       request:
         proto: HTTP/1.1
@@ -5329,7 +5329,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5338,7 +5338,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c241a0fd-8f43-4556-b5c7-abdac3151c29
+                - 61e5b0ff-a213-4cff-ad44-7e9c23ba2a2f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5346,8 +5346,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133729Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/
+                - 20260908T144911Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -5359,21 +5359,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:29 GMT
+                - Tue, 08 Sep 2026 14:49:12 GMT
             X-Amz-Id-2:
-                - txga4c50f197a60447290c8-006aa00f99
+                - txg598ec7f6b7a64f6fa26b-006aa02068
             X-Amz-Request-Id:
-                - txga4c50f197a60447290c8-006aa00f99
+                - txg598ec7f6b7a64f6fa26b-006aa02068
         status: 200 OK
         code: 200
-        duration: 97.605875ms
+        duration: 625.403625ms
     - id: 103
       request:
         proto: HTTP/1.1
@@ -5382,7 +5382,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5391,7 +5391,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ec93e078-1e78-4239-93df-5235bf1c4966
+                - 7e4cdacc-313d-4ea7-b885-5c9b2582547b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5399,8 +5399,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133729Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T144912Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5410,21 +5410,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg8416dd7a7f714a08972d-006aa00f99</RequestId><HostId>txg8416dd7a7f714a08972d-006aa00f99</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgcd65da8e571b4c8196ea-006aa02068</RequestId><HostId>txgcd65da8e571b4c8196ea-006aa02068</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:29 GMT
+                - Tue, 08 Sep 2026 14:49:12 GMT
             X-Amz-Id-2:
-                - txg8416dd7a7f714a08972d-006aa00f99
+                - txgcd65da8e571b4c8196ea-006aa02068
             X-Amz-Request-Id:
-                - txg8416dd7a7f714a08972d-006aa00f99
+                - txgcd65da8e571b4c8196ea-006aa02068
         status: 404 Not Found
         code: 404
-        duration: 89.172208ms
+        duration: 101.311917ms
     - id: 104
       request:
         proto: HTTP/1.1
@@ -5433,7 +5433,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5442,7 +5442,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b77cdccb-fd1f-4229-a2db-d4acf00820eb
+                - 797f467d-897b-4c2b-9c9c-e83fdf486dbc
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5450,8 +5450,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133729Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T144912Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5461,21 +5461,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg6f95b4bd574644bd8b27-006aa00f99</RequestId><HostId>txg6f95b4bd574644bd8b27-006aa00f99</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgff49530df44c4de2a931-006aa02068</RequestId><HostId>txgff49530df44c4de2a931-006aa02068</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:29 GMT
+                - Tue, 08 Sep 2026 14:49:12 GMT
             X-Amz-Id-2:
-                - txg6f95b4bd574644bd8b27-006aa00f99
+                - txgff49530df44c4de2a931-006aa02068
             X-Amz-Request-Id:
-                - txg6f95b4bd574644bd8b27-006aa00f99
+                - txgff49530df44c4de2a931-006aa02068
         status: 404 Not Found
         code: 404
-        duration: 20.536083ms
+        duration: 393.349083ms
     - id: 105
       request:
         proto: HTTP/1.1
@@ -5484,7 +5484,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5493,7 +5493,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 31c77f89-b07d-40d4-9ed0-6accc85b79db
+                - 2cc6bffc-fe1c-41a3-9f47-f97fa11dbd29
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5501,8 +5501,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133729Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T144912Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5521,14 +5521,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:29 GMT
+                - Tue, 08 Sep 2026 14:49:13 GMT
             X-Amz-Id-2:
-                - txgf8bf65f6630442c09076-006aa00f99
+                - txgb4b8c6be95df4a41821c-006aa02069
             X-Amz-Request-Id:
-                - txgf8bf65f6630442c09076-006aa00f99
+                - txgb4b8c6be95df4a41821c-006aa02069
         status: 200 OK
         code: 200
-        duration: 166.223959ms
+        duration: 290.31025ms
     - id: 106
       request:
         proto: HTTP/1.1
@@ -5537,7 +5537,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5546,7 +5546,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f6644616-e2fb-4e0e-b06a-e53aed26a679
+                - ea2a64a0-cb24-4200-a310-639921b0ef98
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5554,8 +5554,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133729Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T144913Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5574,14 +5574,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:29 GMT
+                - Tue, 08 Sep 2026 14:49:13 GMT
             X-Amz-Id-2:
-                - txg744c5c324de9478299ca-006aa00f99
+                - txge0d20e4877654305be30-006aa02069
             X-Amz-Request-Id:
-                - txg744c5c324de9478299ca-006aa00f99
+                - txge0d20e4877654305be30-006aa02069
         status: 200 OK
         code: 200
-        duration: 22.231166ms
+        duration: 316.106292ms
     - id: 107
       request:
         proto: HTTP/1.1
@@ -5590,7 +5590,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5599,7 +5599,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 83fc1e97-2706-4b37-a808-2ffd53f1f045
+                - d074aa10-dbee-47da-82eb-3f276c2caae0
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5607,8 +5607,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133729Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T144913Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5627,14 +5627,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:29 GMT
+                - Tue, 08 Sep 2026 14:49:13 GMT
             X-Amz-Id-2:
-                - txg1597ca1dd0514a729bb3-006aa00f99
+                - txg266653b8ba98460b89f1-006aa02069
             X-Amz-Request-Id:
-                - txg1597ca1dd0514a729bb3-006aa00f99
+                - txg266653b8ba98460b89f1-006aa02069
         status: 200 OK
         code: 200
-        duration: 27.878ms
+        duration: 116.669208ms
     - id: 108
       request:
         proto: HTTP/1.1
@@ -5643,7 +5643,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5652,7 +5652,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9230fc42-97cf-4280-b380-3cfe04d0c329
+                - c998aa42-fa3c-4769-927c-ca944e6c6961
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5660,8 +5660,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133729Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T144913Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5671,21 +5671,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg388688de8c3d420fbbbb-006aa00f99</RequestId><HostId>txg388688de8c3d420fbbbb-006aa00f99</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgdb87e850960e4b4f8bb4-006aa0206a</RequestId><HostId>txgdb87e850960e4b4f8bb4-006aa0206a</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:29 GMT
+                - Tue, 08 Sep 2026 14:49:14 GMT
             X-Amz-Id-2:
-                - txg388688de8c3d420fbbbb-006aa00f99
+                - txgdb87e850960e4b4f8bb4-006aa0206a
             X-Amz-Request-Id:
-                - txg388688de8c3d420fbbbb-006aa00f99
+                - txgdb87e850960e4b4f8bb4-006aa0206a
         status: 404 Not Found
         code: 404
-        duration: 23.664166ms
+        duration: 99.029ms
     - id: 109
       request:
         proto: HTTP/1.1
@@ -5694,7 +5694,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5703,7 +5703,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 185c7e18-3ae9-40b2-9019-bc68272c14a8
+                - a573a6ef-6c52-4f70-877a-fff0d1aef899
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5711,8 +5711,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133729Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/
+                - 20260908T144914Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -5724,21 +5724,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:29 GMT
+                - Tue, 08 Sep 2026 14:49:14 GMT
             X-Amz-Id-2:
-                - txgdd0fe7bd1f23434cb468-006aa00f99
+                - txg7b0416dccc9c43c581fd-006aa0206a
             X-Amz-Request-Id:
-                - txgdd0fe7bd1f23434cb468-006aa00f99
+                - txg7b0416dccc9c43c581fd-006aa0206a
         status: 200 OK
         code: 200
-        duration: 90.982708ms
+        duration: 602.770375ms
     - id: 110
       request:
         proto: HTTP/1.1
@@ -5747,7 +5747,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5756,7 +5756,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c34ca5e6-4227-4cb1-818c-7723fcdb049b
+                - 7870b11b-9fec-4196-a723-a2b466f55caa
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5764,8 +5764,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133729Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T144914Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5775,21 +5775,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg4811e471dbe942bd8165-006aa00f99</RequestId><HostId>txg4811e471dbe942bd8165-006aa00f99</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txge39b736a6156432bb341-006aa0206a</RequestId><HostId>txge39b736a6156432bb341-006aa0206a</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:29 GMT
+                - Tue, 08 Sep 2026 14:49:14 GMT
             X-Amz-Id-2:
-                - txg4811e471dbe942bd8165-006aa00f99
+                - txge39b736a6156432bb341-006aa0206a
             X-Amz-Request-Id:
-                - txg4811e471dbe942bd8165-006aa00f99
+                - txge39b736a6156432bb341-006aa0206a
         status: 404 Not Found
         code: 404
-        duration: 27.60275ms
+        duration: 535.856167ms
     - id: 111
       request:
         proto: HTTP/1.1
@@ -5798,7 +5798,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5807,7 +5807,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4e2abdfa-a52f-4d63-8916-be5d65500814
+                - 9bb6317d-aa50-4060-9c8b-c1e2fc1719c6
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5815,8 +5815,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133729Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T144914Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5826,21 +5826,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg02912f49c46540f69637-006aa00f99</RequestId><HostId>txg02912f49c46540f69637-006aa00f99</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgac0f3babec1c48d5a850-006aa0206b</RequestId><HostId>txgac0f3babec1c48d5a850-006aa0206b</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:29 GMT
+                - Tue, 08 Sep 2026 14:49:15 GMT
             X-Amz-Id-2:
-                - txg02912f49c46540f69637-006aa00f99
+                - txgac0f3babec1c48d5a850-006aa0206b
             X-Amz-Request-Id:
-                - txg02912f49c46540f69637-006aa00f99
+                - txgac0f3babec1c48d5a850-006aa0206b
         status: 404 Not Found
         code: 404
-        duration: 191.524041ms
+        duration: 288.692209ms
     - id: 112
       request:
         proto: HTTP/1.1
@@ -5849,7 +5849,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5858,7 +5858,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 17b55c9e-bbb5-43e9-b07e-b9074bbd11f4
+                - ddc21405-7e7f-497f-9158-7fb69d418291
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5866,8 +5866,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133729Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T144915Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5886,14 +5886,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:30 GMT
+                - Tue, 08 Sep 2026 14:49:15 GMT
             X-Amz-Id-2:
-                - txg1db9c3ac33484694bd5e-006aa00f9a
+                - txg845ac288c7d247ae919f-006aa0206b
             X-Amz-Request-Id:
-                - txg1db9c3ac33484694bd5e-006aa00f9a
+                - txg845ac288c7d247ae919f-006aa0206b
         status: 200 OK
         code: 200
-        duration: 96.494584ms
+        duration: 217.168084ms
     - id: 113
       request:
         proto: HTTP/1.1
@@ -5902,7 +5902,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5911,7 +5911,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - fabfe7c9-1a91-42d5-882d-b413adcc39cc
+                - 3f96b60b-616e-46ba-bf5a-f1c9dbc3a952
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5919,8 +5919,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133730Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T144915Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5939,14 +5939,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:30 GMT
+                - Tue, 08 Sep 2026 14:49:15 GMT
             X-Amz-Id-2:
-                - txg7e76f8ef477f455584ba-006aa00f9a
+                - txgfa23964e00a94745ab11-006aa0206b
             X-Amz-Request-Id:
-                - txg7e76f8ef477f455584ba-006aa00f9a
+                - txgfa23964e00a94745ab11-006aa0206b
         status: 200 OK
         code: 200
-        duration: 22.841583ms
+        duration: 98.34025ms
     - id: 114
       request:
         proto: HTTP/1.1
@@ -5955,7 +5955,7 @@ interactions:
         content_length: 284
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path1/</Prefix><Tag><Key>deleted</Key><Value>true</Value></Tag></And></Filter><ID>id1</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
@@ -5964,7 +5964,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - bef5f4a4-7b7f-4149-9176-0fedb66c41b7
+                - 55d8e144-3768-475a-81db-15dbbce42e76
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -5976,8 +5976,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - c66696878cc52fbe5f1b5468d871024fe4d94447494e4b1797bc44a183ccc313
             X-Amz-Date:
-                - 20260908T133730Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T144916Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -5992,14 +5992,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 08 Sep 2026 13:37:30 GMT
+                - Tue, 08 Sep 2026 14:49:16 GMT
             X-Amz-Id-2:
-                - txg2c3d7e8adea2476d8f92-006aa00f9a
+                - txg03dd93c69d51409c9949-006aa0206c
             X-Amz-Request-Id:
-                - txg2c3d7e8adea2476d8f92-006aa00f9a
+                - txg03dd93c69d51409c9949-006aa0206c
         status: 200 OK
         code: 200
-        duration: 221.7885ms
+        duration: 396.310292ms
     - id: 115
       request:
         proto: HTTP/1.1
@@ -6008,7 +6008,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6017,7 +6017,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e3e9ab7c-11a1-4e4d-938f-d5cd567ca0c4
+                - da980943-4cd9-4cc0-a4c1-6910c32b5e30
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6025,8 +6025,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133730Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T144916Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6045,14 +6045,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:30 GMT
+                - Tue, 08 Sep 2026 14:49:16 GMT
             X-Amz-Id-2:
-                - txg78dea2a0857149968146-006aa00f9a
+                - txg56b084a0940745d495fd-006aa0206c
             X-Amz-Request-Id:
-                - txg78dea2a0857149968146-006aa00f9a
+                - txg56b084a0940745d495fd-006aa0206c
         status: 200 OK
         code: 200
-        duration: 222.049833ms
+        duration: 511.732208ms
     - id: 116
       request:
         proto: HTTP/1.1
@@ -6061,7 +6061,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6070,7 +6070,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 1f6c284f-ffd6-4017-88a0-f12240906b70
+                - b23d2e74-bfb7-41a1-8a0c-aa8b40f6652a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6078,8 +6078,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133730Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T144916Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6089,21 +6089,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgd5e06ec9e5484d178450-006aa00f9a</RequestId><HostId>txgd5e06ec9e5484d178450-006aa00f9a</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg4afebcbcbf4e4d818646-006aa0206d</RequestId><HostId>txg4afebcbcbf4e4d818646-006aa0206d</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:30 GMT
+                - Tue, 08 Sep 2026 14:49:17 GMT
             X-Amz-Id-2:
-                - txgd5e06ec9e5484d178450-006aa00f9a
+                - txg4afebcbcbf4e4d818646-006aa0206d
             X-Amz-Request-Id:
-                - txgd5e06ec9e5484d178450-006aa00f9a
+                - txg4afebcbcbf4e4d818646-006aa0206d
         status: 404 Not Found
         code: 404
-        duration: 106.637708ms
+        duration: 103.458125ms
     - id: 117
       request:
         proto: HTTP/1.1
@@ -6112,7 +6112,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6121,7 +6121,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3e90a9af-f4fc-4821-b5c1-1601bfb5435e
+                - c2a1b245-b3b9-4ba3-ad6f-5b11690698ff
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6129,8 +6129,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133730Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/
+                - 20260908T144917Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -6142,21 +6142,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:30 GMT
+                - Tue, 08 Sep 2026 14:49:17 GMT
             X-Amz-Id-2:
-                - txg89633eae49bb4d1190d0-006aa00f9a
+                - txg766e525311d04b19a3fb-006aa0206d
             X-Amz-Request-Id:
-                - txg89633eae49bb4d1190d0-006aa00f9a
+                - txg766e525311d04b19a3fb-006aa0206d
         status: 200 OK
         code: 200
-        duration: 61.989875ms
+        duration: 407.346208ms
     - id: 118
       request:
         proto: HTTP/1.1
@@ -6165,7 +6165,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6174,7 +6174,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 1dab215b-e9d4-4c05-a753-6ac45e0c56c6
+                - c621f059-1580-4910-89e2-1cd51f3e59ba
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6182,8 +6182,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133730Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T144917Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6193,21 +6193,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg411023894ef4468e944e-006aa00f9a</RequestId><HostId>txg411023894ef4468e944e-006aa00f9a</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgf35cd8805a154e0e96ea-006aa0206d</RequestId><HostId>txgf35cd8805a154e0e96ea-006aa0206d</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:30 GMT
+                - Tue, 08 Sep 2026 14:49:17 GMT
             X-Amz-Id-2:
-                - txg411023894ef4468e944e-006aa00f9a
+                - txgf35cd8805a154e0e96ea-006aa0206d
             X-Amz-Request-Id:
-                - txg411023894ef4468e944e-006aa00f9a
+                - txgf35cd8805a154e0e96ea-006aa0206d
         status: 404 Not Found
         code: 404
-        duration: 22.223333ms
+        duration: 209.990417ms
     - id: 119
       request:
         proto: HTTP/1.1
@@ -6216,7 +6216,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6225,7 +6225,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6749901e-d9e0-4d4e-a106-04882ecfb182
+                - 78ce7885-2f54-4f0b-89bd-4620eddf18c5
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6233,8 +6233,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133730Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T144917Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6244,21 +6244,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg6913b780899948a8a682-006aa00f9a</RequestId><HostId>txg6913b780899948a8a682-006aa00f9a</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg8ac915e83df64c668c9f-006aa0206d</RequestId><HostId>txg8ac915e83df64c668c9f-006aa0206d</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:30 GMT
+                - Tue, 08 Sep 2026 14:49:17 GMT
             X-Amz-Id-2:
-                - txg6913b780899948a8a682-006aa00f9a
+                - txg8ac915e83df64c668c9f-006aa0206d
             X-Amz-Request-Id:
-                - txg6913b780899948a8a682-006aa00f9a
+                - txg8ac915e83df64c668c9f-006aa0206d
         status: 404 Not Found
         code: 404
-        duration: 81.847542ms
+        duration: 198.60525ms
     - id: 120
       request:
         proto: HTTP/1.1
@@ -6267,7 +6267,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6276,7 +6276,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 331f3648-e758-4502-b267-a45743dc060f
+                - ed042110-1b71-49fd-baef-69db4a76b5c3
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6284,8 +6284,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133730Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T144917Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6304,14 +6304,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:31 GMT
+                - Tue, 08 Sep 2026 14:49:17 GMT
             X-Amz-Id-2:
-                - txg4ff52a478bad49519bbf-006aa00f9b
+                - txg48751902577347709f0a-006aa0206d
             X-Amz-Request-Id:
-                - txg4ff52a478bad49519bbf-006aa00f9b
+                - txg48751902577347709f0a-006aa0206d
         status: 200 OK
         code: 200
-        duration: 20.596709ms
+        duration: 273.835375ms
     - id: 121
       request:
         proto: HTTP/1.1
@@ -6320,7 +6320,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6329,16 +6329,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5534201a-0200-4844-93b4-0148204e4516
+                - 93c3820e-15fc-45fb-89f5-18ad61597753
             Amz-Sdk-Request:
-                - attempt=1; max=3; ttl=20260908T154730Z
+                - attempt=1; max=3
             User-Agent:
                 - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133731Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T144917Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6357,14 +6357,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:31 GMT
+                - Tue, 08 Sep 2026 14:49:18 GMT
             X-Amz-Id-2:
-                - txged880ff4237742e59cea-006aa00f9b
+                - txge21fd5077c494937837f-006aa0206e
             X-Amz-Request-Id:
-                - txged880ff4237742e59cea-006aa00f9b
+                - txge21fd5077c494937837f-006aa0206e
         status: 200 OK
         code: 200
-        duration: 96.156834ms
+        duration: 545.023458ms
     - id: 122
       request:
         proto: HTTP/1.1
@@ -6373,7 +6373,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6382,7 +6382,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 39620d04-b5d4-4d24-a82d-db355266aabd
+                - 71cffb4a-0e0e-4001-b412-fbbc8e888747
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6390,8 +6390,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133731Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/
+                - 20260908T144918Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -6406,16 +6406,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:31 GMT
+                - Tue, 08 Sep 2026 14:49:18 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txg90b4743414f44d93822b-006aa00f9b
+                - txg471ad78208fb4c8b85dd-006aa0206e
             X-Amz-Request-Id:
-                - txg90b4743414f44d93822b-006aa00f9b
+                - txg471ad78208fb4c8b85dd-006aa0206e
         status: 200 OK
         code: 200
-        duration: 21.868708ms
+        duration: 168.130875ms
     - id: 123
       request:
         proto: HTTP/1.1
@@ -6424,7 +6424,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6433,7 +6433,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 56a7f8d4-dbdf-45d4-ad52-d9cb4e6f7d8c
+                - ce9ceddb-4d7b-4706-8fe5-23a77c45195a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6441,8 +6441,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133731Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T144918Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6461,14 +6461,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:31 GMT
+                - Tue, 08 Sep 2026 14:49:19 GMT
             X-Amz-Id-2:
-                - txg91f67934ad904d799ea1-006aa00f9b
+                - txgf8edf1aa243d442f82bc-006aa0206f
             X-Amz-Request-Id:
-                - txg91f67934ad904d799ea1-006aa00f9b
+                - txgf8edf1aa243d442f82bc-006aa0206f
         status: 200 OK
         code: 200
-        duration: 22.754417ms
+        duration: 25.293541ms
     - id: 124
       request:
         proto: HTTP/1.1
@@ -6477,7 +6477,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6486,7 +6486,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - dcebbf04-e108-4eb0-80aa-e4976817166b
+                - e6e3e545-791d-462e-a876-fc19e4d02866
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6494,8 +6494,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133731Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T144919Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6514,14 +6514,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:31 GMT
+                - Tue, 08 Sep 2026 14:49:19 GMT
             X-Amz-Id-2:
-                - txg1b8ca92d21bb40948e6e-006aa00f9b
+                - txge7fce95df90f4875b646-006aa0206f
             X-Amz-Request-Id:
-                - txg1b8ca92d21bb40948e6e-006aa00f9b
+                - txge7fce95df90f4875b646-006aa0206f
         status: 200 OK
         code: 200
-        duration: 35.6635ms
+        duration: 78.816833ms
     - id: 125
       request:
         proto: HTTP/1.1
@@ -6530,7 +6530,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6539,7 +6539,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 33ec7ad4-3579-4de7-b65d-a046d247082c
+                - 15e39a2f-4a4b-413f-b1d9-aba8f3afc97e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6547,8 +6547,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133731Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T144919Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6558,21 +6558,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg8a092876735c423dba73-006aa00f9b</RequestId><HostId>txg8a092876735c423dba73-006aa00f9b</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg49d63cbcc3d9485ba871-006aa0206f</RequestId><HostId>txg49d63cbcc3d9485ba871-006aa0206f</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:31 GMT
+                - Tue, 08 Sep 2026 14:49:19 GMT
             X-Amz-Id-2:
-                - txg8a092876735c423dba73-006aa00f9b
+                - txg49d63cbcc3d9485ba871-006aa0206f
             X-Amz-Request-Id:
-                - txg8a092876735c423dba73-006aa00f9b
+                - txg49d63cbcc3d9485ba871-006aa0206f
         status: 404 Not Found
         code: 404
-        duration: 103.553666ms
+        duration: 21.802833ms
     - id: 126
       request:
         proto: HTTP/1.1
@@ -6581,7 +6581,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6590,7 +6590,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7342d16c-40df-45c9-9238-e9455e18ae7d
+                - 0f4bb95b-b734-4d84-a8e2-8498a52cd8a1
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6598,8 +6598,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133731Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/
+                - 20260908T144919Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -6611,21 +6611,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:31 GMT
+                - Tue, 08 Sep 2026 14:49:19 GMT
             X-Amz-Id-2:
-                - txg606100b5837f4e37a3b7-006aa00f9b
+                - txgc46454d9225a48e2929b-006aa0206f
             X-Amz-Request-Id:
-                - txg606100b5837f4e37a3b7-006aa00f9b
+                - txgc46454d9225a48e2929b-006aa0206f
         status: 200 OK
         code: 200
-        duration: 248.898417ms
+        duration: 417.492292ms
     - id: 127
       request:
         proto: HTTP/1.1
@@ -6634,7 +6634,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6643,7 +6643,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e8b0092a-eaf5-4fbc-84b8-9cd3a9aeee6d
+                - 46dcbf84-237a-4584-bf61-aab981c08cba
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6651,8 +6651,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133731Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T144919Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6662,21 +6662,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgebb92fc0c5364cb19fbc-006aa00f9b</RequestId><HostId>txgebb92fc0c5364cb19fbc-006aa00f9b</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg3362218930d94dd0ab7b-006aa0206f</RequestId><HostId>txg3362218930d94dd0ab7b-006aa0206f</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:31 GMT
+                - Tue, 08 Sep 2026 14:49:19 GMT
             X-Amz-Id-2:
-                - txgebb92fc0c5364cb19fbc-006aa00f9b
+                - txg3362218930d94dd0ab7b-006aa0206f
             X-Amz-Request-Id:
-                - txgebb92fc0c5364cb19fbc-006aa00f9b
+                - txg3362218930d94dd0ab7b-006aa0206f
         status: 404 Not Found
         code: 404
-        duration: 407.32825ms
+        duration: 493.688958ms
     - id: 128
       request:
         proto: HTTP/1.1
@@ -6685,7 +6685,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6694,7 +6694,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 23ba11fa-ca5b-4350-932c-eb8849d512fc
+                - 5633229e-b65d-4ca2-97c4-71fcfb9fc95c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6702,8 +6702,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133731Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T144919Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6713,21 +6713,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg6c3f447ac7644cf4a455-006aa00f9c</RequestId><HostId>txg6c3f447ac7644cf4a455-006aa00f9c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg5d07b8831ada480482d7-006aa02070</RequestId><HostId>txg5d07b8831ada480482d7-006aa02070</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:32 GMT
+                - Tue, 08 Sep 2026 14:49:20 GMT
             X-Amz-Id-2:
-                - txg6c3f447ac7644cf4a455-006aa00f9c
+                - txg5d07b8831ada480482d7-006aa02070
             X-Amz-Request-Id:
-                - txg6c3f447ac7644cf4a455-006aa00f9c
+                - txg5d07b8831ada480482d7-006aa02070
         status: 404 Not Found
         code: 404
-        duration: 68.623958ms
+        duration: 423.440375ms
     - id: 129
       request:
         proto: HTTP/1.1
@@ -6736,7 +6736,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6745,7 +6745,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 2992c8f0-5f8e-4ac7-8d40-0e6ff6f0a268
+                - 5392b039-0b55-4a8b-b0bf-05ef1988e6d2
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6753,8 +6753,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133732Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T144920Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6773,14 +6773,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:32 GMT
+                - Tue, 08 Sep 2026 14:49:20 GMT
             X-Amz-Id-2:
-                - txgee5f638803df49839f8c-006aa00f9c
+                - txg5eeac17666224e71b9a3-006aa02070
             X-Amz-Request-Id:
-                - txgee5f638803df49839f8c-006aa00f9c
+                - txg5eeac17666224e71b9a3-006aa02070
         status: 200 OK
         code: 200
-        duration: 20.945041ms
+        duration: 104.119708ms
     - id: 130
       request:
         proto: HTTP/1.1
@@ -6789,7 +6789,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6798,7 +6798,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f52df25b-069e-4a79-87aa-eda26ac57b86
+                - c8d4e45d-bb96-4036-affe-72c9c3977da0
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6806,8 +6806,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133732Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T144920Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6826,14 +6826,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:32 GMT
+                - Tue, 08 Sep 2026 14:49:20 GMT
             X-Amz-Id-2:
-                - txg03cb2949fba3469ea518-006aa00f9c
+                - txg86614f631af744a9abf4-006aa02070
             X-Amz-Request-Id:
-                - txg03cb2949fba3469ea518-006aa00f9c
+                - txg86614f631af744a9abf4-006aa02070
         status: 200 OK
         code: 200
-        duration: 88.791708ms
+        duration: 178.544417ms
     - id: 131
       request:
         proto: HTTP/1.1
@@ -6842,7 +6842,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6851,7 +6851,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3b76b00a-3800-4df8-902a-7251d27786fa
+                - 80ca7477-1c60-4709-b322-2b4b5dc6cf03
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6859,8 +6859,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133732Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T144921Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6879,14 +6879,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:32 GMT
+                - Tue, 08 Sep 2026 14:49:21 GMT
             X-Amz-Id-2:
-                - txg190861a9046646749d4e-006aa00f9c
+                - txg893c13edd49940f5ba13-006aa02071
             X-Amz-Request-Id:
-                - txg190861a9046646749d4e-006aa00f9c
+                - txg893c13edd49940f5ba13-006aa02071
         status: 200 OK
         code: 200
-        duration: 35.971958ms
+        duration: 207.613333ms
     - id: 132
       request:
         proto: HTTP/1.1
@@ -6895,7 +6895,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6904,7 +6904,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - affb8200-82e5-4af5-9011-2e0bcb1a2d6c
+                - f1fee753-44eb-4bd0-ba17-54f42bb24899
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6912,8 +6912,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133732Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T144921Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6923,21 +6923,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgdaa223a74e2c4838b74b-006aa00f9c</RequestId><HostId>txgdaa223a74e2c4838b74b-006aa00f9c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg4ea766e2aa1e46b48afc-006aa02071</RequestId><HostId>txg4ea766e2aa1e46b48afc-006aa02071</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:32 GMT
+                - Tue, 08 Sep 2026 14:49:21 GMT
             X-Amz-Id-2:
-                - txgdaa223a74e2c4838b74b-006aa00f9c
+                - txg4ea766e2aa1e46b48afc-006aa02071
             X-Amz-Request-Id:
-                - txgdaa223a74e2c4838b74b-006aa00f9c
+                - txg4ea766e2aa1e46b48afc-006aa02071
         status: 404 Not Found
         code: 404
-        duration: 104.420333ms
+        duration: 520.683291ms
     - id: 133
       request:
         proto: HTTP/1.1
@@ -6946,7 +6946,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6955,7 +6955,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - fed22c54-2b8e-44a2-9f26-1377d4007ff5
+                - 8a772ed4-d0a0-41c5-a350-045ca40945ca
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6963,8 +6963,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133732Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/
+                - 20260908T144921Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -6976,21 +6976,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:32 GMT
+                - Tue, 08 Sep 2026 14:49:22 GMT
             X-Amz-Id-2:
-                - txgd12d449f30444dda995a-006aa00f9c
+                - txgd0f8014afe4c4149aa77-006aa02072
             X-Amz-Request-Id:
-                - txgd12d449f30444dda995a-006aa00f9c
+                - txgd0f8014afe4c4149aa77-006aa02072
         status: 200 OK
         code: 200
-        duration: 22.123625ms
+        duration: 93.824125ms
     - id: 134
       request:
         proto: HTTP/1.1
@@ -6999,7 +6999,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7008,7 +7008,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 761443a6-1bd3-4822-8c39-d15e9c357443
+                - be9344d3-d065-4899-9993-86879276cbb7
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7016,8 +7016,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133732Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T144922Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7027,21 +7027,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg6ab39391c0cd4f1abf7d-006aa00f9c</RequestId><HostId>txg6ab39391c0cd4f1abf7d-006aa00f9c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg73dab7b8faea471d9520-006aa02072</RequestId><HostId>txg73dab7b8faea471d9520-006aa02072</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:32 GMT
+                - Tue, 08 Sep 2026 14:49:22 GMT
             X-Amz-Id-2:
-                - txg6ab39391c0cd4f1abf7d-006aa00f9c
+                - txg73dab7b8faea471d9520-006aa02072
             X-Amz-Request-Id:
-                - txg6ab39391c0cd4f1abf7d-006aa00f9c
+                - txg73dab7b8faea471d9520-006aa02072
         status: 404 Not Found
         code: 404
-        duration: 23.41225ms
+        duration: 112.51275ms
     - id: 135
       request:
         proto: HTTP/1.1
@@ -7050,7 +7050,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7059,7 +7059,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3329e978-b754-4f2e-96f6-d352e39c2b70
+                - e228d25a-2146-4f2d-828c-915a62a70c06
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7067,8 +7067,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133732Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T144922Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7078,21 +7078,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgc0434c7b05fc42eeb830-006aa00f9c</RequestId><HostId>txgc0434c7b05fc42eeb830-006aa00f9c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg037bf3ca71b54d11a03a-006aa02072</RequestId><HostId>txg037bf3ca71b54d11a03a-006aa02072</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:32 GMT
+                - Tue, 08 Sep 2026 14:49:22 GMT
             X-Amz-Id-2:
-                - txgc0434c7b05fc42eeb830-006aa00f9c
+                - txg037bf3ca71b54d11a03a-006aa02072
             X-Amz-Request-Id:
-                - txgc0434c7b05fc42eeb830-006aa00f9c
+                - txg037bf3ca71b54d11a03a-006aa02072
         status: 404 Not Found
         code: 404
-        duration: 94.342167ms
+        duration: 583.61725ms
     - id: 136
       request:
         proto: HTTP/1.1
@@ -7101,7 +7101,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7110,7 +7110,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5ec60327-b5ce-4e7d-85bc-690f47180b9d
+                - 7f1fe87a-f922-4917-8501-2e84aa8072f7
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7118,8 +7118,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133732Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T144922Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7138,14 +7138,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:32 GMT
+                - Tue, 08 Sep 2026 14:49:22 GMT
             X-Amz-Id-2:
-                - txg89fb4f80ad2543d0a18c-006aa00f9c
+                - txg87dcc87d79b84e559a00-006aa02072
             X-Amz-Request-Id:
-                - txg89fb4f80ad2543d0a18c-006aa00f9c
+                - txg87dcc87d79b84e559a00-006aa02072
         status: 200 OK
         code: 200
-        duration: 60.159125ms
+        duration: 300.527708ms
     - id: 137
       request:
         proto: HTTP/1.1
@@ -7154,7 +7154,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7163,7 +7163,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6ad4fca3-5a91-4585-8daf-0d6616221a4e
+                - 51e9cdf3-efbf-49e0-9205-80a1678485f8
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7171,8 +7171,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133732Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T144922Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7191,14 +7191,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 13:37:32 GMT
+                - Tue, 08 Sep 2026 14:49:23 GMT
             X-Amz-Id-2:
-                - txg7012599540b34719b819-006aa00f9c
+                - txg0275274dc012422f9e08-006aa02073
             X-Amz-Request-Id:
-                - txg7012599540b34719b819-006aa00f9c
+                - txg0275274dc012422f9e08-006aa02073
         status: 200 OK
         code: 200
-        duration: 22.020209ms
+        duration: 234.485333ms
     - id: 138
       request:
         proto: HTTP/1.1
@@ -7207,7 +7207,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7216,7 +7216,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 31876a79-7519-447d-8f5c-0ed13d16691c
+                - daa42728-d7f1-449c-a9aa-ac1124493f4e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7224,8 +7224,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133733Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/
+                - 20260908T144923Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -7233,23 +7233,19 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 285
+        content_length: 0
         uncompressed: false
-        body: <Error><Code>NoSuchBucket</Code><Message>The specified bucket does not exist</Message><RequestId>txgb64af6da527044ff8fe0-006aa00f9d</RequestId><HostId>txgb64af6da527044ff8fe0-006aa00f9d</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
+        body: ""
         headers:
-            Content-Length:
-                - "285"
-            Content-Type:
-                - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:33 GMT
+                - Tue, 08 Sep 2026 14:49:23 GMT
             X-Amz-Id-2:
-                - txgb64af6da527044ff8fe0-006aa00f9d
+                - txgc6ebac88c55f4375a2e3-006aa02073
             X-Amz-Request-Id:
-                - txgb64af6da527044ff8fe0-006aa00f9d
-        status: 404 Not Found
-        code: 404
-        duration: 1.5535265s
+                - txgc6ebac88c55f4375a2e3-006aa02073
+        status: 204 No Content
+        code: 204
+        duration: 606.015584ms
     - id: 139
       request:
         proto: HTTP/1.1
@@ -7258,7 +7254,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7267,7 +7263,166 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 36059fc7-2378-46fb-a937-10cff0cc54cf
+                - 05b598a8-7e6a-4fbf-bd0e-2618d64ffabd
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Bucket-Object-Lock-Enabled:
+                - "true"
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T144924Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Length:
+                - "0"
+            Date:
+                - Tue, 08 Sep 2026 14:49:24 GMT
+            Location:
+                - /tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016
+            X-Amz-Id-2:
+                - txgf113b05ba1204928a638-006aa02074
+            X-Amz-Request-Id:
+                - txgf113b05ba1204928a638-006aa02074
+        status: 200 OK
+        code: 200
+        duration: 1.728726875s
+    - id: 140
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 2fab45ff-5222-4fbd-886a-d014a8c712c3
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,Z,e
+            X-Amz-Acl:
+                - private
+            X-Amz-Checksum-Crc32:
+                - AAAAAA==
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T144925Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?acl=
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Length:
+                - "0"
+            Date:
+                - Tue, 08 Sep 2026 14:49:25 GMT
+            X-Amz-Id-2:
+                - txgedbf23fd6dae4843a782-006aa02075
+            X-Amz-Request-Id:
+                - txgedbf23fd6dae4843a782-006aa02075
+        status: 200 OK
+        code: 200
+        duration: 1.224040083s
+    - id: 141
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 472
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>2</Days></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260908144927109200000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260908144927109300000002</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 6b8c1251-1d80-442b-866f-c5a9242c5243
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            Content-Type:
+                - application/xml
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,Z,e
+            X-Amz-Checksum-Crc32:
+                - vnUydg==
+            X-Amz-Content-Sha256:
+                - cb4533e7f8e7b1308c2aa9d9d21aa4f156a8c53164e07e5f48c67e2eaff236be
+            X-Amz-Date:
+                - 20260908T144925Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?lifecycle=
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Length:
+                - "0"
+            Date:
+                - Tue, 08 Sep 2026 14:49:27 GMT
+            X-Amz-Id-2:
+                - txg30b7370e995240b4a273-006aa02077
+            X-Amz-Request-Id:
+                - txg30b7370e995240b4a273-006aa02077
+        status: 200 OK
+        code: 200
+        duration: 704.2925ms
+    - id: 142
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - e4d515ef-0815-4d11-86eb-1ecf7e832d6c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7275,8 +7430,1580 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T133734Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/
+                - 20260908T144927Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?acl=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 698
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+        headers:
+            Content-Length:
+                - "698"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Tue, 08 Sep 2026 14:49:27 GMT
+            X-Amz-Id-2:
+                - txgd2f25f7cf47c47e0835d-006aa02077
+            X-Amz-Request-Id:
+                - txgd2f25f7cf47c47e0835d-006aa02077
+        status: 200 OK
+        code: 200
+        duration: 86.47825ms
+    - id: 143
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - b0936654-6f74-4a33-b215-561b85f9ca59
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T144927Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?object-lock=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 184
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <ObjectLockConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><ObjectLockEnabled>Enabled</ObjectLockEnabled></ObjectLockConfiguration>
+        headers:
+            Content-Length:
+                - "184"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Tue, 08 Sep 2026 14:49:27 GMT
+            X-Amz-Id-2:
+                - txga57008f825184fa7aa0b-006aa02077
+            X-Amz-Request-Id:
+                - txga57008f825184fa7aa0b-006aa02077
+        status: 200 OK
+        code: 200
+        duration: 1.051218875s
+    - id: 144
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - f11d7fec-4e96-441f-bec7-32ef5872f5d0
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T144927Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 287
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+        headers:
+            Content-Length:
+                - "287"
+            Content-Type:
+                - application/xml
+            Date:
+                - Tue, 08 Sep 2026 14:49:29 GMT
+            X-Amz-Id-2:
+                - txg9bc171557cf64d7596aa-006aa02079
+            X-Amz-Request-Id:
+                - txg9bc171557cf64d7596aa-006aa02079
+        status: 200 OK
+        code: 200
+        duration: 2.122215834s
+    - id: 145
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - b2b63bf2-65a3-4eaf-822f-f52f498975b0
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T144930Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?tagging=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 361
+        uncompressed: false
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg94ab9814e86149efbe4e-006aa0207b</RequestId><HostId>txg94ab9814e86149efbe4e-006aa0207b</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</BucketName></Error>
+        headers:
+            Content-Length:
+                - "361"
+            Content-Type:
+                - application/xml
+            Date:
+                - Tue, 08 Sep 2026 14:49:31 GMT
+            X-Amz-Id-2:
+                - txg94ab9814e86149efbe4e-006aa0207b
+            X-Amz-Request-Id:
+                - txg94ab9814e86149efbe4e-006aa0207b
+        status: 404 Not Found
+        code: 404
+        duration: 7.478100875s
+    - id: 146
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 983dabb9-edec-4102-b470-ccabc3bf342b
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T144934Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?cors=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 298
+        uncompressed: false
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg630521946b8e4c2197ba-006aa02083</RequestId><HostId>txg630521946b8e4c2197ba-006aa02083</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource></Error>
+        headers:
+            Content-Length:
+                - "298"
+            Content-Type:
+                - application/xml
+            Date:
+                - Tue, 08 Sep 2026 14:49:39 GMT
+            X-Amz-Id-2:
+                - txg630521946b8e4c2197ba-006aa02083
+            X-Amz-Request-Id:
+                - txg630521946b8e4c2197ba-006aa02083
+        status: 404 Not Found
+        code: 404
+        duration: 683.382167ms
+    - id: 147
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - ef4cbeed-58d0-475a-8a09-70cbbad3174a
+            Amz-Sdk-Request:
+                - attempt=1; max=3; ttl=20260908T165924Z
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T144939Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?versioning=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 114
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <VersioningConfiguration><Status>Enabled</Status></VersioningConfiguration>
+        headers:
+            Content-Length:
+                - "114"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Tue, 08 Sep 2026 14:49:39 GMT
+            X-Amz-Id-2:
+                - txgb7596a66519b4030b381-006aa02083
+            X-Amz-Request-Id:
+                - txgb7596a66519b4030b381-006aa02083
+        status: 200 OK
+        code: 200
+        duration: 229.571708ms
+    - id: 148
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 7fe37be9-e7d4-4d32-a8a3-80d6b15bfaf4
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T144939Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?lifecycle=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 445
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <Configuration><Rule><Expiration><Days>2</Days></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260908144927109200000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260908144927109300000002</ID><Status>Enabled</Status></Rule></Configuration>
+        headers:
+            Content-Length:
+                - "445"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Tue, 08 Sep 2026 14:49:39 GMT
+            X-Amz-Id-2:
+                - txga37aa911e47d49a890da-006aa02083
+            X-Amz-Request-Id:
+                - txga37aa911e47d49a890da-006aa02083
+        status: 200 OK
+        code: 200
+        duration: 201.540041ms
+    - id: 149
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 1d5963af-be14-400c-ad7a-a788756b4f2e
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T144939Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/
+        method: HEAD
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/xml
+            Date:
+                - Tue, 08 Sep 2026 14:49:39 GMT
+            X-Amz-Bucket-Region:
+                - nl-ams
+            X-Amz-Id-2:
+                - txg6057cf693819442f8fc6-006aa02083
+            X-Amz-Request-Id:
+                - txg6057cf693819442f8fc6-006aa02083
+        status: 200 OK
+        code: 200
+        duration: 350.418209ms
+    - id: 150
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 518f4085-a178-4533-8639-6c8dfc4c0793
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T144940Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?lifecycle=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 445
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <Configuration><Rule><Expiration><Days>2</Days></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260908144927109200000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260908144927109300000002</ID><Status>Enabled</Status></Rule></Configuration>
+        headers:
+            Content-Length:
+                - "445"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Tue, 08 Sep 2026 14:49:40 GMT
+            X-Amz-Id-2:
+                - txgab4f2d787fc440e1ba1e-006aa02084
+            X-Amz-Request-Id:
+                - txgab4f2d787fc440e1ba1e-006aa02084
+        status: 200 OK
+        code: 200
+        duration: 207.387709ms
+    - id: 151
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 57d316f1-1c48-4770-a609-c94283873f9e
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T144940Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?acl=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 698
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+        headers:
+            Content-Length:
+                - "698"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Tue, 08 Sep 2026 14:49:40 GMT
+            X-Amz-Id-2:
+                - txgbede526a6b4e4e4d99b7-006aa02084
+            X-Amz-Request-Id:
+                - txgbede526a6b4e4e4d99b7-006aa02084
+        status: 200 OK
+        code: 200
+        duration: 171.03625ms
+    - id: 152
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 227d35ec-e209-4214-bb6e-ab25e866df12
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T144940Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?object-lock=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 184
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <ObjectLockConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><ObjectLockEnabled>Enabled</ObjectLockEnabled></ObjectLockConfiguration>
+        headers:
+            Content-Length:
+                - "184"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Tue, 08 Sep 2026 14:49:40 GMT
+            X-Amz-Id-2:
+                - txg1d3501c8442a43a49b26-006aa02084
+            X-Amz-Request-Id:
+                - txg1d3501c8442a43a49b26-006aa02084
+        status: 200 OK
+        code: 200
+        duration: 369.406ms
+    - id: 153
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - a7c04a0a-0986-43fa-a51a-7f52d72eed3f
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T144940Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 287
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+        headers:
+            Content-Length:
+                - "287"
+            Content-Type:
+                - application/xml
+            Date:
+                - Tue, 08 Sep 2026 14:49:41 GMT
+            X-Amz-Id-2:
+                - txg3ad536adbe52420f9e02-006aa02085
+            X-Amz-Request-Id:
+                - txg3ad536adbe52420f9e02-006aa02085
+        status: 200 OK
+        code: 200
+        duration: 643.731791ms
+    - id: 154
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 9b21619d-210b-4eef-9fab-2bd1bfec991e
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T144941Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?tagging=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 361
+        uncompressed: false
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg1ca8af8ba1524011bf2d-006aa02085</RequestId><HostId>txg1ca8af8ba1524011bf2d-006aa02085</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</BucketName></Error>
+        headers:
+            Content-Length:
+                - "361"
+            Content-Type:
+                - application/xml
+            Date:
+                - Tue, 08 Sep 2026 14:49:41 GMT
+            X-Amz-Id-2:
+                - txg1ca8af8ba1524011bf2d-006aa02085
+            X-Amz-Request-Id:
+                - txg1ca8af8ba1524011bf2d-006aa02085
+        status: 404 Not Found
+        code: 404
+        duration: 344.911042ms
+    - id: 155
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 3cadca6a-937e-4593-b443-c4e17b643617
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T144941Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?cors=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 298
+        uncompressed: false
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg1a2443981f2f4799a417-006aa02086</RequestId><HostId>txg1a2443981f2f4799a417-006aa02086</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource></Error>
+        headers:
+            Content-Length:
+                - "298"
+            Content-Type:
+                - application/xml
+            Date:
+                - Tue, 08 Sep 2026 14:49:42 GMT
+            X-Amz-Id-2:
+                - txg1a2443981f2f4799a417-006aa02086
+            X-Amz-Request-Id:
+                - txg1a2443981f2f4799a417-006aa02086
+        status: 404 Not Found
+        code: 404
+        duration: 637.604166ms
+    - id: 156
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 4a932dfd-00c0-4093-9fa9-0bc36d4582af
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T144942Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?versioning=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 114
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <VersioningConfiguration><Status>Enabled</Status></VersioningConfiguration>
+        headers:
+            Content-Length:
+                - "114"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Tue, 08 Sep 2026 14:49:42 GMT
+            X-Amz-Id-2:
+                - txg640f08bf087e47bdb5e9-006aa02086
+            X-Amz-Request-Id:
+                - txg640f08bf087e47bdb5e9-006aa02086
+        status: 200 OK
+        code: 200
+        duration: 364.240916ms
+    - id: 157
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - d2c02ecb-c503-48ba-a581-2aa23522b2c7
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T144942Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?lifecycle=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 445
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <Configuration><Rule><Expiration><Days>2</Days></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260908144927109200000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260908144927109300000002</ID><Status>Enabled</Status></Rule></Configuration>
+        headers:
+            Content-Length:
+                - "445"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Tue, 08 Sep 2026 14:49:43 GMT
+            X-Amz-Id-2:
+                - txgefb0c5b49d674f909e2d-006aa02087
+            X-Amz-Request-Id:
+                - txgefb0c5b49d674f909e2d-006aa02087
+        status: 200 OK
+        code: 200
+        duration: 471.754583ms
+    - id: 158
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 548553fc-e131-45bf-9e4b-f0451dba0d20
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T144943Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?acl=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 698
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+        headers:
+            Content-Length:
+                - "698"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Tue, 08 Sep 2026 14:49:43 GMT
+            X-Amz-Id-2:
+                - txgfdbcf892e6b04e7bb5fe-006aa02087
+            X-Amz-Request-Id:
+                - txgfdbcf892e6b04e7bb5fe-006aa02087
+        status: 200 OK
+        code: 200
+        duration: 363.093167ms
+    - id: 159
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 3c322073-20b9-4eee-b59d-a43627f1078f
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T144943Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?object-lock=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 184
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <ObjectLockConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><ObjectLockEnabled>Enabled</ObjectLockEnabled></ObjectLockConfiguration>
+        headers:
+            Content-Length:
+                - "184"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Tue, 08 Sep 2026 14:49:44 GMT
+            X-Amz-Id-2:
+                - txg474c5de02fe642158c7b-006aa02088
+            X-Amz-Request-Id:
+                - txg474c5de02fe642158c7b-006aa02088
+        status: 200 OK
+        code: 200
+        duration: 56.170084ms
+    - id: 160
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 22d73601-5060-436f-acbe-d376d22c3cb8
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T144944Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 287
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+        headers:
+            Content-Length:
+                - "287"
+            Content-Type:
+                - application/xml
+            Date:
+                - Tue, 08 Sep 2026 14:49:44 GMT
+            X-Amz-Id-2:
+                - txg96ae353ded9c46c28593-006aa02088
+            X-Amz-Request-Id:
+                - txg96ae353ded9c46c28593-006aa02088
+        status: 200 OK
+        code: 200
+        duration: 174.785167ms
+    - id: 161
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 19372bd5-cf3b-4b2b-b72f-d8ecf784168e
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T144944Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?tagging=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 361
+        uncompressed: false
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgd32ff0def174456f8e79-006aa02088</RequestId><HostId>txgd32ff0def174456f8e79-006aa02088</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</BucketName></Error>
+        headers:
+            Content-Length:
+                - "361"
+            Content-Type:
+                - application/xml
+            Date:
+                - Tue, 08 Sep 2026 14:49:44 GMT
+            X-Amz-Id-2:
+                - txgd32ff0def174456f8e79-006aa02088
+            X-Amz-Request-Id:
+                - txgd32ff0def174456f8e79-006aa02088
+        status: 404 Not Found
+        code: 404
+        duration: 86.436584ms
+    - id: 162
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 0410caea-e366-4068-8bee-dafe4dc76d54
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T144944Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?cors=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 298
+        uncompressed: false
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg303764497743432b80f4-006aa02088</RequestId><HostId>txg303764497743432b80f4-006aa02088</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource></Error>
+        headers:
+            Content-Length:
+                - "298"
+            Content-Type:
+                - application/xml
+            Date:
+                - Tue, 08 Sep 2026 14:49:44 GMT
+            X-Amz-Id-2:
+                - txg303764497743432b80f4-006aa02088
+            X-Amz-Request-Id:
+                - txg303764497743432b80f4-006aa02088
+        status: 404 Not Found
+        code: 404
+        duration: 259.244042ms
+    - id: 163
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 9979e13a-2d55-4bc4-ab18-9fdb448490cc
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T144944Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?versioning=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 114
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <VersioningConfiguration><Status>Enabled</Status></VersioningConfiguration>
+        headers:
+            Content-Length:
+                - "114"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Tue, 08 Sep 2026 14:49:44 GMT
+            X-Amz-Id-2:
+                - txgdc6f5ea7183948c7a4a7-006aa02088
+            X-Amz-Request-Id:
+                - txgdc6f5ea7183948c7a4a7-006aa02088
+        status: 200 OK
+        code: 200
+        duration: 355.81025ms
+    - id: 164
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 0e9a6910-b780-4bd7-b859-1230383cf37f
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T144944Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?lifecycle=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 445
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <Configuration><Rule><Expiration><Days>2</Days></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260908144927109200000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260908144927109300000002</ID><Status>Enabled</Status></Rule></Configuration>
+        headers:
+            Content-Length:
+                - "445"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Tue, 08 Sep 2026 14:49:45 GMT
+            X-Amz-Id-2:
+                - txg3240840f473f49609a48-006aa02089
+            X-Amz-Request-Id:
+                - txg3240840f473f49609a48-006aa02089
+        status: 200 OK
+        code: 200
+        duration: 137.759416ms
+    - id: 165
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - e81b9375-e8d2-45fe-84d5-3a8bca713b39
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T144945Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?acl=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 698
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+        headers:
+            Content-Length:
+                - "698"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Tue, 08 Sep 2026 14:49:45 GMT
+            X-Amz-Id-2:
+                - txg58c3bf8f97d347dc99ec-006aa02089
+            X-Amz-Request-Id:
+                - txg58c3bf8f97d347dc99ec-006aa02089
+        status: 200 OK
+        code: 200
+        duration: 28.057625ms
+    - id: 166
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 30ef5b49-9001-4818-bc4e-24a057423418
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T144945Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?object-lock=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 184
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <ObjectLockConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><ObjectLockEnabled>Enabled</ObjectLockEnabled></ObjectLockConfiguration>
+        headers:
+            Content-Length:
+                - "184"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Tue, 08 Sep 2026 14:49:45 GMT
+            X-Amz-Id-2:
+                - txgb0452d2d1b714fe49142-006aa02089
+            X-Amz-Request-Id:
+                - txgb0452d2d1b714fe49142-006aa02089
+        status: 200 OK
+        code: 200
+        duration: 144.050583ms
+    - id: 167
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - a3f83599-48fe-405d-9553-af82921a954d
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T144945Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 287
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+        headers:
+            Content-Length:
+                - "287"
+            Content-Type:
+                - application/xml
+            Date:
+                - Tue, 08 Sep 2026 14:49:45 GMT
+            X-Amz-Id-2:
+                - txg01a16aac73ef493c9a6c-006aa02089
+            X-Amz-Request-Id:
+                - txg01a16aac73ef493c9a6c-006aa02089
+        status: 200 OK
+        code: 200
+        duration: 317.374583ms
+    - id: 168
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - fe8004df-7cb6-41f8-99be-3f13f453d756
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T144945Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?tagging=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 361
+        uncompressed: false
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg54d76ce06972425dae1c-006aa02089</RequestId><HostId>txg54d76ce06972425dae1c-006aa02089</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</BucketName></Error>
+        headers:
+            Content-Length:
+                - "361"
+            Content-Type:
+                - application/xml
+            Date:
+                - Tue, 08 Sep 2026 14:49:45 GMT
+            X-Amz-Id-2:
+                - txg54d76ce06972425dae1c-006aa02089
+            X-Amz-Request-Id:
+                - txg54d76ce06972425dae1c-006aa02089
+        status: 404 Not Found
+        code: 404
+        duration: 158.831958ms
+    - id: 169
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - ff9e81a2-dda6-4dbd-8aa2-ccb2f9254ff8
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T144945Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?cors=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 298
+        uncompressed: false
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg5432921196134fb48eed-006aa0208a</RequestId><HostId>txg5432921196134fb48eed-006aa0208a</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource></Error>
+        headers:
+            Content-Length:
+                - "298"
+            Content-Type:
+                - application/xml
+            Date:
+                - Tue, 08 Sep 2026 14:49:46 GMT
+            X-Amz-Id-2:
+                - txg5432921196134fb48eed-006aa0208a
+            X-Amz-Request-Id:
+                - txg5432921196134fb48eed-006aa0208a
+        status: 404 Not Found
+        code: 404
+        duration: 742.220292ms
+    - id: 170
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 3805db3b-f80b-45a3-a404-bdadc5e00275
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T144946Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?versioning=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 114
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <VersioningConfiguration><Status>Enabled</Status></VersioningConfiguration>
+        headers:
+            Content-Length:
+                - "114"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Tue, 08 Sep 2026 14:49:46 GMT
+            X-Amz-Id-2:
+                - txg6a786ecb085a455b8a28-006aa0208a
+            X-Amz-Request-Id:
+                - txg6a786ecb085a455b8a28-006aa0208a
+        status: 200 OK
+        code: 200
+        duration: 3.469031125s
+    - id: 171
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 8ac87e2f-2288-4f0e-9519-cf26ec974637
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T144947Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?lifecycle=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 445
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <Configuration><Rule><Expiration><Days>2</Days></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260908144927109200000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260908144927109300000002</ID><Status>Enabled</Status></Rule></Configuration>
+        headers:
+            Content-Length:
+                - "445"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Tue, 08 Sep 2026 14:49:50 GMT
+            X-Amz-Id-2:
+                - txge6c28db83511410097e7-006aa0208e
+            X-Amz-Request-Id:
+                - txge6c28db83511410097e7-006aa0208e
+        status: 200 OK
+        code: 200
+        duration: 1.049191916s
+    - id: 172
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 09ca7a38-dc9c-4981-b764-65352957bfbe
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T144951Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -7284,20 +9011,1001 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 285
+        content_length: 0
         uncompressed: false
-        body: <Error><Code>NoSuchBucket</Code><Message>The specified bucket does not exist</Message><RequestId>txgfb259af95caa4dc4aea2-006aa00f9e</RequestId><HostId>txgfb259af95caa4dc4aea2-006aa00f9e</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
+        body: ""
+        headers:
+            Date:
+                - Tue, 08 Sep 2026 14:49:51 GMT
+            X-Amz-Id-2:
+                - txg936b1e8f8fb04127aea0-006aa0208f
+            X-Amz-Request-Id:
+                - txg936b1e8f8fb04127aea0-006aa0208f
+        status: 204 No Content
+        code: 204
+        duration: 4.187839875s
+    - id: 173
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 31680ddd-fabb-4c5e-aa58-146c5891777d
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T144955Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
         headers:
             Content-Length:
-                - "285"
+                - "0"
+            Date:
+                - Tue, 08 Sep 2026 14:49:55 GMT
+            Location:
+                - /tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016
+            X-Amz-Id-2:
+                - txg86bbb1fc1fd24128a6ba-006aa02093
+            X-Amz-Request-Id:
+                - txg86bbb1fc1fd24128a6ba-006aa02093
+        status: 200 OK
+        code: 200
+        duration: 948.39375ms
+    - id: 174
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 0a28d796-80ad-4d48-a024-3ce8047a466c
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,Z,e
+            X-Amz-Acl:
+                - private
+            X-Amz-Checksum-Crc32:
+                - AAAAAA==
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T144956Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?acl=
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Length:
+                - "0"
+            Date:
+                - Tue, 08 Sep 2026 14:49:56 GMT
+            X-Amz-Id-2:
+                - txg635c500d20684d82a808-006aa02094
+            X-Amz-Request-Id:
+                - txg635c500d20684d82a808-006aa02094
+        status: 200 OK
+        code: 200
+        duration: 297.087792ms
+    - id: 175
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 1649
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>30</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition><Transition><Days>210</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>95</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Filter><Prefix>path3/</Prefix></Filter><ID>id3</ID><Status>Enabled</Status><Transition><Days>130</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date></Expiration><Filter><And><Prefix>path4/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>155</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id6</ID><Status>Enabled</Status><Transition><Days>156</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></LifecycleConfiguration>
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 81c46761-cc2d-42bb-8288-0167361958ed
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            Content-Type:
+                - application/xml
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,Z,e
+            X-Amz-Checksum-Crc32:
+                - 1Ffwww==
+            X-Amz-Content-Sha256:
+                - 8a7c9d7e0dd84c226be1d7431209cac6b0d102fe8fd8f0e08c5d3b90ce4e5dfb
+            X-Amz-Date:
+                - 20260908T144956Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?lifecycle=
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Length:
+                - "0"
+            Date:
+                - Tue, 08 Sep 2026 14:49:57 GMT
+            X-Amz-Id-2:
+                - txg0ea9bee35e214340994d-006aa02095
+            X-Amz-Request-Id:
+                - txg0ea9bee35e214340994d-006aa02095
+        status: 200 OK
+        code: 200
+        duration: 285.233167ms
+    - id: 176
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 535ddf4d-ddda-4055-a901-cb0c37b0c289
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T144957Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?acl=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 698
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+        headers:
+            Content-Length:
+                - "698"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Tue, 08 Sep 2026 14:49:57 GMT
+            X-Amz-Id-2:
+                - txg27b2f21dc25e498b875d-006aa02095
+            X-Amz-Request-Id:
+                - txg27b2f21dc25e498b875d-006aa02095
+        status: 200 OK
+        code: 200
+        duration: 198.200458ms
+    - id: 177
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 67e8deab-a838-41bd-b682-6c1803ccd758
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T144957Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?object-lock=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 330
+        uncompressed: false
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgc4f4827a59e94d79b882-006aa02095</RequestId><HostId>txgc4f4827a59e94d79b882-006aa02095</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource></Error>
+        headers:
+            Content-Length:
+                - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 13:37:34 GMT
+                - Tue, 08 Sep 2026 14:49:57 GMT
             X-Amz-Id-2:
-                - txgfb259af95caa4dc4aea2-006aa00f9e
+                - txgc4f4827a59e94d79b882-006aa02095
             X-Amz-Request-Id:
-                - txgfb259af95caa4dc4aea2-006aa00f9e
+                - txgc4f4827a59e94d79b882-006aa02095
         status: 404 Not Found
         code: 404
-        duration: 1.105843709s
+        duration: 329.665125ms
+    - id: 178
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - e020daf2-4938-490a-950d-e04c3c34ea0e
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T144957Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 287
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+        headers:
+            Content-Length:
+                - "287"
+            Content-Type:
+                - application/xml
+            Date:
+                - Tue, 08 Sep 2026 14:49:57 GMT
+            X-Amz-Id-2:
+                - txg5a8cba484bd2461e9a38-006aa02095
+            X-Amz-Request-Id:
+                - txg5a8cba484bd2461e9a38-006aa02095
+        status: 200 OK
+        code: 200
+        duration: 307.279375ms
+    - id: 179
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 3c16190f-01d5-4fd8-9b56-011a2ab38e90
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T144957Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?tagging=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 361
+        uncompressed: false
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg621baf98a5ff40a1a253-006aa02096</RequestId><HostId>txg621baf98a5ff40a1a253-006aa02096</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</BucketName></Error>
+        headers:
+            Content-Length:
+                - "361"
+            Content-Type:
+                - application/xml
+            Date:
+                - Tue, 08 Sep 2026 14:49:58 GMT
+            X-Amz-Id-2:
+                - txg621baf98a5ff40a1a253-006aa02096
+            X-Amz-Request-Id:
+                - txg621baf98a5ff40a1a253-006aa02096
+        status: 404 Not Found
+        code: 404
+        duration: 101.3825ms
+    - id: 180
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 6e07b414-c02f-4031-b8bb-f18009a29a96
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T144958Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?cors=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 298
+        uncompressed: false
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgc0f23f2cb3b84ec787c0-006aa02096</RequestId><HostId>txgc0f23f2cb3b84ec787c0-006aa02096</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource></Error>
+        headers:
+            Content-Length:
+                - "298"
+            Content-Type:
+                - application/xml
+            Date:
+                - Tue, 08 Sep 2026 14:49:58 GMT
+            X-Amz-Id-2:
+                - txgc0f23f2cb3b84ec787c0-006aa02096
+            X-Amz-Request-Id:
+                - txgc0f23f2cb3b84ec787c0-006aa02096
+        status: 404 Not Found
+        code: 404
+        duration: 101.099958ms
+    - id: 181
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 88955891-94bb-484c-a27e-283a53acc649
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T144958Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?versioning=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 107
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <VersioningConfiguration><Status></Status></VersioningConfiguration>
+        headers:
+            Content-Length:
+                - "107"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Tue, 08 Sep 2026 14:49:58 GMT
+            X-Amz-Id-2:
+                - txge4ff8af375744eb38b60-006aa02096
+            X-Amz-Request-Id:
+                - txge4ff8af375744eb38b60-006aa02096
+        status: 200 OK
+        code: 200
+        duration: 213.642041ms
+    - id: 182
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 70ed19f7-0f1e-4ab4-9ed5-9c41d7c16ecd
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T144958Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?lifecycle=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1622
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>30</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition><Transition><Days>210</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>95</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Filter><Prefix>path3/</Prefix></Filter><ID>id3</ID><Status>Enabled</Status><Transition><Days>130</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date></Expiration><Filter><And><Prefix>path4/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>155</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id6</ID><Status>Enabled</Status><Transition><Days>156</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
+        headers:
+            Content-Length:
+                - "1622"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Tue, 08 Sep 2026 14:49:58 GMT
+            X-Amz-Id-2:
+                - txg6755ab86dac842c1b82b-006aa02096
+            X-Amz-Request-Id:
+                - txg6755ab86dac842c1b82b-006aa02096
+        status: 200 OK
+        code: 200
+        duration: 293.149125ms
+    - id: 183
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - f0e51942-acd7-4947-acd1-6dbebcca75d1
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T144958Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/
+        method: HEAD
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/xml
+            Date:
+                - Tue, 08 Sep 2026 14:49:59 GMT
+            X-Amz-Bucket-Region:
+                - nl-ams
+            X-Amz-Id-2:
+                - txg78db0193241b41238b50-006aa02097
+            X-Amz-Request-Id:
+                - txg78db0193241b41238b50-006aa02097
+        status: 200 OK
+        code: 200
+        duration: 1.122894708s
+    - id: 184
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - fcdea431-be2d-4504-a864-4555e1de3780
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T145000Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?acl=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 698
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+        headers:
+            Content-Length:
+                - "698"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Tue, 08 Sep 2026 14:50:00 GMT
+            X-Amz-Id-2:
+                - txg562c1de0c76e47d9be29-006aa02098
+            X-Amz-Request-Id:
+                - txg562c1de0c76e47d9be29-006aa02098
+        status: 200 OK
+        code: 200
+        duration: 288.55225ms
+    - id: 185
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - beb79086-2ff1-4a00-8db1-a315162d0720
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T145000Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?object-lock=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 330
+        uncompressed: false
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg7cb5b43042c248ff895d-006aa02098</RequestId><HostId>txg7cb5b43042c248ff895d-006aa02098</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource></Error>
+        headers:
+            Content-Length:
+                - "330"
+            Content-Type:
+                - application/xml
+            Date:
+                - Tue, 08 Sep 2026 14:50:00 GMT
+            X-Amz-Id-2:
+                - txg7cb5b43042c248ff895d-006aa02098
+            X-Amz-Request-Id:
+                - txg7cb5b43042c248ff895d-006aa02098
+        status: 404 Not Found
+        code: 404
+        duration: 1.090294625s
+    - id: 186
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 3b1e5e53-198a-4480-8609-a6ad417f11ee
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T145000Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 287
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+        headers:
+            Content-Length:
+                - "287"
+            Content-Type:
+                - application/xml
+            Date:
+                - Tue, 08 Sep 2026 14:50:01 GMT
+            X-Amz-Id-2:
+                - txg10aca15911204d6bbfbd-006aa02099
+            X-Amz-Request-Id:
+                - txg10aca15911204d6bbfbd-006aa02099
+        status: 200 OK
+        code: 200
+        duration: 241.809125ms
+    - id: 187
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - d623e39d-f20e-4e35-9a4f-ac70ad046616
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T145001Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?tagging=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 361
+        uncompressed: false
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txga9f45166931a4cd0b0ac-006aa0209a</RequestId><HostId>txga9f45166931a4cd0b0ac-006aa0209a</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</BucketName></Error>
+        headers:
+            Content-Length:
+                - "361"
+            Content-Type:
+                - application/xml
+            Date:
+                - Tue, 08 Sep 2026 14:50:02 GMT
+            X-Amz-Id-2:
+                - txga9f45166931a4cd0b0ac-006aa0209a
+            X-Amz-Request-Id:
+                - txga9f45166931a4cd0b0ac-006aa0209a
+        status: 404 Not Found
+        code: 404
+        duration: 198.0305ms
+    - id: 188
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 2fc3b867-bf8f-479c-b239-0b5a5eef4311
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T145002Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?cors=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 298
+        uncompressed: false
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgc9d774fa969b438d8f11-006aa0209a</RequestId><HostId>txgc9d774fa969b438d8f11-006aa0209a</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016</Resource></Error>
+        headers:
+            Content-Length:
+                - "298"
+            Content-Type:
+                - application/xml
+            Date:
+                - Tue, 08 Sep 2026 14:50:02 GMT
+            X-Amz-Id-2:
+                - txgc9d774fa969b438d8f11-006aa0209a
+            X-Amz-Request-Id:
+                - txgc9d774fa969b438d8f11-006aa0209a
+        status: 404 Not Found
+        code: 404
+        duration: 79.552ms
+    - id: 189
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - b05ac652-bc2e-4434-8e44-339b6c2b7953
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T145002Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?versioning=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 107
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <VersioningConfiguration><Status></Status></VersioningConfiguration>
+        headers:
+            Content-Length:
+                - "107"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Tue, 08 Sep 2026 14:50:02 GMT
+            X-Amz-Id-2:
+                - txge8510ba913db4436aa66-006aa0209a
+            X-Amz-Request-Id:
+                - txge8510ba913db4436aa66-006aa0209a
+        status: 200 OK
+        code: 200
+        duration: 228.081167ms
+    - id: 190
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 9a9ec4ea-1f33-46e9-9cc3-3820e7ab1421
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T145002Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/?lifecycle=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1622
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>30</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition><Transition><Days>210</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>95</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Filter><Prefix>path3/</Prefix></Filter><ID>id3</ID><Status>Enabled</Status><Transition><Days>130</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date></Expiration><Filter><And><Prefix>path4/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>155</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id6</ID><Status>Enabled</Status><Transition><Days>156</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
+        headers:
+            Content-Length:
+                - "1622"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Tue, 08 Sep 2026 14:50:02 GMT
+            X-Amz-Id-2:
+                - txgdfacf1a37227443da585-006aa0209a
+            X-Amz-Request-Id:
+                - txgdfacf1a37227443da585-006aa0209a
+        status: 200 OK
+        code: 200
+        duration: 306.330667ms
+    - id: 191
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 0259702d-4f0b-49c5-b4e7-f3511ee2ed97
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T145003Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2367057674154516016.s3.nl-ams.scw.cloud/
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Date:
+                - Tue, 08 Sep 2026 14:50:03 GMT
+            X-Amz-Id-2:
+                - txgaa12ffd383194bdf8a75-006aa0209b
+            X-Amz-Request-Id:
+                - txgaa12ffd383194bdf8a75-006aa0209b
+        status: 204 No Content
+        code: 204
+        duration: 514.525125ms

--- a/internal/services/object/testdata/object-bucket-lifecycle.cassette.yaml
+++ b/internal/services/object/testdata/object-bucket-lifecycle.cassette.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -18,16 +18,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c5533397-00d9-4ccb-ab9e-56422d5cf28a
+                - fb1673f6-1680-48a2-a241-e9af8b94ae42
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142036Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/
+                - 20260908T125222Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
         method: PUT
       response:
         proto: HTTP/2.0
@@ -42,16 +42,16 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 21 Jul 2026 14:20:36 GMT
+                - Tue, 08 Sep 2026 12:52:22 GMT
             Location:
-                - /tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544
+                - /tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110
             X-Amz-Id-2:
-                - txg73b582307079486580db-006a5f8034
+                - txgb63ded51997c4d36af57-006aa00506
             X-Amz-Request-Id:
-                - txg73b582307079486580db-006a5f8034
+                - txgb63ded51997c4d36af57-006aa00506
         status: 200 OK
         code: 200
-        duration: 4.671020333s
+        duration: 1.360353458s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -60,7 +60,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -69,11 +69,11 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3b8085b7-9d81-451e-ab81-ff93f2be58ea
+                - 9bea23da-5564-41ca-adab-f6f89348e16e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,Z,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,Z,e
             X-Amz-Acl:
                 - private
             X-Amz-Checksum-Crc32:
@@ -81,8 +81,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142040Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T125223Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?acl=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -97,14 +97,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 21 Jul 2026 14:20:40 GMT
+                - Tue, 08 Sep 2026 12:52:23 GMT
             X-Amz-Id-2:
-                - txg8d0b7573670f437fa28a-006a5f8038
+                - txg33c0e35e82f64cbcbb90-006aa00507
             X-Amz-Request-Id:
-                - txg8d0b7573670f437fa28a-006a5f8038
+                - txg33c0e35e82f64cbcbb90-006aa00507
         status: 200 OK
         code: 200
-        duration: 134.394042ms
+        duration: 413.443166ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -113,7 +113,7 @@ interactions:
         content_length: 363
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></LifecycleConfiguration>
@@ -122,20 +122,20 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 8c19144c-84c3-4ef1-ac36-21f3b18312ef
+                - 8c55414c-3285-4880-8ea1-5d870a310a35
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
                 - application/xml
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,Z,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,Z,e
             X-Amz-Checksum-Crc32:
                 - oUpeiA==
             X-Amz-Content-Sha256:
                 - 512733381e697ad60e3f974cfb76a92f1c9d2b97cb251bdf165a2579d5e88cd5
             X-Amz-Date:
-                - 20260721T142040Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T125223Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -150,14 +150,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 21 Jul 2026 14:20:41 GMT
+                - Tue, 08 Sep 2026 12:52:24 GMT
             X-Amz-Id-2:
-                - txgef740eb804cc437596d2-006a5f8039
+                - txg97c57eda699847c99d7f-006aa00508
             X-Amz-Request-Id:
-                - txgef740eb804cc437596d2-006a5f8039
+                - txg97c57eda699847c99d7f-006aa00508
         status: 200 OK
         code: 200
-        duration: 203.045666ms
+        duration: 423.0225ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -166,7 +166,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -175,16 +175,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 805ffcee-90d3-4aac-b106-18f647d0971d
+                - 52fd0610-dfb6-450b-8b8f-12973e046052
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142041Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T125224Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -196,21 +196,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:20:41 GMT
+                - Tue, 08 Sep 2026 12:52:24 GMT
             X-Amz-Id-2:
-                - txg0ea8b8d32107401d811c-006a5f8039
+                - txg6a2b5fa34130448e9c32-006aa00508
             X-Amz-Request-Id:
-                - txg0ea8b8d32107401d811c-006a5f8039
+                - txg6a2b5fa34130448e9c32-006aa00508
         status: 200 OK
         code: 200
-        duration: 97.81775ms
+        duration: 178.268708ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -219,7 +219,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -228,16 +228,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ecde9d14-f032-4d25-abee-3e0b6a76c72a
+                - 606b7e90-6e8b-4122-a88c-3b7c9c8cea4e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142041Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T125224Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -247,21 +247,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg6eafa1e8ac8e4136898d-006a5f8039</RequestId><HostId>txg6eafa1e8ac8e4136898d-006a5f8039</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg2f7ab2ce46f840c9a05d-006aa00508</RequestId><HostId>txg2f7ab2ce46f840c9a05d-006aa00508</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:20:41 GMT
+                - Tue, 08 Sep 2026 12:52:24 GMT
             X-Amz-Id-2:
-                - txg6eafa1e8ac8e4136898d-006a5f8039
+                - txg2f7ab2ce46f840c9a05d-006aa00508
             X-Amz-Request-Id:
-                - txg6eafa1e8ac8e4136898d-006a5f8039
+                - txg2f7ab2ce46f840c9a05d-006aa00508
         status: 404 Not Found
         code: 404
-        duration: 125.869584ms
+        duration: 210.520083ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -270,7 +270,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -279,16 +279,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 58f077b4-dab5-445e-909d-22c9f9794e33
+                - c593da9f-a6eb-4b20-b076-2c016d505d3c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142041Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/
+                - 20260908T125224Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -300,21 +300,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:20:41 GMT
+                - Tue, 08 Sep 2026 12:52:25 GMT
             X-Amz-Id-2:
-                - txga948b70dee4e44b081ff-006a5f8039
+                - txg6db210765d804166954e-006aa00509
             X-Amz-Request-Id:
-                - txga948b70dee4e44b081ff-006a5f8039
+                - txg6db210765d804166954e-006aa00509
         status: 200 OK
         code: 200
-        duration: 293.877875ms
+        duration: 318.855833ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -323,7 +323,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -332,16 +332,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ebca56af-b748-4136-b7eb-e2b32fb70d25
+                - d7d449b8-c1d2-443e-b3ea-a85e8007f027
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142041Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T125225Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -351,21 +351,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgbf50ee0dc42d41ec887e-006a5f8039</RequestId><HostId>txgbf50ee0dc42d41ec887e-006a5f8039</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg739de52a32c54a1994c9-006aa00509</RequestId><HostId>txg739de52a32c54a1994c9-006aa00509</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:20:41 GMT
+                - Tue, 08 Sep 2026 12:52:25 GMT
             X-Amz-Id-2:
-                - txgbf50ee0dc42d41ec887e-006a5f8039
+                - txg739de52a32c54a1994c9-006aa00509
             X-Amz-Request-Id:
-                - txgbf50ee0dc42d41ec887e-006a5f8039
+                - txg739de52a32c54a1994c9-006aa00509
         status: 404 Not Found
         code: 404
-        duration: 76.571833ms
+        duration: 203.835583ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -374,7 +374,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -383,16 +383,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b1715d0a-9b99-4f0c-9840-7eb2eacf70b5
+                - 076ce010-a4fa-47eb-a94c-9afdbbc58db9
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142041Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T125225Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -402,21 +402,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg0ee9f34c718547d5afa3-006a5f8039</RequestId><HostId>txg0ee9f34c718547d5afa3-006a5f8039</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg00164ee5a1414f71b514-006aa00509</RequestId><HostId>txg00164ee5a1414f71b514-006aa00509</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:20:41 GMT
+                - Tue, 08 Sep 2026 12:52:25 GMT
             X-Amz-Id-2:
-                - txg0ee9f34c718547d5afa3-006a5f8039
+                - txg00164ee5a1414f71b514-006aa00509
             X-Amz-Request-Id:
-                - txg0ee9f34c718547d5afa3-006a5f8039
+                - txg00164ee5a1414f71b514-006aa00509
         status: 404 Not Found
         code: 404
-        duration: 232.582416ms
+        duration: 181.037583ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -425,7 +425,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -434,16 +434,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c0dea489-faf1-4f7b-a31d-356defdaa28b
+                - 7f1c3f59-e63a-4595-bf5d-3df4a820a60c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142041Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T125225Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -462,14 +462,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:20:42 GMT
+                - Tue, 08 Sep 2026 12:52:25 GMT
             X-Amz-Id-2:
-                - txg4c4e986563fb4247b14d-006a5f803a
+                - txg0e71aa07a309445eb20b-006aa00509
             X-Amz-Request-Id:
-                - txg4c4e986563fb4247b14d-006a5f803a
+                - txg0e71aa07a309445eb20b-006aa00509
         status: 200 OK
         code: 200
-        duration: 206.343292ms
+        duration: 309.288125ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -478,7 +478,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -487,16 +487,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d276961a-c54f-45c1-863d-bb5464c28c08
+                - 0206766a-b889-4b55-b337-7b4e71c79417
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142042Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T125225Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -515,14 +515,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:20:42 GMT
+                - Tue, 08 Sep 2026 12:52:26 GMT
             X-Amz-Id-2:
-                - txgc8fd5b1896dd45e897d5-006a5f803a
+                - txgf62401f24e364039883b-006aa0050a
             X-Amz-Request-Id:
-                - txgc8fd5b1896dd45e897d5-006a5f803a
+                - txgf62401f24e364039883b-006aa0050a
         status: 200 OK
         code: 200
-        duration: 305.575417ms
+        duration: 219.534833ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -531,7 +531,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -540,16 +540,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 8bce2ec3-2255-4568-ac46-c42527eb774a
+                - 94bc67c7-6dba-4d62-8afc-ec73db59dc7c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142042Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/
+                - 20260908T125226Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -564,16 +564,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:20:42 GMT
+                - Tue, 08 Sep 2026 12:52:26 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txg574bfecdc5104f78b7e6-006a5f803a
+                - txga90fb958c5954a85b7d4-006aa0050a
             X-Amz-Request-Id:
-                - txg574bfecdc5104f78b7e6-006a5f803a
+                - txga90fb958c5954a85b7d4-006aa0050a
         status: 200 OK
         code: 200
-        duration: 280.204625ms
+        duration: 915.095125ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -582,7 +582,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -591,16 +591,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 09bbdd55-07a4-4296-99b8-9f81a5e9df54
+                - a513f5ed-4016-4452-959f-bb648e2bb082
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142042Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T125227Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -619,14 +619,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:20:43 GMT
+                - Tue, 08 Sep 2026 12:52:27 GMT
             X-Amz-Id-2:
-                - txg0cdccbbaa80b42edb858-006a5f803b
+                - txg42ee44227e6f4258a0d1-006aa0050b
             X-Amz-Request-Id:
-                - txg0cdccbbaa80b42edb858-006a5f803b
+                - txg42ee44227e6f4258a0d1-006aa0050b
         status: 200 OK
         code: 200
-        duration: 190.339083ms
+        duration: 224.199584ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -635,7 +635,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -644,16 +644,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c802da66-d58a-4d46-830d-6b908298f608
+                - f987b2a1-226f-40f7-bcf6-4a969d21ad4e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142043Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T125227Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -665,21 +665,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:20:43 GMT
+                - Tue, 08 Sep 2026 12:52:27 GMT
             X-Amz-Id-2:
-                - txg07cabf42bb794a249d9d-006a5f803b
+                - txgb0955dc068f84fc5b083-006aa0050b
             X-Amz-Request-Id:
-                - txg07cabf42bb794a249d9d-006a5f803b
+                - txgb0955dc068f84fc5b083-006aa0050b
         status: 200 OK
         code: 200
-        duration: 113.398625ms
+        duration: 693.54575ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -688,7 +688,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -697,16 +697,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 25dfa6d6-f201-41dd-b48f-3efe64005e6e
+                - e9ebc528-b97d-4989-8695-8911c3e5e6d9
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142043Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T125227Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -716,21 +716,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgebf63dec9d38438d88fd-006a5f803b</RequestId><HostId>txgebf63dec9d38438d88fd-006a5f803b</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg903e5adb973f43f8b9f0-006aa0050c</RequestId><HostId>txg903e5adb973f43f8b9f0-006aa0050c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:20:43 GMT
+                - Tue, 08 Sep 2026 12:52:28 GMT
             X-Amz-Id-2:
-                - txgebf63dec9d38438d88fd-006a5f803b
+                - txg903e5adb973f43f8b9f0-006aa0050c
             X-Amz-Request-Id:
-                - txgebf63dec9d38438d88fd-006a5f803b
+                - txg903e5adb973f43f8b9f0-006aa0050c
         status: 404 Not Found
         code: 404
-        duration: 78.126291ms
+        duration: 213.23525ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -739,7 +739,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -748,16 +748,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - bbead47d-1863-43cf-88a7-f3c8908026d2
+                - 725ef728-f183-42cd-b219-0a55122fd1ba
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142043Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/
+                - 20260908T125228Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -769,21 +769,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:20:43 GMT
+                - Tue, 08 Sep 2026 12:52:28 GMT
             X-Amz-Id-2:
-                - txg79f4c453ddaa4c16b95f-006a5f803b
+                - txge34c1f2e970540cf98a2-006aa0050c
             X-Amz-Request-Id:
-                - txg79f4c453ddaa4c16b95f-006a5f803b
+                - txge34c1f2e970540cf98a2-006aa0050c
         status: 200 OK
         code: 200
-        duration: 183.994083ms
+        duration: 265.709916ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -792,7 +792,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -801,16 +801,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 55e9afbe-9f89-47d7-bd0e-8eac6af9ca7f
+                - 833f3eb1-286a-4241-a18d-31ec3dd5cc00
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142043Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T125228Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -820,21 +820,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgceff83e5ab8b498f93f3-006a5f803b</RequestId><HostId>txgceff83e5ab8b498f93f3-006a5f803b</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg7b68bce990044f13b225-006aa0050d</RequestId><HostId>txg7b68bce990044f13b225-006aa0050d</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:20:43 GMT
+                - Tue, 08 Sep 2026 12:52:29 GMT
             X-Amz-Id-2:
-                - txgceff83e5ab8b498f93f3-006a5f803b
+                - txg7b68bce990044f13b225-006aa0050d
             X-Amz-Request-Id:
-                - txgceff83e5ab8b498f93f3-006a5f803b
+                - txg7b68bce990044f13b225-006aa0050d
         status: 404 Not Found
         code: 404
-        duration: 121.09ms
+        duration: 411.153625ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -843,7 +843,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -852,16 +852,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 925fe4eb-875b-4ee2-9f96-c3963b57f04d
+                - 0d0487ff-edbb-41eb-9724-4744dcbff87f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142043Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T125229Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -871,21 +871,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg80de872696c84db989f4-006a5f803c</RequestId><HostId>txg80de872696c84db989f4-006a5f803c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg8e0248eb2d304150b1c4-006aa0050d</RequestId><HostId>txg8e0248eb2d304150b1c4-006aa0050d</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:20:44 GMT
+                - Tue, 08 Sep 2026 12:52:29 GMT
             X-Amz-Id-2:
-                - txg80de872696c84db989f4-006a5f803c
+                - txg8e0248eb2d304150b1c4-006aa0050d
             X-Amz-Request-Id:
-                - txg80de872696c84db989f4-006a5f803c
+                - txg8e0248eb2d304150b1c4-006aa0050d
         status: 404 Not Found
         code: 404
-        duration: 113.496292ms
+        duration: 208.54775ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -894,7 +894,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -903,16 +903,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - dcf3fef8-1bc3-44e8-aa9f-8cb45100ece9
+                - a9cbd869-8dd2-48d9-bf64-104dca5a5772
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142044Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T125229Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -931,14 +931,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:20:44 GMT
+                - Tue, 08 Sep 2026 12:52:29 GMT
             X-Amz-Id-2:
-                - txge997f8384b5d4d69929d-006a5f803c
+                - txgec3af5c10787401b9b75-006aa0050d
             X-Amz-Request-Id:
-                - txge997f8384b5d4d69929d-006a5f803c
+                - txgec3af5c10787401b9b75-006aa0050d
         status: 200 OK
         code: 200
-        duration: 111.184417ms
+        duration: 674.9155ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -947,7 +947,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -956,16 +956,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f06050f0-4a4a-4d25-999f-e84cd2961353
+                - 7ab81fda-9cd8-482f-a157-25b5af8ba101
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142044Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T125229Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -984,14 +984,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:20:44 GMT
+                - Tue, 08 Sep 2026 12:52:30 GMT
             X-Amz-Id-2:
-                - txg03d27307237748679b76-006a5f803c
+                - txg8f3d7b021695413980b7-006aa0050e
             X-Amz-Request-Id:
-                - txg03d27307237748679b76-006a5f803c
+                - txg8f3d7b021695413980b7-006aa0050e
         status: 200 OK
         code: 200
-        duration: 54.958375ms
+        duration: 593.555375ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -1000,7 +1000,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1009,16 +1009,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 69b34f0a-db7d-4bb1-b185-fe281771fa09
+                - 11c35acb-9bd0-493f-ae63-fe8c5712eba8
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142044Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T125231Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1030,21 +1030,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:20:44 GMT
+                - Tue, 08 Sep 2026 12:52:31 GMT
             X-Amz-Id-2:
-                - txga343f980e809472b9d97-006a5f803c
+                - txg77d1b0dc6e1f4e0b857d-006aa0050f
             X-Amz-Request-Id:
-                - txga343f980e809472b9d97-006a5f803c
+                - txg77d1b0dc6e1f4e0b857d-006aa0050f
         status: 200 OK
         code: 200
-        duration: 17.702083ms
+        duration: 449.389583ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1053,7 +1053,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1062,16 +1062,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5b197a4e-265a-4915-ad39-8cfcbca1cc0c
+                - 89de28bf-3cb4-4a30-8410-e6898a2b3e8e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142044Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T125231Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1081,21 +1081,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg81284bc17dc3473cafff-006a5f803c</RequestId><HostId>txg81284bc17dc3473cafff-006a5f803c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg29bc96ac479f47b7834c-006aa0050f</RequestId><HostId>txg29bc96ac479f47b7834c-006aa0050f</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:20:44 GMT
+                - Tue, 08 Sep 2026 12:52:31 GMT
             X-Amz-Id-2:
-                - txg81284bc17dc3473cafff-006a5f803c
+                - txg29bc96ac479f47b7834c-006aa0050f
             X-Amz-Request-Id:
-                - txg81284bc17dc3473cafff-006a5f803c
+                - txg29bc96ac479f47b7834c-006aa0050f
         status: 404 Not Found
         code: 404
-        duration: 18.434291ms
+        duration: 260.609667ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1104,7 +1104,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1113,16 +1113,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d986af5b-640f-4841-8ae0-6ea392934342
+                - d84d4161-f658-4c48-a275-5250c0aa6740
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142044Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/
+                - 20260908T125231Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -1134,21 +1134,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:20:44 GMT
+                - Tue, 08 Sep 2026 12:52:31 GMT
             X-Amz-Id-2:
-                - txg308904bdaf694119907e-006a5f803c
+                - txg0ba7fd3ff1ce4d9fb2f8-006aa0050f
             X-Amz-Request-Id:
-                - txg308904bdaf694119907e-006a5f803c
+                - txg0ba7fd3ff1ce4d9fb2f8-006aa0050f
         status: 200 OK
         code: 200
-        duration: 297.962333ms
+        duration: 792.109875ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1157,7 +1157,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1166,16 +1166,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f686457c-a034-4ed9-910e-bc111ccf05e3
+                - 50943e60-c3e7-4d28-b806-4e78278cb60d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142044Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T125231Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1185,21 +1185,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg862dc4a993154c419771-006a5f803c</RequestId><HostId>txg862dc4a993154c419771-006a5f803c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgf32616d18774438cac1a-006aa00510</RequestId><HostId>txgf32616d18774438cac1a-006aa00510</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:20:44 GMT
+                - Tue, 08 Sep 2026 12:52:32 GMT
             X-Amz-Id-2:
-                - txg862dc4a993154c419771-006a5f803c
+                - txgf32616d18774438cac1a-006aa00510
             X-Amz-Request-Id:
-                - txg862dc4a993154c419771-006a5f803c
+                - txgf32616d18774438cac1a-006aa00510
         status: 404 Not Found
         code: 404
-        duration: 193.991459ms
+        duration: 83.544041ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1208,7 +1208,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1217,16 +1217,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 1c9413ba-7496-4c07-ac98-a6b4eaab4e2e
+                - 0dbe588c-da76-4528-a25d-7c02ab44616e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142044Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T125232Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1236,21 +1236,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg68506a8662bf4e3a89bd-006a5f803d</RequestId><HostId>txg68506a8662bf4e3a89bd-006a5f803d</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgbd3e595b19444617ba09-006aa00510</RequestId><HostId>txgbd3e595b19444617ba09-006aa00510</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:20:45 GMT
+                - Tue, 08 Sep 2026 12:52:32 GMT
             X-Amz-Id-2:
-                - txg68506a8662bf4e3a89bd-006a5f803d
+                - txgbd3e595b19444617ba09-006aa00510
             X-Amz-Request-Id:
-                - txg68506a8662bf4e3a89bd-006a5f803d
+                - txgbd3e595b19444617ba09-006aa00510
         status: 404 Not Found
         code: 404
-        duration: 172.46025ms
+        duration: 198.569708ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1259,7 +1259,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1268,16 +1268,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 83b187fe-77f8-4604-b9df-6e39a16f80bc
+                - 5f7dd0a4-104c-481f-af82-33a46cc6c4ae
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142045Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T125232Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1296,14 +1296,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:20:45 GMT
+                - Tue, 08 Sep 2026 12:52:32 GMT
             X-Amz-Id-2:
-                - txgc16a287d439145a5a883-006a5f803d
+                - txge9bd4b4c2f644f93acbb-006aa00510
             X-Amz-Request-Id:
-                - txgc16a287d439145a5a883-006a5f803d
+                - txge9bd4b4c2f644f93acbb-006aa00510
         status: 200 OK
         code: 200
-        duration: 18.064125ms
+        duration: 21.130375ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1312,7 +1312,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1321,16 +1321,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7e9a7e51-e764-4b40-b9f0-e3ea434993df
+                - 5f073881-c583-4548-b8d7-a3d9f1e0869f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142045Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T125232Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1349,14 +1349,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:20:45 GMT
+                - Tue, 08 Sep 2026 12:52:32 GMT
             X-Amz-Id-2:
-                - txg9b55b73bded249ceb0af-006a5f803d
+                - txg6260b57fd2d04511b200-006aa00510
             X-Amz-Request-Id:
-                - txg9b55b73bded249ceb0af-006a5f803d
+                - txg6260b57fd2d04511b200-006aa00510
         status: 200 OK
         code: 200
-        duration: 27.116083ms
+        duration: 218.894958ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1365,7 +1365,7 @@ interactions:
         content_length: 366
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition></Rule></LifecycleConfiguration>
@@ -1374,20 +1374,20 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4214aee3-caf9-4e1f-a29b-9f1ca86a0996
+                - d1155663-f8a1-495c-97c8-e9ce4f4298b0
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
                 - application/xml
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,Z,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,Z,e
             X-Amz-Checksum-Crc32:
                 - o6dwOA==
             X-Amz-Content-Sha256:
                 - 1695287f0c18bfb8c0d3d10989fec9b3e430afbc2914de7c50f434a75491894c
             X-Amz-Date:
-                - 20260721T142045Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T125233Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -1402,14 +1402,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 21 Jul 2026 14:20:45 GMT
+                - Tue, 08 Sep 2026 12:52:33 GMT
             X-Amz-Id-2:
-                - txgf2d4eba90f2444ba9b02-006a5f803d
+                - txg4fb50ec040e749c6b9a3-006aa00511
             X-Amz-Request-Id:
-                - txgf2d4eba90f2444ba9b02-006a5f803d
+                - txg4fb50ec040e749c6b9a3-006aa00511
         status: 200 OK
         code: 200
-        duration: 362.343916ms
+        duration: 258.953375ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1418,7 +1418,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1427,16 +1427,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ce6f9d84-0265-4f7a-8d40-c9b9819b11b0
+                - 6ba7a5d8-75ef-4e34-ab56-27bd396a596e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142045Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T125233Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1448,21 +1448,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:20:45 GMT
+                - Tue, 08 Sep 2026 12:52:33 GMT
             X-Amz-Id-2:
-                - txg7e1a6109ba9c457ea038-006a5f803d
+                - txge6781e633d274b6a9381-006aa00511
             X-Amz-Request-Id:
-                - txg7e1a6109ba9c457ea038-006a5f803d
+                - txge6781e633d274b6a9381-006aa00511
         status: 200 OK
         code: 200
-        duration: 292.234375ms
+        duration: 344.712167ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1471,7 +1471,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1480,16 +1480,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - fd9d972b-16e9-4887-8f42-c6eefc6eeb8c
+                - e245bb62-5e6a-4777-b88a-a477d9392477
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142045Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T125233Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1499,21 +1499,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgc278f5394e894b7eb5d0-006a5f803e</RequestId><HostId>txgc278f5394e894b7eb5d0-006a5f803e</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg4f34152f0d9a4058962f-006aa00511</RequestId><HostId>txg4f34152f0d9a4058962f-006aa00511</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:20:46 GMT
+                - Tue, 08 Sep 2026 12:52:33 GMT
             X-Amz-Id-2:
-                - txgc278f5394e894b7eb5d0-006a5f803e
+                - txg4f34152f0d9a4058962f-006aa00511
             X-Amz-Request-Id:
-                - txgc278f5394e894b7eb5d0-006a5f803e
+                - txg4f34152f0d9a4058962f-006aa00511
         status: 404 Not Found
         code: 404
-        duration: 87.75225ms
+        duration: 450.184833ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1522,7 +1522,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1531,16 +1531,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 77e250fb-42d3-409b-b9ec-b398f1550164
+                - a331a9cd-3d7e-4396-a993-df3ca0f3921f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142046Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/
+                - 20260908T125233Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -1552,21 +1552,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:20:46 GMT
+                - Tue, 08 Sep 2026 12:52:34 GMT
             X-Amz-Id-2:
-                - txgcfd227bf73a8408185ec-006a5f803e
+                - txg8daea85ddf3646d0bfd0-006aa00512
             X-Amz-Request-Id:
-                - txgcfd227bf73a8408185ec-006a5f803e
+                - txg8daea85ddf3646d0bfd0-006aa00512
         status: 200 OK
         code: 200
-        duration: 402.313166ms
+        duration: 376.858791ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1575,7 +1575,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1584,16 +1584,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 85e65c3d-7a1a-4a7f-ab14-23b16f20b1d4
+                - 398fa481-d433-4d9e-be05-635e7cb5977b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142046Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T125234Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1603,21 +1603,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg677981cde84b477d86de-006a5f803e</RequestId><HostId>txg677981cde84b477d86de-006a5f803e</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg538286d7602342b389af-006aa00512</RequestId><HostId>txg538286d7602342b389af-006aa00512</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:20:46 GMT
+                - Tue, 08 Sep 2026 12:52:34 GMT
             X-Amz-Id-2:
-                - txg677981cde84b477d86de-006a5f803e
+                - txg538286d7602342b389af-006aa00512
             X-Amz-Request-Id:
-                - txg677981cde84b477d86de-006a5f803e
+                - txg538286d7602342b389af-006aa00512
         status: 404 Not Found
         code: 404
-        duration: 25.119292ms
+        duration: 24.844792ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1626,7 +1626,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1635,16 +1635,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ebd0fa10-36de-456b-a35b-8441b8ffd1d2
+                - 86fdf269-dfc3-4ea2-9336-28d4be9d6d53
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142046Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T125234Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1654,21 +1654,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg9435a1a58cd74ab89122-006a5f803e</RequestId><HostId>txg9435a1a58cd74ab89122-006a5f803e</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgf202d59113684f029db2-006aa00512</RequestId><HostId>txgf202d59113684f029db2-006aa00512</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:20:46 GMT
+                - Tue, 08 Sep 2026 12:52:34 GMT
             X-Amz-Id-2:
-                - txg9435a1a58cd74ab89122-006a5f803e
+                - txgf202d59113684f029db2-006aa00512
             X-Amz-Request-Id:
-                - txg9435a1a58cd74ab89122-006a5f803e
+                - txgf202d59113684f029db2-006aa00512
         status: 404 Not Found
         code: 404
-        duration: 109.696792ms
+        duration: 188.743416ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1677,7 +1677,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1686,16 +1686,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4b4bb65b-12cf-4ccd-89da-b9933e622182
+                - ef948bbc-2778-4946-a8bd-1713551b68a5
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142046Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T125234Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1714,14 +1714,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:20:46 GMT
+                - Tue, 08 Sep 2026 12:52:34 GMT
             X-Amz-Id-2:
-                - txgf0e64fe4eafd4d97a7fa-006a5f803e
+                - txgf470982537de45f4abab-006aa00512
             X-Amz-Request-Id:
-                - txgf0e64fe4eafd4d97a7fa-006a5f803e
+                - txgf470982537de45f4abab-006aa00512
         status: 200 OK
         code: 200
-        duration: 76.366ms
+        duration: 172.104834ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1730,7 +1730,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1739,16 +1739,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c3df7871-5c0c-4f2a-86d9-34b3844f5f2f
+                - 19e3b8cf-0b5b-4c4a-bc60-bd97101a3027
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142046Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T125234Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1767,14 +1767,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:20:46 GMT
+                - Tue, 08 Sep 2026 12:52:35 GMT
             X-Amz-Id-2:
-                - txg0eb84dba7f7548b7bf62-006a5f803e
+                - txg43a0a7dd6c65429a84a9-006aa00513
             X-Amz-Request-Id:
-                - txg0eb84dba7f7548b7bf62-006a5f803e
+                - txg43a0a7dd6c65429a84a9-006aa00513
         status: 200 OK
         code: 200
-        duration: 34.599375ms
+        duration: 221.301167ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1783,7 +1783,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1792,16 +1792,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 24f7b688-7288-4044-9151-4f2601fe214e
+                - e5086f31-4619-4f4c-8e97-60a6a6c5c479
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142046Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/
+                - 20260908T125235Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -1816,16 +1816,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:20:47 GMT
+                - Tue, 08 Sep 2026 12:52:35 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txg52cef22720924358814d-006a5f803f
+                - txgd138c643a92d4527b36c-006aa00513
             X-Amz-Request-Id:
-                - txg52cef22720924358814d-006a5f803f
+                - txgd138c643a92d4527b36c-006aa00513
         status: 200 OK
         code: 200
-        duration: 241.942167ms
+        duration: 480.348542ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1834,7 +1834,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1843,16 +1843,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 30865cd6-289f-4e57-bf35-815459f857c3
+                - de7d486c-7169-4197-bb90-3be19cb6bda2
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142047Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T125235Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1871,14 +1871,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:20:47 GMT
+                - Tue, 08 Sep 2026 12:52:35 GMT
             X-Amz-Id-2:
-                - txg6988f8380660459e961d-006a5f803f
+                - txg54fe3f2aadca40dfb55b-006aa00513
             X-Amz-Request-Id:
-                - txg6988f8380660459e961d-006a5f803f
+                - txg54fe3f2aadca40dfb55b-006aa00513
         status: 200 OK
         code: 200
-        duration: 199.165875ms
+        duration: 193.358416ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1887,7 +1887,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1896,16 +1896,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f2c08d31-335f-4ee8-9da7-f65723f92694
+                - cc5d9641-d2e4-400a-8cb7-914888c23432
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142047Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T125236Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1917,21 +1917,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:20:47 GMT
+                - Tue, 08 Sep 2026 12:52:36 GMT
             X-Amz-Id-2:
-                - txgec33a9a312e048169fad-006a5f803f
+                - txg2caaea015d374ac0b670-006aa00514
             X-Amz-Request-Id:
-                - txgec33a9a312e048169fad-006a5f803f
+                - txg2caaea015d374ac0b670-006aa00514
         status: 200 OK
         code: 200
-        duration: 182.082833ms
+        duration: 182.045083ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1940,7 +1940,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1949,16 +1949,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 67a998c2-f0f2-4e4f-83d7-44d2212586a2
+                - fc07e8e7-12c7-4b04-bf7c-6e0f495f0d80
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142047Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T125236Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1968,21 +1968,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txge88e16caf7f64e9586e2-006a5f803f</RequestId><HostId>txge88e16caf7f64e9586e2-006a5f803f</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgd974b5c4976c4e249c70-006aa00514</RequestId><HostId>txgd974b5c4976c4e249c70-006aa00514</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:20:47 GMT
+                - Tue, 08 Sep 2026 12:52:36 GMT
             X-Amz-Id-2:
-                - txge88e16caf7f64e9586e2-006a5f803f
+                - txgd974b5c4976c4e249c70-006aa00514
             X-Amz-Request-Id:
-                - txge88e16caf7f64e9586e2-006a5f803f
+                - txgd974b5c4976c4e249c70-006aa00514
         status: 404 Not Found
         code: 404
-        duration: 20.5975ms
+        duration: 194.309666ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1991,7 +1991,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2000,16 +2000,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a3be1758-d455-4e9f-8ae1-9f786ea20dc7
+                - 6f74f041-a4b1-42c5-a77c-118de12d1371
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142047Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/
+                - 20260908T125236Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -2021,21 +2021,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:20:48 GMT
+                - Tue, 08 Sep 2026 12:52:36 GMT
             X-Amz-Id-2:
-                - txgb81f826228a04d3fb198-006a5f8040
+                - txgd55f4bb893a0454d8fdb-006aa00514
             X-Amz-Request-Id:
-                - txgb81f826228a04d3fb198-006a5f8040
+                - txgd55f4bb893a0454d8fdb-006aa00514
         status: 200 OK
         code: 200
-        duration: 418.395042ms
+        duration: 26.675375ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -2044,7 +2044,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2053,16 +2053,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 2bb739d4-3969-49ed-8e42-4ba527ae5b25
+                - 4e6409b7-3ede-4a85-9e79-62a2d947c74e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142048Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T125236Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2072,21 +2072,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg81414a73351048c29e04-006a5f8040</RequestId><HostId>txg81414a73351048c29e04-006a5f8040</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgd3e772658477401b940d-006aa00514</RequestId><HostId>txgd3e772658477401b940d-006aa00514</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:20:48 GMT
+                - Tue, 08 Sep 2026 12:52:36 GMT
             X-Amz-Id-2:
-                - txg81414a73351048c29e04-006a5f8040
+                - txgd3e772658477401b940d-006aa00514
             X-Amz-Request-Id:
-                - txg81414a73351048c29e04-006a5f8040
+                - txgd3e772658477401b940d-006aa00514
         status: 404 Not Found
         code: 404
-        duration: 807.882583ms
+        duration: 183.079375ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -2095,7 +2095,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2104,16 +2104,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5044afa1-8be8-44c7-80d0-3d415ec97538
+                - b98e89de-0897-40f1-9c21-c77a8ced99eb
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142048Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T125236Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2123,21 +2123,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg392f10a722fe45aea286-006a5f8041</RequestId><HostId>txg392f10a722fe45aea286-006a5f8041</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgac3962c4ad15442b813d-006aa00514</RequestId><HostId>txgac3962c4ad15442b813d-006aa00514</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:20:49 GMT
+                - Tue, 08 Sep 2026 12:52:36 GMT
             X-Amz-Id-2:
-                - txg392f10a722fe45aea286-006a5f8041
+                - txgac3962c4ad15442b813d-006aa00514
             X-Amz-Request-Id:
-                - txg392f10a722fe45aea286-006a5f8041
+                - txgac3962c4ad15442b813d-006aa00514
         status: 404 Not Found
         code: 404
-        duration: 150.381083ms
+        duration: 284.613084ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2146,7 +2146,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2155,16 +2155,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - eb0e45bc-0989-4032-a161-d08bb37d345b
+                - 235b303a-a745-4a13-9968-7fa37edf0886
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142049Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T125236Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2183,14 +2183,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:20:49 GMT
+                - Tue, 08 Sep 2026 12:52:37 GMT
             X-Amz-Id-2:
-                - txga9cd45526e754c01b99f-006a5f8041
+                - txg0aa575f1b6d24ddf9b99-006aa00515
             X-Amz-Request-Id:
-                - txga9cd45526e754c01b99f-006a5f8041
+                - txg0aa575f1b6d24ddf9b99-006aa00515
         status: 200 OK
         code: 200
-        duration: 76.974209ms
+        duration: 234.592958ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -2199,7 +2199,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2208,16 +2208,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 195bf275-19ac-4f92-beb4-f41f48221331
+                - 350fe206-af06-417b-a096-1a448f677d1d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142049Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T125237Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2236,14 +2236,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:20:49 GMT
+                - Tue, 08 Sep 2026 12:52:37 GMT
             X-Amz-Id-2:
-                - txg67e55facf4ff4c458386-006a5f8041
+                - txgdfae1cb0769a4df7b834-006aa00515
             X-Amz-Request-Id:
-                - txg67e55facf4ff4c458386-006a5f8041
+                - txgdfae1cb0769a4df7b834-006aa00515
         status: 200 OK
         code: 200
-        duration: 19.28875ms
+        duration: 302.247542ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -2252,7 +2252,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2261,16 +2261,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d26b809b-16fe-4736-8a61-4b784c8ef0bb
+                - 145cd7e8-00a0-4502-a0e1-b52676f981dc
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142049Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T125237Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2282,21 +2282,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:20:49 GMT
+                - Tue, 08 Sep 2026 12:52:37 GMT
             X-Amz-Id-2:
-                - txg180ad80ea6bc42db9b3c-006a5f8041
+                - txg7914ab9c6d0b43baa39e-006aa00515
             X-Amz-Request-Id:
-                - txg180ad80ea6bc42db9b3c-006a5f8041
+                - txg7914ab9c6d0b43baa39e-006aa00515
         status: 200 OK
         code: 200
-        duration: 51.346291ms
+        duration: 235.330458ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -2305,7 +2305,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2314,16 +2314,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 18e1542a-15b6-4129-92eb-db11628cfd6b
+                - 73119ee5-00e8-482b-812d-59a7f43b705d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142049Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T125237Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2333,21 +2333,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg63bf4a39cae54078aaf9-006a5f8041</RequestId><HostId>txg63bf4a39cae54078aaf9-006a5f8041</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg263c39678b244b50a912-006aa00516</RequestId><HostId>txg263c39678b244b50a912-006aa00516</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:20:49 GMT
+                - Tue, 08 Sep 2026 12:52:38 GMT
             X-Amz-Id-2:
-                - txg63bf4a39cae54078aaf9-006a5f8041
+                - txg263c39678b244b50a912-006aa00516
             X-Amz-Request-Id:
-                - txg63bf4a39cae54078aaf9-006a5f8041
+                - txg263c39678b244b50a912-006aa00516
         status: 404 Not Found
         code: 404
-        duration: 110.68075ms
+        duration: 197.555625ms
     - id: 45
       request:
         proto: HTTP/1.1
@@ -2356,7 +2356,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2365,16 +2365,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d5cd75d6-8e05-4b40-81ee-0cdbdf6d7c55
+                - 87872a2b-4003-4ef7-971a-16f6f416cc1a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142049Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/
+                - 20260908T125238Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -2386,21 +2386,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:20:49 GMT
+                - Tue, 08 Sep 2026 12:52:38 GMT
             X-Amz-Id-2:
-                - txg4b4494be95ff4fbe9bb1-006a5f8041
+                - txgfbd4fba108c049ae9108-006aa00516
             X-Amz-Request-Id:
-                - txg4b4494be95ff4fbe9bb1-006a5f8041
+                - txgfbd4fba108c049ae9108-006aa00516
         status: 200 OK
         code: 200
-        duration: 342.605666ms
+        duration: 402.96175ms
     - id: 46
       request:
         proto: HTTP/1.1
@@ -2409,7 +2409,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2418,16 +2418,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 1ebc2c49-8190-4259-8d96-9173f328a8d3
+                - 47109473-a93f-4588-a61f-13ad9e584cd3
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142049Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T125238Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2437,21 +2437,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg6f28ca7929a14b0ca421-006a5f8042</RequestId><HostId>txg6f28ca7929a14b0ca421-006a5f8042</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg973d8362b6844dd3b1b2-006aa00516</RequestId><HostId>txg973d8362b6844dd3b1b2-006aa00516</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:20:50 GMT
+                - Tue, 08 Sep 2026 12:52:38 GMT
             X-Amz-Id-2:
-                - txg6f28ca7929a14b0ca421-006a5f8042
+                - txg973d8362b6844dd3b1b2-006aa00516
             X-Amz-Request-Id:
-                - txg6f28ca7929a14b0ca421-006a5f8042
+                - txg973d8362b6844dd3b1b2-006aa00516
         status: 404 Not Found
         code: 404
-        duration: 63.584209ms
+        duration: 199.706875ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -2460,7 +2460,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2469,16 +2469,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5f711f14-2818-4939-b0f1-67588279903e
+                - bd8cb8b0-e0f1-471c-a2b9-0ec7d0893aea
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142050Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T125238Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2488,21 +2488,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg64e01ee9363242968260-006a5f8042</RequestId><HostId>txg64e01ee9363242968260-006a5f8042</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg227cbd4a95b54eedba2d-006aa00516</RequestId><HostId>txg227cbd4a95b54eedba2d-006aa00516</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:20:50 GMT
+                - Tue, 08 Sep 2026 12:52:38 GMT
             X-Amz-Id-2:
-                - txg64e01ee9363242968260-006a5f8042
+                - txg227cbd4a95b54eedba2d-006aa00516
             X-Amz-Request-Id:
-                - txg64e01ee9363242968260-006a5f8042
+                - txg227cbd4a95b54eedba2d-006aa00516
         status: 404 Not Found
         code: 404
-        duration: 26.380375ms
+        duration: 21.67425ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -2511,7 +2511,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2520,16 +2520,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a6e1f71b-f9ee-4646-844e-99aa2ecb9111
+                - 351b91bb-6d41-4699-8907-27faa37bd1c9
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142050Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T125238Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2548,14 +2548,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:20:50 GMT
+                - Tue, 08 Sep 2026 12:52:38 GMT
             X-Amz-Id-2:
-                - txgf490c19d4fff48c1be48-006a5f8042
+                - txgcc87499910634a78acc3-006aa00516
             X-Amz-Request-Id:
-                - txgf490c19d4fff48c1be48-006a5f8042
+                - txgcc87499910634a78acc3-006aa00516
         status: 200 OK
         code: 200
-        duration: 168.024167ms
+        duration: 195.192458ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -2564,7 +2564,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2573,16 +2573,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 751b040c-3b55-491d-847d-c465000f4454
+                - 044bf033-ba37-428c-9fd4-db55936cd41f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142050Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T125238Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2601,14 +2601,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:20:50 GMT
+                - Tue, 08 Sep 2026 12:52:39 GMT
             X-Amz-Id-2:
-                - txg352e38e75d884fd1ae16-006a5f8042
+                - txg68bdf2fcb80d492f92bd-006aa00517
             X-Amz-Request-Id:
-                - txg352e38e75d884fd1ae16-006a5f8042
+                - txg68bdf2fcb80d492f92bd-006aa00517
         status: 200 OK
         code: 200
-        duration: 1.103541375s
+        duration: 21.955834ms
     - id: 50
       request:
         proto: HTTP/1.1
@@ -2617,29 +2617,29 @@ interactions:
         content_length: 1312
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
-        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></LifecycleConfiguration>
+        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></LifecycleConfiguration>
         form: {}
         headers:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3e05a649-65d7-4360-8add-644abcf622a2
+                - 9eef577f-9a50-455a-9753-cb19eeb1e9ee
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
                 - application/xml
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,Z,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,Z,e
             X-Amz-Checksum-Crc32:
-                - pPLx6g==
+                - 4NH0sw==
             X-Amz-Content-Sha256:
-                - 470295ace4b044f717c552c2027846524dad4509d1af1ee0e1d1439541cbacd6
+                - 26f747e15ce1a1b780c6752abe8ce8948c374f5a893f30d1d89454d547619049
             X-Amz-Date:
-                - 20260721T142051Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T125239Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -2654,14 +2654,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 21 Jul 2026 14:20:51 GMT
+                - Tue, 08 Sep 2026 12:52:39 GMT
             X-Amz-Id-2:
-                - txgafeb0b61cb6c4f09ab00-006a5f8043
+                - txgdf19210d15f647398279-006aa00517
             X-Amz-Request-Id:
-                - txgafeb0b61cb6c4f09ab00-006a5f8043
+                - txgdf19210d15f647398279-006aa00517
         status: 200 OK
         code: 200
-        duration: 215.181542ms
+        duration: 424.322708ms
     - id: 51
       request:
         proto: HTTP/1.1
@@ -2670,7 +2670,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2679,16 +2679,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9233790d-aa85-4682-a11d-aba37fdb740f
+                - dbad868e-6dd5-4aae-a019-f7c354de8e2b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142051Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T125239Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2700,21 +2700,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:20:52 GMT
+                - Tue, 08 Sep 2026 12:52:39 GMT
             X-Amz-Id-2:
-                - txg5a2a6063bc90400cb9f0-006a5f8044
+                - txg0ad82931823b4d2dbd0a-006aa00517
             X-Amz-Request-Id:
-                - txg5a2a6063bc90400cb9f0-006a5f8044
+                - txg0ad82931823b4d2dbd0a-006aa00517
         status: 200 OK
         code: 200
-        duration: 103.221375ms
+        duration: 136.962959ms
     - id: 52
       request:
         proto: HTTP/1.1
@@ -2723,7 +2723,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2732,16 +2732,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 999605ed-cdd3-4148-ae49-da62c1f73c8e
+                - 405db5a5-d878-48e6-b77b-798cbdab16f0
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142052Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T125239Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2751,21 +2751,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgc867654a8daa4206a5e9-006a5f8044</RequestId><HostId>txgc867654a8daa4206a5e9-006a5f8044</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg974500e4385c4306a7e6-006aa00517</RequestId><HostId>txg974500e4385c4306a7e6-006aa00517</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:20:52 GMT
+                - Tue, 08 Sep 2026 12:52:39 GMT
             X-Amz-Id-2:
-                - txgc867654a8daa4206a5e9-006a5f8044
+                - txg974500e4385c4306a7e6-006aa00517
             X-Amz-Request-Id:
-                - txgc867654a8daa4206a5e9-006a5f8044
+                - txg974500e4385c4306a7e6-006aa00517
         status: 404 Not Found
         code: 404
-        duration: 98.904958ms
+        duration: 91.808ms
     - id: 53
       request:
         proto: HTTP/1.1
@@ -2774,7 +2774,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2783,16 +2783,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 2523c6fb-ca90-4b94-8629-36ec9c6edf39
+                - 43b5a15b-5ea2-4657-9a37-b662c9743583
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142052Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/
+                - 20260908T125239Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -2804,21 +2804,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:20:52 GMT
+                - Tue, 08 Sep 2026 12:52:39 GMT
             X-Amz-Id-2:
-                - txgcd5b8eef44904f358ad2-006a5f8044
+                - txg818ac05c046b4ebb9201-006aa00517
             X-Amz-Request-Id:
-                - txgcd5b8eef44904f358ad2-006a5f8044
+                - txg818ac05c046b4ebb9201-006aa00517
         status: 200 OK
         code: 200
-        duration: 107.496958ms
+        duration: 785.303167ms
     - id: 54
       request:
         proto: HTTP/1.1
@@ -2827,7 +2827,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2836,16 +2836,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 104c2393-daf0-4703-8bb4-25c7211dac32
+                - 42ee14b3-ce9d-4cf5-9822-ac7ed70bb3b9
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142052Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T125239Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2855,21 +2855,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg6b3a865eb18c49158b4e-006a5f8044</RequestId><HostId>txg6b3a865eb18c49158b4e-006a5f8044</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg91e824ebeba5431eb8bd-006aa00518</RequestId><HostId>txg91e824ebeba5431eb8bd-006aa00518</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:20:52 GMT
+                - Tue, 08 Sep 2026 12:52:40 GMT
             X-Amz-Id-2:
-                - txg6b3a865eb18c49158b4e-006a5f8044
+                - txg91e824ebeba5431eb8bd-006aa00518
             X-Amz-Request-Id:
-                - txg6b3a865eb18c49158b4e-006a5f8044
+                - txg91e824ebeba5431eb8bd-006aa00518
         status: 404 Not Found
         code: 404
-        duration: 81.568417ms
+        duration: 1.153561916s
     - id: 55
       request:
         proto: HTTP/1.1
@@ -2878,7 +2878,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2887,16 +2887,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ff3cf8ab-9c6e-43d5-8690-71fb8134dff3
+                - c0cabc8c-ec57-4f17-a067-b305d4017c98
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142052Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T125240Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2906,21 +2906,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg54424d61cbaa4fbc9401-006a5f8044</RequestId><HostId>txg54424d61cbaa4fbc9401-006a5f8044</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgaa39bbe9f26c437e9d35-006aa00519</RequestId><HostId>txgaa39bbe9f26c437e9d35-006aa00519</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:20:52 GMT
+                - Tue, 08 Sep 2026 12:52:41 GMT
             X-Amz-Id-2:
-                - txg54424d61cbaa4fbc9401-006a5f8044
+                - txgaa39bbe9f26c437e9d35-006aa00519
             X-Amz-Request-Id:
-                - txg54424d61cbaa4fbc9401-006a5f8044
+                - txgaa39bbe9f26c437e9d35-006aa00519
         status: 404 Not Found
         code: 404
-        duration: 39.554666ms
+        duration: 387.433875ms
     - id: 56
       request:
         proto: HTTP/1.1
@@ -2929,7 +2929,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2938,16 +2938,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 69eb39cd-eea4-47cc-91fe-5a8a997a15ed
+                - 9839a3cc-da10-4ed3-bc7e-bdace97e6280
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142052Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T125241Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2966,14 +2966,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:20:52 GMT
+                - Tue, 08 Sep 2026 12:52:42 GMT
             X-Amz-Id-2:
-                - txg975a5a9810ec490f9bd7-006a5f8044
+                - txga8f60bdf3ee248349191-006aa0051a
             X-Amz-Request-Id:
-                - txg975a5a9810ec490f9bd7-006a5f8044
+                - txga8f60bdf3ee248349191-006aa0051a
         status: 200 OK
         code: 200
-        duration: 78.358209ms
+        duration: 368.740459ms
     - id: 57
       request:
         proto: HTTP/1.1
@@ -2982,7 +2982,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2991,16 +2991,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 1e1990fd-bcb7-41df-b48d-56865592fff9
+                - 4836c7a2-0df0-44bd-83a9-7c1b9db41cbb
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142052Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T125242Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3012,21 +3012,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
                 - "1285"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:20:52 GMT
+                - Tue, 08 Sep 2026 12:52:42 GMT
             X-Amz-Id-2:
-                - txgfd4494f7a8874381a67c-006a5f8044
+                - txga782bac633fc44c2894e-006aa0051a
             X-Amz-Request-Id:
-                - txgfd4494f7a8874381a67c-006a5f8044
+                - txga782bac633fc44c2894e-006aa0051a
         status: 200 OK
         code: 200
-        duration: 224.720292ms
+        duration: 258.857292ms
     - id: 58
       request:
         proto: HTTP/1.1
@@ -3035,7 +3035,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3044,16 +3044,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c53028c9-32ff-461b-b5c1-247399336b44
+                - 0ee2a79d-2dd8-412d-8f29-0ada18980941
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142052Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/
+                - 20260908T125242Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -3068,16 +3068,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:20:52 GMT
+                - Tue, 08 Sep 2026 12:52:42 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txg9c379d020b9d439480f3-006a5f8044
+                - txgbcd99ff3b2e54e338ba6-006aa0051a
             X-Amz-Request-Id:
-                - txg9c379d020b9d439480f3-006a5f8044
+                - txgbcd99ff3b2e54e338ba6-006aa0051a
         status: 200 OK
         code: 200
-        duration: 25.780917ms
+        duration: 338.845375ms
     - id: 59
       request:
         proto: HTTP/1.1
@@ -3086,7 +3086,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3095,16 +3095,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - bdbe103c-69cf-4711-bb29-c6c6aa45f89a
+                - 8408e3b7-03ac-4981-aa06-86fcb2d2a47f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142052Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T125243Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3116,21 +3116,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
                 - "1285"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:20:52 GMT
+                - Tue, 08 Sep 2026 12:52:43 GMT
             X-Amz-Id-2:
-                - txg3a12c920595846bd8d60-006a5f8044
+                - txg93c580572a364aee9069-006aa0051b
             X-Amz-Request-Id:
-                - txg3a12c920595846bd8d60-006a5f8044
+                - txg93c580572a364aee9069-006aa0051b
         status: 200 OK
         code: 200
-        duration: 180.405083ms
+        duration: 264.818125ms
     - id: 60
       request:
         proto: HTTP/1.1
@@ -3139,7 +3139,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3148,16 +3148,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3f241025-9722-4211-858a-9a127bd69f34
+                - ce14655e-38ea-4e14-b71a-1091aeb781eb
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142053Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T125243Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3169,21 +3169,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:20:53 GMT
+                - Tue, 08 Sep 2026 12:52:43 GMT
             X-Amz-Id-2:
-                - txg6318350b1dce4fb48f27-006a5f8045
+                - txg9d712b133f11424f9749-006aa0051b
             X-Amz-Request-Id:
-                - txg6318350b1dce4fb48f27-006a5f8045
+                - txg9d712b133f11424f9749-006aa0051b
         status: 200 OK
         code: 200
-        duration: 336.880583ms
+        duration: 372.8625ms
     - id: 61
       request:
         proto: HTTP/1.1
@@ -3192,7 +3192,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3201,16 +3201,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ac0e9366-a809-4375-9f69-eb4f69cd5d7f
+                - c8bafbbc-2bb5-461b-b05c-7425b6624e9e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142053Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T125243Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3220,21 +3220,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgf5c87378e7fd4c769427-006a5f8045</RequestId><HostId>txgf5c87378e7fd4c769427-006a5f8045</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgbe41a087b5574e6295e7-006aa0051c</RequestId><HostId>txgbe41a087b5574e6295e7-006aa0051c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:20:53 GMT
+                - Tue, 08 Sep 2026 12:52:44 GMT
             X-Amz-Id-2:
-                - txgf5c87378e7fd4c769427-006a5f8045
+                - txgbe41a087b5574e6295e7-006aa0051c
             X-Amz-Request-Id:
-                - txgf5c87378e7fd4c769427-006a5f8045
+                - txgbe41a087b5574e6295e7-006aa0051c
         status: 404 Not Found
         code: 404
-        duration: 423.554042ms
+        duration: 28.204708ms
     - id: 62
       request:
         proto: HTTP/1.1
@@ -3243,7 +3243,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3252,16 +3252,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a758862a-2905-4772-b587-5d1809b7110b
+                - 23b92a98-e3a9-4261-a91d-76da238c8b6a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142053Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/
+                - 20260908T125244Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -3273,21 +3273,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:20:54 GMT
+                - Tue, 08 Sep 2026 12:52:44 GMT
             X-Amz-Id-2:
-                - txg1ef6cecfe4f045d6a2db-006a5f8046
+                - txg78070221aa94448a9b1a-006aa0051c
             X-Amz-Request-Id:
-                - txg1ef6cecfe4f045d6a2db-006a5f8046
+                - txg78070221aa94448a9b1a-006aa0051c
         status: 200 OK
         code: 200
-        duration: 100.786084ms
+        duration: 498.090958ms
     - id: 63
       request:
         proto: HTTP/1.1
@@ -3296,7 +3296,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3305,16 +3305,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 593f2cbf-b5f8-4250-8620-e98bb16b0d2a
+                - 9b816580-4cae-4b7e-854d-66055d7a3e40
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142054Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T125244Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3324,21 +3324,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg47af7f50f4294242a29a-006a5f8046</RequestId><HostId>txg47af7f50f4294242a29a-006a5f8046</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txga9ed07db17284168a646-006aa0051c</RequestId><HostId>txga9ed07db17284168a646-006aa0051c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:20:54 GMT
+                - Tue, 08 Sep 2026 12:52:44 GMT
             X-Amz-Id-2:
-                - txg47af7f50f4294242a29a-006a5f8046
+                - txga9ed07db17284168a646-006aa0051c
             X-Amz-Request-Id:
-                - txg47af7f50f4294242a29a-006a5f8046
+                - txga9ed07db17284168a646-006aa0051c
         status: 404 Not Found
         code: 404
-        duration: 27.244834ms
+        duration: 203.893625ms
     - id: 64
       request:
         proto: HTTP/1.1
@@ -3347,7 +3347,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3356,16 +3356,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - dd302170-bda5-4138-a9b2-34cce6c0f21d
+                - 0410f769-1c5a-43f2-b150-bf3bf862eb66
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142054Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T125244Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3375,21 +3375,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg27a75d7a08dd4735bbb2-006a5f8046</RequestId><HostId>txg27a75d7a08dd4735bbb2-006a5f8046</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgc6ad33bca0f34c19b8e4-006aa0051c</RequestId><HostId>txgc6ad33bca0f34c19b8e4-006aa0051c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:20:54 GMT
+                - Tue, 08 Sep 2026 12:52:44 GMT
             X-Amz-Id-2:
-                - txg27a75d7a08dd4735bbb2-006a5f8046
+                - txgc6ad33bca0f34c19b8e4-006aa0051c
             X-Amz-Request-Id:
-                - txg27a75d7a08dd4735bbb2-006a5f8046
+                - txgc6ad33bca0f34c19b8e4-006aa0051c
         status: 404 Not Found
         code: 404
-        duration: 296.659542ms
+        duration: 427.570708ms
     - id: 65
       request:
         proto: HTTP/1.1
@@ -3398,7 +3398,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3407,16 +3407,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b9c7486c-daf9-49b8-80ff-ebab2d38fa53
+                - 000fdf96-7f9e-4989-99d0-0bfd06540b3c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142054Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T125244Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3435,14 +3435,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:20:54 GMT
+                - Tue, 08 Sep 2026 12:52:45 GMT
             X-Amz-Id-2:
-                - txg102a7ee28c744a8c8f95-006a5f8046
+                - txge183accb0ec44b29ba0f-006aa0051d
             X-Amz-Request-Id:
-                - txg102a7ee28c744a8c8f95-006a5f8046
+                - txge183accb0ec44b29ba0f-006aa0051d
         status: 200 OK
         code: 200
-        duration: 57.201667ms
+        duration: 75.969083ms
     - id: 66
       request:
         proto: HTTP/1.1
@@ -3451,7 +3451,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3460,16 +3460,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 89dcba2f-501e-4b02-a22f-82de8393aae3
+                - b189dbb6-eead-4182-8f7e-2c709a44d371
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142054Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T125245Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3481,21 +3481,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
                 - "1285"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:20:54 GMT
+                - Tue, 08 Sep 2026 12:52:45 GMT
             X-Amz-Id-2:
-                - txgf6f6f3c07dc040099c99-006a5f8046
+                - txg6f50a7e1edec459db653-006aa0051d
             X-Amz-Request-Id:
-                - txgf6f6f3c07dc040099c99-006a5f8046
+                - txg6f50a7e1edec459db653-006aa0051d
         status: 200 OK
         code: 200
-        duration: 81.460375ms
+        duration: 22.610166ms
     - id: 67
       request:
         proto: HTTP/1.1
@@ -3504,7 +3504,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3513,16 +3513,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7f9a3db0-7dbc-45c6-ad54-f0dd8e5ecbe5
+                - f29739e1-602a-4e8e-aee9-40d9999b0f18
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142054Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T125245Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3534,21 +3534,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:20:55 GMT
+                - Tue, 08 Sep 2026 12:52:45 GMT
             X-Amz-Id-2:
-                - txg37e234e1650140cfb197-006a5f8047
+                - txga641a32493084bd688c7-006aa0051d
             X-Amz-Request-Id:
-                - txg37e234e1650140cfb197-006a5f8047
+                - txga641a32493084bd688c7-006aa0051d
         status: 200 OK
         code: 200
-        duration: 92.159375ms
+        duration: 37.649166ms
     - id: 68
       request:
         proto: HTTP/1.1
@@ -3557,7 +3557,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3566,16 +3566,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 473ddea5-bf2b-48b5-9409-8438ca40d603
+                - 755afe07-a4a1-472d-a5b7-d6e257830d6a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142055Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T125245Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3585,21 +3585,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgc4d51bdde5e744f08d18-006a5f8047</RequestId><HostId>txgc4d51bdde5e744f08d18-006a5f8047</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txga1acd19fee5e4d79b64f-006aa0051d</RequestId><HostId>txga1acd19fee5e4d79b64f-006aa0051d</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:20:55 GMT
+                - Tue, 08 Sep 2026 12:52:45 GMT
             X-Amz-Id-2:
-                - txgc4d51bdde5e744f08d18-006a5f8047
+                - txga1acd19fee5e4d79b64f-006aa0051d
             X-Amz-Request-Id:
-                - txgc4d51bdde5e744f08d18-006a5f8047
+                - txga1acd19fee5e4d79b64f-006aa0051d
         status: 404 Not Found
         code: 404
-        duration: 24.968792ms
+        duration: 198.45275ms
     - id: 69
       request:
         proto: HTTP/1.1
@@ -3608,7 +3608,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3617,16 +3617,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 93c419db-fe28-462f-9af1-022e9c0fa3c5
+                - 752c3541-a340-4723-809c-488abaaa61d4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142055Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/
+                - 20260908T125245Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -3638,21 +3638,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:20:55 GMT
+                - Tue, 08 Sep 2026 12:52:45 GMT
             X-Amz-Id-2:
-                - txg075e745c06e343fcbca2-006a5f8047
+                - txgf8d1d79e51464a56bdb0-006aa0051d
             X-Amz-Request-Id:
-                - txg075e745c06e343fcbca2-006a5f8047
+                - txgf8d1d79e51464a56bdb0-006aa0051d
         status: 200 OK
         code: 200
-        duration: 82.686834ms
+        duration: 353.194959ms
     - id: 70
       request:
         proto: HTTP/1.1
@@ -3661,7 +3661,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3670,16 +3670,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f3e53c7a-14da-45cc-9318-ff2576cae7ef
+                - faf3f403-79e4-4363-b08e-efea083966c0
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142055Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T125245Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3689,21 +3689,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg6268580edb464c70842b-006a5f8047</RequestId><HostId>txg6268580edb464c70842b-006a5f8047</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg8a0788ff4d8f440da7eb-006aa0051e</RequestId><HostId>txg8a0788ff4d8f440da7eb-006aa0051e</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:20:55 GMT
+                - Tue, 08 Sep 2026 12:52:46 GMT
             X-Amz-Id-2:
-                - txg6268580edb464c70842b-006a5f8047
+                - txg8a0788ff4d8f440da7eb-006aa0051e
             X-Amz-Request-Id:
-                - txg6268580edb464c70842b-006a5f8047
+                - txg8a0788ff4d8f440da7eb-006aa0051e
         status: 404 Not Found
         code: 404
-        duration: 19.619125ms
+        duration: 55.314666ms
     - id: 71
       request:
         proto: HTTP/1.1
@@ -3712,7 +3712,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3721,16 +3721,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 2a55805f-d4b0-4648-a498-e9352e77c4a2
+                - 1bb5a595-eff5-414f-a7b2-577d12e1ff52
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142055Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T125246Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3740,21 +3740,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg65c96a178b304149a7fd-006a5f8047</RequestId><HostId>txg65c96a178b304149a7fd-006a5f8047</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgb1ce2dd19f8e4760bf2b-006aa0051e</RequestId><HostId>txgb1ce2dd19f8e4760bf2b-006aa0051e</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:20:55 GMT
+                - Tue, 08 Sep 2026 12:52:46 GMT
             X-Amz-Id-2:
-                - txg65c96a178b304149a7fd-006a5f8047
+                - txgb1ce2dd19f8e4760bf2b-006aa0051e
             X-Amz-Request-Id:
-                - txg65c96a178b304149a7fd-006a5f8047
+                - txgb1ce2dd19f8e4760bf2b-006aa0051e
         status: 404 Not Found
         code: 404
-        duration: 66.866917ms
+        duration: 251.327959ms
     - id: 72
       request:
         proto: HTTP/1.1
@@ -3763,7 +3763,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3772,16 +3772,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - df139933-7f9c-4f0a-8dd9-365d9c67ad76
+                - 8ea97cf5-a197-4596-9c7d-6fe389494dc6
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142055Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T125246Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3800,14 +3800,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:20:55 GMT
+                - Tue, 08 Sep 2026 12:52:46 GMT
             X-Amz-Id-2:
-                - txg0b9991a7aca54dd18539-006a5f8047
+                - txgce4fcd245ef240088243-006aa0051e
             X-Amz-Request-Id:
-                - txg0b9991a7aca54dd18539-006a5f8047
+                - txgce4fcd245ef240088243-006aa0051e
         status: 200 OK
         code: 200
-        duration: 197.591041ms
+        duration: 254.727125ms
     - id: 73
       request:
         proto: HTTP/1.1
@@ -3816,7 +3816,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3825,16 +3825,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e3465b73-11cf-40ad-bbe9-61048333b06f
+                - bae1596d-d0bf-4b1e-8a06-8d9ec5b09e64
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142055Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T125246Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3846,21 +3846,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
                 - "1285"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:20:55 GMT
+                - Tue, 08 Sep 2026 12:52:46 GMT
             X-Amz-Id-2:
-                - txg0b10e647c8904c88a0b9-006a5f8047
+                - txg1d60a61a9c224d8d90c1-006aa0051e
             X-Amz-Request-Id:
-                - txg0b10e647c8904c88a0b9-006a5f8047
+                - txg1d60a61a9c224d8d90c1-006aa0051e
         status: 200 OK
         code: 200
-        duration: 21.484583ms
+        duration: 31.240458ms
     - id: 74
       request:
         proto: HTTP/1.1
@@ -3869,7 +3869,7 @@ interactions:
         content_length: 296
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
@@ -3878,20 +3878,20 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d3cc7f2a-208a-4a9a-b6d4-952b847a6cd1
+                - 70bcab7f-74e5-4ab2-a151-215261f105b8
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
                 - application/xml
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,Z,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,Z,e
             X-Amz-Checksum-Crc32:
                 - O87+gQ==
             X-Amz-Content-Sha256:
                 - 7756d51b786b61edff20b7957d22346417f85f71d19eeca0d6d28d6df7b15bbc
             X-Amz-Date:
-                - 20260721T142055Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T125246Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -3906,14 +3906,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 21 Jul 2026 14:20:55 GMT
+                - Tue, 08 Sep 2026 12:52:46 GMT
             X-Amz-Id-2:
-                - txg7994a48ef5864a6791cf-006a5f8047
+                - txgae70eccdcbbb449c8a79-006aa0051e
             X-Amz-Request-Id:
-                - txg7994a48ef5864a6791cf-006a5f8047
+                - txgae70eccdcbbb449c8a79-006aa0051e
         status: 200 OK
         code: 200
-        duration: 476.011917ms
+        duration: 241.606917ms
     - id: 75
       request:
         proto: HTTP/1.1
@@ -3922,7 +3922,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3931,16 +3931,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 959ebffa-9364-4cd7-8ead-41b4fe09e8bf
+                - 23e1d9da-b5b8-4a3a-a2b8-605e497389dc
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142056Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T125247Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3952,21 +3952,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:20:56 GMT
+                - Tue, 08 Sep 2026 12:52:47 GMT
             X-Amz-Id-2:
-                - txg50357fe94c6c45b298af-006a5f8048
+                - txg3c25f4a6267546ea88c0-006aa0051f
             X-Amz-Request-Id:
-                - txg50357fe94c6c45b298af-006a5f8048
+                - txg3c25f4a6267546ea88c0-006aa0051f
         status: 200 OK
         code: 200
-        duration: 21.771792ms
+        duration: 181.573792ms
     - id: 76
       request:
         proto: HTTP/1.1
@@ -3975,7 +3975,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3984,16 +3984,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a3d8945b-928e-4305-bac8-74b567112c9e
+                - 1bacbcca-b8cb-45ac-a5ba-01801aa277b9
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142056Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T125247Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4003,21 +4003,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txge2acc677d4dc4acda9b4-006a5f8048</RequestId><HostId>txge2acc677d4dc4acda9b4-006a5f8048</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgd6de9fa32a944c3eb49f-006aa0051f</RequestId><HostId>txgd6de9fa32a944c3eb49f-006aa0051f</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:20:56 GMT
+                - Tue, 08 Sep 2026 12:52:47 GMT
             X-Amz-Id-2:
-                - txge2acc677d4dc4acda9b4-006a5f8048
+                - txgd6de9fa32a944c3eb49f-006aa0051f
             X-Amz-Request-Id:
-                - txge2acc677d4dc4acda9b4-006a5f8048
+                - txgd6de9fa32a944c3eb49f-006aa0051f
         status: 404 Not Found
         code: 404
-        duration: 83.43725ms
+        duration: 109.887208ms
     - id: 77
       request:
         proto: HTTP/1.1
@@ -4026,7 +4026,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4035,16 +4035,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 232e2f24-7dbb-4dd1-9616-c578892d62bf
+                - 71d057ec-5eab-4709-8c35-a8c8cffea14f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142056Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/
+                - 20260908T125247Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -4056,21 +4056,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:20:56 GMT
+                - Tue, 08 Sep 2026 12:52:47 GMT
             X-Amz-Id-2:
-                - txg53abb41b6b9345929636-006a5f8048
+                - txgc9a1735085a4425e94de-006aa0051f
             X-Amz-Request-Id:
-                - txg53abb41b6b9345929636-006a5f8048
+                - txgc9a1735085a4425e94de-006aa0051f
         status: 200 OK
         code: 200
-        duration: 106.873417ms
+        duration: 427.860792ms
     - id: 78
       request:
         proto: HTTP/1.1
@@ -4079,7 +4079,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4088,16 +4088,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5436b20d-1c5a-4ab1-a09c-08a9cba60736
+                - 72cbc988-af2f-4e87-be15-da0215dab1d6
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142056Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T125247Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4107,21 +4107,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txge972ee08733342d69b7e-006a5f8048</RequestId><HostId>txge972ee08733342d69b7e-006a5f8048</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg9ed83e436c7e4669bc6c-006aa0051f</RequestId><HostId>txg9ed83e436c7e4669bc6c-006aa0051f</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:20:56 GMT
+                - Tue, 08 Sep 2026 12:52:47 GMT
             X-Amz-Id-2:
-                - txge972ee08733342d69b7e-006a5f8048
+                - txg9ed83e436c7e4669bc6c-006aa0051f
             X-Amz-Request-Id:
-                - txge972ee08733342d69b7e-006a5f8048
+                - txg9ed83e436c7e4669bc6c-006aa0051f
         status: 404 Not Found
         code: 404
-        duration: 184.114042ms
+        duration: 124.400083ms
     - id: 79
       request:
         proto: HTTP/1.1
@@ -4130,7 +4130,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4139,16 +4139,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 73ce2f51-9115-49a7-8432-d54e164ddd40
+                - 304d7c09-9ae0-4b6d-96c4-4efbd9edd7d5
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142056Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T125247Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4158,21 +4158,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg50c4c5bec50a429e9e06-006a5f8048</RequestId><HostId>txg50c4c5bec50a429e9e06-006a5f8048</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg97c6249f001f424a83e1-006aa00520</RequestId><HostId>txg97c6249f001f424a83e1-006aa00520</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:20:56 GMT
+                - Tue, 08 Sep 2026 12:52:48 GMT
             X-Amz-Id-2:
-                - txg50c4c5bec50a429e9e06-006a5f8048
+                - txg97c6249f001f424a83e1-006aa00520
             X-Amz-Request-Id:
-                - txg50c4c5bec50a429e9e06-006a5f8048
+                - txg97c6249f001f424a83e1-006aa00520
         status: 404 Not Found
         code: 404
-        duration: 18.786875ms
+        duration: 159.150166ms
     - id: 80
       request:
         proto: HTTP/1.1
@@ -4181,7 +4181,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4190,16 +4190,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 8793a96e-87e2-4990-9241-3ab73779736c
+                - 3d576127-e28f-480c-942e-31797a86c554
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142056Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T125248Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4218,14 +4218,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:20:56 GMT
+                - Tue, 08 Sep 2026 12:52:48 GMT
             X-Amz-Id-2:
-                - txg4c1c579872d345a1a0d5-006a5f8048
+                - txg28bb7f2335644c95bbe9-006aa00520
             X-Amz-Request-Id:
-                - txg4c1c579872d345a1a0d5-006a5f8048
+                - txg28bb7f2335644c95bbe9-006aa00520
         status: 200 OK
         code: 200
-        duration: 222.132083ms
+        duration: 21.7395ms
     - id: 81
       request:
         proto: HTTP/1.1
@@ -4234,7 +4234,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4243,16 +4243,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f4fd2e10-ab43-42f0-b4fc-46c935e75305
+                - 542f33cc-c406-4feb-a5ab-13c1ca589281
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142056Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T125248Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4271,14 +4271,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:20:56 GMT
+                - Tue, 08 Sep 2026 12:52:48 GMT
             X-Amz-Id-2:
-                - txgbb75b4385db94ef9b916-006a5f8048
+                - txg6f04484c332f48098870-006aa00520
             X-Amz-Request-Id:
-                - txgbb75b4385db94ef9b916-006a5f8048
+                - txg6f04484c332f48098870-006aa00520
         status: 200 OK
         code: 200
-        duration: 92.262625ms
+        duration: 196.866917ms
     - id: 82
       request:
         proto: HTTP/1.1
@@ -4287,7 +4287,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4296,16 +4296,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7a8c70ff-17a4-45e6-b3e7-aaedb8a4141e
+                - f2eeb9d4-db0c-458a-bc64-0b79e2ab1e11
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142057Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/
+                - 20260908T125248Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -4320,16 +4320,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:20:57 GMT
+                - Tue, 08 Sep 2026 12:52:48 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txg76cbb4fa02374e8aad89-006a5f8049
+                - txgcd180260475f46c4b60d-006aa00520
             X-Amz-Request-Id:
-                - txg76cbb4fa02374e8aad89-006a5f8049
+                - txgcd180260475f46c4b60d-006aa00520
         status: 200 OK
         code: 200
-        duration: 76.167917ms
+        duration: 447.7945ms
     - id: 83
       request:
         proto: HTTP/1.1
@@ -4338,7 +4338,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4347,16 +4347,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 2fa7cb49-3b04-4688-a04e-c8f354c5476a
+                - 5b2a307f-ff3d-439a-be0c-2bc1cd274873
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142057Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T125248Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4375,14 +4375,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:20:57 GMT
+                - Tue, 08 Sep 2026 12:52:48 GMT
             X-Amz-Id-2:
-                - txge05d926b99694a8eb4f7-006a5f8049
+                - txg90fbee8058514be684a9-006aa00520
             X-Amz-Request-Id:
-                - txge05d926b99694a8eb4f7-006a5f8049
+                - txg90fbee8058514be684a9-006aa00520
         status: 200 OK
         code: 200
-        duration: 73.192875ms
+        duration: 415.703958ms
     - id: 84
       request:
         proto: HTTP/1.1
@@ -4391,7 +4391,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4400,16 +4400,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 151b5161-3ea7-4d13-9866-aff2e8a19071
+                - 9ae528ba-b986-4d0c-85ba-dca1c82e53e9
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142057Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T125249Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4421,21 +4421,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:20:57 GMT
+                - Tue, 08 Sep 2026 12:52:49 GMT
             X-Amz-Id-2:
-                - txge0c34a3234d443c1a575-006a5f8049
+                - txg6a92e9cca7964b5d9a58-006aa00521
             X-Amz-Request-Id:
-                - txge0c34a3234d443c1a575-006a5f8049
+                - txg6a92e9cca7964b5d9a58-006aa00521
         status: 200 OK
         code: 200
-        duration: 310.388792ms
+        duration: 53.042834ms
     - id: 85
       request:
         proto: HTTP/1.1
@@ -4444,7 +4444,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4453,16 +4453,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 525652e1-0e04-4170-a3ae-7add4da8eb1f
+                - 198785ce-9a58-4676-8f73-8b3c6fbd6e37
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142057Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T125249Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4472,21 +4472,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgbcc8b0c0baea48edb319-006a5f8049</RequestId><HostId>txgbcc8b0c0baea48edb319-006a5f8049</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg3b24e1bcf50a45e2ba65-006aa00521</RequestId><HostId>txg3b24e1bcf50a45e2ba65-006aa00521</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:20:57 GMT
+                - Tue, 08 Sep 2026 12:52:49 GMT
             X-Amz-Id-2:
-                - txgbcc8b0c0baea48edb319-006a5f8049
+                - txg3b24e1bcf50a45e2ba65-006aa00521
             X-Amz-Request-Id:
-                - txgbcc8b0c0baea48edb319-006a5f8049
+                - txg3b24e1bcf50a45e2ba65-006aa00521
         status: 404 Not Found
         code: 404
-        duration: 94.304208ms
+        duration: 26.213291ms
     - id: 86
       request:
         proto: HTTP/1.1
@@ -4495,7 +4495,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4504,16 +4504,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 97963f8a-c4a6-4ea6-93ce-8432e6264573
+                - d5ad4b80-71be-4e11-895a-0716175ee9b7
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142057Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/
+                - 20260908T125249Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -4525,21 +4525,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:20:57 GMT
+                - Tue, 08 Sep 2026 12:52:49 GMT
             X-Amz-Id-2:
-                - txge09e462e6a1843dfb5c9-006a5f8049
+                - txg86c7ec5321494308be0a-006aa00521
             X-Amz-Request-Id:
-                - txge09e462e6a1843dfb5c9-006a5f8049
+                - txg86c7ec5321494308be0a-006aa00521
         status: 200 OK
         code: 200
-        duration: 310.512625ms
+        duration: 297.928959ms
     - id: 87
       request:
         proto: HTTP/1.1
@@ -4548,7 +4548,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4557,16 +4557,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 713d14a2-b231-4a58-be88-6bbba214310f
+                - 91945115-0d79-4019-a9ff-af4c909e8a74
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142057Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T125249Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4576,21 +4576,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgebad035b9be04dfaa81c-006a5f804a</RequestId><HostId>txgebad035b9be04dfaa81c-006a5f804a</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg3104588f6ae54847b902-006aa00521</RequestId><HostId>txg3104588f6ae54847b902-006aa00521</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:20:58 GMT
+                - Tue, 08 Sep 2026 12:52:49 GMT
             X-Amz-Id-2:
-                - txgebad035b9be04dfaa81c-006a5f804a
+                - txg3104588f6ae54847b902-006aa00521
             X-Amz-Request-Id:
-                - txgebad035b9be04dfaa81c-006a5f804a
+                - txg3104588f6ae54847b902-006aa00521
         status: 404 Not Found
         code: 404
-        duration: 197.482542ms
+        duration: 22.274ms
     - id: 88
       request:
         proto: HTTP/1.1
@@ -4599,7 +4599,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4608,16 +4608,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - cf739c7a-dea5-4ea8-9e58-12e11b99279f
+                - 92ae704c-c3a0-4f63-97ed-0cad79716f65
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142058Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T125249Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4627,21 +4627,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgfd0db9f92b1845cf85de-006a5f804a</RequestId><HostId>txgfd0db9f92b1845cf85de-006a5f804a</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgc607ee78ba57497c925f-006aa00521</RequestId><HostId>txgc607ee78ba57497c925f-006aa00521</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:20:58 GMT
+                - Tue, 08 Sep 2026 12:52:49 GMT
             X-Amz-Id-2:
-                - txgfd0db9f92b1845cf85de-006a5f804a
+                - txgc607ee78ba57497c925f-006aa00521
             X-Amz-Request-Id:
-                - txgfd0db9f92b1845cf85de-006a5f804a
+                - txgc607ee78ba57497c925f-006aa00521
         status: 404 Not Found
         code: 404
-        duration: 136.164917ms
+        duration: 274.094041ms
     - id: 89
       request:
         proto: HTTP/1.1
@@ -4650,7 +4650,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4659,16 +4659,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 519ca981-1a73-47d8-8cf8-8332c4dafa3b
+                - 023adc25-9c84-4395-86df-f755ccd4b2e9
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142058Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T125249Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4687,14 +4687,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:20:58 GMT
+                - Tue, 08 Sep 2026 12:52:50 GMT
             X-Amz-Id-2:
-                - txgc8c64b7083744d3e8cf8-006a5f804a
+                - txg8a22ae9d416243d68898-006aa00522
             X-Amz-Request-Id:
-                - txgc8c64b7083744d3e8cf8-006a5f804a
+                - txg8a22ae9d416243d68898-006aa00522
         status: 200 OK
         code: 200
-        duration: 74.055584ms
+        duration: 28.7355ms
     - id: 90
       request:
         proto: HTTP/1.1
@@ -4703,7 +4703,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4712,16 +4712,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 37848400-b995-4cf3-a1b0-f9d5dfe169f3
+                - 13f08141-f99c-4e17-a51f-ba738ccbf4b7
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142058Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T125250Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4740,14 +4740,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:20:58 GMT
+                - Tue, 08 Sep 2026 12:52:50 GMT
             X-Amz-Id-2:
-                - txg7a859967e4924e10acfc-006a5f804a
+                - txg4a500e8007b04f6f8c80-006aa00522
             X-Amz-Request-Id:
-                - txg7a859967e4924e10acfc-006a5f804a
+                - txg4a500e8007b04f6f8c80-006aa00522
         status: 200 OK
         code: 200
-        duration: 212.053917ms
+        duration: 64.845791ms
     - id: 91
       request:
         proto: HTTP/1.1
@@ -4756,7 +4756,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4765,16 +4765,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 08dcb17a-7291-4613-b966-bb7d0f8dcf83
+                - 41cf03bb-3919-4bad-be52-a42e23f3c4f4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142059Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T125250Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4786,21 +4786,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:20:59 GMT
+                - Tue, 08 Sep 2026 12:52:50 GMT
             X-Amz-Id-2:
-                - txg4ead4df3774d4826b53d-006a5f804b
+                - txg041a996f47b54491a22c-006aa00522
             X-Amz-Request-Id:
-                - txg4ead4df3774d4826b53d-006a5f804b
+                - txg041a996f47b54491a22c-006aa00522
         status: 200 OK
         code: 200
-        duration: 70.871167ms
+        duration: 154.933583ms
     - id: 92
       request:
         proto: HTTP/1.1
@@ -4809,7 +4809,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4818,16 +4818,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 44ba85b9-704f-4ed2-9524-e2a9f96d526a
+                - dbf2c360-bf6a-4a48-af6f-aeb108c1757d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142059Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T125250Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4837,21 +4837,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgeec17defab204bfa82de-006a5f804b</RequestId><HostId>txgeec17defab204bfa82de-006a5f804b</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgad1f2d85a69d4bbfa73c-006aa00522</RequestId><HostId>txgad1f2d85a69d4bbfa73c-006aa00522</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:20:59 GMT
+                - Tue, 08 Sep 2026 12:52:50 GMT
             X-Amz-Id-2:
-                - txgeec17defab204bfa82de-006a5f804b
+                - txgad1f2d85a69d4bbfa73c-006aa00522
             X-Amz-Request-Id:
-                - txgeec17defab204bfa82de-006a5f804b
+                - txgad1f2d85a69d4bbfa73c-006aa00522
         status: 404 Not Found
         code: 404
-        duration: 135.930542ms
+        duration: 124.333666ms
     - id: 93
       request:
         proto: HTTP/1.1
@@ -4860,7 +4860,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4869,16 +4869,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 74a27797-5d8a-42c9-b30a-dda839a94eb6
+                - e79a30da-e426-4184-ae23-757be13b16bd
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142059Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/
+                - 20260908T125250Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -4890,21 +4890,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:20:59 GMT
+                - Tue, 08 Sep 2026 12:52:50 GMT
             X-Amz-Id-2:
-                - txg2d0ab1e9c82241f289fa-006a5f804b
+                - txgde8c9bc7227241a18640-006aa00522
             X-Amz-Request-Id:
-                - txg2d0ab1e9c82241f289fa-006a5f804b
+                - txgde8c9bc7227241a18640-006aa00522
         status: 200 OK
         code: 200
-        duration: 245.760834ms
+        duration: 391.855458ms
     - id: 94
       request:
         proto: HTTP/1.1
@@ -4913,7 +4913,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4922,16 +4922,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f342a5a8-e260-4946-85c0-61fe4ce5b307
+                - 581808ef-ea58-43f7-ba1b-44498fd97c0a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142059Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T125250Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4941,21 +4941,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txge1da0e33762743e39738-006a5f804b</RequestId><HostId>txge1da0e33762743e39738-006a5f804b</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgb1f925193c5d4fca8b30-006aa00523</RequestId><HostId>txgb1f925193c5d4fca8b30-006aa00523</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:20:59 GMT
+                - Tue, 08 Sep 2026 12:52:51 GMT
             X-Amz-Id-2:
-                - txge1da0e33762743e39738-006a5f804b
+                - txgb1f925193c5d4fca8b30-006aa00523
             X-Amz-Request-Id:
-                - txge1da0e33762743e39738-006a5f804b
+                - txgb1f925193c5d4fca8b30-006aa00523
         status: 404 Not Found
         code: 404
-        duration: 18.168667ms
+        duration: 292.613166ms
     - id: 95
       request:
         proto: HTTP/1.1
@@ -4964,7 +4964,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4973,16 +4973,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e36e7d4d-f05f-400d-b302-168dc4a9581a
+                - 19b4980c-7896-446e-90a3-50f59350aae0
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142059Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T125251Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4992,21 +4992,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg936a92e41d3847c7ba1c-006a5f804b</RequestId><HostId>txg936a92e41d3847c7ba1c-006a5f804b</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg8d96082677a44135a15b-006aa00523</RequestId><HostId>txg8d96082677a44135a15b-006aa00523</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:20:59 GMT
+                - Tue, 08 Sep 2026 12:52:51 GMT
             X-Amz-Id-2:
-                - txg936a92e41d3847c7ba1c-006a5f804b
+                - txg8d96082677a44135a15b-006aa00523
             X-Amz-Request-Id:
-                - txg936a92e41d3847c7ba1c-006a5f804b
+                - txg8d96082677a44135a15b-006aa00523
         status: 404 Not Found
         code: 404
-        duration: 21.192416ms
+        duration: 233.939333ms
     - id: 96
       request:
         proto: HTTP/1.1
@@ -5015,7 +5015,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5024,16 +5024,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b546705c-a99b-41f0-a4c8-8b96338c97d7
+                - a7741225-89b8-4949-a911-ea017bc456c0
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142059Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T125251Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5052,14 +5052,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:20:59 GMT
+                - Tue, 08 Sep 2026 12:52:51 GMT
             X-Amz-Id-2:
-                - txgf99be248661547f7bf0d-006a5f804b
+                - txg7584230a88d641b186c1-006aa00523
             X-Amz-Request-Id:
-                - txgf99be248661547f7bf0d-006a5f804b
+                - txg7584230a88d641b186c1-006aa00523
         status: 200 OK
         code: 200
-        duration: 186.793167ms
+        duration: 207.095125ms
     - id: 97
       request:
         proto: HTTP/1.1
@@ -5068,7 +5068,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5077,16 +5077,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b5a2c0e3-340f-4719-9887-6b48c9da2693
+                - 4ff9839a-d531-4d2c-bb79-9efb56c18fd7
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142059Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T125251Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5105,14 +5105,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:20:59 GMT
+                - Tue, 08 Sep 2026 12:52:51 GMT
             X-Amz-Id-2:
-                - txga97c2739dcbd4a84a23c-006a5f804b
+                - txg4e01d1ce3b9846f3a9c6-006aa00523
             X-Amz-Request-Id:
-                - txga97c2739dcbd4a84a23c-006a5f804b
+                - txg4e01d1ce3b9846f3a9c6-006aa00523
         status: 200 OK
         code: 200
-        duration: 18.754917ms
+        duration: 185.065458ms
     - id: 98
       request:
         proto: HTTP/1.1
@@ -5121,7 +5121,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5130,16 +5130,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 80206c27-0ef1-4b6f-aa2f-3f4f557edd23
+                - c96a05e2-3273-497c-9f2a-bed1680fcafe
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142059Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/
+                - 20260908T125252Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -5154,16 +5154,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:21:00 GMT
+                - Tue, 08 Sep 2026 12:52:52 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txg2a0d0e9eaa254b3081f6-006a5f804c
+                - txg4b8ebdf734134bd595fd-006aa00524
             X-Amz-Request-Id:
-                - txg2a0d0e9eaa254b3081f6-006a5f804c
+                - txg4b8ebdf734134bd595fd-006aa00524
         status: 200 OK
         code: 200
-        duration: 215.003834ms
+        duration: 34.581333ms
     - id: 99
       request:
         proto: HTTP/1.1
@@ -5172,7 +5172,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5181,16 +5181,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b372f169-f047-43a0-b0f4-7791114bd96c
+                - f907133a-2490-4cff-8cf4-6dabd8dd3dbc
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142100Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T125252Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5209,14 +5209,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:21:00 GMT
+                - Tue, 08 Sep 2026 12:52:52 GMT
             X-Amz-Id-2:
-                - txg378643831fc7468faad1-006a5f804c
+                - txg99fe9fb3581744d09c81-006aa00524
             X-Amz-Request-Id:
-                - txg378643831fc7468faad1-006a5f804c
+                - txg99fe9fb3581744d09c81-006aa00524
         status: 200 OK
         code: 200
-        duration: 142.5575ms
+        duration: 213.725292ms
     - id: 100
       request:
         proto: HTTP/1.1
@@ -5225,7 +5225,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5234,16 +5234,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b18a4950-93df-4aa5-a7e7-a391df40bcc6
+                - 6171aa49-f496-4959-b31e-6ac5260a68d8
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142100Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T125252Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5255,21 +5255,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:21:00 GMT
+                - Tue, 08 Sep 2026 12:52:52 GMT
             X-Amz-Id-2:
-                - txg79ec598f62e049e1b1fb-006a5f804c
+                - txg9ee863171f584235bb05-006aa00524
             X-Amz-Request-Id:
-                - txg79ec598f62e049e1b1fb-006a5f804c
+                - txg9ee863171f584235bb05-006aa00524
         status: 200 OK
         code: 200
-        duration: 180.264875ms
+        duration: 191.157667ms
     - id: 101
       request:
         proto: HTTP/1.1
@@ -5278,7 +5278,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5287,16 +5287,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 807fe79b-da6d-4a61-89a7-4e812b10e02b
+                - 31914369-561c-4e27-9487-ed217c764e53
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142100Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T125252Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5306,21 +5306,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg98fed865c3e641439dda-006a5f804c</RequestId><HostId>txg98fed865c3e641439dda-006a5f804c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg31a4bf5f06204f1e8f28-006aa00524</RequestId><HostId>txg31a4bf5f06204f1e8f28-006aa00524</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:21:00 GMT
+                - Tue, 08 Sep 2026 12:52:52 GMT
             X-Amz-Id-2:
-                - txg98fed865c3e641439dda-006a5f804c
+                - txg31a4bf5f06204f1e8f28-006aa00524
             X-Amz-Request-Id:
-                - txg98fed865c3e641439dda-006a5f804c
+                - txg31a4bf5f06204f1e8f28-006aa00524
         status: 404 Not Found
         code: 404
-        duration: 18.502ms
+        duration: 21.868292ms
     - id: 102
       request:
         proto: HTTP/1.1
@@ -5329,7 +5329,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5338,16 +5338,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 66a8b32c-054c-481b-bd59-a81aea0da012
+                - c1c207ad-8201-45a7-a361-84a49bd88c1e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142100Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/
+                - 20260908T125252Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -5359,21 +5359,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:21:00 GMT
+                - Tue, 08 Sep 2026 12:52:52 GMT
             X-Amz-Id-2:
-                - txgfb1cfd27d8b849c39c6a-006a5f804c
+                - txg06aaf4425cf8468d8ef7-006aa00524
             X-Amz-Request-Id:
-                - txgfb1cfd27d8b849c39c6a-006a5f804c
+                - txg06aaf4425cf8468d8ef7-006aa00524
         status: 200 OK
         code: 200
-        duration: 672.594416ms
+        duration: 388.976417ms
     - id: 103
       request:
         proto: HTTP/1.1
@@ -5382,7 +5382,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5391,16 +5391,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9a3104a1-f8b7-4087-a576-20738c6a9639
+                - 91007d85-0dd5-433d-8413-aeef2b35d2e2
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142100Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T125252Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5410,21 +5410,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg65e724fc17de4f28b55b-006a5f804d</RequestId><HostId>txg65e724fc17de4f28b55b-006a5f804d</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg07dc553b0f7e459ca9c6-006aa00525</RequestId><HostId>txg07dc553b0f7e459ca9c6-006aa00525</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:21:01 GMT
+                - Tue, 08 Sep 2026 12:52:53 GMT
             X-Amz-Id-2:
-                - txg65e724fc17de4f28b55b-006a5f804d
+                - txg07dc553b0f7e459ca9c6-006aa00525
             X-Amz-Request-Id:
-                - txg65e724fc17de4f28b55b-006a5f804d
+                - txg07dc553b0f7e459ca9c6-006aa00525
         status: 404 Not Found
         code: 404
-        duration: 23.029875ms
+        duration: 188.699166ms
     - id: 104
       request:
         proto: HTTP/1.1
@@ -5433,7 +5433,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5442,16 +5442,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 31af680b-3bd3-4e01-bf91-d8bb5b69077b
+                - 8fd0a21c-cf38-4d7a-8338-091624f8c871
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142101Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T125253Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5461,21 +5461,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg29404efd8b9e492095e5-006a5f804d</RequestId><HostId>txg29404efd8b9e492095e5-006a5f804d</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgc941390647804a65b6ed-006aa00525</RequestId><HostId>txgc941390647804a65b6ed-006aa00525</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:21:01 GMT
+                - Tue, 08 Sep 2026 12:52:53 GMT
             X-Amz-Id-2:
-                - txg29404efd8b9e492095e5-006a5f804d
+                - txgc941390647804a65b6ed-006aa00525
             X-Amz-Request-Id:
-                - txg29404efd8b9e492095e5-006a5f804d
+                - txgc941390647804a65b6ed-006aa00525
         status: 404 Not Found
         code: 404
-        duration: 18.821ms
+        duration: 24.816417ms
     - id: 105
       request:
         proto: HTTP/1.1
@@ -5484,7 +5484,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5493,16 +5493,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 1f7510d1-5559-4c7d-a95a-f9123fa02698
+                - bc4186fe-23e7-4308-b9e4-28f9a2b49f57
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142101Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T125253Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5521,14 +5521,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:21:01 GMT
+                - Tue, 08 Sep 2026 12:52:53 GMT
             X-Amz-Id-2:
-                - txg417b8b678e8440e7a83b-006a5f804d
+                - txgae7ca74fd7d5409683d8-006aa00525
             X-Amz-Request-Id:
-                - txg417b8b678e8440e7a83b-006a5f804d
+                - txgae7ca74fd7d5409683d8-006aa00525
         status: 200 OK
         code: 200
-        duration: 17.745709ms
+        duration: 190.442084ms
     - id: 106
       request:
         proto: HTTP/1.1
@@ -5537,7 +5537,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5546,16 +5546,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 90c06513-2632-43df-a4bd-fd89bcc2ad9e
+                - 4f2c2e2d-9001-4490-a2b4-e2382ec8f6ed
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142101Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T125253Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5574,14 +5574,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:21:01 GMT
+                - Tue, 08 Sep 2026 12:52:53 GMT
             X-Amz-Id-2:
-                - txgadd4d5834394474b88b1-006a5f804d
+                - txg6e2bd81333a04aab8adb-006aa00525
             X-Amz-Request-Id:
-                - txgadd4d5834394474b88b1-006a5f804d
+                - txg6e2bd81333a04aab8adb-006aa00525
         status: 200 OK
         code: 200
-        duration: 147.29975ms
+        duration: 28.221042ms
     - id: 107
       request:
         proto: HTTP/1.1
@@ -5590,7 +5590,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5599,16 +5599,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f7513dd4-4468-415a-89b8-f1d64867ff3f
+                - 2e517cab-986a-4829-b06d-98cb20cd6256
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142102Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T125253Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5620,21 +5620,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:21:02 GMT
+                - Tue, 08 Sep 2026 12:52:53 GMT
             X-Amz-Id-2:
-                - txgc35ddd8616aa420382da-006a5f804e
+                - txg67c96739938b4239bbb5-006aa00525
             X-Amz-Request-Id:
-                - txgc35ddd8616aa420382da-006a5f804e
+                - txg67c96739938b4239bbb5-006aa00525
         status: 200 OK
         code: 200
-        duration: 31.539375ms
+        duration: 110.459958ms
     - id: 108
       request:
         proto: HTTP/1.1
@@ -5643,7 +5643,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5652,16 +5652,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 939732b0-dc98-4ee3-905f-ca4b60eed89b
+                - 4afaf953-152c-4987-aa5a-4a57255d5e0c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142102Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T125253Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5671,21 +5671,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg68c4321f7502488c9d3d-006a5f804e</RequestId><HostId>txg68c4321f7502488c9d3d-006a5f804e</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txge74b869e6cb04fbc9158-006aa00526</RequestId><HostId>txge74b869e6cb04fbc9158-006aa00526</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:21:02 GMT
+                - Tue, 08 Sep 2026 12:52:54 GMT
             X-Amz-Id-2:
-                - txg68c4321f7502488c9d3d-006a5f804e
+                - txge74b869e6cb04fbc9158-006aa00526
             X-Amz-Request-Id:
-                - txg68c4321f7502488c9d3d-006a5f804e
+                - txge74b869e6cb04fbc9158-006aa00526
         status: 404 Not Found
         code: 404
-        duration: 128.029958ms
+        duration: 23.263208ms
     - id: 109
       request:
         proto: HTTP/1.1
@@ -5694,7 +5694,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5703,16 +5703,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c82325b8-73ef-4018-a311-e63905cfcc24
+                - 4d1eaae7-881e-4a30-a4df-a61fea2c4ed6
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142102Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/
+                - 20260908T125254Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -5724,21 +5724,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:21:02 GMT
+                - Tue, 08 Sep 2026 12:52:54 GMT
             X-Amz-Id-2:
-                - txgf178e42023c54b89965a-006a5f804e
+                - txga8fc91b43d1a4f178d97-006aa00526
             X-Amz-Request-Id:
-                - txgf178e42023c54b89965a-006a5f804e
+                - txga8fc91b43d1a4f178d97-006aa00526
         status: 200 OK
         code: 200
-        duration: 71.315875ms
+        duration: 301.63325ms
     - id: 110
       request:
         proto: HTTP/1.1
@@ -5747,7 +5747,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5756,16 +5756,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 57f8bc4e-ea55-4a3a-bf45-f2cc546bfc0b
+                - 6e5a8188-9dee-49dc-8a43-d58c1740b598
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142102Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T125254Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5775,21 +5775,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg29c90dd234b34c9898c4-006a5f804e</RequestId><HostId>txg29c90dd234b34c9898c4-006a5f804e</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txga63acaa9c67846d5a04c-006aa00526</RequestId><HostId>txga63acaa9c67846d5a04c-006aa00526</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:21:02 GMT
+                - Tue, 08 Sep 2026 12:52:54 GMT
             X-Amz-Id-2:
-                - txg29c90dd234b34c9898c4-006a5f804e
+                - txga63acaa9c67846d5a04c-006aa00526
             X-Amz-Request-Id:
-                - txg29c90dd234b34c9898c4-006a5f804e
+                - txga63acaa9c67846d5a04c-006aa00526
         status: 404 Not Found
         code: 404
-        duration: 21.500125ms
+        duration: 198.994333ms
     - id: 111
       request:
         proto: HTTP/1.1
@@ -5798,7 +5798,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5807,16 +5807,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9dba3cab-c2ad-4098-a0ab-f9ae7defb4f0
+                - 703fa2f0-5096-4035-ac46-dc3a253e664e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142102Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T125254Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5826,21 +5826,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgbec861142f3844aab11d-006a5f804e</RequestId><HostId>txgbec861142f3844aab11d-006a5f804e</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg6d8694d19a6540a0b742-006aa00526</RequestId><HostId>txg6d8694d19a6540a0b742-006aa00526</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:21:02 GMT
+                - Tue, 08 Sep 2026 12:52:54 GMT
             X-Amz-Id-2:
-                - txgbec861142f3844aab11d-006a5f804e
+                - txg6d8694d19a6540a0b742-006aa00526
             X-Amz-Request-Id:
-                - txgbec861142f3844aab11d-006a5f804e
+                - txg6d8694d19a6540a0b742-006aa00526
         status: 404 Not Found
         code: 404
-        duration: 82.980333ms
+        duration: 180.015084ms
     - id: 112
       request:
         proto: HTTP/1.1
@@ -5849,7 +5849,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5858,16 +5858,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3004c889-96bf-4805-9d45-245bedb503c3
+                - e99ced73-0f92-4ff6-9f4c-10edd1e8794f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142102Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T125254Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5886,14 +5886,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:21:02 GMT
+                - Tue, 08 Sep 2026 12:52:54 GMT
             X-Amz-Id-2:
-                - txgb0dc57746cfd45c4a35c-006a5f804e
+                - txg5095981c677546739b9e-006aa00526
             X-Amz-Request-Id:
-                - txgb0dc57746cfd45c4a35c-006a5f804e
+                - txg5095981c677546739b9e-006aa00526
         status: 200 OK
         code: 200
-        duration: 20.328333ms
+        duration: 29.328333ms
     - id: 113
       request:
         proto: HTTP/1.1
@@ -5902,7 +5902,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5911,16 +5911,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3d5ed149-9698-4137-a9ec-ab1fb447d1f5
+                - 9080c740-daa2-4566-8d72-83f942cd7bce
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142102Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T125254Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5939,14 +5939,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:21:02 GMT
+                - Tue, 08 Sep 2026 12:52:54 GMT
             X-Amz-Id-2:
-                - txg4e1a3796207b4068b016-006a5f804e
+                - txg3fc2653e10af417396d8-006aa00526
             X-Amz-Request-Id:
-                - txg4e1a3796207b4068b016-006a5f804e
+                - txg3fc2653e10af417396d8-006aa00526
         status: 200 OK
         code: 200
-        duration: 18.823375ms
+        duration: 21.72775ms
     - id: 114
       request:
         proto: HTTP/1.1
@@ -5955,7 +5955,7 @@ interactions:
         content_length: 344
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path1/</Prefix><Tag><Key>deleted</Key><Value>true</Value></Tag></And></Filter><ID>id1</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
@@ -5964,20 +5964,20 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b12b74a8-11d7-4496-b511-9595460ba8af
+                - 94529181-9113-4529-8616-df2acf3d4ad2
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
                 - application/xml
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,Z,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,Z,e
             X-Amz-Checksum-Crc32:
                 - /SEMnQ==
             X-Amz-Content-Sha256:
                 - b0de451c31309fbdd3611c566f2f38ddccf0dd237feb3e8d186422993ecf7a1f
             X-Amz-Date:
-                - 20260721T142102Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T125254Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -5992,14 +5992,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 21 Jul 2026 14:21:02 GMT
+                - Tue, 08 Sep 2026 12:52:54 GMT
             X-Amz-Id-2:
-                - txg97c6af87f5b2471a9ea0-006a5f804e
+                - txg738a5fb0e8b14db3a040-006aa00526
             X-Amz-Request-Id:
-                - txg97c6af87f5b2471a9ea0-006a5f804e
+                - txg738a5fb0e8b14db3a040-006aa00526
         status: 200 OK
         code: 200
-        duration: 59.142208ms
+        duration: 553.225833ms
     - id: 115
       request:
         proto: HTTP/1.1
@@ -6008,7 +6008,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6017,16 +6017,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 37972482-51fd-415b-9f8a-a59b1954da97
+                - 1ee62df0-5689-49d3-bf6b-e2c41e639003
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142102Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T125255Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6038,21 +6038,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:21:02 GMT
+                - Tue, 08 Sep 2026 12:52:55 GMT
             X-Amz-Id-2:
-                - txg16f6673e497245e6acda-006a5f804e
+                - txg6edd47c68771453387e7-006aa00527
             X-Amz-Request-Id:
-                - txg16f6673e497245e6acda-006a5f804e
+                - txg6edd47c68771453387e7-006aa00527
         status: 200 OK
         code: 200
-        duration: 25.448583ms
+        duration: 263.009ms
     - id: 116
       request:
         proto: HTTP/1.1
@@ -6061,7 +6061,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6070,16 +6070,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 514abe93-b2a7-4eb0-b8f7-9839c09f0515
+                - e80319f4-e52c-4af5-a040-ef9ce25546dc
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142102Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T125255Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6089,21 +6089,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg89f6d4f7e18744b0b8f1-006a5f804e</RequestId><HostId>txg89f6d4f7e18744b0b8f1-006a5f804e</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgb9ce655925254ccc99ca-006aa00527</RequestId><HostId>txgb9ce655925254ccc99ca-006aa00527</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:21:02 GMT
+                - Tue, 08 Sep 2026 12:52:55 GMT
             X-Amz-Id-2:
-                - txg89f6d4f7e18744b0b8f1-006a5f804e
+                - txgb9ce655925254ccc99ca-006aa00527
             X-Amz-Request-Id:
-                - txg89f6d4f7e18744b0b8f1-006a5f804e
+                - txgb9ce655925254ccc99ca-006aa00527
         status: 404 Not Found
         code: 404
-        duration: 110.548083ms
+        duration: 27.069334ms
     - id: 117
       request:
         proto: HTTP/1.1
@@ -6112,7 +6112,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6121,16 +6121,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5d73624a-de9c-49e2-a010-a65d90a9c9b5
+                - 9c060e80-5ac7-4830-9743-6db6fbe4a938
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142102Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/
+                - 20260908T125255Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -6142,21 +6142,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:21:02 GMT
+                - Tue, 08 Sep 2026 12:52:55 GMT
             X-Amz-Id-2:
-                - txgf19f1b83e4b443089519-006a5f804e
+                - txg9916dc5e2d8144d8880f-006aa00527
             X-Amz-Request-Id:
-                - txgf19f1b83e4b443089519-006a5f804e
+                - txg9916dc5e2d8144d8880f-006aa00527
         status: 200 OK
         code: 200
-        duration: 92.304375ms
+        duration: 66.531916ms
     - id: 118
       request:
         proto: HTTP/1.1
@@ -6165,7 +6165,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6174,16 +6174,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a8f87016-cd10-4372-b0f5-391b3e4ec44a
+                - 13226c2e-7106-4fce-935a-479784d844b7
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142102Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T125255Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6193,21 +6193,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg6d4c891397214afd88f0-006a5f804f</RequestId><HostId>txg6d4c891397214afd88f0-006a5f804f</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgd18fc49c3bf947c9a8cf-006aa00527</RequestId><HostId>txgd18fc49c3bf947c9a8cf-006aa00527</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:21:03 GMT
+                - Tue, 08 Sep 2026 12:52:55 GMT
             X-Amz-Id-2:
-                - txg6d4c891397214afd88f0-006a5f804f
+                - txgd18fc49c3bf947c9a8cf-006aa00527
             X-Amz-Request-Id:
-                - txg6d4c891397214afd88f0-006a5f804f
+                - txgd18fc49c3bf947c9a8cf-006aa00527
         status: 404 Not Found
         code: 404
-        duration: 62.263791ms
+        duration: 21.394917ms
     - id: 119
       request:
         proto: HTTP/1.1
@@ -6216,7 +6216,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6225,16 +6225,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 246abf2f-e774-4bee-9264-7fdf5a634364
+                - 988cd5cc-550e-4eff-a76b-8621938ddbc2
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142103Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T125255Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6244,21 +6244,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg597b3b9f7f164773b9d3-006a5f804f</RequestId><HostId>txg597b3b9f7f164773b9d3-006a5f804f</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg2cb697d3e4fe4ee697da-006aa00527</RequestId><HostId>txg2cb697d3e4fe4ee697da-006aa00527</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:21:03 GMT
+                - Tue, 08 Sep 2026 12:52:55 GMT
             X-Amz-Id-2:
-                - txg597b3b9f7f164773b9d3-006a5f804f
+                - txg2cb697d3e4fe4ee697da-006aa00527
             X-Amz-Request-Id:
-                - txg597b3b9f7f164773b9d3-006a5f804f
+                - txg2cb697d3e4fe4ee697da-006aa00527
         status: 404 Not Found
         code: 404
-        duration: 28.397791ms
+        duration: 421.500959ms
     - id: 120
       request:
         proto: HTTP/1.1
@@ -6267,7 +6267,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6276,16 +6276,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d7e0ca3e-6fee-47e4-955f-e930687761eb
+                - bed64b84-8255-4610-9a9c-a76f8b59f374
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142103Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T125255Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6304,14 +6304,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:21:03 GMT
+                - Tue, 08 Sep 2026 12:52:56 GMT
             X-Amz-Id-2:
-                - txg910e36baed794bcab6fa-006a5f804f
+                - txg1ff8a7c6fab74d15bbe7-006aa00528
             X-Amz-Request-Id:
-                - txg910e36baed794bcab6fa-006a5f804f
+                - txg1ff8a7c6fab74d15bbe7-006aa00528
         status: 200 OK
         code: 200
-        duration: 182.041042ms
+        duration: 408.66075ms
     - id: 121
       request:
         proto: HTTP/1.1
@@ -6320,7 +6320,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6329,16 +6329,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 09c6ce53-275b-43f5-ba91-9af29d71ce37
+                - 74073e95-9f2e-46e2-92b8-eb5671a79d4f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142103Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T125256Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6357,14 +6357,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:21:03 GMT
+                - Tue, 08 Sep 2026 12:52:56 GMT
             X-Amz-Id-2:
-                - txg5555fd3bd85b4178968b-006a5f804f
+                - txgd548315e07bc48fe8452-006aa00528
             X-Amz-Request-Id:
-                - txg5555fd3bd85b4178968b-006a5f804f
+                - txgd548315e07bc48fe8452-006aa00528
         status: 200 OK
         code: 200
-        duration: 129.041625ms
+        duration: 187.071541ms
     - id: 122
       request:
         proto: HTTP/1.1
@@ -6373,7 +6373,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6382,16 +6382,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 056fc0de-308c-4df0-9440-3a0a402cdff2
+                - c23b5f20-e96f-4a41-9c6b-c5bc2c6c2f7d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142103Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/
+                - 20260908T125256Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -6406,16 +6406,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:21:03 GMT
+                - Tue, 08 Sep 2026 12:52:57 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txg19c1a573d8b64bea9fe8-006a5f804f
+                - txge2de4dd3fc9f48598d83-006aa00529
             X-Amz-Request-Id:
-                - txg19c1a573d8b64bea9fe8-006a5f804f
+                - txge2de4dd3fc9f48598d83-006aa00529
         status: 200 OK
         code: 200
-        duration: 59.128083ms
+        duration: 253.187791ms
     - id: 123
       request:
         proto: HTTP/1.1
@@ -6424,7 +6424,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6433,16 +6433,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 56c4dd84-fac0-4c4d-ad93-917aa8daa195
+                - e1e506d8-e480-4f67-8ac1-7009f8c5a6ea
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142103Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T125257Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6461,14 +6461,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:21:03 GMT
+                - Tue, 08 Sep 2026 12:52:57 GMT
             X-Amz-Id-2:
-                - txg34d1366b089247819cd7-006a5f804f
+                - txg3f55a516d1e7438b9084-006aa00529
             X-Amz-Request-Id:
-                - txg34d1366b089247819cd7-006a5f804f
+                - txg3f55a516d1e7438b9084-006aa00529
         status: 200 OK
         code: 200
-        duration: 23.334125ms
+        duration: 76.404208ms
     - id: 124
       request:
         proto: HTTP/1.1
@@ -6477,7 +6477,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6486,16 +6486,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 47363246-278a-43c6-a09c-a34a062c8c73
+                - feb5a51f-19b8-4c76-8de3-d8dbd3157408
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142103Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T125257Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6507,21 +6507,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:21:03 GMT
+                - Tue, 08 Sep 2026 12:52:57 GMT
             X-Amz-Id-2:
-                - txg3f7813e78973442cbe98-006a5f804f
+                - txgde421d8c97e349cd88fd-006aa00529
             X-Amz-Request-Id:
-                - txg3f7813e78973442cbe98-006a5f804f
+                - txgde421d8c97e349cd88fd-006aa00529
         status: 200 OK
         code: 200
-        duration: 25.439791ms
+        duration: 1.034540708s
     - id: 125
       request:
         proto: HTTP/1.1
@@ -6530,7 +6530,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6539,16 +6539,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c10c15ef-b16e-4b0d-8792-a5240cb85e7d
+                - 55872551-3027-41f4-a5f0-2c79f9c0b325
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142103Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T125257Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6558,21 +6558,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg24bd20300f8649fa9ca5-006a5f8050</RequestId><HostId>txg24bd20300f8649fa9ca5-006a5f8050</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg5efefa6db3e74e4ab616-006aa0052a</RequestId><HostId>txg5efefa6db3e74e4ab616-006aa0052a</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:21:04 GMT
+                - Tue, 08 Sep 2026 12:52:58 GMT
             X-Amz-Id-2:
-                - txg24bd20300f8649fa9ca5-006a5f8050
+                - txg5efefa6db3e74e4ab616-006aa0052a
             X-Amz-Request-Id:
-                - txg24bd20300f8649fa9ca5-006a5f8050
+                - txg5efefa6db3e74e4ab616-006aa0052a
         status: 404 Not Found
         code: 404
-        duration: 97.290875ms
+        duration: 193.489792ms
     - id: 126
       request:
         proto: HTTP/1.1
@@ -6581,7 +6581,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6590,16 +6590,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c46a9cf5-547f-4c84-bfe9-a099a3f51a39
+                - 30fe21dd-d147-4519-9d35-b088f7246abb
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142104Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/
+                - 20260908T125258Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -6611,21 +6611,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:21:04 GMT
+                - Tue, 08 Sep 2026 12:52:58 GMT
             X-Amz-Id-2:
-                - txg537c2edad6294975b515-006a5f8050
+                - txgf1be0894189545c1b9bf-006aa0052a
             X-Amz-Request-Id:
-                - txg537c2edad6294975b515-006a5f8050
+                - txgf1be0894189545c1b9bf-006aa0052a
         status: 200 OK
         code: 200
-        duration: 18.603042ms
+        duration: 188.172375ms
     - id: 127
       request:
         proto: HTTP/1.1
@@ -6634,7 +6634,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6643,16 +6643,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 793809f5-1c35-4288-bdca-747e61b1e77e
+                - b5faea87-0d29-4228-9f27-31e15503b11d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142104Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T125258Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6662,21 +6662,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgb21cffefb3414f32b94c-006a5f8050</RequestId><HostId>txgb21cffefb3414f32b94c-006a5f8050</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg02e445ba9f9d4c7fb59e-006aa0052a</RequestId><HostId>txg02e445ba9f9d4c7fb59e-006aa0052a</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:21:04 GMT
+                - Tue, 08 Sep 2026 12:52:58 GMT
             X-Amz-Id-2:
-                - txgb21cffefb3414f32b94c-006a5f8050
+                - txg02e445ba9f9d4c7fb59e-006aa0052a
             X-Amz-Request-Id:
-                - txgb21cffefb3414f32b94c-006a5f8050
+                - txg02e445ba9f9d4c7fb59e-006aa0052a
         status: 404 Not Found
         code: 404
-        duration: 49.92ms
+        duration: 22.140542ms
     - id: 128
       request:
         proto: HTTP/1.1
@@ -6685,7 +6685,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6694,16 +6694,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c5720877-32c2-493b-92d5-fab8284b74e3
+                - 1cb3e8b5-a127-4c48-8ec6-58812f3cc6d5
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142104Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T125258Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6713,21 +6713,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg1017e2ccb87c4ccf85b9-006a5f8050</RequestId><HostId>txg1017e2ccb87c4ccf85b9-006a5f8050</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg24e4bca38429475fa207-006aa0052a</RequestId><HostId>txg24e4bca38429475fa207-006aa0052a</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:21:04 GMT
+                - Tue, 08 Sep 2026 12:52:58 GMT
             X-Amz-Id-2:
-                - txg1017e2ccb87c4ccf85b9-006a5f8050
+                - txg24e4bca38429475fa207-006aa0052a
             X-Amz-Request-Id:
-                - txg1017e2ccb87c4ccf85b9-006a5f8050
+                - txg24e4bca38429475fa207-006aa0052a
         status: 404 Not Found
         code: 404
-        duration: 140.91775ms
+        duration: 76.55725ms
     - id: 129
       request:
         proto: HTTP/1.1
@@ -6736,7 +6736,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6745,16 +6745,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4ef4661e-955d-4d84-93a8-06f4a3b5299c
+                - d99b0498-150a-4f2d-a8bc-95712c51266a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142104Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T125258Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6773,14 +6773,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:21:04 GMT
+                - Tue, 08 Sep 2026 12:52:59 GMT
             X-Amz-Id-2:
-                - txg09196d85b8d643069bd9-006a5f8050
+                - txgc9f47b381f714c9dab3d-006aa0052b
             X-Amz-Request-Id:
-                - txg09196d85b8d643069bd9-006a5f8050
+                - txgc9f47b381f714c9dab3d-006aa0052b
         status: 200 OK
         code: 200
-        duration: 19.86425ms
+        duration: 419.369542ms
     - id: 130
       request:
         proto: HTTP/1.1
@@ -6789,7 +6789,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6798,16 +6798,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c319c5db-f3b3-4df4-b6dd-564cdf0bc401
+                - 50e1bab2-c70b-40fa-b1a8-0cea8d3b856c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142104Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T125259Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6826,14 +6826,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:21:04 GMT
+                - Tue, 08 Sep 2026 12:52:59 GMT
             X-Amz-Id-2:
-                - txgc8cba64f5ddf4bd39955-006a5f8050
+                - txg043f7df63eab4a8b8547-006aa0052b
             X-Amz-Request-Id:
-                - txgc8cba64f5ddf4bd39955-006a5f8050
+                - txg043f7df63eab4a8b8547-006aa0052b
         status: 200 OK
         code: 200
-        duration: 23.255042ms
+        duration: 208.7875ms
     - id: 131
       request:
         proto: HTTP/1.1
@@ -6842,7 +6842,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6851,16 +6851,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7085ab61-9787-4cf0-afff-7a3f0638a325
+                - da93a2e7-906c-4e17-8b2f-6c16b4495007
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142104Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T125259Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6872,21 +6872,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:21:04 GMT
+                - Tue, 08 Sep 2026 12:52:59 GMT
             X-Amz-Id-2:
-                - txgae7644ee635e483a907c-006a5f8050
+                - txg1306f20c36b84537be5d-006aa0052b
             X-Amz-Request-Id:
-                - txgae7644ee635e483a907c-006a5f8050
+                - txg1306f20c36b84537be5d-006aa0052b
         status: 200 OK
         code: 200
-        duration: 47.216042ms
+        duration: 48.827792ms
     - id: 132
       request:
         proto: HTTP/1.1
@@ -6895,7 +6895,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6904,16 +6904,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - be402e5b-0fe8-42d7-9552-acf11878f3ec
+                - 1e0dcc3d-1e7d-4433-9b48-c0ff3f23825f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142104Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T125259Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6923,21 +6923,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg02fc7c18524c431fb8cd-006a5f8050</RequestId><HostId>txg02fc7c18524c431fb8cd-006a5f8050</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg910bb89b6a6649818b11-006aa0052b</RequestId><HostId>txg910bb89b6a6649818b11-006aa0052b</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:21:04 GMT
+                - Tue, 08 Sep 2026 12:52:59 GMT
             X-Amz-Id-2:
-                - txg02fc7c18524c431fb8cd-006a5f8050
+                - txg910bb89b6a6649818b11-006aa0052b
             X-Amz-Request-Id:
-                - txg02fc7c18524c431fb8cd-006a5f8050
+                - txg910bb89b6a6649818b11-006aa0052b
         status: 404 Not Found
         code: 404
-        duration: 97.618542ms
+        duration: 35.231209ms
     - id: 133
       request:
         proto: HTTP/1.1
@@ -6946,7 +6946,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6955,16 +6955,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a0465d25-9b69-4a89-808a-49dacc0d0910
+                - a87a4b0a-b447-4ce6-8753-f01c86d49675
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142104Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/
+                - 20260908T125259Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -6976,21 +6976,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:21:04 GMT
+                - Tue, 08 Sep 2026 12:52:59 GMT
             X-Amz-Id-2:
-                - txg52ea35b0f2dc4e9d9f60-006a5f8050
+                - txg55a64214abe84f858237-006aa0052b
             X-Amz-Request-Id:
-                - txg52ea35b0f2dc4e9d9f60-006a5f8050
+                - txg55a64214abe84f858237-006aa0052b
         status: 200 OK
         code: 200
-        duration: 50.63925ms
+        duration: 31.3925ms
     - id: 134
       request:
         proto: HTTP/1.1
@@ -6999,7 +6999,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7008,16 +7008,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - aa6d7a1a-56cb-42cd-8049-d64480a71cad
+                - f9f9163b-bb43-428c-910e-7671bad35c4c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142104Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T125259Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7027,21 +7027,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg187cabb00c044a9c8b9e-006a5f8050</RequestId><HostId>txg187cabb00c044a9c8b9e-006a5f8050</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg531e1f97dda54c22a016-006aa0052b</RequestId><HostId>txg531e1f97dda54c22a016-006aa0052b</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:21:04 GMT
+                - Tue, 08 Sep 2026 12:52:59 GMT
             X-Amz-Id-2:
-                - txg187cabb00c044a9c8b9e-006a5f8050
+                - txg531e1f97dda54c22a016-006aa0052b
             X-Amz-Request-Id:
-                - txg187cabb00c044a9c8b9e-006a5f8050
+                - txg531e1f97dda54c22a016-006aa0052b
         status: 404 Not Found
         code: 404
-        duration: 19.397708ms
+        duration: 114.823041ms
     - id: 135
       request:
         proto: HTTP/1.1
@@ -7050,7 +7050,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7059,16 +7059,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f974f42a-d691-46ec-ae89-4344c6d847cc
+                - 5f7be6e5-2880-482a-a6a4-4b66bd328691
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142104Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T125259Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7078,21 +7078,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg181dd930407a4bebb699-006a5f8050</RequestId><HostId>txg181dd930407a4bebb699-006a5f8050</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg029ea26f0fc648808c43-006aa0052c</RequestId><HostId>txg029ea26f0fc648808c43-006aa0052c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:21:04 GMT
+                - Tue, 08 Sep 2026 12:53:00 GMT
             X-Amz-Id-2:
-                - txg181dd930407a4bebb699-006a5f8050
+                - txg029ea26f0fc648808c43-006aa0052c
             X-Amz-Request-Id:
-                - txg181dd930407a4bebb699-006a5f8050
+                - txg029ea26f0fc648808c43-006aa0052c
         status: 404 Not Found
         code: 404
-        duration: 20.330625ms
+        duration: 21.9235ms
     - id: 136
       request:
         proto: HTTP/1.1
@@ -7101,7 +7101,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7110,16 +7110,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 48b5dd4a-b000-4890-8f92-62bcf7afb6ba
+                - e73d1ff8-3298-4c77-a1bd-83686fe73325
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142104Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T125300Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7138,14 +7138,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:21:04 GMT
+                - Tue, 08 Sep 2026 12:53:00 GMT
             X-Amz-Id-2:
-                - txg4fa80b843c404cb8b089-006a5f8050
+                - txgc6de3ebd78644b1180c1-006aa0052c
             X-Amz-Request-Id:
-                - txg4fa80b843c404cb8b089-006a5f8050
+                - txgc6de3ebd78644b1180c1-006aa0052c
         status: 200 OK
         code: 200
-        duration: 151.498542ms
+        duration: 142.206292ms
     - id: 137
       request:
         proto: HTTP/1.1
@@ -7154,7 +7154,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7163,16 +7163,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 788b46e8-8722-431b-b77c-a19f21ba362c
+                - 8faf2242-9825-435e-8440-b0e9547dd334
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142104Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T125300Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7191,14 +7191,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:21:05 GMT
+                - Tue, 08 Sep 2026 12:53:00 GMT
             X-Amz-Id-2:
-                - txg4b609c694e764444abcd-006a5f8051
+                - txg191c3fd6bd0141ca914e-006aa0052c
             X-Amz-Request-Id:
-                - txg4b609c694e764444abcd-006a5f8051
+                - txg191c3fd6bd0141ca914e-006aa0052c
         status: 200 OK
         code: 200
-        duration: 28.434083ms
+        duration: 299.251125ms
     - id: 138
       request:
         proto: HTTP/1.1
@@ -7207,7 +7207,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7216,16 +7216,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 23f14623-bc55-4399-ac19-70d95079ca00
+                - 31ad8669-b1bb-43fd-9897-74575ef12e3d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142105Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/
+                - 20260908T125300Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -7238,14 +7238,14 @@ interactions:
         body: ""
         headers:
             Date:
-                - Tue, 21 Jul 2026 14:21:05 GMT
+                - Tue, 08 Sep 2026 12:53:00 GMT
             X-Amz-Id-2:
-                - txg40dc8356ed234679b931-006a5f8051
+                - txg5204da01c545442c8386-006aa0052c
             X-Amz-Request-Id:
-                - txg40dc8356ed234679b931-006a5f8051
+                - txg5204da01c545442c8386-006aa0052c
         status: 204 No Content
         code: 204
-        duration: 319.147292ms
+        duration: 587.406ms
     - id: 139
       request:
         proto: HTTP/1.1
@@ -7254,7 +7254,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7263,18 +7263,18 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 246134cc-f88d-43e9-9fa2-fd7501d7628f
+                - 499633aa-ce84-498e-83eb-f95a21ee658a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Bucket-Object-Lock-Enabled:
                 - "true"
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142105Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/
+                - 20260908T125301Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
         method: PUT
       response:
         proto: HTTP/2.0
@@ -7289,16 +7289,16 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 21 Jul 2026 14:21:05 GMT
+                - Tue, 08 Sep 2026 12:53:01 GMT
             Location:
-                - /tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544
+                - /tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110
             X-Amz-Id-2:
-                - txgab25716a2afd4eb6b313-006a5f8051
+                - txgcb0816860ce9463291f5-006aa0052d
             X-Amz-Request-Id:
-                - txgab25716a2afd4eb6b313-006a5f8051
+                - txgcb0816860ce9463291f5-006aa0052d
         status: 200 OK
         code: 200
-        duration: 6.49940975s
+        duration: 2.343049s
     - id: 140
       request:
         proto: HTTP/1.1
@@ -7307,7 +7307,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7316,11 +7316,11 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d9c99fc3-b53e-41c5-acae-a6f0cab07395
+                - 76842c5b-b721-4694-86fe-68fcfe3bc5e2
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,Z,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,Z,e
             X-Amz-Acl:
                 - private
             X-Amz-Checksum-Crc32:
@@ -7328,8 +7328,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142112Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T125303Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?acl=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -7344,14 +7344,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 21 Jul 2026 14:21:12 GMT
+                - Tue, 08 Sep 2026 12:53:03 GMT
             X-Amz-Id-2:
-                - txgf2004cc2afda4f179bcd-006a5f8058
+                - txg74eebfeafd36431c91bd-006aa0052f
             X-Amz-Request-Id:
-                - txgf2004cc2afda4f179bcd-006a5f8058
+                - txg74eebfeafd36431c91bd-006aa0052f
         status: 200 OK
         code: 200
-        duration: 1.123980917s
+        duration: 22.275625ms
     - id: 141
       request:
         proto: HTTP/1.1
@@ -7360,29 +7360,29 @@ interactions:
         content_length: 532
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
-        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>2</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260721142113150500000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260721142113150500000002</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
+        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>2</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260908125303648800000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260908125303648800000002</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
         form: {}
         headers:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ba1f95ed-a46d-49d7-a1a2-f3712f5ebbcb
+                - 544b86fe-9e38-40d8-8fb8-939e7759c6bd
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
                 - application/xml
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,Z,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,Z,e
             X-Amz-Checksum-Crc32:
-                - EqaQBQ==
+                - U+q7Fw==
             X-Amz-Content-Sha256:
-                - 181f33c3d1c19761cda4ef21b84524f38da04b50330394d01b813fd46c583751
+                - a7e253fedff3fb7512746b1cd99ea2a285fde55df8c019da66f2c17cb9d7ac8c
             X-Amz-Date:
-                - 20260721T142112Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T125303Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -7397,14 +7397,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 21 Jul 2026 14:21:13 GMT
+                - Tue, 08 Sep 2026 12:53:03 GMT
             X-Amz-Id-2:
-                - txgc3bf8a13d69e47f6ad53-006a5f8059
+                - txg83a595e1d0c64295a877-006aa0052f
             X-Amz-Request-Id:
-                - txgc3bf8a13d69e47f6ad53-006a5f8059
+                - txg83a595e1d0c64295a877-006aa0052f
         status: 200 OK
         code: 200
-        duration: 2.153986541s
+        duration: 25.155375ms
     - id: 142
       request:
         proto: HTTP/1.1
@@ -7413,7 +7413,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7422,16 +7422,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6175aa53-bd58-41ed-b219-109186f46f16
+                - 80819ad1-7294-4f3a-9322-0c30a91c11fb
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142115Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T125303Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7443,21 +7443,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:21:15 GMT
+                - Tue, 08 Sep 2026 12:53:03 GMT
             X-Amz-Id-2:
-                - txgfe4ed7f12de54030a968-006a5f805b
+                - txg980c536d5bec414680f2-006aa0052f
             X-Amz-Request-Id:
-                - txgfe4ed7f12de54030a968-006a5f805b
+                - txg980c536d5bec414680f2-006aa0052f
         status: 200 OK
         code: 200
-        duration: 301.070458ms
+        duration: 173.107166ms
     - id: 143
       request:
         proto: HTTP/1.1
@@ -7466,7 +7466,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7475,16 +7475,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7c6788fc-a7b8-4065-ae02-53f1b8c254bd
+                - 88d9b94b-18c7-4642-8142-830af347ee41
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142115Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T125303Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7503,14 +7503,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:21:15 GMT
+                - Tue, 08 Sep 2026 12:53:03 GMT
             X-Amz-Id-2:
-                - txg57fb72ab6dde46a7aa8e-006a5f805b
+                - txgedc3ac882c8547d58ac1-006aa0052f
             X-Amz-Request-Id:
-                - txg57fb72ab6dde46a7aa8e-006a5f805b
+                - txgedc3ac882c8547d58ac1-006aa0052f
         status: 200 OK
         code: 200
-        duration: 1.020398584s
+        duration: 205.760917ms
     - id: 144
       request:
         proto: HTTP/1.1
@@ -7519,7 +7519,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7528,16 +7528,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4a418917-1e8f-4c47-ab32-3a71fb071941
+                - 899507c2-459d-45bf-966c-a2cf9cb1f83e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142115Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/
+                - 20260908T125303Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -7549,21 +7549,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:21:16 GMT
+                - Tue, 08 Sep 2026 12:53:04 GMT
             X-Amz-Id-2:
-                - txg2771d0974fee4107b8d2-006a5f805c
+                - txgffe935dca8e94586a0ef-006aa00530
             X-Amz-Request-Id:
-                - txg2771d0974fee4107b8d2-006a5f805c
+                - txgffe935dca8e94586a0ef-006aa00530
         status: 200 OK
         code: 200
-        duration: 2.064086s
+        duration: 21.6895ms
     - id: 145
       request:
         proto: HTTP/1.1
@@ -7572,7 +7572,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7581,16 +7581,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0c9dd919-6cd3-4894-84a1-3a11bd0ef421
+                - 934e25ec-cd5f-4147-9ea7-2715dabf956a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142116Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T125304Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7600,21 +7600,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg2f34ae06dc0a4125beb9-006a5f805e</RequestId><HostId>txg2f34ae06dc0a4125beb9-006a5f805e</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgc1303615f26544d8960b-006aa00530</RequestId><HostId>txgc1303615f26544d8960b-006aa00530</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:21:18 GMT
+                - Tue, 08 Sep 2026 12:53:04 GMT
             X-Amz-Id-2:
-                - txg2f34ae06dc0a4125beb9-006a5f805e
+                - txgc1303615f26544d8960b-006aa00530
             X-Amz-Request-Id:
-                - txg2f34ae06dc0a4125beb9-006a5f805e
+                - txgc1303615f26544d8960b-006aa00530
         status: 404 Not Found
         code: 404
-        duration: 1.028542667s
+        duration: 21.438667ms
     - id: 146
       request:
         proto: HTTP/1.1
@@ -7623,7 +7623,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7632,16 +7632,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 76d73e39-b68c-4e1a-a02f-8a4b469084b1
+                - 0a7e6077-38a4-4c43-9316-e6d5740f90af
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142118Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T125304Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7651,21 +7651,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg90c58b8fd44546aca157-006a5f805f</RequestId><HostId>txg90c58b8fd44546aca157-006a5f805f</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg1eedaf156d2249989e76-006aa00530</RequestId><HostId>txg1eedaf156d2249989e76-006aa00530</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:21:19 GMT
+                - Tue, 08 Sep 2026 12:53:04 GMT
             X-Amz-Id-2:
-                - txg90c58b8fd44546aca157-006a5f805f
+                - txg1eedaf156d2249989e76-006aa00530
             X-Amz-Request-Id:
-                - txg90c58b8fd44546aca157-006a5f805f
+                - txg1eedaf156d2249989e76-006aa00530
         status: 404 Not Found
         code: 404
-        duration: 70.619167ms
+        duration: 204.574833ms
     - id: 147
       request:
         proto: HTTP/1.1
@@ -7674,7 +7674,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7683,16 +7683,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 860e1385-1983-4ac5-a25f-38ff95cb5cc7
+                - f5cee3d6-6568-4f1c-99e8-b4c8bfc45066
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142119Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T125304Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7711,14 +7711,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:21:19 GMT
+                - Tue, 08 Sep 2026 12:53:04 GMT
             X-Amz-Id-2:
-                - txg9107b49ea6054d67a81f-006a5f805f
+                - txge82d9c70ab5b41e889bc-006aa00530
             X-Amz-Request-Id:
-                - txg9107b49ea6054d67a81f-006a5f805f
+                - txge82d9c70ab5b41e889bc-006aa00530
         status: 200 OK
         code: 200
-        duration: 1.051489791s
+        duration: 53.922916ms
     - id: 148
       request:
         proto: HTTP/1.1
@@ -7727,7 +7727,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7736,16 +7736,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 75a5563a-5690-46a9-85d3-deedb3d4c255
+                - 46fe32e8-8a92-4831-a5f2-737b894eab6d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142119Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T125304Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7757,21 +7757,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>2</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260721142113150500000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260721142113150500000002</ID><Status>Enabled</Status></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>2</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260908125303648800000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260908125303648800000002</ID><Status>Enabled</Status></Rule></Configuration>
         headers:
             Content-Length:
                 - "505"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:21:20 GMT
+                - Tue, 08 Sep 2026 12:53:04 GMT
             X-Amz-Id-2:
-                - txgf559f9728a824adabc80-006a5f8060
+                - txg00e3e50f6d9c4b428ed7-006aa00530
             X-Amz-Request-Id:
-                - txgf559f9728a824adabc80-006a5f8060
+                - txg00e3e50f6d9c4b428ed7-006aa00530
         status: 200 OK
         code: 200
-        duration: 1.019193709s
+        duration: 26.165959ms
     - id: 149
       request:
         proto: HTTP/1.1
@@ -7780,7 +7780,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7789,16 +7789,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 00971029-7431-4c87-bb13-39777ffd5979
+                - f1ade7fe-6d88-40c6-9a83-e067476c2822
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142122Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/
+                - 20260908T125304Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -7813,16 +7813,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:21:22 GMT
+                - Tue, 08 Sep 2026 12:53:04 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txg459784b944004e2296cb-006a5f8062
+                - txgce294f4959bb4be0b32c-006aa00530
             X-Amz-Request-Id:
-                - txg459784b944004e2296cb-006a5f8062
+                - txgce294f4959bb4be0b32c-006aa00530
         status: 200 OK
         code: 200
-        duration: 1.093766208s
+        duration: 20.652708ms
     - id: 150
       request:
         proto: HTTP/1.1
@@ -7831,7 +7831,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7840,16 +7840,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f949ef3c-8dfc-4f46-882b-86093820c710
+                - 2f3fba24-363b-45cb-baf7-0b0aa439a52a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142123Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T125304Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7861,21 +7861,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>2</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260721142113150500000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260721142113150500000002</ID><Status>Enabled</Status></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>2</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260908125303648800000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260908125303648800000002</ID><Status>Enabled</Status></Rule></Configuration>
         headers:
             Content-Length:
                 - "505"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:21:23 GMT
+                - Tue, 08 Sep 2026 12:53:04 GMT
             X-Amz-Id-2:
-                - txgae47a3f98cee409492bd-006a5f8063
+                - txg8a65f5112774445683b7-006aa00530
             X-Amz-Request-Id:
-                - txgae47a3f98cee409492bd-006a5f8063
+                - txg8a65f5112774445683b7-006aa00530
         status: 200 OK
         code: 200
-        duration: 88.511792ms
+        duration: 201.404333ms
     - id: 151
       request:
         proto: HTTP/1.1
@@ -7884,7 +7884,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7893,16 +7893,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6468888f-c1c3-435a-b033-5ba4ec67ab6f
+                - dd627bfa-fbc6-425a-989b-722e561324c4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142123Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T125304Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7914,21 +7914,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:21:23 GMT
+                - Tue, 08 Sep 2026 12:53:04 GMT
             X-Amz-Id-2:
-                - txg071fc640ada342e18046-006a5f8063
+                - txgc5cbfc1dea1d42fd9968-006aa00530
             X-Amz-Request-Id:
-                - txg071fc640ada342e18046-006a5f8063
+                - txgc5cbfc1dea1d42fd9968-006aa00530
         status: 200 OK
         code: 200
-        duration: 1.078076667s
+        duration: 59.55075ms
     - id: 152
       request:
         proto: HTTP/1.1
@@ -7937,7 +7937,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7946,16 +7946,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 70931f81-c424-4af1-a847-41565c0c08e0
+                - 6851cdec-5e7c-428c-8eef-434c16cc26bd
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142123Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T125304Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7974,14 +7974,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:21:24 GMT
+                - Tue, 08 Sep 2026 12:53:04 GMT
             X-Amz-Id-2:
-                - txg378b3593370140838178-006a5f8064
+                - txg5bbab8f541e641508ef4-006aa00530
             X-Amz-Request-Id:
-                - txg378b3593370140838178-006a5f8064
+                - txg5bbab8f541e641508ef4-006aa00530
         status: 200 OK
         code: 200
-        duration: 194.61325ms
+        duration: 28.312333ms
     - id: 153
       request:
         proto: HTTP/1.1
@@ -7990,7 +7990,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7999,16 +7999,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d815cd52-71ea-40f2-b307-38caf144c2f6
+                - 7b592df2-e29b-42b1-aed4-40800a11c97b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142124Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/
+                - 20260908T125304Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -8020,21 +8020,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:21:24 GMT
+                - Tue, 08 Sep 2026 12:53:05 GMT
             X-Amz-Id-2:
-                - txgc74cb14e44a442908c18-006a5f8064
+                - txg1ef137f412de43f7af22-006aa00531
             X-Amz-Request-Id:
-                - txgc74cb14e44a442908c18-006a5f8064
+                - txg1ef137f412de43f7af22-006aa00531
         status: 200 OK
         code: 200
-        duration: 1.114000917s
+        duration: 190.279292ms
     - id: 154
       request:
         proto: HTTP/1.1
@@ -8043,7 +8043,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8052,16 +8052,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 93f646ba-f4e1-4be5-9cc2-58bbe76df137
+                - bafa1ba6-dd86-48f0-808f-f64ce603464b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142124Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T125305Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8071,21 +8071,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg8bc11d66f22e4ec7bf65-006a5f8066</RequestId><HostId>txg8bc11d66f22e4ec7bf65-006a5f8066</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgb17f52831e8e4745a64b-006aa00531</RequestId><HostId>txgb17f52831e8e4745a64b-006aa00531</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:21:26 GMT
+                - Tue, 08 Sep 2026 12:53:05 GMT
             X-Amz-Id-2:
-                - txg8bc11d66f22e4ec7bf65-006a5f8066
+                - txgb17f52831e8e4745a64b-006aa00531
             X-Amz-Request-Id:
-                - txg8bc11d66f22e4ec7bf65-006a5f8066
+                - txgb17f52831e8e4745a64b-006aa00531
         status: 404 Not Found
         code: 404
-        duration: 1.027068667s
+        duration: 26.868709ms
     - id: 155
       request:
         proto: HTTP/1.1
@@ -8094,7 +8094,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8103,16 +8103,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6467d74f-82c9-4d06-a000-5ed02f7a4804
+                - 22328f86-26a9-4012-a950-b3905ea53be0
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142126Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T125305Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8122,21 +8122,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgfbd915a360ff4828bc3a-006a5f8067</RequestId><HostId>txgfbd915a360ff4828bc3a-006a5f8067</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg84411d95c237429d871b-006aa00531</RequestId><HostId>txg84411d95c237429d871b-006aa00531</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:21:27 GMT
+                - Tue, 08 Sep 2026 12:53:05 GMT
             X-Amz-Id-2:
-                - txgfbd915a360ff4828bc3a-006a5f8067
+                - txg84411d95c237429d871b-006aa00531
             X-Amz-Request-Id:
-                - txgfbd915a360ff4828bc3a-006a5f8067
+                - txg84411d95c237429d871b-006aa00531
         status: 404 Not Found
         code: 404
-        duration: 1.071230875s
+        duration: 82.432458ms
     - id: 156
       request:
         proto: HTTP/1.1
@@ -8145,7 +8145,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8154,16 +8154,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3e9465cc-60d4-4ee1-a5a7-257530c5f3ad
+                - 79d6c0d8-6dc0-48bb-9c45-6bd926494458
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142127Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T125305Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8182,14 +8182,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:21:28 GMT
+                - Tue, 08 Sep 2026 12:53:05 GMT
             X-Amz-Id-2:
-                - txg947455e35e54424c99cf-006a5f8068
+                - txg86d148ef61294cc5852c-006aa00531
             X-Amz-Request-Id:
-                - txg947455e35e54424c99cf-006a5f8068
+                - txg86d148ef61294cc5852c-006aa00531
         status: 200 OK
         code: 200
-        duration: 1.12322325s
+        duration: 220.649125ms
     - id: 157
       request:
         proto: HTTP/1.1
@@ -8198,7 +8198,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8207,16 +8207,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f2100c21-fd33-40fa-a86f-8c28d00fbf77
+                - 2c630ef9-19f9-4cd2-b694-484e36a35bc0
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142128Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T125305Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8228,21 +8228,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>2</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260721142113150500000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260721142113150500000002</ID><Status>Enabled</Status></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>2</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260908125303648800000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260908125303648800000002</ID><Status>Enabled</Status></Rule></Configuration>
         headers:
             Content-Length:
                 - "505"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:21:29 GMT
+                - Tue, 08 Sep 2026 12:53:05 GMT
             X-Amz-Id-2:
-                - txg69cc025817b8416baada-006a5f8069
+                - txg85b7c99b9c9448a18d7c-006aa00531
             X-Amz-Request-Id:
-                - txg69cc025817b8416baada-006a5f8069
+                - txg85b7c99b9c9448a18d7c-006aa00531
         status: 200 OK
         code: 200
-        duration: 1.026249042s
+        duration: 271.759292ms
     - id: 158
       request:
         proto: HTTP/1.1
@@ -8251,7 +8251,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8260,16 +8260,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7590bff7-313d-4615-998d-95604d99d3b5
+                - b7a6b071-fc56-4c69-a8c4-eae8de31d2a9
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142130Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T125305Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8281,21 +8281,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:21:30 GMT
+                - Tue, 08 Sep 2026 12:53:05 GMT
             X-Amz-Id-2:
-                - txg17087ea7489e4ad69293-006a5f806a
+                - txga77b3e31dc884a88b580-006aa00531
             X-Amz-Request-Id:
-                - txg17087ea7489e4ad69293-006a5f806a
+                - txga77b3e31dc884a88b580-006aa00531
         status: 200 OK
         code: 200
-        duration: 1.069596s
+        duration: 62.976166ms
     - id: 159
       request:
         proto: HTTP/1.1
@@ -8304,7 +8304,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8313,16 +8313,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e731fc88-3437-45c3-a5b9-a1738ce829b7
+                - 38993d2b-9ee6-4874-baff-2d9dd464d92d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142130Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T125305Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8341,14 +8341,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:21:31 GMT
+                - Tue, 08 Sep 2026 12:53:06 GMT
             X-Amz-Id-2:
-                - txgd921a9d2dae74d4abe77-006a5f806b
+                - txg178342127e924ec0a143-006aa00532
             X-Amz-Request-Id:
-                - txgd921a9d2dae74d4abe77-006a5f806b
+                - txg178342127e924ec0a143-006aa00532
         status: 200 OK
         code: 200
-        duration: 52.807875ms
+        duration: 24.061208ms
     - id: 160
       request:
         proto: HTTP/1.1
@@ -8357,7 +8357,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8366,16 +8366,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 27bf3c3f-69dc-4f73-a2fc-82e7d28a4e4b
+                - 62897ec1-e93b-4348-b3f2-c4f086010b2f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142131Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/
+                - 20260908T125306Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -8387,21 +8387,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:21:31 GMT
+                - Tue, 08 Sep 2026 12:53:06 GMT
             X-Amz-Id-2:
-                - txg9bafb594af3b457f90e0-006a5f806b
+                - txg0d75dc23a4424c87a517-006aa00532
             X-Amz-Request-Id:
-                - txg9bafb594af3b457f90e0-006a5f806b
+                - txg0d75dc23a4424c87a517-006aa00532
         status: 200 OK
         code: 200
-        duration: 2.060347542s
+        duration: 68.191667ms
     - id: 161
       request:
         proto: HTTP/1.1
@@ -8410,7 +8410,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8419,16 +8419,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 1ecd9af3-be9b-49de-9f17-3142f6789ae7
+                - 63e31cdc-422b-46d6-b714-3ca995dafc96
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142131Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T125306Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8438,21 +8438,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg11d677f3dc624516b76d-006a5f806d</RequestId><HostId>txg11d677f3dc624516b76d-006a5f806d</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgb094286f65d14660b407-006aa00532</RequestId><HostId>txgb094286f65d14660b407-006aa00532</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:21:33 GMT
+                - Tue, 08 Sep 2026 12:53:06 GMT
             X-Amz-Id-2:
-                - txg11d677f3dc624516b76d-006a5f806d
+                - txgb094286f65d14660b407-006aa00532
             X-Amz-Request-Id:
-                - txg11d677f3dc624516b76d-006a5f806d
+                - txgb094286f65d14660b407-006aa00532
         status: 404 Not Found
         code: 404
-        duration: 21.072667ms
+        duration: 22.462ms
     - id: 162
       request:
         proto: HTTP/1.1
@@ -8461,7 +8461,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8470,16 +8470,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7c16aac1-260f-4bbf-aa8f-a9d155e60afc
+                - 5f770be7-039f-48bc-866b-fdf6d6441c0e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142133Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T125306Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8489,21 +8489,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg033c6dd1bebb4bec98be-006a5f806d</RequestId><HostId>txg033c6dd1bebb4bec98be-006a5f806d</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgd6be2acb3af1489fb4c1-006aa00532</RequestId><HostId>txgd6be2acb3af1489fb4c1-006aa00532</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:21:33 GMT
+                - Tue, 08 Sep 2026 12:53:06 GMT
             X-Amz-Id-2:
-                - txg033c6dd1bebb4bec98be-006a5f806d
+                - txgd6be2acb3af1489fb4c1-006aa00532
             X-Amz-Request-Id:
-                - txg033c6dd1bebb4bec98be-006a5f806d
+                - txgd6be2acb3af1489fb4c1-006aa00532
         status: 404 Not Found
         code: 404
-        duration: 1.0226555s
+        duration: 96.902208ms
     - id: 163
       request:
         proto: HTTP/1.1
@@ -8512,7 +8512,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8521,16 +8521,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 18f9b149-3a8d-487b-8bc2-d5c8271d4686
+                - 6ef2f81e-f43f-4956-82d9-4b37e0bdf0a1
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142133Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T125306Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8549,14 +8549,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:21:34 GMT
+                - Tue, 08 Sep 2026 12:53:06 GMT
             X-Amz-Id-2:
-                - txg9d45e812a0dc419d813f-006a5f806e
+                - txg790d317c63864662a6fe-006aa00532
             X-Amz-Request-Id:
-                - txg9d45e812a0dc419d813f-006a5f806e
+                - txg790d317c63864662a6fe-006aa00532
         status: 200 OK
         code: 200
-        duration: 1.034301333s
+        duration: 85.6105ms
     - id: 164
       request:
         proto: HTTP/1.1
@@ -8565,7 +8565,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8574,16 +8574,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c7a41691-8cb9-467e-a02e-2679b66601ad
+                - 5f4f02da-f713-45f1-a720-81d4735abf5c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142134Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T125306Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8595,21 +8595,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>2</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260721142113150500000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260721142113150500000002</ID><Status>Enabled</Status></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>2</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260908125303648800000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260908125303648800000002</ID><Status>Enabled</Status></Rule></Configuration>
         headers:
             Content-Length:
                 - "505"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:21:35 GMT
+                - Tue, 08 Sep 2026 12:53:06 GMT
             X-Amz-Id-2:
-                - txg5250266f80d24b35bda3-006a5f806f
+                - txgc274f50612fc4d6cb50e-006aa00532
             X-Amz-Request-Id:
-                - txg5250266f80d24b35bda3-006a5f806f
+                - txgc274f50612fc4d6cb50e-006aa00532
         status: 200 OK
         code: 200
-        duration: 17.522834ms
+        duration: 26.147ms
     - id: 165
       request:
         proto: HTTP/1.1
@@ -8618,7 +8618,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8627,16 +8627,383 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4a4221ab-1e01-4e73-b402-bf869ff5cedb
+                - 3325f09c-6a06-4451-9738-35b7fa2cbad3
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142135Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/
+                - 20260908T125306Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?acl=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 698
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+        headers:
+            Content-Length:
+                - "698"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Tue, 08 Sep 2026 12:53:06 GMT
+            X-Amz-Id-2:
+                - txg3cb6ab3cbe7247b69346-006aa00532
+            X-Amz-Request-Id:
+                - txg3cb6ab3cbe7247b69346-006aa00532
+        status: 200 OK
+        code: 200
+        duration: 201.592792ms
+    - id: 166
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - db23f006-269c-4ee0-95e6-9232a13a66d0
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T125306Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?object-lock=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 184
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <ObjectLockConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><ObjectLockEnabled>Enabled</ObjectLockEnabled></ObjectLockConfiguration>
+        headers:
+            Content-Length:
+                - "184"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Tue, 08 Sep 2026 12:53:06 GMT
+            X-Amz-Id-2:
+                - txg56d1125eb1ce4dab80d9-006aa00532
+            X-Amz-Request-Id:
+                - txg56d1125eb1ce4dab80d9-006aa00532
+        status: 200 OK
+        code: 200
+        duration: 23.087542ms
+    - id: 167
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - ee597572-0cc4-4ba2-863a-fdb30de30cdc
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T125306Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 287
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+        headers:
+            Content-Length:
+                - "287"
+            Content-Type:
+                - application/xml
+            Date:
+                - Tue, 08 Sep 2026 12:53:06 GMT
+            X-Amz-Id-2:
+                - txgc0bc3c79841443f79698-006aa00532
+            X-Amz-Request-Id:
+                - txgc0bc3c79841443f79698-006aa00532
+        status: 200 OK
+        code: 200
+        duration: 180.743292ms
+    - id: 168
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - a40034f6-5409-4d3e-bfb3-8f6681a44a6b
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T125306Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?tagging=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 361
+        uncompressed: false
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg143669351705497d90c9-006aa00532</RequestId><HostId>txg143669351705497d90c9-006aa00532</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</BucketName></Error>
+        headers:
+            Content-Length:
+                - "361"
+            Content-Type:
+                - application/xml
+            Date:
+                - Tue, 08 Sep 2026 12:53:06 GMT
+            X-Amz-Id-2:
+                - txg143669351705497d90c9-006aa00532
+            X-Amz-Request-Id:
+                - txg143669351705497d90c9-006aa00532
+        status: 404 Not Found
+        code: 404
+        duration: 319.86525ms
+    - id: 169
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - bfc12923-3ff2-49e4-89c1-a772a48b134e
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T125306Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?cors=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 298
+        uncompressed: false
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgb051cfc761564547b673-006aa00533</RequestId><HostId>txgb051cfc761564547b673-006aa00533</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
+        headers:
+            Content-Length:
+                - "298"
+            Content-Type:
+                - application/xml
+            Date:
+                - Tue, 08 Sep 2026 12:53:07 GMT
+            X-Amz-Id-2:
+                - txgb051cfc761564547b673-006aa00533
+            X-Amz-Request-Id:
+                - txgb051cfc761564547b673-006aa00533
+        status: 404 Not Found
+        code: 404
+        duration: 21.433708ms
+    - id: 170
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 6f09532b-ee89-41e6-bc8a-f86b8b8dbbdd
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T125307Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?versioning=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 114
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <VersioningConfiguration><Status>Enabled</Status></VersioningConfiguration>
+        headers:
+            Content-Length:
+                - "114"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Tue, 08 Sep 2026 12:53:07 GMT
+            X-Amz-Id-2:
+                - txg3538c14c380a49bfa732-006aa00533
+            X-Amz-Request-Id:
+                - txg3538c14c380a49bfa732-006aa00533
+        status: 200 OK
+        code: 200
+        duration: 61.897416ms
+    - id: 171
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - a8067b87-adcc-4507-9f10-c3c389847639
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T125307Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 505
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <Configuration><Rule><Expiration><Days>2</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260908125303648800000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260908125303648800000002</ID><Status>Enabled</Status></Rule></Configuration>
+        headers:
+            Content-Length:
+                - "505"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Tue, 08 Sep 2026 12:53:07 GMT
+            X-Amz-Id-2:
+                - txg97c98fe0590f4a1dacb6-006aa00533
+            X-Amz-Request-Id:
+                - txg97c98fe0590f4a1dacb6-006aa00533
+        status: 200 OK
+        code: 200
+        duration: 25.593292ms
+    - id: 172
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 34f62489-8029-4985-b237-13dd958c5443
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260908T125307Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -8649,15 +9016,15 @@ interactions:
         body: ""
         headers:
             Date:
-                - Tue, 21 Jul 2026 14:21:36 GMT
+                - Tue, 08 Sep 2026 12:53:07 GMT
             X-Amz-Id-2:
-                - txg9cdab22543844fa48319-006a5f8070
+                - txga5081276ab9e4c91a76f-006aa00533
             X-Amz-Request-Id:
-                - txg9cdab22543844fa48319-006a5f8070
+                - txga5081276ab9e4c91a76f-006aa00533
         status: 204 No Content
         code: 204
-        duration: 158.617666ms
-    - id: 166
+        duration: 452.752791ms
+    - id: 173
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -8665,7 +9032,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8674,16 +9041,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7b350b04-b2ff-4d85-a146-b0d05f3cb589
+                - ec11f832-0c22-4698-9aa0-a9b4c92b72ef
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142136Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/
+                - 20260908T125307Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
         method: PUT
       response:
         proto: HTTP/2.0
@@ -8698,17 +9065,17 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 21 Jul 2026 14:21:36 GMT
+                - Tue, 08 Sep 2026 12:53:07 GMT
             Location:
-                - /tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544
+                - /tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110
             X-Amz-Id-2:
-                - txgf3ac3899fe3e41fd872a-006a5f8070
+                - txg3b848eeae15e4c73abb8-006aa00533
             X-Amz-Request-Id:
-                - txgf3ac3899fe3e41fd872a-006a5f8070
+                - txg3b848eeae15e4c73abb8-006aa00533
         status: 200 OK
         code: 200
-        duration: 1.475537459s
-    - id: 167
+        duration: 4.403801334s
+    - id: 174
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -8716,7 +9083,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8725,11 +9092,11 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 87e418a7-4a1e-46d7-8a09-ce326d720cf9
+                - efcc1168-1430-46ff-a55c-155f23a05cbc
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,Z,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,Z,e
             X-Amz-Acl:
                 - private
             X-Amz-Checksum-Crc32:
@@ -8737,8 +9104,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142137Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T125312Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?acl=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -8753,15 +9120,15 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 21 Jul 2026 14:21:37 GMT
+                - Tue, 08 Sep 2026 12:53:12 GMT
             X-Amz-Id-2:
-                - txg34cf32af4ada4e389c36-006a5f8071
+                - txgbc7fce4428494c4da8e5-006aa00538
             X-Amz-Request-Id:
-                - txg34cf32af4ada4e389c36-006a5f8071
+                - txgbc7fce4428494c4da8e5-006aa00538
         status: 200 OK
         code: 200
-        duration: 1.173532375s
-    - id: 168
+        duration: 2.131452375s
+    - id: 175
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -8769,29 +9136,29 @@ interactions:
         content_length: 1829
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
-        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>30</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition><Transition><Days>210</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>95</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Filter><Prefix>path3/</Prefix></Filter><ID>id3</ID><Status>Enabled</Status><Transition><Days>130</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path4/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>155</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id6</ID><Status>Enabled</Status><Transition><Days>156</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></LifecycleConfiguration>
+        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>30</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition><Transition><Days>210</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>95</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Filter><Prefix>path3/</Prefix></Filter><ID>id3</ID><Status>Enabled</Status><Transition><Days>130</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path4/</Prefix><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>155</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id6</ID><Status>Enabled</Status><Transition><Days>156</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></LifecycleConfiguration>
         form: {}
         headers:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 98a94df7-c36e-42d6-b954-b7b1d81d91f2
+                - 5344a251-7d61-4b32-bbc0-f046438bbde7
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
                 - application/xml
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,Z,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,Z,e
             X-Amz-Checksum-Crc32:
-                - c8+Vuw==
+                - K95RHg==
             X-Amz-Content-Sha256:
-                - fc83411e62e4857b538b96c9721a15262cd16929d89e89e20f8565c5c2638c16
+                - e8ad0a665d4b49c819e7ca5b44b920cf11ff47b2647c6df77d468c637b6b1394
             X-Amz-Date:
-                - 20260721T142137Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T125313Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -8806,15 +9173,15 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 21 Jul 2026 14:21:38 GMT
+                - Tue, 08 Sep 2026 12:53:14 GMT
             X-Amz-Id-2:
-                - txg67e0b9f339254bf3b5af-006a5f8072
+                - txgccb93a032ba74bf9a23d-006aa0053a
             X-Amz-Request-Id:
-                - txg67e0b9f339254bf3b5af-006a5f8072
+                - txgccb93a032ba74bf9a23d-006aa0053a
         status: 200 OK
         code: 200
-        duration: 2.047765459s
-    - id: 169
+        duration: 2.040218083s
+    - id: 176
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -8822,7 +9189,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8831,16 +9198,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 569acf4c-0b05-48b3-8520-edfcb695535d
+                - 658cf47a-6b0d-40f9-a00b-3890efd694a3
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142140Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T125316Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8852,22 +9219,22 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:21:40 GMT
+                - Tue, 08 Sep 2026 12:53:16 GMT
             X-Amz-Id-2:
-                - txge1ac465febb041b4b5ce-006a5f8074
+                - txg7ba04de970af43be8b45-006aa0053c
             X-Amz-Request-Id:
-                - txge1ac465febb041b4b5ce-006a5f8074
+                - txg7ba04de970af43be8b45-006aa0053c
         status: 200 OK
         code: 200
-        duration: 1.090301458s
-    - id: 170
+        duration: 514.220625ms
+    - id: 177
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -8875,7 +9242,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8884,16 +9251,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 25bfc5e0-3f1f-4680-bd28-c8d01eb009d2
+                - c43daed3-bf29-496a-9a86-977958922d8e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142140Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T125316Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8903,22 +9270,22 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg852d3db9eb694a2cae02-006a5f8075</RequestId><HostId>txg852d3db9eb694a2cae02-006a5f8075</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgb55fd921e20b49df87a7-006aa0053c</RequestId><HostId>txgb55fd921e20b49df87a7-006aa0053c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:21:41 GMT
+                - Tue, 08 Sep 2026 12:53:16 GMT
             X-Amz-Id-2:
-                - txg852d3db9eb694a2cae02-006a5f8075
+                - txgb55fd921e20b49df87a7-006aa0053c
             X-Amz-Request-Id:
-                - txg852d3db9eb694a2cae02-006a5f8075
+                - txgb55fd921e20b49df87a7-006aa0053c
         status: 404 Not Found
         code: 404
-        duration: 1.327641s
-    - id: 171
+        duration: 1.198346167s
+    - id: 178
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -8926,7 +9293,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8935,16 +9302,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f8e142e7-a011-4a4e-ac5d-bb7f299ccf96
+                - 0f5f50ad-46db-4b78-8018-fbc4eaeb5cdc
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142141Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/
+                - 20260908T125316Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -8956,22 +9323,22 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:21:43 GMT
+                - Tue, 08 Sep 2026 12:53:18 GMT
             X-Amz-Id-2:
-                - txgc41ed7cbae194d7cb227-006a5f8077
+                - txg12f84c8ca9aa434fa672-006aa0053e
             X-Amz-Request-Id:
-                - txgc41ed7cbae194d7cb227-006a5f8077
+                - txg12f84c8ca9aa434fa672-006aa0053e
         status: 200 OK
         code: 200
-        duration: 340.696ms
-    - id: 172
+        duration: 1.052834792s
+    - id: 179
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -8979,7 +9346,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8988,16 +9355,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4f38b342-6b5d-44d6-a60a-6613ede322f5
+                - 5ab0c999-d142-4b52-bb50-406cfb99e42d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142143Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T125318Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -9007,22 +9374,22 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txga43b5ff5b1cf44c0b9a3-006a5f8077</RequestId><HostId>txga43b5ff5b1cf44c0b9a3-006a5f8077</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg6b586855de3e4053967f-006aa0053f</RequestId><HostId>txg6b586855de3e4053967f-006aa0053f</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:21:43 GMT
+                - Tue, 08 Sep 2026 12:53:19 GMT
             X-Amz-Id-2:
-                - txga43b5ff5b1cf44c0b9a3-006a5f8077
+                - txg6b586855de3e4053967f-006aa0053f
             X-Amz-Request-Id:
-                - txga43b5ff5b1cf44c0b9a3-006a5f8077
+                - txg6b586855de3e4053967f-006aa0053f
         status: 404 Not Found
         code: 404
-        duration: 1.025492541s
-    - id: 173
+        duration: 434.226542ms
+    - id: 180
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -9030,7 +9397,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -9039,16 +9406,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f6150c5f-f0a2-4f96-a9ba-4f90f3d2f56d
+                - a6986d1f-9f98-45b9-81d9-558086e62f5d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142143Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T125319Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -9058,22 +9425,22 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg378b8afe689a4b0dbf0d-006a5f8078</RequestId><HostId>txg378b8afe689a4b0dbf0d-006a5f8078</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg17b1329aa6304602bb89-006aa0053f</RequestId><HostId>txg17b1329aa6304602bb89-006aa0053f</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:21:44 GMT
+                - Tue, 08 Sep 2026 12:53:19 GMT
             X-Amz-Id-2:
-                - txg378b8afe689a4b0dbf0d-006a5f8078
+                - txg17b1329aa6304602bb89-006aa0053f
             X-Amz-Request-Id:
-                - txg378b8afe689a4b0dbf0d-006a5f8078
+                - txg17b1329aa6304602bb89-006aa0053f
         status: 404 Not Found
         code: 404
-        duration: 35.501458ms
-    - id: 174
+        duration: 564.442375ms
+    - id: 181
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -9081,7 +9448,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -9090,16 +9457,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 40cb4ec2-e7c0-4cf6-b027-2843cc523045
+                - 747b9976-5c76-4f20-a8f5-c662f774c1f1
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142144Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T125319Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -9118,15 +9485,15 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:21:44 GMT
+                - Tue, 08 Sep 2026 12:53:20 GMT
             X-Amz-Id-2:
-                - txga4c6999201674d5bb392-006a5f8078
+                - txgf55e56afec654450b70f-006aa00540
             X-Amz-Request-Id:
-                - txga4c6999201674d5bb392-006a5f8078
+                - txgf55e56afec654450b70f-006aa00540
         status: 200 OK
         code: 200
-        duration: 1.049831916s
-    - id: 175
+        duration: 1.059197083s
+    - id: 182
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -9134,7 +9501,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -9143,16 +9510,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d9dadaad-1cf4-4644-b56f-37fe8f358696
+                - 8e951efd-f7da-469c-8911-2a9c2858113a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142144Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T125320Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -9164,22 +9531,22 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>30</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition><Transition><Days>210</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>95</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Filter><Prefix>path3/</Prefix></Filter><ID>id3</ID><Status>Enabled</Status><Transition><Days>130</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path4/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>155</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id6</ID><Status>Enabled</Status><Transition><Days>156</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>30</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition><Transition><Days>210</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>95</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Filter><Prefix>path3/</Prefix></Filter><ID>id3</ID><Status>Enabled</Status><Transition><Days>130</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path4/</Prefix><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>155</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id6</ID><Status>Enabled</Status><Transition><Days>156</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
                 - "1802"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:21:45 GMT
+                - Tue, 08 Sep 2026 12:53:21 GMT
             X-Amz-Id-2:
-                - txga5463d2442ef4af3b7f4-006a5f8079
+                - txg53e69adc00654510ae79-006aa00541
             X-Amz-Request-Id:
-                - txga5463d2442ef4af3b7f4-006a5f8079
+                - txg53e69adc00654510ae79-006aa00541
         status: 200 OK
         code: 200
-        duration: 1.048613542s
-    - id: 176
+        duration: 1.080747958s
+    - id: 183
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -9187,7 +9554,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -9196,16 +9563,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e770bddb-5fc3-48ab-bd49-9d1f3f64e5e5
+                - 6971fd34-dd8f-4de4-83e2-48e9803e0b61
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142146Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/
+                - 20260908T125322Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -9220,17 +9587,17 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:21:46 GMT
+                - Tue, 08 Sep 2026 12:53:22 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txgee00aab8d4c54ea5b01f-006a5f807a
+                - txg4de0bcc970574d2c96e5-006aa00542
             X-Amz-Request-Id:
-                - txgee00aab8d4c54ea5b01f-006a5f807a
+                - txg4de0bcc970574d2c96e5-006aa00542
         status: 200 OK
         code: 200
-        duration: 123.083416ms
-    - id: 177
+        duration: 1.20437775s
+    - id: 184
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -9238,7 +9605,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -9247,16 +9614,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f107a224-9353-4813-a2ed-a24d94304eaa
+                - 0e698502-29d6-4bdc-b6c6-99dfbb91aa67
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142147Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T125323Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -9268,22 +9635,22 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:21:47 GMT
+                - Tue, 08 Sep 2026 12:53:23 GMT
             X-Amz-Id-2:
-                - txg59673836ffba4aa99049-006a5f807b
+                - txg0a26e6bebe3641d8af94-006aa00543
             X-Amz-Request-Id:
-                - txg59673836ffba4aa99049-006a5f807b
+                - txg0a26e6bebe3641d8af94-006aa00543
         status: 200 OK
         code: 200
-        duration: 1.118708208s
-    - id: 178
+        duration: 134.985625ms
+    - id: 185
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -9291,7 +9658,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -9300,16 +9667,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 159cba41-c559-4554-9059-e6b78bc71fe3
+                - b6019a85-7759-463a-a541-05e60df90d50
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142147Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T125323Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -9319,22 +9686,22 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg3e1f2c8adb144c9498ec-006a5f807c</RequestId><HostId>txg3e1f2c8adb144c9498ec-006a5f807c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg817455b9ba924c949796-006aa00544</RequestId><HostId>txg817455b9ba924c949796-006aa00544</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:21:48 GMT
+                - Tue, 08 Sep 2026 12:53:24 GMT
             X-Amz-Id-2:
-                - txg3e1f2c8adb144c9498ec-006a5f807c
+                - txg817455b9ba924c949796-006aa00544
             X-Amz-Request-Id:
-                - txg3e1f2c8adb144c9498ec-006a5f807c
+                - txg817455b9ba924c949796-006aa00544
         status: 404 Not Found
         code: 404
-        duration: 1.020604917s
-    - id: 179
+        duration: 1.033425416s
+    - id: 186
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -9342,7 +9709,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -9351,16 +9718,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4594dd0b-29b2-4d77-aa11-bd12cdd37c05
+                - 46961374-4582-4325-bd11-0cdc61e5d379
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142148Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/
+                - 20260908T125324Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -9372,22 +9739,22 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:21:49 GMT
+                - Tue, 08 Sep 2026 12:53:25 GMT
             X-Amz-Id-2:
-                - txg9c00e30a7485429bb3ff-006a5f807d
+                - txg872753d1f594486babba-006aa00545
             X-Amz-Request-Id:
-                - txg9c00e30a7485429bb3ff-006a5f807d
+                - txg872753d1f594486babba-006aa00545
         status: 200 OK
         code: 200
-        duration: 2.043638666s
-    - id: 180
+        duration: 2.072258792s
+    - id: 187
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -9395,7 +9762,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -9404,16 +9771,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3591a287-97af-499f-86ed-3f42cf375782
+                - 98bb7a4c-07a8-4626-97d7-692aa28c610b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142149Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T125326Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -9423,22 +9790,22 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgd8ddf1fe4da64006bd31-006a5f807f</RequestId><HostId>txgd8ddf1fe4da64006bd31-006a5f807f</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg47df57f1f2944ab88275-006aa00547</RequestId><HostId>txg47df57f1f2944ab88275-006aa00547</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:21:51 GMT
+                - Tue, 08 Sep 2026 12:53:27 GMT
             X-Amz-Id-2:
-                - txgd8ddf1fe4da64006bd31-006a5f807f
+                - txg47df57f1f2944ab88275-006aa00547
             X-Amz-Request-Id:
-                - txgd8ddf1fe4da64006bd31-006a5f807f
+                - txg47df57f1f2944ab88275-006aa00547
         status: 404 Not Found
         code: 404
-        duration: 1.025188167s
-    - id: 181
+        duration: 2.7415095s
+    - id: 188
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -9446,7 +9813,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -9455,16 +9822,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c0b2060e-a6e6-4f75-bd26-a47b3a802ec2
+                - 277d6d81-51e9-45f2-aec2-26ff46c4a71f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142151Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T125328Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -9474,22 +9841,22 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgbdc15b3a530141248a48-006a5f8080</RequestId><HostId>txgbdc15b3a530141248a48-006a5f8080</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg2d2541b2855841d0b8dc-006aa00549</RequestId><HostId>txg2d2541b2855841d0b8dc-006aa00549</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 21 Jul 2026 14:21:52 GMT
+                - Tue, 08 Sep 2026 12:53:29 GMT
             X-Amz-Id-2:
-                - txgbdc15b3a530141248a48-006a5f8080
+                - txg2d2541b2855841d0b8dc-006aa00549
             X-Amz-Request-Id:
-                - txgbdc15b3a530141248a48-006a5f8080
+                - txg2d2541b2855841d0b8dc-006aa00549
         status: 404 Not Found
         code: 404
-        duration: 1.024170208s
-    - id: 182
+        duration: 1.02713025s
+    - id: 189
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -9497,7 +9864,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -9506,16 +9873,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - cbc59dc5-95a8-4b1f-967a-f9a3b86b43cf
+                - 6f4d9bfc-f5f4-43ab-8261-e4e8e174d600
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142152Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T125329Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -9534,15 +9901,15 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:21:53 GMT
+                - Tue, 08 Sep 2026 12:53:30 GMT
             X-Amz-Id-2:
-                - txg6f11338e6df74af693f7-006a5f8081
+                - txgb921777c3bf0429da7fe-006aa0054a
             X-Amz-Request-Id:
-                - txg6f11338e6df74af693f7-006a5f8081
+                - txgb921777c3bf0429da7fe-006aa0054a
         status: 200 OK
         code: 200
-        duration: 1.032888458s
-    - id: 183
+        duration: 1.158707417s
+    - id: 190
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -9550,7 +9917,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -9559,16 +9926,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5d61109b-8990-4df3-9542-4d68792f22aa
+                - 9827c9e4-6fda-4c64-af09-e1ccdbb6c261
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142153Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T125330Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -9580,22 +9947,22 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>30</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition><Transition><Days>210</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>95</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Filter><Prefix>path3/</Prefix></Filter><ID>id3</ID><Status>Enabled</Status><Transition><Days>130</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path4/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>155</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id6</ID><Status>Enabled</Status><Transition><Days>156</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>30</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition><Transition><Days>210</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>95</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Filter><Prefix>path3/</Prefix></Filter><ID>id3</ID><Status>Enabled</Status><Transition><Days>130</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path4/</Prefix><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>155</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id6</ID><Status>Enabled</Status><Transition><Days>156</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
                 - "1802"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 21 Jul 2026 14:21:54 GMT
+                - Tue, 08 Sep 2026 12:53:32 GMT
             X-Amz-Id-2:
-                - txg7d5283f685804fad886d-006a5f8082
+                - txg6d4868f312764b1f9d25-006aa0054c
             X-Amz-Request-Id:
-                - txg7d5283f685804fad886d-006a5f8082
+                - txg6d4868f312764b1f9d25-006aa0054c
         status: 200 OK
         code: 200
-        duration: 137.98175ms
-    - id: 184
+        duration: 1.041690542s
+    - id: 191
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -9603,7 +9970,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -9612,16 +9979,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - af516c44-3610-4129-b00e-f75cd3a3b824
+                - 66100e53-7fd5-4cd3-be8e-699cf488ea0b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.42.1 ua/2.1 os/macos lang/go#1.26.4 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.104.2 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260721T142155Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2101156282035066544.s3.nl-ams.scw.cloud/
+                - 20260908T125333Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -9634,11 +10001,11 @@ interactions:
         body: ""
         headers:
             Date:
-                - Tue, 21 Jul 2026 14:21:55 GMT
+                - Tue, 08 Sep 2026 12:53:33 GMT
             X-Amz-Id-2:
-                - txg3f9a8f34d8de4e3db6f6-006a5f8083
+                - txg417e0902991b471ab947-006aa0054d
             X-Amz-Request-Id:
-                - txg3f9a8f34d8de4e3db6f6-006a5f8083
+                - txg417e0902991b471ab947-006aa0054d
         status: 204 No Content
         code: 204
-        duration: 1.23168925s
+        duration: 1.700333958s

--- a/internal/services/object/testdata/object-bucket-lifecycle.cassette.yaml
+++ b/internal/services/object/testdata/object-bucket-lifecycle.cassette.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -18,7 +18,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - fb1673f6-1680-48a2-a241-e9af8b94ae42
+                - 683f4075-36b2-4330-b565-31f1f6cf0c40
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -26,8 +26,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125222Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
+                - 20260908T133706Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/
         method: PUT
       response:
         proto: HTTP/2.0
@@ -42,16 +42,16 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 08 Sep 2026 12:52:22 GMT
+                - Tue, 08 Sep 2026 13:37:06 GMT
             Location:
-                - /tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110
+                - /tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797
             X-Amz-Id-2:
-                - txgb63ded51997c4d36af57-006aa00506
+                - txg1cb3d1073d894c83ab91-006aa00f82
             X-Amz-Request-Id:
-                - txgb63ded51997c4d36af57-006aa00506
+                - txg1cb3d1073d894c83ab91-006aa00f82
         status: 200 OK
         code: 200
-        duration: 1.360353458s
+        duration: 4.906836417s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -60,7 +60,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -69,7 +69,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9bea23da-5564-41ca-adab-f6f89348e16e
+                - 186350e3-2b4c-461f-8798-c050bfd28a19
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -81,8 +81,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125223Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T133711Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?acl=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -97,32 +97,32 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 08 Sep 2026 12:52:23 GMT
+                - Tue, 08 Sep 2026 13:37:11 GMT
             X-Amz-Id-2:
-                - txg33c0e35e82f64cbcbb90-006aa00507
+                - txg3574c212df5c462b8791-006aa00f87
             X-Amz-Request-Id:
-                - txg33c0e35e82f64cbcbb90-006aa00507
+                - txg3574c212df5c462b8791-006aa00f87
         status: 200 OK
         code: 200
-        duration: 413.443166ms
+        duration: 307.025958ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 363
+        content_length: 303
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
-        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></LifecycleConfiguration>
+        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></LifecycleConfiguration>
         form: {}
         headers:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 8c55414c-3285-4880-8ea1-5d870a310a35
+                - 6874ecea-635d-4bd3-b1e6-afb6fad25275
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -130,12 +130,12 @@ interactions:
             User-Agent:
                 - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,Z,e
             X-Amz-Checksum-Crc32:
-                - oUpeiA==
+                - PjCcoA==
             X-Amz-Content-Sha256:
-                - 512733381e697ad60e3f974cfb76a92f1c9d2b97cb251bdf165a2579d5e88cd5
+                - 13feec03c398f242f302d24e62c26ce8c47f46e3921d2bf7a84ca9914cd3488a
             X-Amz-Date:
-                - 20260908T125223Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T133711Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -150,14 +150,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 08 Sep 2026 12:52:24 GMT
+                - Tue, 08 Sep 2026 13:37:11 GMT
             X-Amz-Id-2:
-                - txg97c57eda699847c99d7f-006aa00508
+                - txg3b15c62872dd4b82ab07-006aa00f87
             X-Amz-Request-Id:
-                - txg97c57eda699847c99d7f-006aa00508
+                - txg3b15c62872dd4b82ab07-006aa00f87
         status: 200 OK
         code: 200
-        duration: 423.0225ms
+        duration: 199.228375ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -166,7 +166,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -175,7 +175,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 52fd0610-dfb6-450b-8b8f-12973e046052
+                - f96262ec-df68-4eae-8a78-59c75373cc1f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -183,8 +183,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125224Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T133711Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -203,14 +203,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:24 GMT
+                - Tue, 08 Sep 2026 13:37:11 GMT
             X-Amz-Id-2:
-                - txg6a2b5fa34130448e9c32-006aa00508
+                - txga74b251f7e6843e2a20a-006aa00f87
             X-Amz-Request-Id:
-                - txg6a2b5fa34130448e9c32-006aa00508
+                - txga74b251f7e6843e2a20a-006aa00f87
         status: 200 OK
         code: 200
-        duration: 178.268708ms
+        duration: 194.503041ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -219,7 +219,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -228,7 +228,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 606b7e90-6e8b-4122-a88c-3b7c9c8cea4e
+                - 7f8e18b1-5276-4b9b-961c-ba765c26d677
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -236,8 +236,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125224Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T133711Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -247,21 +247,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg2f7ab2ce46f840c9a05d-006aa00508</RequestId><HostId>txg2f7ab2ce46f840c9a05d-006aa00508</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgfb1f759c53e64f038ab6-006aa00f87</RequestId><HostId>txgfb1f759c53e64f038ab6-006aa00f87</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:24 GMT
+                - Tue, 08 Sep 2026 13:37:11 GMT
             X-Amz-Id-2:
-                - txg2f7ab2ce46f840c9a05d-006aa00508
+                - txgfb1f759c53e64f038ab6-006aa00f87
             X-Amz-Request-Id:
-                - txg2f7ab2ce46f840c9a05d-006aa00508
+                - txgfb1f759c53e64f038ab6-006aa00f87
         status: 404 Not Found
         code: 404
-        duration: 210.520083ms
+        duration: 123.692458ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -270,7 +270,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -279,7 +279,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c593da9f-a6eb-4b20-b076-2c016d505d3c
+                - 5a9c9c6c-1fbe-4606-b433-9819749e8b63
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -287,8 +287,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125224Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
+                - 20260908T133711Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -300,21 +300,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:25 GMT
+                - Tue, 08 Sep 2026 13:37:12 GMT
             X-Amz-Id-2:
-                - txg6db210765d804166954e-006aa00509
+                - txgbf0fc20791d44259af84-006aa00f88
             X-Amz-Request-Id:
-                - txg6db210765d804166954e-006aa00509
+                - txgbf0fc20791d44259af84-006aa00f88
         status: 200 OK
         code: 200
-        duration: 318.855833ms
+        duration: 309.889292ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -323,7 +323,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -332,7 +332,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d7d449b8-c1d2-443e-b3ea-a85e8007f027
+                - 15663e5d-d428-4d7b-b676-c52fab19a5b4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -340,8 +340,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125225Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T133712Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -351,21 +351,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg739de52a32c54a1994c9-006aa00509</RequestId><HostId>txg739de52a32c54a1994c9-006aa00509</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg1f6c32f4b69c46169aff-006aa00f88</RequestId><HostId>txg1f6c32f4b69c46169aff-006aa00f88</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:25 GMT
+                - Tue, 08 Sep 2026 13:37:12 GMT
             X-Amz-Id-2:
-                - txg739de52a32c54a1994c9-006aa00509
+                - txg1f6c32f4b69c46169aff-006aa00f88
             X-Amz-Request-Id:
-                - txg739de52a32c54a1994c9-006aa00509
+                - txg1f6c32f4b69c46169aff-006aa00f88
         status: 404 Not Found
         code: 404
-        duration: 203.835583ms
+        duration: 91.519833ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -374,7 +374,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -383,7 +383,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 076ce010-a4fa-47eb-a94c-9afdbbc58db9
+                - 9a5f685c-514d-45b8-ae18-6fd86a87c831
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -391,8 +391,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125225Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T133712Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -402,21 +402,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg00164ee5a1414f71b514-006aa00509</RequestId><HostId>txg00164ee5a1414f71b514-006aa00509</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg42f5d026907e4d2a8bdf-006aa00f88</RequestId><HostId>txg42f5d026907e4d2a8bdf-006aa00f88</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:25 GMT
+                - Tue, 08 Sep 2026 13:37:12 GMT
             X-Amz-Id-2:
-                - txg00164ee5a1414f71b514-006aa00509
+                - txg42f5d026907e4d2a8bdf-006aa00f88
             X-Amz-Request-Id:
-                - txg00164ee5a1414f71b514-006aa00509
+                - txg42f5d026907e4d2a8bdf-006aa00f88
         status: 404 Not Found
         code: 404
-        duration: 181.037583ms
+        duration: 106.539ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -425,7 +425,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -434,7 +434,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7f1c3f59-e63a-4595-bf5d-3df4a820a60c
+                - 985d03fd-0794-4a5c-b630-9b731629913b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -442,8 +442,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125225Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T133712Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -462,14 +462,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:25 GMT
+                - Tue, 08 Sep 2026 13:37:12 GMT
             X-Amz-Id-2:
-                - txg0e71aa07a309445eb20b-006aa00509
+                - txg6140163fe45d41ee8700-006aa00f88
             X-Amz-Request-Id:
-                - txg0e71aa07a309445eb20b-006aa00509
+                - txg6140163fe45d41ee8700-006aa00f88
         status: 200 OK
         code: 200
-        duration: 309.288125ms
+        duration: 376.971ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -478,7 +478,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -487,7 +487,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0206766a-b889-4b55-b337-7b4e71c79417
+                - 79cebb40-dcb9-4077-b8dd-f0d33e401637
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -495,8 +495,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125225Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T133712Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -504,25 +504,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 336
+        content_length: 276
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
-                - "336"
+                - "276"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:26 GMT
+                - Tue, 08 Sep 2026 13:37:12 GMT
             X-Amz-Id-2:
-                - txgf62401f24e364039883b-006aa0050a
+                - txga069a23832f140369e1e-006aa00f88
             X-Amz-Request-Id:
-                - txgf62401f24e364039883b-006aa0050a
+                - txga069a23832f140369e1e-006aa00f88
         status: 200 OK
         code: 200
-        duration: 219.534833ms
+        duration: 132.898917ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -531,7 +531,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -540,7 +540,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 94bc67c7-6dba-4d62-8afc-ec73db59dc7c
+                - 6783d199-692a-4b83-9b4a-5926b946b9ae
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -548,8 +548,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125226Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
+                - 20260908T133713Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -564,16 +564,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:26 GMT
+                - Tue, 08 Sep 2026 13:37:13 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txga90fb958c5954a85b7d4-006aa0050a
+                - txge120d07ab462469eb692-006aa00f89
             X-Amz-Request-Id:
-                - txga90fb958c5954a85b7d4-006aa0050a
+                - txge120d07ab462469eb692-006aa00f89
         status: 200 OK
         code: 200
-        duration: 915.095125ms
+        duration: 98.823875ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -582,7 +582,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -591,7 +591,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a513f5ed-4016-4452-959f-bb648e2bb082
+                - 790a745b-8656-4596-b21d-3d2389e8c8b3
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -599,8 +599,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125227Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T133713Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -608,25 +608,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 336
+        content_length: 276
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
-                - "336"
+                - "276"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:27 GMT
+                - Tue, 08 Sep 2026 13:37:13 GMT
             X-Amz-Id-2:
-                - txg42ee44227e6f4258a0d1-006aa0050b
+                - txgf943fb4444c14eb9af58-006aa00f89
             X-Amz-Request-Id:
-                - txg42ee44227e6f4258a0d1-006aa0050b
+                - txgf943fb4444c14eb9af58-006aa00f89
         status: 200 OK
         code: 200
-        duration: 224.199584ms
+        duration: 94.698625ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -635,7 +635,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -644,7 +644,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f987b2a1-226f-40f7-bcf6-4a969d21ad4e
+                - 9d77be8a-5c17-48d6-96f1-6d5b2fbb7a2a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -652,8 +652,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125227Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T133713Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -672,14 +672,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:27 GMT
+                - Tue, 08 Sep 2026 13:37:13 GMT
             X-Amz-Id-2:
-                - txgb0955dc068f84fc5b083-006aa0050b
+                - txg4c986f9aab854bcaa464-006aa00f89
             X-Amz-Request-Id:
-                - txgb0955dc068f84fc5b083-006aa0050b
+                - txg4c986f9aab854bcaa464-006aa00f89
         status: 200 OK
         code: 200
-        duration: 693.54575ms
+        duration: 1.417191209s
     - id: 13
       request:
         proto: HTTP/1.1
@@ -688,7 +688,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -697,7 +697,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e9ebc528-b97d-4989-8695-8911c3e5e6d9
+                - 0733f9bd-4099-4489-8946-be23747f94d0
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -705,8 +705,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125227Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T133713Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -716,21 +716,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg903e5adb973f43f8b9f0-006aa0050c</RequestId><HostId>txg903e5adb973f43f8b9f0-006aa0050c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg5e293ff6b2834b2facc2-006aa00f8b</RequestId><HostId>txg5e293ff6b2834b2facc2-006aa00f8b</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:28 GMT
+                - Tue, 08 Sep 2026 13:37:15 GMT
             X-Amz-Id-2:
-                - txg903e5adb973f43f8b9f0-006aa0050c
+                - txg5e293ff6b2834b2facc2-006aa00f8b
             X-Amz-Request-Id:
-                - txg903e5adb973f43f8b9f0-006aa0050c
+                - txg5e293ff6b2834b2facc2-006aa00f8b
         status: 404 Not Found
         code: 404
-        duration: 213.23525ms
+        duration: 95.644333ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -739,7 +739,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -748,7 +748,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 725ef728-f183-42cd-b219-0a55122fd1ba
+                - dc15c76f-c134-4ead-bc90-84842877b3d4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -756,8 +756,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125228Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
+                - 20260908T133715Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -769,21 +769,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:28 GMT
+                - Tue, 08 Sep 2026 13:37:15 GMT
             X-Amz-Id-2:
-                - txge34c1f2e970540cf98a2-006aa0050c
+                - txgdb97160fce6b4109b310-006aa00f8b
             X-Amz-Request-Id:
-                - txge34c1f2e970540cf98a2-006aa0050c
+                - txgdb97160fce6b4109b310-006aa00f8b
         status: 200 OK
         code: 200
-        duration: 265.709916ms
+        duration: 340.541916ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -792,7 +792,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -801,7 +801,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 833f3eb1-286a-4241-a18d-31ec3dd5cc00
+                - ccf00b14-31a3-40be-b515-9379caa37474
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -809,8 +809,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125228Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T133715Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -820,21 +820,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg7b68bce990044f13b225-006aa0050d</RequestId><HostId>txg7b68bce990044f13b225-006aa0050d</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg96c5d53d9706449ba361-006aa00f8b</RequestId><HostId>txg96c5d53d9706449ba361-006aa00f8b</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:29 GMT
+                - Tue, 08 Sep 2026 13:37:15 GMT
             X-Amz-Id-2:
-                - txg7b68bce990044f13b225-006aa0050d
+                - txg96c5d53d9706449ba361-006aa00f8b
             X-Amz-Request-Id:
-                - txg7b68bce990044f13b225-006aa0050d
+                - txg96c5d53d9706449ba361-006aa00f8b
         status: 404 Not Found
         code: 404
-        duration: 411.153625ms
+        duration: 93.498291ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -843,7 +843,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -852,7 +852,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0d0487ff-edbb-41eb-9724-4744dcbff87f
+                - ed1e8a95-5e47-426d-8c93-fb5ba5a82323
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -860,8 +860,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125229Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T133715Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -871,21 +871,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg8e0248eb2d304150b1c4-006aa0050d</RequestId><HostId>txg8e0248eb2d304150b1c4-006aa0050d</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgb43b107941d64a13acc9-006aa00f8b</RequestId><HostId>txgb43b107941d64a13acc9-006aa00f8b</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:29 GMT
+                - Tue, 08 Sep 2026 13:37:15 GMT
             X-Amz-Id-2:
-                - txg8e0248eb2d304150b1c4-006aa0050d
+                - txgb43b107941d64a13acc9-006aa00f8b
             X-Amz-Request-Id:
-                - txg8e0248eb2d304150b1c4-006aa0050d
+                - txgb43b107941d64a13acc9-006aa00f8b
         status: 404 Not Found
         code: 404
-        duration: 208.54775ms
+        duration: 88.028708ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -894,7 +894,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -903,7 +903,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a9cbd869-8dd2-48d9-bf64-104dca5a5772
+                - 6d5d3924-ec16-4114-b897-38f2e135ab6b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -911,8 +911,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125229Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T133715Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -931,14 +931,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:29 GMT
+                - Tue, 08 Sep 2026 13:37:15 GMT
             X-Amz-Id-2:
-                - txgec3af5c10787401b9b75-006aa0050d
+                - txga13c90986436420792da-006aa00f8b
             X-Amz-Request-Id:
-                - txgec3af5c10787401b9b75-006aa0050d
+                - txga13c90986436420792da-006aa00f8b
         status: 200 OK
         code: 200
-        duration: 674.9155ms
+        duration: 89.615958ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -947,7 +947,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -956,7 +956,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7ab81fda-9cd8-482f-a157-25b5af8ba101
+                - 5c910f41-7c9a-4897-934e-6c64e34f112c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -964,8 +964,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125229Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T133715Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -973,25 +973,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 336
+        content_length: 276
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
-                - "336"
+                - "276"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:30 GMT
+                - Tue, 08 Sep 2026 13:37:15 GMT
             X-Amz-Id-2:
-                - txg8f3d7b021695413980b7-006aa0050e
+                - txg9cfd988996ab4bf18be1-006aa00f8b
             X-Amz-Request-Id:
-                - txg8f3d7b021695413980b7-006aa0050e
+                - txg9cfd988996ab4bf18be1-006aa00f8b
         status: 200 OK
         code: 200
-        duration: 593.555375ms
+        duration: 109.02575ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -1000,7 +1000,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1009,7 +1009,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 11c35acb-9bd0-493f-ae63-fe8c5712eba8
+                - 2f98c709-0e9d-472a-8d35-60b5be653f94
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1017,8 +1017,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125231Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T133715Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1037,14 +1037,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:31 GMT
+                - Tue, 08 Sep 2026 13:37:16 GMT
             X-Amz-Id-2:
-                - txg77d1b0dc6e1f4e0b857d-006aa0050f
+                - txg459efc7af828451cb373-006aa00f8c
             X-Amz-Request-Id:
-                - txg77d1b0dc6e1f4e0b857d-006aa0050f
+                - txg459efc7af828451cb373-006aa00f8c
         status: 200 OK
         code: 200
-        duration: 449.389583ms
+        duration: 38.607959ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1053,7 +1053,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1062,7 +1062,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 89de28bf-3cb4-4a30-8410-e6898a2b3e8e
+                - 7ea39e66-93c8-471c-aec0-53310ae04a9d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1070,8 +1070,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125231Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T133716Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1081,21 +1081,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg29bc96ac479f47b7834c-006aa0050f</RequestId><HostId>txg29bc96ac479f47b7834c-006aa0050f</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txga740aa51d41d46f3b8a3-006aa00f8c</RequestId><HostId>txga740aa51d41d46f3b8a3-006aa00f8c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:31 GMT
+                - Tue, 08 Sep 2026 13:37:16 GMT
             X-Amz-Id-2:
-                - txg29bc96ac479f47b7834c-006aa0050f
+                - txga740aa51d41d46f3b8a3-006aa00f8c
             X-Amz-Request-Id:
-                - txg29bc96ac479f47b7834c-006aa0050f
+                - txga740aa51d41d46f3b8a3-006aa00f8c
         status: 404 Not Found
         code: 404
-        duration: 260.609667ms
+        duration: 94.861875ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1104,7 +1104,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1113,7 +1113,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d84d4161-f658-4c48-a275-5250c0aa6740
+                - 2885a0e9-089c-4569-84ee-aac0fe3e6e85
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1121,8 +1121,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125231Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
+                - 20260908T133716Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -1134,21 +1134,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:31 GMT
+                - Tue, 08 Sep 2026 13:37:16 GMT
             X-Amz-Id-2:
-                - txg0ba7fd3ff1ce4d9fb2f8-006aa0050f
+                - txgcff11d4aa482425c8ee1-006aa00f8c
             X-Amz-Request-Id:
-                - txg0ba7fd3ff1ce4d9fb2f8-006aa0050f
+                - txgcff11d4aa482425c8ee1-006aa00f8c
         status: 200 OK
         code: 200
-        duration: 792.109875ms
+        duration: 184.201042ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1157,7 +1157,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1166,7 +1166,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 50943e60-c3e7-4d28-b806-4e78278cb60d
+                - dff9e37d-a2b3-4ee2-a16f-8e816bc76c38
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1174,8 +1174,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125231Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T133716Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1185,21 +1185,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgf32616d18774438cac1a-006aa00510</RequestId><HostId>txgf32616d18774438cac1a-006aa00510</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgaf25435a48df412190c2-006aa00f8c</RequestId><HostId>txgaf25435a48df412190c2-006aa00f8c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:32 GMT
+                - Tue, 08 Sep 2026 13:37:16 GMT
             X-Amz-Id-2:
-                - txgf32616d18774438cac1a-006aa00510
+                - txgaf25435a48df412190c2-006aa00f8c
             X-Amz-Request-Id:
-                - txgf32616d18774438cac1a-006aa00510
+                - txgaf25435a48df412190c2-006aa00f8c
         status: 404 Not Found
         code: 404
-        duration: 83.544041ms
+        duration: 29.233083ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1208,7 +1208,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1217,7 +1217,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0dbe588c-da76-4528-a25d-7c02ab44616e
+                - 4ee9e9da-7675-4170-b0e9-6bd78086b7b1
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1225,8 +1225,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125232Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T133716Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1236,21 +1236,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgbd3e595b19444617ba09-006aa00510</RequestId><HostId>txgbd3e595b19444617ba09-006aa00510</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg6fa95486f8a943de80c9-006aa00f8c</RequestId><HostId>txg6fa95486f8a943de80c9-006aa00f8c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:32 GMT
+                - Tue, 08 Sep 2026 13:37:16 GMT
             X-Amz-Id-2:
-                - txgbd3e595b19444617ba09-006aa00510
+                - txg6fa95486f8a943de80c9-006aa00f8c
             X-Amz-Request-Id:
-                - txgbd3e595b19444617ba09-006aa00510
+                - txg6fa95486f8a943de80c9-006aa00f8c
         status: 404 Not Found
         code: 404
-        duration: 198.569708ms
+        duration: 108.289542ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1259,7 +1259,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1268,7 +1268,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5f7dd0a4-104c-481f-af82-33a46cc6c4ae
+                - 42273f05-6ffa-4acd-823f-248259039aaa
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1276,8 +1276,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125232Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T133716Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1296,14 +1296,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:32 GMT
+                - Tue, 08 Sep 2026 13:37:16 GMT
             X-Amz-Id-2:
-                - txge9bd4b4c2f644f93acbb-006aa00510
+                - txg2fa5a02952a64ce0a24a-006aa00f8c
             X-Amz-Request-Id:
-                - txge9bd4b4c2f644f93acbb-006aa00510
+                - txg2fa5a02952a64ce0a24a-006aa00f8c
         status: 200 OK
         code: 200
-        duration: 21.130375ms
+        duration: 99.087042ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1312,7 +1312,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1321,7 +1321,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5f073881-c583-4548-b8d7-a3d9f1e0869f
+                - 70fba48c-5c48-442b-ba2c-1754f3d4461d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1329,8 +1329,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125232Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T133716Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1338,43 +1338,43 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 336
+        content_length: 276
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
-                - "336"
+                - "276"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:32 GMT
+                - Tue, 08 Sep 2026 13:37:16 GMT
             X-Amz-Id-2:
-                - txg6260b57fd2d04511b200-006aa00510
+                - txg0e6c7375579f464580db-006aa00f8c
             X-Amz-Request-Id:
-                - txg6260b57fd2d04511b200-006aa00510
+                - txg0e6c7375579f464580db-006aa00f8c
         status: 200 OK
         code: 200
-        duration: 218.894958ms
+        duration: 128.684875ms
     - id: 26
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 366
+        content_length: 306
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
-        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition></Rule></LifecycleConfiguration>
+        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition></Rule></LifecycleConfiguration>
         form: {}
         headers:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d1155663-f8a1-495c-97c8-e9ce4f4298b0
+                - 68747362-50c4-475c-b3d7-5bf285bcb493
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -1382,12 +1382,12 @@ interactions:
             User-Agent:
                 - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,Z,e
             X-Amz-Checksum-Crc32:
-                - o6dwOA==
+                - 3OVKEQ==
             X-Amz-Content-Sha256:
-                - 1695287f0c18bfb8c0d3d10989fec9b3e430afbc2914de7c50f434a75491894c
+                - de1418e62a2680330e07a11a092b47b671d4ed12fe9fe6d9780b095b8f45d69c
             X-Amz-Date:
-                - 20260908T125233Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T133716Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -1402,14 +1402,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 08 Sep 2026 12:52:33 GMT
+                - Tue, 08 Sep 2026 13:37:16 GMT
             X-Amz-Id-2:
-                - txg4fb50ec040e749c6b9a3-006aa00511
+                - txg32bce155a1534af59643-006aa00f8c
             X-Amz-Request-Id:
-                - txg4fb50ec040e749c6b9a3-006aa00511
+                - txg32bce155a1534af59643-006aa00f8c
         status: 200 OK
         code: 200
-        duration: 258.953375ms
+        duration: 462.33625ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1418,7 +1418,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1427,7 +1427,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6ba7a5d8-75ef-4e34-ab56-27bd396a596e
+                - d1903ff8-5e4d-4252-8a17-11d3bb102601
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1435,8 +1435,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125233Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T133717Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1455,14 +1455,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:33 GMT
+                - Tue, 08 Sep 2026 13:37:17 GMT
             X-Amz-Id-2:
-                - txge6781e633d274b6a9381-006aa00511
+                - txg86a41f55ae7a4f118a73-006aa00f8d
             X-Amz-Request-Id:
-                - txge6781e633d274b6a9381-006aa00511
+                - txg86a41f55ae7a4f118a73-006aa00f8d
         status: 200 OK
         code: 200
-        duration: 344.712167ms
+        duration: 182.54425ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1471,7 +1471,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1480,7 +1480,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e245bb62-5e6a-4777-b88a-a477d9392477
+                - 2566460f-18b7-4e20-a189-d916b2d8c0a3
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1488,8 +1488,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125233Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T133717Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1499,21 +1499,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg4f34152f0d9a4058962f-006aa00511</RequestId><HostId>txg4f34152f0d9a4058962f-006aa00511</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgef316cdc7a824f069f61-006aa00f8d</RequestId><HostId>txgef316cdc7a824f069f61-006aa00f8d</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:33 GMT
+                - Tue, 08 Sep 2026 13:37:17 GMT
             X-Amz-Id-2:
-                - txg4f34152f0d9a4058962f-006aa00511
+                - txgef316cdc7a824f069f61-006aa00f8d
             X-Amz-Request-Id:
-                - txg4f34152f0d9a4058962f-006aa00511
+                - txgef316cdc7a824f069f61-006aa00f8d
         status: 404 Not Found
         code: 404
-        duration: 450.184833ms
+        duration: 180.051417ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1522,7 +1522,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1531,7 +1531,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a331a9cd-3d7e-4396-a993-df3ca0f3921f
+                - feeaae05-2e4e-4087-b18c-8701c3883cc9
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1539,8 +1539,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125233Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
+                - 20260908T133717Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -1552,21 +1552,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:34 GMT
+                - Tue, 08 Sep 2026 13:37:17 GMT
             X-Amz-Id-2:
-                - txg8daea85ddf3646d0bfd0-006aa00512
+                - txg0982a68eb68f4841926f-006aa00f8d
             X-Amz-Request-Id:
-                - txg8daea85ddf3646d0bfd0-006aa00512
+                - txg0982a68eb68f4841926f-006aa00f8d
         status: 200 OK
         code: 200
-        duration: 376.858791ms
+        duration: 216.821459ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1575,7 +1575,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1584,7 +1584,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 398fa481-d433-4d9e-be05-635e7cb5977b
+                - 041f484d-c0c4-4ce4-aaf7-c34279edab10
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1592,8 +1592,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125234Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T133717Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1603,21 +1603,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg538286d7602342b389af-006aa00512</RequestId><HostId>txg538286d7602342b389af-006aa00512</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg56a2debae3224280af5a-006aa00f8d</RequestId><HostId>txg56a2debae3224280af5a-006aa00f8d</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:34 GMT
+                - Tue, 08 Sep 2026 13:37:17 GMT
             X-Amz-Id-2:
-                - txg538286d7602342b389af-006aa00512
+                - txg56a2debae3224280af5a-006aa00f8d
             X-Amz-Request-Id:
-                - txg538286d7602342b389af-006aa00512
+                - txg56a2debae3224280af5a-006aa00f8d
         status: 404 Not Found
         code: 404
-        duration: 24.844792ms
+        duration: 294.874667ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1626,7 +1626,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1635,7 +1635,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 86fdf269-dfc3-4ea2-9336-28d4be9d6d53
+                - d8851b97-f2ce-483f-9a6c-4a0aa6334df0
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1643,8 +1643,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125234Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T133717Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1654,21 +1654,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgf202d59113684f029db2-006aa00512</RequestId><HostId>txgf202d59113684f029db2-006aa00512</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg5e2d169c5ee241d4bf05-006aa00f8e</RequestId><HostId>txg5e2d169c5ee241d4bf05-006aa00f8e</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:34 GMT
+                - Tue, 08 Sep 2026 13:37:18 GMT
             X-Amz-Id-2:
-                - txgf202d59113684f029db2-006aa00512
+                - txg5e2d169c5ee241d4bf05-006aa00f8e
             X-Amz-Request-Id:
-                - txgf202d59113684f029db2-006aa00512
+                - txg5e2d169c5ee241d4bf05-006aa00f8e
         status: 404 Not Found
         code: 404
-        duration: 188.743416ms
+        duration: 25.572333ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1677,7 +1677,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1686,7 +1686,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ef948bbc-2778-4946-a8bd-1713551b68a5
+                - a0d12aa3-778f-4c44-983c-c15bebae2b94
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1694,8 +1694,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125234Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T133718Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1714,14 +1714,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:34 GMT
+                - Tue, 08 Sep 2026 13:37:18 GMT
             X-Amz-Id-2:
-                - txgf470982537de45f4abab-006aa00512
+                - txgb4c5a802f0b04a6c8bd2-006aa00f8e
             X-Amz-Request-Id:
-                - txgf470982537de45f4abab-006aa00512
+                - txgb4c5a802f0b04a6c8bd2-006aa00f8e
         status: 200 OK
         code: 200
-        duration: 172.104834ms
+        duration: 179.778625ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1730,7 +1730,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1739,7 +1739,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 19e3b8cf-0b5b-4c4a-bc60-bd97101a3027
+                - c4e57d56-0a81-4012-a623-7c476788ced2
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1747,8 +1747,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125234Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T133718Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1756,25 +1756,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 339
+        content_length: 279
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
-                - "339"
+                - "279"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:35 GMT
+                - Tue, 08 Sep 2026 13:37:18 GMT
             X-Amz-Id-2:
-                - txg43a0a7dd6c65429a84a9-006aa00513
+                - txg5911dc0ed3da42d7b823-006aa00f8e
             X-Amz-Request-Id:
-                - txg43a0a7dd6c65429a84a9-006aa00513
+                - txg5911dc0ed3da42d7b823-006aa00f8e
         status: 200 OK
         code: 200
-        duration: 221.301167ms
+        duration: 322.596875ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1783,7 +1783,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1792,7 +1792,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e5086f31-4619-4f4c-8e97-60a6a6c5c479
+                - 68f80bf1-6f10-4fb6-bf74-6cccd2abf649
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1800,8 +1800,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125235Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
+                - 20260908T133718Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -1816,16 +1816,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:35 GMT
+                - Tue, 08 Sep 2026 13:37:18 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txgd138c643a92d4527b36c-006aa00513
+                - txge9277a7b1f9a467f9c72-006aa00f8e
             X-Amz-Request-Id:
-                - txgd138c643a92d4527b36c-006aa00513
+                - txge9277a7b1f9a467f9c72-006aa00f8e
         status: 200 OK
         code: 200
-        duration: 480.348542ms
+        duration: 106.319417ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1834,7 +1834,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1843,7 +1843,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - de7d486c-7169-4197-bb90-3be19cb6bda2
+                - 60fa0dcf-185c-4643-a607-28e9b531e09d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1851,8 +1851,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125235Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T133718Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1860,25 +1860,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 339
+        content_length: 279
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
-                - "339"
+                - "279"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:35 GMT
+                - Tue, 08 Sep 2026 13:37:18 GMT
             X-Amz-Id-2:
-                - txg54fe3f2aadca40dfb55b-006aa00513
+                - txge1408719618a4fa880a8-006aa00f8e
             X-Amz-Request-Id:
-                - txg54fe3f2aadca40dfb55b-006aa00513
+                - txge1408719618a4fa880a8-006aa00f8e
         status: 200 OK
         code: 200
-        duration: 193.358416ms
+        duration: 190.389583ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1887,7 +1887,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1896,7 +1896,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - cc5d9641-d2e4-400a-8cb7-914888c23432
+                - d8a7833d-b88b-4a2c-9047-723bfd678e38
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1904,8 +1904,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125236Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T133719Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1924,14 +1924,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:36 GMT
+                - Tue, 08 Sep 2026 13:37:19 GMT
             X-Amz-Id-2:
-                - txg2caaea015d374ac0b670-006aa00514
+                - txg35d45c6233c14222bed3-006aa00f8f
             X-Amz-Request-Id:
-                - txg2caaea015d374ac0b670-006aa00514
+                - txg35d45c6233c14222bed3-006aa00f8f
         status: 200 OK
         code: 200
-        duration: 182.045083ms
+        duration: 93.345708ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1940,7 +1940,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1949,7 +1949,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - fc07e8e7-12c7-4b04-bf7c-6e0f495f0d80
+                - 6ed2a4da-9c17-47eb-9109-79c7c77a4fdd
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1957,8 +1957,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125236Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T133719Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1968,21 +1968,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgd974b5c4976c4e249c70-006aa00514</RequestId><HostId>txgd974b5c4976c4e249c70-006aa00514</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg9ae1414fea2245598d76-006aa00f8f</RequestId><HostId>txg9ae1414fea2245598d76-006aa00f8f</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:36 GMT
+                - Tue, 08 Sep 2026 13:37:19 GMT
             X-Amz-Id-2:
-                - txgd974b5c4976c4e249c70-006aa00514
+                - txg9ae1414fea2245598d76-006aa00f8f
             X-Amz-Request-Id:
-                - txgd974b5c4976c4e249c70-006aa00514
+                - txg9ae1414fea2245598d76-006aa00f8f
         status: 404 Not Found
         code: 404
-        duration: 194.309666ms
+        duration: 26.067667ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1991,7 +1991,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2000,7 +2000,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6f74f041-a4b1-42c5-a77c-118de12d1371
+                - 42b95634-6258-4b9b-ae9e-70c43f91ee97
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2008,8 +2008,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125236Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
+                - 20260908T133719Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -2021,21 +2021,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:36 GMT
+                - Tue, 08 Sep 2026 13:37:19 GMT
             X-Amz-Id-2:
-                - txgd55f4bb893a0454d8fdb-006aa00514
+                - txgd37836b67e684ef8bbea-006aa00f8f
             X-Amz-Request-Id:
-                - txgd55f4bb893a0454d8fdb-006aa00514
+                - txgd37836b67e684ef8bbea-006aa00f8f
         status: 200 OK
         code: 200
-        duration: 26.675375ms
+        duration: 90.474542ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -2044,7 +2044,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2053,7 +2053,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4e6409b7-3ede-4a85-9e79-62a2d947c74e
+                - 81ccca10-5c2a-4fbd-a942-0b5d16a2d68c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2061,8 +2061,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125236Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T133719Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2072,21 +2072,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgd3e772658477401b940d-006aa00514</RequestId><HostId>txgd3e772658477401b940d-006aa00514</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgc3bdcffd91974a36b08b-006aa00f8f</RequestId><HostId>txgc3bdcffd91974a36b08b-006aa00f8f</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:36 GMT
+                - Tue, 08 Sep 2026 13:37:19 GMT
             X-Amz-Id-2:
-                - txgd3e772658477401b940d-006aa00514
+                - txgc3bdcffd91974a36b08b-006aa00f8f
             X-Amz-Request-Id:
-                - txgd3e772658477401b940d-006aa00514
+                - txgc3bdcffd91974a36b08b-006aa00f8f
         status: 404 Not Found
         code: 404
-        duration: 183.079375ms
+        duration: 91.935209ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -2095,7 +2095,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2104,7 +2104,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b98e89de-0897-40f1-9c21-c77a8ced99eb
+                - fdc18b1d-b07e-408a-9bac-9e66be732df5
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2112,8 +2112,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125236Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T133719Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2123,21 +2123,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgac3962c4ad15442b813d-006aa00514</RequestId><HostId>txgac3962c4ad15442b813d-006aa00514</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txga92410989f834798a34d-006aa00f8f</RequestId><HostId>txga92410989f834798a34d-006aa00f8f</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:36 GMT
+                - Tue, 08 Sep 2026 13:37:19 GMT
             X-Amz-Id-2:
-                - txgac3962c4ad15442b813d-006aa00514
+                - txga92410989f834798a34d-006aa00f8f
             X-Amz-Request-Id:
-                - txgac3962c4ad15442b813d-006aa00514
+                - txga92410989f834798a34d-006aa00f8f
         status: 404 Not Found
         code: 404
-        duration: 284.613084ms
+        duration: 93.539875ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2146,7 +2146,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2155,7 +2155,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 235b303a-a745-4a13-9968-7fa37edf0886
+                - 2a0dd427-b9fc-48bc-8388-d8bcc0c8119b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2163,8 +2163,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125236Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T133719Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2183,14 +2183,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:37 GMT
+                - Tue, 08 Sep 2026 13:37:19 GMT
             X-Amz-Id-2:
-                - txg0aa575f1b6d24ddf9b99-006aa00515
+                - txg60c08668e7d345d8a983-006aa00f8f
             X-Amz-Request-Id:
-                - txg0aa575f1b6d24ddf9b99-006aa00515
+                - txg60c08668e7d345d8a983-006aa00f8f
         status: 200 OK
         code: 200
-        duration: 234.592958ms
+        duration: 104.030666ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -2199,7 +2199,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2208,7 +2208,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 350fe206-af06-417b-a096-1a448f677d1d
+                - 8b2502a6-5803-4c6d-9e82-05fbf50fc73a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2216,8 +2216,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125237Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T133719Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2225,25 +2225,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 339
+        content_length: 279
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
-                - "339"
+                - "279"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:37 GMT
+                - Tue, 08 Sep 2026 13:37:19 GMT
             X-Amz-Id-2:
-                - txgdfae1cb0769a4df7b834-006aa00515
+                - txg86ab79a1c0ee4b43a85b-006aa00f8f
             X-Amz-Request-Id:
-                - txgdfae1cb0769a4df7b834-006aa00515
+                - txg86ab79a1c0ee4b43a85b-006aa00f8f
         status: 200 OK
         code: 200
-        duration: 302.247542ms
+        duration: 205.015542ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -2252,7 +2252,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2261,7 +2261,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 145cd7e8-00a0-4502-a0e1-b52676f981dc
+                - 3bf02d37-2de2-48de-9311-0737e377bac7
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2269,8 +2269,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125237Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T133720Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2289,14 +2289,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:37 GMT
+                - Tue, 08 Sep 2026 13:37:20 GMT
             X-Amz-Id-2:
-                - txg7914ab9c6d0b43baa39e-006aa00515
+                - txg29fdf679deb0423daf0e-006aa00f90
             X-Amz-Request-Id:
-                - txg7914ab9c6d0b43baa39e-006aa00515
+                - txg29fdf679deb0423daf0e-006aa00f90
         status: 200 OK
         code: 200
-        duration: 235.330458ms
+        duration: 140.370584ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -2305,7 +2305,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2314,7 +2314,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 73119ee5-00e8-482b-812d-59a7f43b705d
+                - de24fd1c-2ea1-400a-a70b-0bd2fbf1f939
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2322,8 +2322,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125237Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T133720Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2333,21 +2333,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg263c39678b244b50a912-006aa00516</RequestId><HostId>txg263c39678b244b50a912-006aa00516</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg47faf48d7329462e9972-006aa00f90</RequestId><HostId>txg47faf48d7329462e9972-006aa00f90</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:38 GMT
+                - Tue, 08 Sep 2026 13:37:20 GMT
             X-Amz-Id-2:
-                - txg263c39678b244b50a912-006aa00516
+                - txg47faf48d7329462e9972-006aa00f90
             X-Amz-Request-Id:
-                - txg263c39678b244b50a912-006aa00516
+                - txg47faf48d7329462e9972-006aa00f90
         status: 404 Not Found
         code: 404
-        duration: 197.555625ms
+        duration: 24.348667ms
     - id: 45
       request:
         proto: HTTP/1.1
@@ -2356,7 +2356,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2365,7 +2365,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 87872a2b-4003-4ef7-971a-16f6f416cc1a
+                - ee19b2fd-5599-4b0b-89d9-0b614c960011
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2373,8 +2373,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125238Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
+                - 20260908T133720Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -2386,21 +2386,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:38 GMT
+                - Tue, 08 Sep 2026 13:37:20 GMT
             X-Amz-Id-2:
-                - txgfbd4fba108c049ae9108-006aa00516
+                - txg16c36952c9c0468f9cbd-006aa00f90
             X-Amz-Request-Id:
-                - txgfbd4fba108c049ae9108-006aa00516
+                - txg16c36952c9c0468f9cbd-006aa00f90
         status: 200 OK
         code: 200
-        duration: 402.96175ms
+        duration: 92.80325ms
     - id: 46
       request:
         proto: HTTP/1.1
@@ -2409,7 +2409,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2418,7 +2418,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 47109473-a93f-4588-a61f-13ad9e584cd3
+                - e896d5ef-9713-4b01-936b-f5756f2e4512
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2426,8 +2426,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125238Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T133720Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2437,21 +2437,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg973d8362b6844dd3b1b2-006aa00516</RequestId><HostId>txg973d8362b6844dd3b1b2-006aa00516</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg9183c70ea2c84daea85c-006aa00f90</RequestId><HostId>txg9183c70ea2c84daea85c-006aa00f90</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:38 GMT
+                - Tue, 08 Sep 2026 13:37:20 GMT
             X-Amz-Id-2:
-                - txg973d8362b6844dd3b1b2-006aa00516
+                - txg9183c70ea2c84daea85c-006aa00f90
             X-Amz-Request-Id:
-                - txg973d8362b6844dd3b1b2-006aa00516
+                - txg9183c70ea2c84daea85c-006aa00f90
         status: 404 Not Found
         code: 404
-        duration: 199.706875ms
+        duration: 21.581959ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -2460,7 +2460,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2469,7 +2469,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - bd8cb8b0-e0f1-471c-a2b9-0ec7d0893aea
+                - eaa45c27-fb18-47e1-9966-182463a961b5
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2477,8 +2477,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125238Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T133720Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2488,21 +2488,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg227cbd4a95b54eedba2d-006aa00516</RequestId><HostId>txg227cbd4a95b54eedba2d-006aa00516</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgd9fc00589c3e49eabec2-006aa00f90</RequestId><HostId>txgd9fc00589c3e49eabec2-006aa00f90</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:38 GMT
+                - Tue, 08 Sep 2026 13:37:20 GMT
             X-Amz-Id-2:
-                - txg227cbd4a95b54eedba2d-006aa00516
+                - txgd9fc00589c3e49eabec2-006aa00f90
             X-Amz-Request-Id:
-                - txg227cbd4a95b54eedba2d-006aa00516
+                - txgd9fc00589c3e49eabec2-006aa00f90
         status: 404 Not Found
         code: 404
-        duration: 21.67425ms
+        duration: 58.066584ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -2511,7 +2511,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2520,7 +2520,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 351b91bb-6d41-4699-8907-27faa37bd1c9
+                - 5cc9ae91-4f36-417f-9196-6f3c4faf5f9b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2528,8 +2528,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125238Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T133720Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2548,14 +2548,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:38 GMT
+                - Tue, 08 Sep 2026 13:37:20 GMT
             X-Amz-Id-2:
-                - txgcc87499910634a78acc3-006aa00516
+                - txg460919d7ef4a4e1d9e84-006aa00f90
             X-Amz-Request-Id:
-                - txgcc87499910634a78acc3-006aa00516
+                - txg460919d7ef4a4e1d9e84-006aa00f90
         status: 200 OK
         code: 200
-        duration: 195.192458ms
+        duration: 21.335958ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -2564,7 +2564,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2573,7 +2573,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 044bf033-ba37-428c-9fd4-db55936cd41f
+                - bdec7b49-1d34-4b98-bed9-19a709eb132f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2581,8 +2581,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125238Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T133720Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2590,43 +2590,43 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 339
+        content_length: 279
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
-                - "339"
+                - "279"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:39 GMT
+                - Tue, 08 Sep 2026 13:37:20 GMT
             X-Amz-Id-2:
-                - txg68bdf2fcb80d492f92bd-006aa00517
+                - txg26e9f8e71dfd433f9f7f-006aa00f90
             X-Amz-Request-Id:
-                - txg68bdf2fcb80d492f92bd-006aa00517
+                - txg26e9f8e71dfd433f9f7f-006aa00f90
         status: 200 OK
         code: 200
-        duration: 21.955834ms
+        duration: 90.269ms
     - id: 50
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 1312
+        content_length: 1132
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
-        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></LifecycleConfiguration>
+        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></LifecycleConfiguration>
         form: {}
         headers:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9eef577f-9a50-455a-9753-cb19eeb1e9ee
+                - cedffbe7-55c7-4cb5-8d10-0b4633dd5a33
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -2634,12 +2634,12 @@ interactions:
             User-Agent:
                 - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,Z,e
             X-Amz-Checksum-Crc32:
-                - 4NH0sw==
+                - Zsh9Ug==
             X-Amz-Content-Sha256:
-                - 26f747e15ce1a1b780c6752abe8ce8948c374f5a893f30d1d89454d547619049
+                - 5f9243f4f931bea9c2119f4e79c617a5c5220b643a54f2c4e442edaf30ca867a
             X-Amz-Date:
-                - 20260908T125239Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T133720Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -2654,14 +2654,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 08 Sep 2026 12:52:39 GMT
+                - Tue, 08 Sep 2026 13:37:20 GMT
             X-Amz-Id-2:
-                - txgdf19210d15f647398279-006aa00517
+                - txg7075495f4ef147749613-006aa00f90
             X-Amz-Request-Id:
-                - txgdf19210d15f647398279-006aa00517
+                - txg7075495f4ef147749613-006aa00f90
         status: 200 OK
         code: 200
-        duration: 424.322708ms
+        duration: 144.447ms
     - id: 51
       request:
         proto: HTTP/1.1
@@ -2670,7 +2670,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2679,7 +2679,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - dbad868e-6dd5-4aae-a019-f7c354de8e2b
+                - e1e5ef64-c9eb-4d76-873d-f2ee3fa8cd1a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2687,8 +2687,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125239Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T133720Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2707,14 +2707,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:39 GMT
+                - Tue, 08 Sep 2026 13:37:20 GMT
             X-Amz-Id-2:
-                - txg0ad82931823b4d2dbd0a-006aa00517
+                - txgb85307bd1a0b4217a6d8-006aa00f90
             X-Amz-Request-Id:
-                - txg0ad82931823b4d2dbd0a-006aa00517
+                - txgb85307bd1a0b4217a6d8-006aa00f90
         status: 200 OK
         code: 200
-        duration: 136.962959ms
+        duration: 136.619292ms
     - id: 52
       request:
         proto: HTTP/1.1
@@ -2723,7 +2723,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2732,7 +2732,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 405db5a5-d878-48e6-b77b-798cbdab16f0
+                - 9daa5437-fb2f-4501-819a-26a0a614fd0b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2740,8 +2740,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125239Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T133720Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2751,21 +2751,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg974500e4385c4306a7e6-006aa00517</RequestId><HostId>txg974500e4385c4306a7e6-006aa00517</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgca6eb843bae84f618e3d-006aa00f91</RequestId><HostId>txgca6eb843bae84f618e3d-006aa00f91</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:39 GMT
+                - Tue, 08 Sep 2026 13:37:21 GMT
             X-Amz-Id-2:
-                - txg974500e4385c4306a7e6-006aa00517
+                - txgca6eb843bae84f618e3d-006aa00f91
             X-Amz-Request-Id:
-                - txg974500e4385c4306a7e6-006aa00517
+                - txgca6eb843bae84f618e3d-006aa00f91
         status: 404 Not Found
         code: 404
-        duration: 91.808ms
+        duration: 92.520167ms
     - id: 53
       request:
         proto: HTTP/1.1
@@ -2774,7 +2774,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2783,7 +2783,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 43b5a15b-5ea2-4657-9a37-b662c9743583
+                - bb3e4e5b-ab03-42f4-a46e-5a7d73977635
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2791,8 +2791,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125239Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
+                - 20260908T133721Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -2804,21 +2804,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:39 GMT
+                - Tue, 08 Sep 2026 13:37:21 GMT
             X-Amz-Id-2:
-                - txg818ac05c046b4ebb9201-006aa00517
+                - txg512036d4b42c4962a652-006aa00f91
             X-Amz-Request-Id:
-                - txg818ac05c046b4ebb9201-006aa00517
+                - txg512036d4b42c4962a652-006aa00f91
         status: 200 OK
         code: 200
-        duration: 785.303167ms
+        duration: 92.6075ms
     - id: 54
       request:
         proto: HTTP/1.1
@@ -2827,7 +2827,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2836,7 +2836,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 42ee14b3-ce9d-4cf5-9822-ac7ed70bb3b9
+                - 5a718076-8f9f-47de-93e4-81797c450dbe
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2844,8 +2844,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125239Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T133721Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2855,21 +2855,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg91e824ebeba5431eb8bd-006aa00518</RequestId><HostId>txg91e824ebeba5431eb8bd-006aa00518</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg3a2ed2e9151a4114a5f9-006aa00f91</RequestId><HostId>txg3a2ed2e9151a4114a5f9-006aa00f91</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:40 GMT
+                - Tue, 08 Sep 2026 13:37:21 GMT
             X-Amz-Id-2:
-                - txg91e824ebeba5431eb8bd-006aa00518
+                - txg3a2ed2e9151a4114a5f9-006aa00f91
             X-Amz-Request-Id:
-                - txg91e824ebeba5431eb8bd-006aa00518
+                - txg3a2ed2e9151a4114a5f9-006aa00f91
         status: 404 Not Found
         code: 404
-        duration: 1.153561916s
+        duration: 89.927375ms
     - id: 55
       request:
         proto: HTTP/1.1
@@ -2878,7 +2878,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2887,7 +2887,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c0cabc8c-ec57-4f17-a067-b305d4017c98
+                - 7427f4ed-8c71-4736-9c10-05e4f99be6b7
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2895,8 +2895,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125240Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T133721Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2906,21 +2906,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgaa39bbe9f26c437e9d35-006aa00519</RequestId><HostId>txgaa39bbe9f26c437e9d35-006aa00519</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg03998f4f54fa4cacbbeb-006aa00f91</RequestId><HostId>txg03998f4f54fa4cacbbeb-006aa00f91</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:41 GMT
+                - Tue, 08 Sep 2026 13:37:21 GMT
             X-Amz-Id-2:
-                - txgaa39bbe9f26c437e9d35-006aa00519
+                - txg03998f4f54fa4cacbbeb-006aa00f91
             X-Amz-Request-Id:
-                - txgaa39bbe9f26c437e9d35-006aa00519
+                - txg03998f4f54fa4cacbbeb-006aa00f91
         status: 404 Not Found
         code: 404
-        duration: 387.433875ms
+        duration: 99.486667ms
     - id: 56
       request:
         proto: HTTP/1.1
@@ -2929,7 +2929,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2938,7 +2938,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9839a3cc-da10-4ed3-bc7e-bdace97e6280
+                - b2068bad-e624-41b7-9ccc-b0a4255a99be
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2946,8 +2946,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125241Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T133721Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2966,14 +2966,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:42 GMT
+                - Tue, 08 Sep 2026 13:37:21 GMT
             X-Amz-Id-2:
-                - txga8f60bdf3ee248349191-006aa0051a
+                - txg5cce0179684d402b9b82-006aa00f91
             X-Amz-Request-Id:
-                - txga8f60bdf3ee248349191-006aa0051a
+                - txg5cce0179684d402b9b82-006aa00f91
         status: 200 OK
         code: 200
-        duration: 368.740459ms
+        duration: 20.3645ms
     - id: 57
       request:
         proto: HTTP/1.1
@@ -2982,7 +2982,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2991,7 +2991,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4836c7a2-0df0-44bd-83a9-7c1b9db41cbb
+                - a3e0524d-1701-4e35-9056-833aca4d9e40
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2999,8 +2999,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125242Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T133721Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3008,25 +3008,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1285
+        content_length: 1105
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
-                - "1285"
+                - "1105"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:42 GMT
+                - Tue, 08 Sep 2026 13:37:21 GMT
             X-Amz-Id-2:
-                - txga782bac633fc44c2894e-006aa0051a
+                - txg96db46e4c29f4de0800c-006aa00f91
             X-Amz-Request-Id:
-                - txga782bac633fc44c2894e-006aa0051a
+                - txg96db46e4c29f4de0800c-006aa00f91
         status: 200 OK
         code: 200
-        duration: 258.857292ms
+        duration: 75.463ms
     - id: 58
       request:
         proto: HTTP/1.1
@@ -3035,7 +3035,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3044,7 +3044,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0ee2a79d-2dd8-412d-8f29-0ada18980941
+                - c517402c-a1d1-413e-80e9-b24478ea3f35
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3052,8 +3052,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125242Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
+                - 20260908T133721Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -3068,16 +3068,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:42 GMT
+                - Tue, 08 Sep 2026 13:37:21 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txgbcd99ff3b2e54e338ba6-006aa0051a
+                - txg7e0269353a7244169d20-006aa00f91
             X-Amz-Request-Id:
-                - txgbcd99ff3b2e54e338ba6-006aa0051a
+                - txg7e0269353a7244169d20-006aa00f91
         status: 200 OK
         code: 200
-        duration: 338.845375ms
+        duration: 24.686167ms
     - id: 59
       request:
         proto: HTTP/1.1
@@ -3086,7 +3086,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3095,7 +3095,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 8408e3b7-03ac-4981-aa06-86fcb2d2a47f
+                - 41c00c2a-2900-461c-a90d-224bef66b032
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3103,8 +3103,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125243Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T133721Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3112,25 +3112,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1285
+        content_length: 1105
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
-                - "1285"
+                - "1105"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:43 GMT
+                - Tue, 08 Sep 2026 13:37:21 GMT
             X-Amz-Id-2:
-                - txg93c580572a364aee9069-006aa0051b
+                - txgadc0f47cd2054d1496e1-006aa00f91
             X-Amz-Request-Id:
-                - txg93c580572a364aee9069-006aa0051b
+                - txgadc0f47cd2054d1496e1-006aa00f91
         status: 200 OK
         code: 200
-        duration: 264.818125ms
+        duration: 99.741125ms
     - id: 60
       request:
         proto: HTTP/1.1
@@ -3139,7 +3139,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3148,7 +3148,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ce14655e-38ea-4e14-b71a-1091aeb781eb
+                - 53ab7584-376c-429e-889b-3f94aa2212b1
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3156,8 +3156,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125243Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T133721Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3176,14 +3176,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:43 GMT
+                - Tue, 08 Sep 2026 13:37:22 GMT
             X-Amz-Id-2:
-                - txg9d712b133f11424f9749-006aa0051b
+                - txg142d310e7f4840eb884a-006aa00f92
             X-Amz-Request-Id:
-                - txg9d712b133f11424f9749-006aa0051b
+                - txg142d310e7f4840eb884a-006aa00f92
         status: 200 OK
         code: 200
-        duration: 372.8625ms
+        duration: 30.643625ms
     - id: 61
       request:
         proto: HTTP/1.1
@@ -3192,7 +3192,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3201,16 +3201,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c8bafbbc-2bb5-461b-b05c-7425b6624e9e
+                - 2392a705-6035-41c8-a196-23cb7931ab87
             Amz-Sdk-Request:
-                - attempt=1; max=3
+                - attempt=1; max=3; ttl=20260908T154721Z
             User-Agent:
                 - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125243Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T133722Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3220,21 +3220,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgbe41a087b5574e6295e7-006aa0051c</RequestId><HostId>txgbe41a087b5574e6295e7-006aa0051c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg909b7e01d5f04adaad9d-006aa00f92</RequestId><HostId>txg909b7e01d5f04adaad9d-006aa00f92</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:44 GMT
+                - Tue, 08 Sep 2026 13:37:22 GMT
             X-Amz-Id-2:
-                - txgbe41a087b5574e6295e7-006aa0051c
+                - txg909b7e01d5f04adaad9d-006aa00f92
             X-Amz-Request-Id:
-                - txgbe41a087b5574e6295e7-006aa0051c
+                - txg909b7e01d5f04adaad9d-006aa00f92
         status: 404 Not Found
         code: 404
-        duration: 28.204708ms
+        duration: 162.242125ms
     - id: 62
       request:
         proto: HTTP/1.1
@@ -3243,7 +3243,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3252,7 +3252,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 23b92a98-e3a9-4261-a91d-76da238c8b6a
+                - c2aea7f8-9596-4dbc-a55d-f69f8360d846
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3260,8 +3260,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125244Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
+                - 20260908T133722Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -3273,21 +3273,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:44 GMT
+                - Tue, 08 Sep 2026 13:37:22 GMT
             X-Amz-Id-2:
-                - txg78070221aa94448a9b1a-006aa0051c
+                - txga2798a353e2a40349b3f-006aa00f92
             X-Amz-Request-Id:
-                - txg78070221aa94448a9b1a-006aa0051c
+                - txga2798a353e2a40349b3f-006aa00f92
         status: 200 OK
         code: 200
-        duration: 498.090958ms
+        duration: 307.907125ms
     - id: 63
       request:
         proto: HTTP/1.1
@@ -3296,7 +3296,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3305,7 +3305,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9b816580-4cae-4b7e-854d-66055d7a3e40
+                - 5639df73-0470-434d-a38e-9b3c7a6e48a4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3313,8 +3313,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125244Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T133722Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3324,21 +3324,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txga9ed07db17284168a646-006aa0051c</RequestId><HostId>txga9ed07db17284168a646-006aa0051c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg55fe6dd866c14ea480e1-006aa00f92</RequestId><HostId>txg55fe6dd866c14ea480e1-006aa00f92</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:44 GMT
+                - Tue, 08 Sep 2026 13:37:22 GMT
             X-Amz-Id-2:
-                - txga9ed07db17284168a646-006aa0051c
+                - txg55fe6dd866c14ea480e1-006aa00f92
             X-Amz-Request-Id:
-                - txga9ed07db17284168a646-006aa0051c
+                - txg55fe6dd866c14ea480e1-006aa00f92
         status: 404 Not Found
         code: 404
-        duration: 203.893625ms
+        duration: 22.374958ms
     - id: 64
       request:
         proto: HTTP/1.1
@@ -3347,7 +3347,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3356,7 +3356,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0410f769-1c5a-43f2-b150-bf3bf862eb66
+                - 9be25433-c765-4a9e-93ab-c5195d303cca
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3364,8 +3364,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125244Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T133722Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3375,21 +3375,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgc6ad33bca0f34c19b8e4-006aa0051c</RequestId><HostId>txgc6ad33bca0f34c19b8e4-006aa0051c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg75df0de8bef7430fbabf-006aa00f92</RequestId><HostId>txg75df0de8bef7430fbabf-006aa00f92</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:44 GMT
+                - Tue, 08 Sep 2026 13:37:22 GMT
             X-Amz-Id-2:
-                - txgc6ad33bca0f34c19b8e4-006aa0051c
+                - txg75df0de8bef7430fbabf-006aa00f92
             X-Amz-Request-Id:
-                - txgc6ad33bca0f34c19b8e4-006aa0051c
+                - txg75df0de8bef7430fbabf-006aa00f92
         status: 404 Not Found
         code: 404
-        duration: 427.570708ms
+        duration: 92.178625ms
     - id: 65
       request:
         proto: HTTP/1.1
@@ -3398,7 +3398,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3407,7 +3407,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 000fdf96-7f9e-4989-99d0-0bfd06540b3c
+                - 14bc1a3b-ddec-4768-a954-7b39fe7b4bf5
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3415,8 +3415,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125244Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T133722Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3435,14 +3435,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:45 GMT
+                - Tue, 08 Sep 2026 13:37:22 GMT
             X-Amz-Id-2:
-                - txge183accb0ec44b29ba0f-006aa0051d
+                - txg968e482d700f4b21a6a4-006aa00f92
             X-Amz-Request-Id:
-                - txge183accb0ec44b29ba0f-006aa0051d
+                - txg968e482d700f4b21a6a4-006aa00f92
         status: 200 OK
         code: 200
-        duration: 75.969083ms
+        duration: 97.305541ms
     - id: 66
       request:
         proto: HTTP/1.1
@@ -3451,7 +3451,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3460,7 +3460,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b189dbb6-eead-4182-8f7e-2c709a44d371
+                - b3ad1705-9aac-4951-87d2-1b895f021be7
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3468,8 +3468,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125245Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T133722Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3477,25 +3477,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1285
+        content_length: 1105
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
-                - "1285"
+                - "1105"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:45 GMT
+                - Tue, 08 Sep 2026 13:37:22 GMT
             X-Amz-Id-2:
-                - txg6f50a7e1edec459db653-006aa0051d
+                - txg8a471ca39895443dae00-006aa00f92
             X-Amz-Request-Id:
-                - txg6f50a7e1edec459db653-006aa0051d
+                - txg8a471ca39895443dae00-006aa00f92
         status: 200 OK
         code: 200
-        duration: 22.610166ms
+        duration: 95.012208ms
     - id: 67
       request:
         proto: HTTP/1.1
@@ -3504,7 +3504,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3513,7 +3513,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f29739e1-602a-4e8e-aee9-40d9999b0f18
+                - b1bab7d1-8370-4b40-bf56-52f0bac07532
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3521,8 +3521,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125245Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T133722Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3541,14 +3541,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:45 GMT
+                - Tue, 08 Sep 2026 13:37:22 GMT
             X-Amz-Id-2:
-                - txga641a32493084bd688c7-006aa0051d
+                - txgbe9a3f318f86424c8d92-006aa00f92
             X-Amz-Request-Id:
-                - txga641a32493084bd688c7-006aa0051d
+                - txgbe9a3f318f86424c8d92-006aa00f92
         status: 200 OK
         code: 200
-        duration: 37.649166ms
+        duration: 129.969167ms
     - id: 68
       request:
         proto: HTTP/1.1
@@ -3557,7 +3557,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3566,7 +3566,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 755afe07-a4a1-472d-a5b7-d6e257830d6a
+                - af3d6aaa-2960-469f-8958-5269aebbdeab
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3574,8 +3574,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125245Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T133722Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3585,21 +3585,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txga1acd19fee5e4d79b64f-006aa0051d</RequestId><HostId>txga1acd19fee5e4d79b64f-006aa0051d</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg9235a186dc6d41ebb098-006aa00f93</RequestId><HostId>txg9235a186dc6d41ebb098-006aa00f93</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:45 GMT
+                - Tue, 08 Sep 2026 13:37:23 GMT
             X-Amz-Id-2:
-                - txga1acd19fee5e4d79b64f-006aa0051d
+                - txg9235a186dc6d41ebb098-006aa00f93
             X-Amz-Request-Id:
-                - txga1acd19fee5e4d79b64f-006aa0051d
+                - txg9235a186dc6d41ebb098-006aa00f93
         status: 404 Not Found
         code: 404
-        duration: 198.45275ms
+        duration: 23.047833ms
     - id: 69
       request:
         proto: HTTP/1.1
@@ -3608,7 +3608,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3617,7 +3617,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 752c3541-a340-4723-809c-488abaaa61d4
+                - b6e2bbfe-74f8-4ac3-8657-43ab343f0c2e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3625,8 +3625,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125245Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
+                - 20260908T133723Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -3638,21 +3638,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:45 GMT
+                - Tue, 08 Sep 2026 13:37:23 GMT
             X-Amz-Id-2:
-                - txgf8d1d79e51464a56bdb0-006aa0051d
+                - txg814820601ae44315b8de-006aa00f93
             X-Amz-Request-Id:
-                - txgf8d1d79e51464a56bdb0-006aa0051d
+                - txg814820601ae44315b8de-006aa00f93
         status: 200 OK
         code: 200
-        duration: 353.194959ms
+        duration: 299.353667ms
     - id: 70
       request:
         proto: HTTP/1.1
@@ -3661,7 +3661,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3670,7 +3670,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - faf3f403-79e4-4363-b08e-efea083966c0
+                - f068fc8a-a26f-4942-a574-1afe1792cba0
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3678,8 +3678,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125245Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T133723Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3689,21 +3689,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg8a0788ff4d8f440da7eb-006aa0051e</RequestId><HostId>txg8a0788ff4d8f440da7eb-006aa0051e</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgacc66817bbd64064b0bf-006aa00f93</RequestId><HostId>txgacc66817bbd64064b0bf-006aa00f93</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:46 GMT
+                - Tue, 08 Sep 2026 13:37:23 GMT
             X-Amz-Id-2:
-                - txg8a0788ff4d8f440da7eb-006aa0051e
+                - txgacc66817bbd64064b0bf-006aa00f93
             X-Amz-Request-Id:
-                - txg8a0788ff4d8f440da7eb-006aa0051e
+                - txgacc66817bbd64064b0bf-006aa00f93
         status: 404 Not Found
         code: 404
-        duration: 55.314666ms
+        duration: 21.909ms
     - id: 71
       request:
         proto: HTTP/1.1
@@ -3712,7 +3712,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3721,7 +3721,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 1bb5a595-eff5-414f-a7b2-577d12e1ff52
+                - ebd5b441-3d1f-467a-aca7-b69d80eb16bc
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3729,8 +3729,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125246Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T133723Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3740,21 +3740,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgb1ce2dd19f8e4760bf2b-006aa0051e</RequestId><HostId>txgb1ce2dd19f8e4760bf2b-006aa0051e</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgfc637a4655724d8c9ba7-006aa00f93</RequestId><HostId>txgfc637a4655724d8c9ba7-006aa00f93</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:46 GMT
+                - Tue, 08 Sep 2026 13:37:23 GMT
             X-Amz-Id-2:
-                - txgb1ce2dd19f8e4760bf2b-006aa0051e
+                - txgfc637a4655724d8c9ba7-006aa00f93
             X-Amz-Request-Id:
-                - txgb1ce2dd19f8e4760bf2b-006aa0051e
+                - txgfc637a4655724d8c9ba7-006aa00f93
         status: 404 Not Found
         code: 404
-        duration: 251.327959ms
+        duration: 46.69825ms
     - id: 72
       request:
         proto: HTTP/1.1
@@ -3763,7 +3763,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3772,7 +3772,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 8ea97cf5-a197-4596-9c7d-6fe389494dc6
+                - 09dab68d-7856-43be-ab89-75fedf811c73
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3780,8 +3780,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125246Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T133723Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3800,14 +3800,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:46 GMT
+                - Tue, 08 Sep 2026 13:37:23 GMT
             X-Amz-Id-2:
-                - txgce4fcd245ef240088243-006aa0051e
+                - txga0fbf31f3fa54832bf49-006aa00f93
             X-Amz-Request-Id:
-                - txgce4fcd245ef240088243-006aa0051e
+                - txga0fbf31f3fa54832bf49-006aa00f93
         status: 200 OK
         code: 200
-        duration: 254.727125ms
+        duration: 138.631875ms
     - id: 73
       request:
         proto: HTTP/1.1
@@ -3816,7 +3816,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3825,7 +3825,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - bae1596d-d0bf-4b1e-8a06-8d9ec5b09e64
+                - 6724c247-1fe4-483d-bae1-85a20bf24344
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3833,8 +3833,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125246Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T133723Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3842,25 +3842,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1285
+        content_length: 1105
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
-                - "1285"
+                - "1105"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:46 GMT
+                - Tue, 08 Sep 2026 13:37:23 GMT
             X-Amz-Id-2:
-                - txg1d60a61a9c224d8d90c1-006aa0051e
+                - txg0ab0a94117cc45de90ec-006aa00f93
             X-Amz-Request-Id:
-                - txg1d60a61a9c224d8d90c1-006aa0051e
+                - txg0ab0a94117cc45de90ec-006aa00f93
         status: 200 OK
         code: 200
-        duration: 31.240458ms
+        duration: 86.92025ms
     - id: 74
       request:
         proto: HTTP/1.1
@@ -3869,7 +3869,7 @@ interactions:
         content_length: 296
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
@@ -3878,7 +3878,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 70bcab7f-74e5-4ab2-a151-215261f105b8
+                - d79debe7-a8a7-4743-8a31-123fd42c1b10
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -3890,8 +3890,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - 7756d51b786b61edff20b7957d22346417f85f71d19eeca0d6d28d6df7b15bbc
             X-Amz-Date:
-                - 20260908T125246Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T133723Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -3906,14 +3906,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 08 Sep 2026 12:52:46 GMT
+                - Tue, 08 Sep 2026 13:37:23 GMT
             X-Amz-Id-2:
-                - txgae70eccdcbbb449c8a79-006aa0051e
+                - txg16539269a8914edfaa23-006aa00f93
             X-Amz-Request-Id:
-                - txgae70eccdcbbb449c8a79-006aa0051e
+                - txg16539269a8914edfaa23-006aa00f93
         status: 200 OK
         code: 200
-        duration: 241.606917ms
+        duration: 333.218667ms
     - id: 75
       request:
         proto: HTTP/1.1
@@ -3922,7 +3922,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3931,7 +3931,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 23e1d9da-b5b8-4a3a-a2b8-605e497389dc
+                - f55ba422-a633-4a11-9384-f37a075c9444
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3939,8 +3939,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125247Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T133724Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3959,14 +3959,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:47 GMT
+                - Tue, 08 Sep 2026 13:37:24 GMT
             X-Amz-Id-2:
-                - txg3c25f4a6267546ea88c0-006aa0051f
+                - txg1d44c83cc3c344f89af0-006aa00f94
             X-Amz-Request-Id:
-                - txg3c25f4a6267546ea88c0-006aa0051f
+                - txg1d44c83cc3c344f89af0-006aa00f94
         status: 200 OK
         code: 200
-        duration: 181.573792ms
+        duration: 215.892209ms
     - id: 76
       request:
         proto: HTTP/1.1
@@ -3975,7 +3975,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3984,7 +3984,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 1bacbcca-b8cb-45ac-a5ba-01801aa277b9
+                - cdaf03b3-3bbe-4e0b-a116-317cb4d368df
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3992,8 +3992,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125247Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T133724Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4003,21 +4003,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgd6de9fa32a944c3eb49f-006aa0051f</RequestId><HostId>txgd6de9fa32a944c3eb49f-006aa0051f</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg2fea404498164de9b8de-006aa00f94</RequestId><HostId>txg2fea404498164de9b8de-006aa00f94</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:47 GMT
+                - Tue, 08 Sep 2026 13:37:24 GMT
             X-Amz-Id-2:
-                - txgd6de9fa32a944c3eb49f-006aa0051f
+                - txg2fea404498164de9b8de-006aa00f94
             X-Amz-Request-Id:
-                - txgd6de9fa32a944c3eb49f-006aa0051f
+                - txg2fea404498164de9b8de-006aa00f94
         status: 404 Not Found
         code: 404
-        duration: 109.887208ms
+        duration: 105.748084ms
     - id: 77
       request:
         proto: HTTP/1.1
@@ -4026,7 +4026,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4035,7 +4035,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 71d057ec-5eab-4709-8c35-a8c8cffea14f
+                - e00fe846-10a8-417c-8a8c-cde6e4bc7aa6
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4043,8 +4043,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125247Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
+                - 20260908T133724Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -4056,21 +4056,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:47 GMT
+                - Tue, 08 Sep 2026 13:37:24 GMT
             X-Amz-Id-2:
-                - txgc9a1735085a4425e94de-006aa0051f
+                - txgea4bf3cbb5d14917bf44-006aa00f94
             X-Amz-Request-Id:
-                - txgc9a1735085a4425e94de-006aa0051f
+                - txgea4bf3cbb5d14917bf44-006aa00f94
         status: 200 OK
         code: 200
-        duration: 427.860792ms
+        duration: 28.744459ms
     - id: 78
       request:
         proto: HTTP/1.1
@@ -4079,7 +4079,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4088,7 +4088,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 72cbc988-af2f-4e87-be15-da0215dab1d6
+                - 752f9008-19b2-48e6-b35d-0cb8b994128d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4096,8 +4096,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125247Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T133724Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4107,21 +4107,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg9ed83e436c7e4669bc6c-006aa0051f</RequestId><HostId>txg9ed83e436c7e4669bc6c-006aa0051f</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg6aec08799f5748628594-006aa00f94</RequestId><HostId>txg6aec08799f5748628594-006aa00f94</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:47 GMT
+                - Tue, 08 Sep 2026 13:37:24 GMT
             X-Amz-Id-2:
-                - txg9ed83e436c7e4669bc6c-006aa0051f
+                - txg6aec08799f5748628594-006aa00f94
             X-Amz-Request-Id:
-                - txg9ed83e436c7e4669bc6c-006aa0051f
+                - txg6aec08799f5748628594-006aa00f94
         status: 404 Not Found
         code: 404
-        duration: 124.400083ms
+        duration: 108.174833ms
     - id: 79
       request:
         proto: HTTP/1.1
@@ -4130,7 +4130,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4139,7 +4139,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 304d7c09-9ae0-4b6d-96c4-4efbd9edd7d5
+                - 93d4183e-5793-41e2-bd7a-649ddf0a6e04
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4147,8 +4147,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125247Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T133724Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4158,21 +4158,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg97c6249f001f424a83e1-006aa00520</RequestId><HostId>txg97c6249f001f424a83e1-006aa00520</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg7d5698ce49c44e528d94-006aa00f94</RequestId><HostId>txg7d5698ce49c44e528d94-006aa00f94</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:48 GMT
+                - Tue, 08 Sep 2026 13:37:24 GMT
             X-Amz-Id-2:
-                - txg97c6249f001f424a83e1-006aa00520
+                - txg7d5698ce49c44e528d94-006aa00f94
             X-Amz-Request-Id:
-                - txg97c6249f001f424a83e1-006aa00520
+                - txg7d5698ce49c44e528d94-006aa00f94
         status: 404 Not Found
         code: 404
-        duration: 159.150166ms
+        duration: 267.753125ms
     - id: 80
       request:
         proto: HTTP/1.1
@@ -4181,7 +4181,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4190,7 +4190,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3d576127-e28f-480c-942e-31797a86c554
+                - e90ae00e-cda5-401c-9d75-5d6e4145cbea
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4198,8 +4198,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125248Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T133724Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4218,14 +4218,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:48 GMT
+                - Tue, 08 Sep 2026 13:37:24 GMT
             X-Amz-Id-2:
-                - txg28bb7f2335644c95bbe9-006aa00520
+                - txga3aebbd604ef4b02a36e-006aa00f94
             X-Amz-Request-Id:
-                - txg28bb7f2335644c95bbe9-006aa00520
+                - txga3aebbd604ef4b02a36e-006aa00f94
         status: 200 OK
         code: 200
-        duration: 21.7395ms
+        duration: 198.777166ms
     - id: 81
       request:
         proto: HTTP/1.1
@@ -4234,7 +4234,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4243,7 +4243,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 542f33cc-c406-4feb-a5ab-13c1ca589281
+                - 4a03e01b-ad69-474f-8379-c1d5e46da7ea
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4251,8 +4251,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125248Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T133724Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4271,14 +4271,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:48 GMT
+                - Tue, 08 Sep 2026 13:37:25 GMT
             X-Amz-Id-2:
-                - txg6f04484c332f48098870-006aa00520
+                - txgc19da5116aa84acdab02-006aa00f95
             X-Amz-Request-Id:
-                - txg6f04484c332f48098870-006aa00520
+                - txgc19da5116aa84acdab02-006aa00f95
         status: 200 OK
         code: 200
-        duration: 196.866917ms
+        duration: 21.749792ms
     - id: 82
       request:
         proto: HTTP/1.1
@@ -4287,7 +4287,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4296,7 +4296,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f2eeb9d4-db0c-458a-bc64-0b79e2ab1e11
+                - 917eacc4-4127-49aa-8ec9-38178f3b70a6
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4304,8 +4304,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125248Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
+                - 20260908T133725Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -4320,16 +4320,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:48 GMT
+                - Tue, 08 Sep 2026 13:37:25 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txgcd180260475f46c4b60d-006aa00520
+                - txga5eb42e6e98448d88604-006aa00f95
             X-Amz-Request-Id:
-                - txgcd180260475f46c4b60d-006aa00520
+                - txga5eb42e6e98448d88604-006aa00f95
         status: 200 OK
         code: 200
-        duration: 447.7945ms
+        duration: 127.748625ms
     - id: 83
       request:
         proto: HTTP/1.1
@@ -4338,7 +4338,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4347,7 +4347,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5b2a307f-ff3d-439a-be0c-2bc1cd274873
+                - dfb162d8-9ccf-49e4-8ebb-80e72618012c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4355,8 +4355,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125248Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T133725Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4375,14 +4375,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:48 GMT
+                - Tue, 08 Sep 2026 13:37:25 GMT
             X-Amz-Id-2:
-                - txg90fbee8058514be684a9-006aa00520
+                - txgb6574441f6054ee4a3f9-006aa00f95
             X-Amz-Request-Id:
-                - txg90fbee8058514be684a9-006aa00520
+                - txgb6574441f6054ee4a3f9-006aa00f95
         status: 200 OK
         code: 200
-        duration: 415.703958ms
+        duration: 308.163875ms
     - id: 84
       request:
         proto: HTTP/1.1
@@ -4391,7 +4391,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4400,7 +4400,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9ae528ba-b986-4d0c-85ba-dca1c82e53e9
+                - 7eb80c58-7df3-4e75-a746-0869b5724b4f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4408,8 +4408,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125249Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T133725Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4428,14 +4428,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:49 GMT
+                - Tue, 08 Sep 2026 13:37:25 GMT
             X-Amz-Id-2:
-                - txg6a92e9cca7964b5d9a58-006aa00521
+                - txga7921fa6fc104eb09dc7-006aa00f95
             X-Amz-Request-Id:
-                - txg6a92e9cca7964b5d9a58-006aa00521
+                - txga7921fa6fc104eb09dc7-006aa00f95
         status: 200 OK
         code: 200
-        duration: 53.042834ms
+        duration: 270.726541ms
     - id: 85
       request:
         proto: HTTP/1.1
@@ -4444,7 +4444,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4453,7 +4453,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 198785ce-9a58-4676-8f73-8b3c6fbd6e37
+                - 25cd31de-13dd-4fba-9ff8-6565a596c948
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4461,8 +4461,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125249Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T133725Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4472,21 +4472,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg3b24e1bcf50a45e2ba65-006aa00521</RequestId><HostId>txg3b24e1bcf50a45e2ba65-006aa00521</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgc5f6c74b03ab4911bcb1-006aa00f96</RequestId><HostId>txgc5f6c74b03ab4911bcb1-006aa00f96</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:49 GMT
+                - Tue, 08 Sep 2026 13:37:26 GMT
             X-Amz-Id-2:
-                - txg3b24e1bcf50a45e2ba65-006aa00521
+                - txgc5f6c74b03ab4911bcb1-006aa00f96
             X-Amz-Request-Id:
-                - txg3b24e1bcf50a45e2ba65-006aa00521
+                - txgc5f6c74b03ab4911bcb1-006aa00f96
         status: 404 Not Found
         code: 404
-        duration: 26.213291ms
+        duration: 98.960834ms
     - id: 86
       request:
         proto: HTTP/1.1
@@ -4495,7 +4495,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4504,7 +4504,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d5ad4b80-71be-4e11-895a-0716175ee9b7
+                - f592e29f-a396-4289-9056-ecbfc5e3be83
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4512,8 +4512,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125249Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
+                - 20260908T133726Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -4525,21 +4525,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:49 GMT
+                - Tue, 08 Sep 2026 13:37:26 GMT
             X-Amz-Id-2:
-                - txg86c7ec5321494308be0a-006aa00521
+                - txgddd141aabfa043528cdd-006aa00f96
             X-Amz-Request-Id:
-                - txg86c7ec5321494308be0a-006aa00521
+                - txgddd141aabfa043528cdd-006aa00f96
         status: 200 OK
         code: 200
-        duration: 297.928959ms
+        duration: 210.199833ms
     - id: 87
       request:
         proto: HTTP/1.1
@@ -4548,7 +4548,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4557,7 +4557,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 91945115-0d79-4019-a9ff-af4c909e8a74
+                - 488e8365-ecd9-4851-9978-8d6a690c0136
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4565,8 +4565,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125249Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T133726Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4576,21 +4576,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg3104588f6ae54847b902-006aa00521</RequestId><HostId>txg3104588f6ae54847b902-006aa00521</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg919a58b528364882a85e-006aa00f96</RequestId><HostId>txg919a58b528364882a85e-006aa00f96</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:49 GMT
+                - Tue, 08 Sep 2026 13:37:26 GMT
             X-Amz-Id-2:
-                - txg3104588f6ae54847b902-006aa00521
+                - txg919a58b528364882a85e-006aa00f96
             X-Amz-Request-Id:
-                - txg3104588f6ae54847b902-006aa00521
+                - txg919a58b528364882a85e-006aa00f96
         status: 404 Not Found
         code: 404
-        duration: 22.274ms
+        duration: 26.50775ms
     - id: 88
       request:
         proto: HTTP/1.1
@@ -4599,7 +4599,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4608,7 +4608,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 92ae704c-c3a0-4f63-97ed-0cad79716f65
+                - c0500857-517f-4521-8aec-08b4d733faad
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4616,8 +4616,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125249Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T133726Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4627,21 +4627,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgc607ee78ba57497c925f-006aa00521</RequestId><HostId>txgc607ee78ba57497c925f-006aa00521</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg9aeaa306b4114a4b8554-006aa00f96</RequestId><HostId>txg9aeaa306b4114a4b8554-006aa00f96</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:49 GMT
+                - Tue, 08 Sep 2026 13:37:26 GMT
             X-Amz-Id-2:
-                - txgc607ee78ba57497c925f-006aa00521
+                - txg9aeaa306b4114a4b8554-006aa00f96
             X-Amz-Request-Id:
-                - txgc607ee78ba57497c925f-006aa00521
+                - txg9aeaa306b4114a4b8554-006aa00f96
         status: 404 Not Found
         code: 404
-        duration: 274.094041ms
+        duration: 65.192542ms
     - id: 89
       request:
         proto: HTTP/1.1
@@ -4650,7 +4650,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4659,7 +4659,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 023adc25-9c84-4395-86df-f755ccd4b2e9
+                - db5e1943-ed77-44ef-a76d-ab0f305559c0
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4667,8 +4667,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125249Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T133726Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4687,14 +4687,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:50 GMT
+                - Tue, 08 Sep 2026 13:37:26 GMT
             X-Amz-Id-2:
-                - txg8a22ae9d416243d68898-006aa00522
+                - txge0d6a58f792842cea9df-006aa00f96
             X-Amz-Request-Id:
-                - txg8a22ae9d416243d68898-006aa00522
+                - txge0d6a58f792842cea9df-006aa00f96
         status: 200 OK
         code: 200
-        duration: 28.7355ms
+        duration: 95.940375ms
     - id: 90
       request:
         proto: HTTP/1.1
@@ -4703,7 +4703,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4712,7 +4712,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 13f08141-f99c-4e17-a51f-ba738ccbf4b7
+                - dafb5a63-47b1-46de-8073-c0773a2d3fcf
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4720,8 +4720,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125250Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T133726Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4740,14 +4740,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:50 GMT
+                - Tue, 08 Sep 2026 13:37:26 GMT
             X-Amz-Id-2:
-                - txg4a500e8007b04f6f8c80-006aa00522
+                - txg96161ab4a44348dabc9b-006aa00f96
             X-Amz-Request-Id:
-                - txg4a500e8007b04f6f8c80-006aa00522
+                - txg96161ab4a44348dabc9b-006aa00f96
         status: 200 OK
         code: 200
-        duration: 64.845791ms
+        duration: 21.991666ms
     - id: 91
       request:
         proto: HTTP/1.1
@@ -4756,7 +4756,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4765,7 +4765,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 41cf03bb-3919-4bad-be52-a42e23f3c4f4
+                - 077303f0-7824-4b12-8a25-6043a9df611d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4773,8 +4773,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125250Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T133726Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4793,14 +4793,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:50 GMT
+                - Tue, 08 Sep 2026 13:37:26 GMT
             X-Amz-Id-2:
-                - txg041a996f47b54491a22c-006aa00522
+                - txg0d0775bac92d45478481-006aa00f96
             X-Amz-Request-Id:
-                - txg041a996f47b54491a22c-006aa00522
+                - txg0d0775bac92d45478481-006aa00f96
         status: 200 OK
         code: 200
-        duration: 154.933583ms
+        duration: 155.03275ms
     - id: 92
       request:
         proto: HTTP/1.1
@@ -4809,7 +4809,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4818,7 +4818,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - dbf2c360-bf6a-4a48-af6f-aeb108c1757d
+                - 960ce9af-af5f-4e38-8e99-3a5dfcc54927
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4826,8 +4826,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125250Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T133726Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4837,21 +4837,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgad1f2d85a69d4bbfa73c-006aa00522</RequestId><HostId>txgad1f2d85a69d4bbfa73c-006aa00522</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg0f2b09c5639f45b9be04-006aa00f97</RequestId><HostId>txg0f2b09c5639f45b9be04-006aa00f97</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:50 GMT
+                - Tue, 08 Sep 2026 13:37:27 GMT
             X-Amz-Id-2:
-                - txgad1f2d85a69d4bbfa73c-006aa00522
+                - txg0f2b09c5639f45b9be04-006aa00f97
             X-Amz-Request-Id:
-                - txgad1f2d85a69d4bbfa73c-006aa00522
+                - txg0f2b09c5639f45b9be04-006aa00f97
         status: 404 Not Found
         code: 404
-        duration: 124.333666ms
+        duration: 269.177083ms
     - id: 93
       request:
         proto: HTTP/1.1
@@ -4860,7 +4860,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4869,7 +4869,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e79a30da-e426-4184-ae23-757be13b16bd
+                - b9059741-85f0-4cee-ad62-abe36d15176b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4877,8 +4877,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125250Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
+                - 20260908T133727Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -4890,21 +4890,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:50 GMT
+                - Tue, 08 Sep 2026 13:37:27 GMT
             X-Amz-Id-2:
-                - txgde8c9bc7227241a18640-006aa00522
+                - txg64caeb369b494c1eb376-006aa00f97
             X-Amz-Request-Id:
-                - txgde8c9bc7227241a18640-006aa00522
+                - txg64caeb369b494c1eb376-006aa00f97
         status: 200 OK
         code: 200
-        duration: 391.855458ms
+        duration: 126.718042ms
     - id: 94
       request:
         proto: HTTP/1.1
@@ -4913,7 +4913,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4922,7 +4922,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 581808ef-ea58-43f7-ba1b-44498fd97c0a
+                - 83c72c35-ce69-4907-bb95-b544d467a90a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4930,8 +4930,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125250Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T133727Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4941,21 +4941,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgb1f925193c5d4fca8b30-006aa00523</RequestId><HostId>txgb1f925193c5d4fca8b30-006aa00523</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg2f825edfcf9f4dd3a26b-006aa00f97</RequestId><HostId>txg2f825edfcf9f4dd3a26b-006aa00f97</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:51 GMT
+                - Tue, 08 Sep 2026 13:37:27 GMT
             X-Amz-Id-2:
-                - txgb1f925193c5d4fca8b30-006aa00523
+                - txg2f825edfcf9f4dd3a26b-006aa00f97
             X-Amz-Request-Id:
-                - txgb1f925193c5d4fca8b30-006aa00523
+                - txg2f825edfcf9f4dd3a26b-006aa00f97
         status: 404 Not Found
         code: 404
-        duration: 292.613166ms
+        duration: 108.724625ms
     - id: 95
       request:
         proto: HTTP/1.1
@@ -4964,7 +4964,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4973,7 +4973,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 19b4980c-7896-446e-90a3-50f59350aae0
+                - 80d64306-b8e3-457d-91b1-cfed8795dc40
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4981,8 +4981,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125251Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T133727Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4992,21 +4992,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg8d96082677a44135a15b-006aa00523</RequestId><HostId>txg8d96082677a44135a15b-006aa00523</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgc110fdf9d0b7444e88f2-006aa00f97</RequestId><HostId>txgc110fdf9d0b7444e88f2-006aa00f97</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:51 GMT
+                - Tue, 08 Sep 2026 13:37:27 GMT
             X-Amz-Id-2:
-                - txg8d96082677a44135a15b-006aa00523
+                - txgc110fdf9d0b7444e88f2-006aa00f97
             X-Amz-Request-Id:
-                - txg8d96082677a44135a15b-006aa00523
+                - txgc110fdf9d0b7444e88f2-006aa00f97
         status: 404 Not Found
         code: 404
-        duration: 233.939333ms
+        duration: 92.619375ms
     - id: 96
       request:
         proto: HTTP/1.1
@@ -5015,7 +5015,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5024,7 +5024,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a7741225-89b8-4949-a911-ea017bc456c0
+                - 4620e04a-24b9-4e08-bb4f-14480b19a6fe
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5032,8 +5032,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125251Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T133727Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5052,14 +5052,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:51 GMT
+                - Tue, 08 Sep 2026 13:37:27 GMT
             X-Amz-Id-2:
-                - txg7584230a88d641b186c1-006aa00523
+                - txgd0e56b79716c41099c2c-006aa00f97
             X-Amz-Request-Id:
-                - txg7584230a88d641b186c1-006aa00523
+                - txgd0e56b79716c41099c2c-006aa00f97
         status: 200 OK
         code: 200
-        duration: 207.095125ms
+        duration: 610.871667ms
     - id: 97
       request:
         proto: HTTP/1.1
@@ -5068,7 +5068,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5077,7 +5077,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4ff9839a-d531-4d2c-bb79-9efb56c18fd7
+                - 001b2810-103a-4f83-a948-34d4aab448bb
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5085,8 +5085,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125251Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T133727Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5105,14 +5105,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:51 GMT
+                - Tue, 08 Sep 2026 13:37:28 GMT
             X-Amz-Id-2:
-                - txg4e01d1ce3b9846f3a9c6-006aa00523
+                - txgee39ee8c86a340eba7c9-006aa00f98
             X-Amz-Request-Id:
-                - txg4e01d1ce3b9846f3a9c6-006aa00523
+                - txgee39ee8c86a340eba7c9-006aa00f98
         status: 200 OK
         code: 200
-        duration: 185.065458ms
+        duration: 88.144ms
     - id: 98
       request:
         proto: HTTP/1.1
@@ -5121,7 +5121,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5130,7 +5130,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c96a05e2-3273-497c-9f2a-bed1680fcafe
+                - 0856c37d-82f9-43c0-9c07-4ac6bc451c05
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5138,8 +5138,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125252Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
+                - 20260908T133728Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -5154,16 +5154,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:52 GMT
+                - Tue, 08 Sep 2026 13:37:28 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txg4b8ebdf734134bd595fd-006aa00524
+                - txgbb01b253e0b24335a454-006aa00f98
             X-Amz-Request-Id:
-                - txg4b8ebdf734134bd595fd-006aa00524
+                - txgbb01b253e0b24335a454-006aa00f98
         status: 200 OK
         code: 200
-        duration: 34.581333ms
+        duration: 233.534875ms
     - id: 99
       request:
         proto: HTTP/1.1
@@ -5172,7 +5172,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5181,7 +5181,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f907133a-2490-4cff-8cf4-6dabd8dd3dbc
+                - 25683e34-2394-4358-bab0-f5040cae0a57
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5189,8 +5189,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125252Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T133728Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5209,14 +5209,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:52 GMT
+                - Tue, 08 Sep 2026 13:37:28 GMT
             X-Amz-Id-2:
-                - txg99fe9fb3581744d09c81-006aa00524
+                - txg93c94d8d8de74ee8a748-006aa00f98
             X-Amz-Request-Id:
-                - txg99fe9fb3581744d09c81-006aa00524
+                - txg93c94d8d8de74ee8a748-006aa00f98
         status: 200 OK
         code: 200
-        duration: 213.725292ms
+        duration: 26.876625ms
     - id: 100
       request:
         proto: HTTP/1.1
@@ -5225,7 +5225,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5234,7 +5234,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6171aa49-f496-4959-b31e-6ac5260a68d8
+                - 9b6e0cf1-f116-44a5-a1ba-3ee235d3269a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5242,8 +5242,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125252Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T133728Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5262,14 +5262,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:52 GMT
+                - Tue, 08 Sep 2026 13:37:29 GMT
             X-Amz-Id-2:
-                - txg9ee863171f584235bb05-006aa00524
+                - txg93ed1c694b0d435480b4-006aa00f99
             X-Amz-Request-Id:
-                - txg9ee863171f584235bb05-006aa00524
+                - txg93ed1c694b0d435480b4-006aa00f99
         status: 200 OK
         code: 200
-        duration: 191.157667ms
+        duration: 71.810875ms
     - id: 101
       request:
         proto: HTTP/1.1
@@ -5278,7 +5278,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5287,7 +5287,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 31914369-561c-4e27-9487-ed217c764e53
+                - 5e9c9ac7-bcaa-4125-b54e-fdf8f3855dca
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5295,8 +5295,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125252Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T133729Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5306,21 +5306,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg31a4bf5f06204f1e8f28-006aa00524</RequestId><HostId>txg31a4bf5f06204f1e8f28-006aa00524</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg32986a0181cb45a2a24a-006aa00f99</RequestId><HostId>txg32986a0181cb45a2a24a-006aa00f99</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:52 GMT
+                - Tue, 08 Sep 2026 13:37:29 GMT
             X-Amz-Id-2:
-                - txg31a4bf5f06204f1e8f28-006aa00524
+                - txg32986a0181cb45a2a24a-006aa00f99
             X-Amz-Request-Id:
-                - txg31a4bf5f06204f1e8f28-006aa00524
+                - txg32986a0181cb45a2a24a-006aa00f99
         status: 404 Not Found
         code: 404
-        duration: 21.868292ms
+        duration: 20.644791ms
     - id: 102
       request:
         proto: HTTP/1.1
@@ -5329,7 +5329,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5338,7 +5338,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c1c207ad-8201-45a7-a361-84a49bd88c1e
+                - c241a0fd-8f43-4556-b5c7-abdac3151c29
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5346,8 +5346,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125252Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
+                - 20260908T133729Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -5359,21 +5359,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:52 GMT
+                - Tue, 08 Sep 2026 13:37:29 GMT
             X-Amz-Id-2:
-                - txg06aaf4425cf8468d8ef7-006aa00524
+                - txga4c50f197a60447290c8-006aa00f99
             X-Amz-Request-Id:
-                - txg06aaf4425cf8468d8ef7-006aa00524
+                - txga4c50f197a60447290c8-006aa00f99
         status: 200 OK
         code: 200
-        duration: 388.976417ms
+        duration: 97.605875ms
     - id: 103
       request:
         proto: HTTP/1.1
@@ -5382,7 +5382,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5391,7 +5391,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 91007d85-0dd5-433d-8413-aeef2b35d2e2
+                - ec93e078-1e78-4239-93df-5235bf1c4966
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5399,8 +5399,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125252Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T133729Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5410,21 +5410,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg07dc553b0f7e459ca9c6-006aa00525</RequestId><HostId>txg07dc553b0f7e459ca9c6-006aa00525</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg8416dd7a7f714a08972d-006aa00f99</RequestId><HostId>txg8416dd7a7f714a08972d-006aa00f99</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:53 GMT
+                - Tue, 08 Sep 2026 13:37:29 GMT
             X-Amz-Id-2:
-                - txg07dc553b0f7e459ca9c6-006aa00525
+                - txg8416dd7a7f714a08972d-006aa00f99
             X-Amz-Request-Id:
-                - txg07dc553b0f7e459ca9c6-006aa00525
+                - txg8416dd7a7f714a08972d-006aa00f99
         status: 404 Not Found
         code: 404
-        duration: 188.699166ms
+        duration: 89.172208ms
     - id: 104
       request:
         proto: HTTP/1.1
@@ -5433,7 +5433,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5442,7 +5442,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 8fd0a21c-cf38-4d7a-8338-091624f8c871
+                - b77cdccb-fd1f-4229-a2db-d4acf00820eb
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5450,8 +5450,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125253Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T133729Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5461,21 +5461,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgc941390647804a65b6ed-006aa00525</RequestId><HostId>txgc941390647804a65b6ed-006aa00525</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg6f95b4bd574644bd8b27-006aa00f99</RequestId><HostId>txg6f95b4bd574644bd8b27-006aa00f99</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:53 GMT
+                - Tue, 08 Sep 2026 13:37:29 GMT
             X-Amz-Id-2:
-                - txgc941390647804a65b6ed-006aa00525
+                - txg6f95b4bd574644bd8b27-006aa00f99
             X-Amz-Request-Id:
-                - txgc941390647804a65b6ed-006aa00525
+                - txg6f95b4bd574644bd8b27-006aa00f99
         status: 404 Not Found
         code: 404
-        duration: 24.816417ms
+        duration: 20.536083ms
     - id: 105
       request:
         proto: HTTP/1.1
@@ -5484,7 +5484,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5493,7 +5493,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - bc4186fe-23e7-4308-b9e4-28f9a2b49f57
+                - 31c77f89-b07d-40d4-9ed0-6accc85b79db
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5501,8 +5501,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125253Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T133729Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5521,14 +5521,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:53 GMT
+                - Tue, 08 Sep 2026 13:37:29 GMT
             X-Amz-Id-2:
-                - txgae7ca74fd7d5409683d8-006aa00525
+                - txgf8bf65f6630442c09076-006aa00f99
             X-Amz-Request-Id:
-                - txgae7ca74fd7d5409683d8-006aa00525
+                - txgf8bf65f6630442c09076-006aa00f99
         status: 200 OK
         code: 200
-        duration: 190.442084ms
+        duration: 166.223959ms
     - id: 106
       request:
         proto: HTTP/1.1
@@ -5537,7 +5537,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5546,7 +5546,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4f2c2e2d-9001-4490-a2b4-e2382ec8f6ed
+                - f6644616-e2fb-4e0e-b06a-e53aed26a679
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5554,8 +5554,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125253Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T133729Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5574,14 +5574,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:53 GMT
+                - Tue, 08 Sep 2026 13:37:29 GMT
             X-Amz-Id-2:
-                - txg6e2bd81333a04aab8adb-006aa00525
+                - txg744c5c324de9478299ca-006aa00f99
             X-Amz-Request-Id:
-                - txg6e2bd81333a04aab8adb-006aa00525
+                - txg744c5c324de9478299ca-006aa00f99
         status: 200 OK
         code: 200
-        duration: 28.221042ms
+        duration: 22.231166ms
     - id: 107
       request:
         proto: HTTP/1.1
@@ -5590,7 +5590,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5599,7 +5599,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 2e517cab-986a-4829-b06d-98cb20cd6256
+                - 83fc1e97-2706-4b37-a808-2ffd53f1f045
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5607,8 +5607,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125253Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T133729Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5627,14 +5627,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:53 GMT
+                - Tue, 08 Sep 2026 13:37:29 GMT
             X-Amz-Id-2:
-                - txg67c96739938b4239bbb5-006aa00525
+                - txg1597ca1dd0514a729bb3-006aa00f99
             X-Amz-Request-Id:
-                - txg67c96739938b4239bbb5-006aa00525
+                - txg1597ca1dd0514a729bb3-006aa00f99
         status: 200 OK
         code: 200
-        duration: 110.459958ms
+        duration: 27.878ms
     - id: 108
       request:
         proto: HTTP/1.1
@@ -5643,7 +5643,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5652,7 +5652,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4afaf953-152c-4987-aa5a-4a57255d5e0c
+                - 9230fc42-97cf-4280-b380-3cfe04d0c329
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5660,8 +5660,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125253Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T133729Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5671,21 +5671,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txge74b869e6cb04fbc9158-006aa00526</RequestId><HostId>txge74b869e6cb04fbc9158-006aa00526</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg388688de8c3d420fbbbb-006aa00f99</RequestId><HostId>txg388688de8c3d420fbbbb-006aa00f99</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:54 GMT
+                - Tue, 08 Sep 2026 13:37:29 GMT
             X-Amz-Id-2:
-                - txge74b869e6cb04fbc9158-006aa00526
+                - txg388688de8c3d420fbbbb-006aa00f99
             X-Amz-Request-Id:
-                - txge74b869e6cb04fbc9158-006aa00526
+                - txg388688de8c3d420fbbbb-006aa00f99
         status: 404 Not Found
         code: 404
-        duration: 23.263208ms
+        duration: 23.664166ms
     - id: 109
       request:
         proto: HTTP/1.1
@@ -5694,7 +5694,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5703,7 +5703,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4d1eaae7-881e-4a30-a4df-a61fea2c4ed6
+                - 185c7e18-3ae9-40b2-9019-bc68272c14a8
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5711,8 +5711,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125254Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
+                - 20260908T133729Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -5724,21 +5724,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:54 GMT
+                - Tue, 08 Sep 2026 13:37:29 GMT
             X-Amz-Id-2:
-                - txga8fc91b43d1a4f178d97-006aa00526
+                - txgdd0fe7bd1f23434cb468-006aa00f99
             X-Amz-Request-Id:
-                - txga8fc91b43d1a4f178d97-006aa00526
+                - txgdd0fe7bd1f23434cb468-006aa00f99
         status: 200 OK
         code: 200
-        duration: 301.63325ms
+        duration: 90.982708ms
     - id: 110
       request:
         proto: HTTP/1.1
@@ -5747,7 +5747,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5756,7 +5756,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6e5a8188-9dee-49dc-8a43-d58c1740b598
+                - c34ca5e6-4227-4cb1-818c-7723fcdb049b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5764,8 +5764,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125254Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T133729Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5775,21 +5775,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txga63acaa9c67846d5a04c-006aa00526</RequestId><HostId>txga63acaa9c67846d5a04c-006aa00526</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg4811e471dbe942bd8165-006aa00f99</RequestId><HostId>txg4811e471dbe942bd8165-006aa00f99</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:54 GMT
+                - Tue, 08 Sep 2026 13:37:29 GMT
             X-Amz-Id-2:
-                - txga63acaa9c67846d5a04c-006aa00526
+                - txg4811e471dbe942bd8165-006aa00f99
             X-Amz-Request-Id:
-                - txga63acaa9c67846d5a04c-006aa00526
+                - txg4811e471dbe942bd8165-006aa00f99
         status: 404 Not Found
         code: 404
-        duration: 198.994333ms
+        duration: 27.60275ms
     - id: 111
       request:
         proto: HTTP/1.1
@@ -5798,7 +5798,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5807,7 +5807,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 703fa2f0-5096-4035-ac46-dc3a253e664e
+                - 4e2abdfa-a52f-4d63-8916-be5d65500814
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5815,8 +5815,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125254Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T133729Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5826,21 +5826,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg6d8694d19a6540a0b742-006aa00526</RequestId><HostId>txg6d8694d19a6540a0b742-006aa00526</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg02912f49c46540f69637-006aa00f99</RequestId><HostId>txg02912f49c46540f69637-006aa00f99</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:54 GMT
+                - Tue, 08 Sep 2026 13:37:29 GMT
             X-Amz-Id-2:
-                - txg6d8694d19a6540a0b742-006aa00526
+                - txg02912f49c46540f69637-006aa00f99
             X-Amz-Request-Id:
-                - txg6d8694d19a6540a0b742-006aa00526
+                - txg02912f49c46540f69637-006aa00f99
         status: 404 Not Found
         code: 404
-        duration: 180.015084ms
+        duration: 191.524041ms
     - id: 112
       request:
         proto: HTTP/1.1
@@ -5849,7 +5849,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5858,7 +5858,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e99ced73-0f92-4ff6-9f4c-10edd1e8794f
+                - 17b55c9e-bbb5-43e9-b07e-b9074bbd11f4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5866,8 +5866,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125254Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T133729Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5886,14 +5886,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:54 GMT
+                - Tue, 08 Sep 2026 13:37:30 GMT
             X-Amz-Id-2:
-                - txg5095981c677546739b9e-006aa00526
+                - txg1db9c3ac33484694bd5e-006aa00f9a
             X-Amz-Request-Id:
-                - txg5095981c677546739b9e-006aa00526
+                - txg1db9c3ac33484694bd5e-006aa00f9a
         status: 200 OK
         code: 200
-        duration: 29.328333ms
+        duration: 96.494584ms
     - id: 113
       request:
         proto: HTTP/1.1
@@ -5902,7 +5902,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5911,7 +5911,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9080c740-daa2-4566-8d72-83f942cd7bce
+                - fabfe7c9-1a91-42d5-882d-b413adcc39cc
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5919,8 +5919,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125254Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T133730Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5939,32 +5939,32 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:54 GMT
+                - Tue, 08 Sep 2026 13:37:30 GMT
             X-Amz-Id-2:
-                - txg3fc2653e10af417396d8-006aa00526
+                - txg7e76f8ef477f455584ba-006aa00f9a
             X-Amz-Request-Id:
-                - txg3fc2653e10af417396d8-006aa00526
+                - txg7e76f8ef477f455584ba-006aa00f9a
         status: 200 OK
         code: 200
-        duration: 21.72775ms
+        duration: 22.841583ms
     - id: 114
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 344
+        content_length: 284
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
-        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path1/</Prefix><Tag><Key>deleted</Key><Value>true</Value></Tag></And></Filter><ID>id1</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
+        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path1/</Prefix><Tag><Key>deleted</Key><Value>true</Value></Tag></And></Filter><ID>id1</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
         form: {}
         headers:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 94529181-9113-4529-8616-df2acf3d4ad2
+                - bef5f4a4-7b7f-4149-9176-0fedb66c41b7
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -5972,12 +5972,12 @@ interactions:
             User-Agent:
                 - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,Z,e
             X-Amz-Checksum-Crc32:
-                - /SEMnQ==
+                - UfU/dQ==
             X-Amz-Content-Sha256:
-                - b0de451c31309fbdd3611c566f2f38ddccf0dd237feb3e8d186422993ecf7a1f
+                - c66696878cc52fbe5f1b5468d871024fe4d94447494e4b1797bc44a183ccc313
             X-Amz-Date:
-                - 20260908T125254Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T133730Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -5992,14 +5992,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 08 Sep 2026 12:52:54 GMT
+                - Tue, 08 Sep 2026 13:37:30 GMT
             X-Amz-Id-2:
-                - txg738a5fb0e8b14db3a040-006aa00526
+                - txg2c3d7e8adea2476d8f92-006aa00f9a
             X-Amz-Request-Id:
-                - txg738a5fb0e8b14db3a040-006aa00526
+                - txg2c3d7e8adea2476d8f92-006aa00f9a
         status: 200 OK
         code: 200
-        duration: 553.225833ms
+        duration: 221.7885ms
     - id: 115
       request:
         proto: HTTP/1.1
@@ -6008,7 +6008,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6017,7 +6017,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 1ee62df0-5689-49d3-bf6b-e2c41e639003
+                - e3e9ab7c-11a1-4e4d-938f-d5cd567ca0c4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6025,8 +6025,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125255Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T133730Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6045,14 +6045,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:55 GMT
+                - Tue, 08 Sep 2026 13:37:30 GMT
             X-Amz-Id-2:
-                - txg6edd47c68771453387e7-006aa00527
+                - txg78dea2a0857149968146-006aa00f9a
             X-Amz-Request-Id:
-                - txg6edd47c68771453387e7-006aa00527
+                - txg78dea2a0857149968146-006aa00f9a
         status: 200 OK
         code: 200
-        duration: 263.009ms
+        duration: 222.049833ms
     - id: 116
       request:
         proto: HTTP/1.1
@@ -6061,7 +6061,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6070,7 +6070,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e80319f4-e52c-4af5-a040-ef9ce25546dc
+                - 1f6c284f-ffd6-4017-88a0-f12240906b70
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6078,8 +6078,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125255Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T133730Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6089,21 +6089,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgb9ce655925254ccc99ca-006aa00527</RequestId><HostId>txgb9ce655925254ccc99ca-006aa00527</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgd5e06ec9e5484d178450-006aa00f9a</RequestId><HostId>txgd5e06ec9e5484d178450-006aa00f9a</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:55 GMT
+                - Tue, 08 Sep 2026 13:37:30 GMT
             X-Amz-Id-2:
-                - txgb9ce655925254ccc99ca-006aa00527
+                - txgd5e06ec9e5484d178450-006aa00f9a
             X-Amz-Request-Id:
-                - txgb9ce655925254ccc99ca-006aa00527
+                - txgd5e06ec9e5484d178450-006aa00f9a
         status: 404 Not Found
         code: 404
-        duration: 27.069334ms
+        duration: 106.637708ms
     - id: 117
       request:
         proto: HTTP/1.1
@@ -6112,7 +6112,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6121,7 +6121,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9c060e80-5ac7-4830-9743-6db6fbe4a938
+                - 3e90a9af-f4fc-4821-b5c1-1601bfb5435e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6129,8 +6129,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125255Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
+                - 20260908T133730Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -6142,21 +6142,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:55 GMT
+                - Tue, 08 Sep 2026 13:37:30 GMT
             X-Amz-Id-2:
-                - txg9916dc5e2d8144d8880f-006aa00527
+                - txg89633eae49bb4d1190d0-006aa00f9a
             X-Amz-Request-Id:
-                - txg9916dc5e2d8144d8880f-006aa00527
+                - txg89633eae49bb4d1190d0-006aa00f9a
         status: 200 OK
         code: 200
-        duration: 66.531916ms
+        duration: 61.989875ms
     - id: 118
       request:
         proto: HTTP/1.1
@@ -6165,7 +6165,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6174,7 +6174,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 13226c2e-7106-4fce-935a-479784d844b7
+                - 1dab215b-e9d4-4c05-a753-6ac45e0c56c6
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6182,8 +6182,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125255Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T133730Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6193,21 +6193,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgd18fc49c3bf947c9a8cf-006aa00527</RequestId><HostId>txgd18fc49c3bf947c9a8cf-006aa00527</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg411023894ef4468e944e-006aa00f9a</RequestId><HostId>txg411023894ef4468e944e-006aa00f9a</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:55 GMT
+                - Tue, 08 Sep 2026 13:37:30 GMT
             X-Amz-Id-2:
-                - txgd18fc49c3bf947c9a8cf-006aa00527
+                - txg411023894ef4468e944e-006aa00f9a
             X-Amz-Request-Id:
-                - txgd18fc49c3bf947c9a8cf-006aa00527
+                - txg411023894ef4468e944e-006aa00f9a
         status: 404 Not Found
         code: 404
-        duration: 21.394917ms
+        duration: 22.223333ms
     - id: 119
       request:
         proto: HTTP/1.1
@@ -6216,7 +6216,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6225,7 +6225,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 988cd5cc-550e-4eff-a76b-8621938ddbc2
+                - 6749901e-d9e0-4d4e-a106-04882ecfb182
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6233,8 +6233,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125255Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T133730Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6244,21 +6244,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg2cb697d3e4fe4ee697da-006aa00527</RequestId><HostId>txg2cb697d3e4fe4ee697da-006aa00527</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg6913b780899948a8a682-006aa00f9a</RequestId><HostId>txg6913b780899948a8a682-006aa00f9a</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:55 GMT
+                - Tue, 08 Sep 2026 13:37:30 GMT
             X-Amz-Id-2:
-                - txg2cb697d3e4fe4ee697da-006aa00527
+                - txg6913b780899948a8a682-006aa00f9a
             X-Amz-Request-Id:
-                - txg2cb697d3e4fe4ee697da-006aa00527
+                - txg6913b780899948a8a682-006aa00f9a
         status: 404 Not Found
         code: 404
-        duration: 421.500959ms
+        duration: 81.847542ms
     - id: 120
       request:
         proto: HTTP/1.1
@@ -6267,7 +6267,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6276,7 +6276,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - bed64b84-8255-4610-9a9c-a76f8b59f374
+                - 331f3648-e758-4502-b267-a45743dc060f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6284,8 +6284,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125255Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T133730Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6304,14 +6304,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:56 GMT
+                - Tue, 08 Sep 2026 13:37:31 GMT
             X-Amz-Id-2:
-                - txg1ff8a7c6fab74d15bbe7-006aa00528
+                - txg4ff52a478bad49519bbf-006aa00f9b
             X-Amz-Request-Id:
-                - txg1ff8a7c6fab74d15bbe7-006aa00528
+                - txg4ff52a478bad49519bbf-006aa00f9b
         status: 200 OK
         code: 200
-        duration: 408.66075ms
+        duration: 20.596709ms
     - id: 121
       request:
         proto: HTTP/1.1
@@ -6320,7 +6320,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6329,16 +6329,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 74073e95-9f2e-46e2-92b8-eb5671a79d4f
+                - 5534201a-0200-4844-93b4-0148204e4516
             Amz-Sdk-Request:
-                - attempt=1; max=3
+                - attempt=1; max=3; ttl=20260908T154730Z
             User-Agent:
                 - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125256Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T133731Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6346,25 +6346,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 317
+        content_length: 257
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path1/</Prefix><Tag><Key>deleted</Key><Value>true</Value></Tag></And></Filter><ID>id1</ID><Status>Enabled</Status></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path1/</Prefix><Tag><Key>deleted</Key><Value>true</Value></Tag></And></Filter><ID>id1</ID><Status>Enabled</Status></Rule></Configuration>
         headers:
             Content-Length:
-                - "317"
+                - "257"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:56 GMT
+                - Tue, 08 Sep 2026 13:37:31 GMT
             X-Amz-Id-2:
-                - txgd548315e07bc48fe8452-006aa00528
+                - txged880ff4237742e59cea-006aa00f9b
             X-Amz-Request-Id:
-                - txgd548315e07bc48fe8452-006aa00528
+                - txged880ff4237742e59cea-006aa00f9b
         status: 200 OK
         code: 200
-        duration: 187.071541ms
+        duration: 96.156834ms
     - id: 122
       request:
         proto: HTTP/1.1
@@ -6373,7 +6373,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6382,7 +6382,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c23b5f20-e96f-4a41-9c6b-c5bc2c6c2f7d
+                - 39620d04-b5d4-4d24-a82d-db355266aabd
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6390,8 +6390,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125256Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
+                - 20260908T133731Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -6406,16 +6406,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:57 GMT
+                - Tue, 08 Sep 2026 13:37:31 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txge2de4dd3fc9f48598d83-006aa00529
+                - txg90b4743414f44d93822b-006aa00f9b
             X-Amz-Request-Id:
-                - txge2de4dd3fc9f48598d83-006aa00529
+                - txg90b4743414f44d93822b-006aa00f9b
         status: 200 OK
         code: 200
-        duration: 253.187791ms
+        duration: 21.868708ms
     - id: 123
       request:
         proto: HTTP/1.1
@@ -6424,7 +6424,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6433,7 +6433,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e1e506d8-e480-4f67-8ac1-7009f8c5a6ea
+                - 56a7f8d4-dbdf-45d4-ad52-d9cb4e6f7d8c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6441,8 +6441,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125257Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T133731Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6450,25 +6450,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 317
+        content_length: 257
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path1/</Prefix><Tag><Key>deleted</Key><Value>true</Value></Tag></And></Filter><ID>id1</ID><Status>Enabled</Status></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path1/</Prefix><Tag><Key>deleted</Key><Value>true</Value></Tag></And></Filter><ID>id1</ID><Status>Enabled</Status></Rule></Configuration>
         headers:
             Content-Length:
-                - "317"
+                - "257"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:57 GMT
+                - Tue, 08 Sep 2026 13:37:31 GMT
             X-Amz-Id-2:
-                - txg3f55a516d1e7438b9084-006aa00529
+                - txg91f67934ad904d799ea1-006aa00f9b
             X-Amz-Request-Id:
-                - txg3f55a516d1e7438b9084-006aa00529
+                - txg91f67934ad904d799ea1-006aa00f9b
         status: 200 OK
         code: 200
-        duration: 76.404208ms
+        duration: 22.754417ms
     - id: 124
       request:
         proto: HTTP/1.1
@@ -6477,7 +6477,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6486,7 +6486,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - feb5a51f-19b8-4c76-8de3-d8dbd3157408
+                - dcebbf04-e108-4eb0-80aa-e4976817166b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6494,8 +6494,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125257Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T133731Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6514,14 +6514,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:57 GMT
+                - Tue, 08 Sep 2026 13:37:31 GMT
             X-Amz-Id-2:
-                - txgde421d8c97e349cd88fd-006aa00529
+                - txg1b8ca92d21bb40948e6e-006aa00f9b
             X-Amz-Request-Id:
-                - txgde421d8c97e349cd88fd-006aa00529
+                - txg1b8ca92d21bb40948e6e-006aa00f9b
         status: 200 OK
         code: 200
-        duration: 1.034540708s
+        duration: 35.6635ms
     - id: 125
       request:
         proto: HTTP/1.1
@@ -6530,7 +6530,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6539,7 +6539,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 55872551-3027-41f4-a5f0-2c79f9c0b325
+                - 33ec7ad4-3579-4de7-b65d-a046d247082c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6547,8 +6547,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125257Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T133731Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6558,21 +6558,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg5efefa6db3e74e4ab616-006aa0052a</RequestId><HostId>txg5efefa6db3e74e4ab616-006aa0052a</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg8a092876735c423dba73-006aa00f9b</RequestId><HostId>txg8a092876735c423dba73-006aa00f9b</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:58 GMT
+                - Tue, 08 Sep 2026 13:37:31 GMT
             X-Amz-Id-2:
-                - txg5efefa6db3e74e4ab616-006aa0052a
+                - txg8a092876735c423dba73-006aa00f9b
             X-Amz-Request-Id:
-                - txg5efefa6db3e74e4ab616-006aa0052a
+                - txg8a092876735c423dba73-006aa00f9b
         status: 404 Not Found
         code: 404
-        duration: 193.489792ms
+        duration: 103.553666ms
     - id: 126
       request:
         proto: HTTP/1.1
@@ -6581,7 +6581,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6590,7 +6590,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 30fe21dd-d147-4519-9d35-b088f7246abb
+                - 7342d16c-40df-45c9-9238-e9455e18ae7d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6598,8 +6598,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125258Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
+                - 20260908T133731Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -6611,21 +6611,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:58 GMT
+                - Tue, 08 Sep 2026 13:37:31 GMT
             X-Amz-Id-2:
-                - txgf1be0894189545c1b9bf-006aa0052a
+                - txg606100b5837f4e37a3b7-006aa00f9b
             X-Amz-Request-Id:
-                - txgf1be0894189545c1b9bf-006aa0052a
+                - txg606100b5837f4e37a3b7-006aa00f9b
         status: 200 OK
         code: 200
-        duration: 188.172375ms
+        duration: 248.898417ms
     - id: 127
       request:
         proto: HTTP/1.1
@@ -6634,7 +6634,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6643,7 +6643,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b5faea87-0d29-4228-9f27-31e15503b11d
+                - e8b0092a-eaf5-4fbc-84b8-9cd3a9aeee6d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6651,8 +6651,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125258Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T133731Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6662,21 +6662,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg02e445ba9f9d4c7fb59e-006aa0052a</RequestId><HostId>txg02e445ba9f9d4c7fb59e-006aa0052a</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgebb92fc0c5364cb19fbc-006aa00f9b</RequestId><HostId>txgebb92fc0c5364cb19fbc-006aa00f9b</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:58 GMT
+                - Tue, 08 Sep 2026 13:37:31 GMT
             X-Amz-Id-2:
-                - txg02e445ba9f9d4c7fb59e-006aa0052a
+                - txgebb92fc0c5364cb19fbc-006aa00f9b
             X-Amz-Request-Id:
-                - txg02e445ba9f9d4c7fb59e-006aa0052a
+                - txgebb92fc0c5364cb19fbc-006aa00f9b
         status: 404 Not Found
         code: 404
-        duration: 22.140542ms
+        duration: 407.32825ms
     - id: 128
       request:
         proto: HTTP/1.1
@@ -6685,7 +6685,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6694,7 +6694,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 1cb3e8b5-a127-4c48-8ec6-58812f3cc6d5
+                - 23ba11fa-ca5b-4350-932c-eb8849d512fc
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6702,8 +6702,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125258Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T133731Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6713,21 +6713,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg24e4bca38429475fa207-006aa0052a</RequestId><HostId>txg24e4bca38429475fa207-006aa0052a</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg6c3f447ac7644cf4a455-006aa00f9c</RequestId><HostId>txg6c3f447ac7644cf4a455-006aa00f9c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:58 GMT
+                - Tue, 08 Sep 2026 13:37:32 GMT
             X-Amz-Id-2:
-                - txg24e4bca38429475fa207-006aa0052a
+                - txg6c3f447ac7644cf4a455-006aa00f9c
             X-Amz-Request-Id:
-                - txg24e4bca38429475fa207-006aa0052a
+                - txg6c3f447ac7644cf4a455-006aa00f9c
         status: 404 Not Found
         code: 404
-        duration: 76.55725ms
+        duration: 68.623958ms
     - id: 129
       request:
         proto: HTTP/1.1
@@ -6736,7 +6736,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6745,7 +6745,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d99b0498-150a-4f2d-a8bc-95712c51266a
+                - 2992c8f0-5f8e-4ac7-8d40-0e6ff6f0a268
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6753,8 +6753,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125258Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T133732Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6773,14 +6773,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:59 GMT
+                - Tue, 08 Sep 2026 13:37:32 GMT
             X-Amz-Id-2:
-                - txgc9f47b381f714c9dab3d-006aa0052b
+                - txgee5f638803df49839f8c-006aa00f9c
             X-Amz-Request-Id:
-                - txgc9f47b381f714c9dab3d-006aa0052b
+                - txgee5f638803df49839f8c-006aa00f9c
         status: 200 OK
         code: 200
-        duration: 419.369542ms
+        duration: 20.945041ms
     - id: 130
       request:
         proto: HTTP/1.1
@@ -6789,7 +6789,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6798,7 +6798,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 50e1bab2-c70b-40fa-b1a8-0cea8d3b856c
+                - f52df25b-069e-4a79-87aa-eda26ac57b86
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6806,8 +6806,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125259Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T133732Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6815,25 +6815,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 317
+        content_length: 257
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path1/</Prefix><Tag><Key>deleted</Key><Value>true</Value></Tag></And></Filter><ID>id1</ID><Status>Enabled</Status></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path1/</Prefix><Tag><Key>deleted</Key><Value>true</Value></Tag></And></Filter><ID>id1</ID><Status>Enabled</Status></Rule></Configuration>
         headers:
             Content-Length:
-                - "317"
+                - "257"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:59 GMT
+                - Tue, 08 Sep 2026 13:37:32 GMT
             X-Amz-Id-2:
-                - txg043f7df63eab4a8b8547-006aa0052b
+                - txg03cb2949fba3469ea518-006aa00f9c
             X-Amz-Request-Id:
-                - txg043f7df63eab4a8b8547-006aa0052b
+                - txg03cb2949fba3469ea518-006aa00f9c
         status: 200 OK
         code: 200
-        duration: 208.7875ms
+        duration: 88.791708ms
     - id: 131
       request:
         proto: HTTP/1.1
@@ -6842,7 +6842,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6851,7 +6851,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - da93a2e7-906c-4e17-8b2f-6c16b4495007
+                - 3b76b00a-3800-4df8-902a-7251d27786fa
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6859,8 +6859,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125259Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?acl=
+                - 20260908T133732Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6879,14 +6879,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:52:59 GMT
+                - Tue, 08 Sep 2026 13:37:32 GMT
             X-Amz-Id-2:
-                - txg1306f20c36b84537be5d-006aa0052b
+                - txg190861a9046646749d4e-006aa00f9c
             X-Amz-Request-Id:
-                - txg1306f20c36b84537be5d-006aa0052b
+                - txg190861a9046646749d4e-006aa00f9c
         status: 200 OK
         code: 200
-        duration: 48.827792ms
+        duration: 35.971958ms
     - id: 132
       request:
         proto: HTTP/1.1
@@ -6895,7 +6895,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6904,7 +6904,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 1e0dcc3d-1e7d-4433-9b48-c0ff3f23825f
+                - affb8200-82e5-4af5-9011-2e0bcb1a2d6c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6912,8 +6912,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125259Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260908T133732Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6923,21 +6923,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg910bb89b6a6649818b11-006aa0052b</RequestId><HostId>txg910bb89b6a6649818b11-006aa0052b</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgdaa223a74e2c4838b74b-006aa00f9c</RequestId><HostId>txgdaa223a74e2c4838b74b-006aa00f9c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:59 GMT
+                - Tue, 08 Sep 2026 13:37:32 GMT
             X-Amz-Id-2:
-                - txg910bb89b6a6649818b11-006aa0052b
+                - txgdaa223a74e2c4838b74b-006aa00f9c
             X-Amz-Request-Id:
-                - txg910bb89b6a6649818b11-006aa0052b
+                - txgdaa223a74e2c4838b74b-006aa00f9c
         status: 404 Not Found
         code: 404
-        duration: 35.231209ms
+        duration: 104.420333ms
     - id: 133
       request:
         proto: HTTP/1.1
@@ -6946,7 +6946,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6955,7 +6955,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a87a4b0a-b447-4ce6-8753-f01c86d49675
+                - fed22c54-2b8e-44a2-9f26-1377d4007ff5
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6963,8 +6963,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125259Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
+                - 20260908T133732Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -6976,21 +6976,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:59 GMT
+                - Tue, 08 Sep 2026 13:37:32 GMT
             X-Amz-Id-2:
-                - txg55a64214abe84f858237-006aa0052b
+                - txgd12d449f30444dda995a-006aa00f9c
             X-Amz-Request-Id:
-                - txg55a64214abe84f858237-006aa0052b
+                - txgd12d449f30444dda995a-006aa00f9c
         status: 200 OK
         code: 200
-        duration: 31.3925ms
+        duration: 22.123625ms
     - id: 134
       request:
         proto: HTTP/1.1
@@ -6999,7 +6999,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7008,7 +7008,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f9f9163b-bb43-428c-910e-7671bad35c4c
+                - 761443a6-1bd3-4822-8c39-d15e9c357443
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7016,8 +7016,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125259Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?tagging=
+                - 20260908T133732Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7027,21 +7027,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg531e1f97dda54c22a016-006aa0052b</RequestId><HostId>txg531e1f97dda54c22a016-006aa0052b</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg6ab39391c0cd4f1abf7d-006aa00f9c</RequestId><HostId>txg6ab39391c0cd4f1abf7d-006aa00f9c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:52:59 GMT
+                - Tue, 08 Sep 2026 13:37:32 GMT
             X-Amz-Id-2:
-                - txg531e1f97dda54c22a016-006aa0052b
+                - txg6ab39391c0cd4f1abf7d-006aa00f9c
             X-Amz-Request-Id:
-                - txg531e1f97dda54c22a016-006aa0052b
+                - txg6ab39391c0cd4f1abf7d-006aa00f9c
         status: 404 Not Found
         code: 404
-        duration: 114.823041ms
+        duration: 23.41225ms
     - id: 135
       request:
         proto: HTTP/1.1
@@ -7050,7 +7050,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7059,7 +7059,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5f7be6e5-2880-482a-a6a4-4b66bd328691
+                - 3329e978-b754-4f2e-96f6-d352e39c2b70
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7067,8 +7067,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125259Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?cors=
+                - 20260908T133732Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7078,21 +7078,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg029ea26f0fc648808c43-006aa0052c</RequestId><HostId>txg029ea26f0fc648808c43-006aa0052c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgc0434c7b05fc42eeb830-006aa00f9c</RequestId><HostId>txgc0434c7b05fc42eeb830-006aa00f9c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:53:00 GMT
+                - Tue, 08 Sep 2026 13:37:32 GMT
             X-Amz-Id-2:
-                - txg029ea26f0fc648808c43-006aa0052c
+                - txgc0434c7b05fc42eeb830-006aa00f9c
             X-Amz-Request-Id:
-                - txg029ea26f0fc648808c43-006aa0052c
+                - txgc0434c7b05fc42eeb830-006aa00f9c
         status: 404 Not Found
         code: 404
-        duration: 21.9235ms
+        duration: 94.342167ms
     - id: 136
       request:
         proto: HTTP/1.1
@@ -7101,7 +7101,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7110,7 +7110,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e73d1ff8-3298-4c77-a1bd-83686fe73325
+                - 5ec60327-b5ce-4e7d-85bc-690f47180b9d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7118,8 +7118,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125300Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?versioning=
+                - 20260908T133732Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7138,14 +7138,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:53:00 GMT
+                - Tue, 08 Sep 2026 13:37:32 GMT
             X-Amz-Id-2:
-                - txgc6de3ebd78644b1180c1-006aa0052c
+                - txg89fb4f80ad2543d0a18c-006aa00f9c
             X-Amz-Request-Id:
-                - txgc6de3ebd78644b1180c1-006aa0052c
+                - txg89fb4f80ad2543d0a18c-006aa00f9c
         status: 200 OK
         code: 200
-        duration: 142.206292ms
+        duration: 60.159125ms
     - id: 137
       request:
         proto: HTTP/1.1
@@ -7154,7 +7154,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7163,7 +7163,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 8faf2242-9825-435e-8440-b0e9547dd334
+                - 6ad4fca3-5a91-4585-8daf-0d6616221a4e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7171,8 +7171,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125300Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260908T133732Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7180,25 +7180,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 317
+        content_length: 257
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path1/</Prefix><Tag><Key>deleted</Key><Value>true</Value></Tag></And></Filter><ID>id1</ID><Status>Enabled</Status></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path1/</Prefix><Tag><Key>deleted</Key><Value>true</Value></Tag></And></Filter><ID>id1</ID><Status>Enabled</Status></Rule></Configuration>
         headers:
             Content-Length:
-                - "317"
+                - "257"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 08 Sep 2026 12:53:00 GMT
+                - Tue, 08 Sep 2026 13:37:32 GMT
             X-Amz-Id-2:
-                - txg191c3fd6bd0141ca914e-006aa0052c
+                - txg7012599540b34719b819-006aa00f9c
             X-Amz-Request-Id:
-                - txg191c3fd6bd0141ca914e-006aa0052c
+                - txg7012599540b34719b819-006aa00f9c
         status: 200 OK
         code: 200
-        duration: 299.251125ms
+        duration: 22.020209ms
     - id: 138
       request:
         proto: HTTP/1.1
@@ -7207,7 +7207,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7216,7 +7216,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 31ad8669-b1bb-43fd-9897-74575ef12e3d
+                - 31876a79-7519-447d-8f5c-0ed13d16691c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7224,8 +7224,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125300Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
+                - 20260908T133733Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -7233,19 +7233,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 285
         uncompressed: false
-        body: ""
+        body: <Error><Code>NoSuchBucket</Code><Message>The specified bucket does not exist</Message><RequestId>txgb64af6da527044ff8fe0-006aa00f9d</RequestId><HostId>txgb64af6da527044ff8fe0-006aa00f9d</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
         headers:
+            Content-Length:
+                - "285"
+            Content-Type:
+                - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:53:00 GMT
+                - Tue, 08 Sep 2026 13:37:33 GMT
             X-Amz-Id-2:
-                - txg5204da01c545442c8386-006aa0052c
+                - txgb64af6da527044ff8fe0-006aa00f9d
             X-Amz-Request-Id:
-                - txg5204da01c545442c8386-006aa0052c
-        status: 204 No Content
-        code: 204
-        duration: 587.406ms
+                - txgb64af6da527044ff8fe0-006aa00f9d
+        status: 404 Not Found
+        code: 404
+        duration: 1.5535265s
     - id: 139
       request:
         proto: HTTP/1.1
@@ -7254,7 +7258,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7263,166 +7267,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 499633aa-ce84-498e-83eb-f95a21ee658a
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Bucket-Object-Lock-Enabled:
-                - "true"
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260908T125301Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
-        method: PUT
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
-        headers:
-            Content-Length:
-                - "0"
-            Date:
-                - Tue, 08 Sep 2026 12:53:01 GMT
-            Location:
-                - /tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110
-            X-Amz-Id-2:
-                - txgcb0816860ce9463291f5-006aa0052d
-            X-Amz-Request-Id:
-                - txgcb0816860ce9463291f5-006aa0052d
-        status: 200 OK
-        code: 200
-        duration: 2.343049s
-    - id: 140
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 76842c5b-b721-4694-86fe-68fcfe3bc5e2
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,Z,e
-            X-Amz-Acl:
-                - private
-            X-Amz-Checksum-Crc32:
-                - AAAAAA==
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260908T125303Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?acl=
-        method: PUT
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
-        headers:
-            Content-Length:
-                - "0"
-            Date:
-                - Tue, 08 Sep 2026 12:53:03 GMT
-            X-Amz-Id-2:
-                - txg74eebfeafd36431c91bd-006aa0052f
-            X-Amz-Request-Id:
-                - txg74eebfeafd36431c91bd-006aa0052f
-        status: 200 OK
-        code: 200
-        duration: 22.275625ms
-    - id: 141
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 532
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>2</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260908125303648800000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260908125303648800000002</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 544b86fe-9e38-40d8-8fb8-939e7759c6bd
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            Content-Type:
-                - application/xml
-            User-Agent:
-                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,Z,e
-            X-Amz-Checksum-Crc32:
-                - U+q7Fw==
-            X-Amz-Content-Sha256:
-                - a7e253fedff3fb7512746b1cd99ea2a285fde55df8c019da66f2c17cb9d7ac8c
-            X-Amz-Date:
-                - 20260908T125303Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
-        method: PUT
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
-        headers:
-            Content-Length:
-                - "0"
-            Date:
-                - Tue, 08 Sep 2026 12:53:03 GMT
-            X-Amz-Id-2:
-                - txg83a595e1d0c64295a877-006aa0052f
-            X-Amz-Request-Id:
-                - txg83a595e1d0c64295a877-006aa0052f
-        status: 200 OK
-        code: 200
-        duration: 25.155375ms
-    - id: 142
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 80819ad1-7294-4f3a-9322-0c30a91c11fb
+                - 36059fc7-2378-46fb-a937-10cff0cc54cf
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7430,1580 +7275,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260908T125303Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?acl=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 698
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
-        headers:
-            Content-Length:
-                - "698"
-            Content-Type:
-                - text/xml; charset=utf-8
-            Date:
-                - Tue, 08 Sep 2026 12:53:03 GMT
-            X-Amz-Id-2:
-                - txg980c536d5bec414680f2-006aa0052f
-            X-Amz-Request-Id:
-                - txg980c536d5bec414680f2-006aa0052f
-        status: 200 OK
-        code: 200
-        duration: 173.107166ms
-    - id: 143
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 88d9b94b-18c7-4642-8142-830af347ee41
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260908T125303Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?object-lock=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 184
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <ObjectLockConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><ObjectLockEnabled>Enabled</ObjectLockEnabled></ObjectLockConfiguration>
-        headers:
-            Content-Length:
-                - "184"
-            Content-Type:
-                - text/xml; charset=utf-8
-            Date:
-                - Tue, 08 Sep 2026 12:53:03 GMT
-            X-Amz-Id-2:
-                - txgedc3ac882c8547d58ac1-006aa0052f
-            X-Amz-Request-Id:
-                - txgedc3ac882c8547d58ac1-006aa0052f
-        status: 200 OK
-        code: 200
-        duration: 205.760917ms
-    - id: 144
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 899507c2-459d-45bf-966c-a2cf9cb1f83e
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260908T125303Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 287
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
-        headers:
-            Content-Length:
-                - "287"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 08 Sep 2026 12:53:04 GMT
-            X-Amz-Id-2:
-                - txgffe935dca8e94586a0ef-006aa00530
-            X-Amz-Request-Id:
-                - txgffe935dca8e94586a0ef-006aa00530
-        status: 200 OK
-        code: 200
-        duration: 21.6895ms
-    - id: 145
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 934e25ec-cd5f-4147-9ea7-2715dabf956a
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260908T125304Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?tagging=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 361
-        uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgc1303615f26544d8960b-006aa00530</RequestId><HostId>txgc1303615f26544d8960b-006aa00530</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</BucketName></Error>
-        headers:
-            Content-Length:
-                - "361"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 08 Sep 2026 12:53:04 GMT
-            X-Amz-Id-2:
-                - txgc1303615f26544d8960b-006aa00530
-            X-Amz-Request-Id:
-                - txgc1303615f26544d8960b-006aa00530
-        status: 404 Not Found
-        code: 404
-        duration: 21.438667ms
-    - id: 146
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 0a7e6077-38a4-4c43-9316-e6d5740f90af
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260908T125304Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?cors=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 298
-        uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg1eedaf156d2249989e76-006aa00530</RequestId><HostId>txg1eedaf156d2249989e76-006aa00530</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
-        headers:
-            Content-Length:
-                - "298"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 08 Sep 2026 12:53:04 GMT
-            X-Amz-Id-2:
-                - txg1eedaf156d2249989e76-006aa00530
-            X-Amz-Request-Id:
-                - txg1eedaf156d2249989e76-006aa00530
-        status: 404 Not Found
-        code: 404
-        duration: 204.574833ms
-    - id: 147
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - f5cee3d6-6568-4f1c-99e8-b4c8bfc45066
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260908T125304Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?versioning=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 114
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <VersioningConfiguration><Status>Enabled</Status></VersioningConfiguration>
-        headers:
-            Content-Length:
-                - "114"
-            Content-Type:
-                - text/xml; charset=utf-8
-            Date:
-                - Tue, 08 Sep 2026 12:53:04 GMT
-            X-Amz-Id-2:
-                - txge82d9c70ab5b41e889bc-006aa00530
-            X-Amz-Request-Id:
-                - txge82d9c70ab5b41e889bc-006aa00530
-        status: 200 OK
-        code: 200
-        duration: 53.922916ms
-    - id: 148
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 46fe32e8-8a92-4831-a5f2-737b894eab6d
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260908T125304Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 505
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>2</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260908125303648800000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260908125303648800000002</ID><Status>Enabled</Status></Rule></Configuration>
-        headers:
-            Content-Length:
-                - "505"
-            Content-Type:
-                - text/xml; charset=utf-8
-            Date:
-                - Tue, 08 Sep 2026 12:53:04 GMT
-            X-Amz-Id-2:
-                - txg00e3e50f6d9c4b428ed7-006aa00530
-            X-Amz-Request-Id:
-                - txg00e3e50f6d9c4b428ed7-006aa00530
-        status: 200 OK
-        code: 200
-        duration: 26.165959ms
-    - id: 149
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - f1ade7fe-6d88-40c6-9a83-e067476c2822
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260908T125304Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
-        method: HEAD
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: false
-        body: ""
-        headers:
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 08 Sep 2026 12:53:04 GMT
-            X-Amz-Bucket-Region:
-                - nl-ams
-            X-Amz-Id-2:
-                - txgce294f4959bb4be0b32c-006aa00530
-            X-Amz-Request-Id:
-                - txgce294f4959bb4be0b32c-006aa00530
-        status: 200 OK
-        code: 200
-        duration: 20.652708ms
-    - id: 150
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 2f3fba24-363b-45cb-baf7-0b0aa439a52a
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260908T125304Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 505
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>2</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260908125303648800000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260908125303648800000002</ID><Status>Enabled</Status></Rule></Configuration>
-        headers:
-            Content-Length:
-                - "505"
-            Content-Type:
-                - text/xml; charset=utf-8
-            Date:
-                - Tue, 08 Sep 2026 12:53:04 GMT
-            X-Amz-Id-2:
-                - txg8a65f5112774445683b7-006aa00530
-            X-Amz-Request-Id:
-                - txg8a65f5112774445683b7-006aa00530
-        status: 200 OK
-        code: 200
-        duration: 201.404333ms
-    - id: 151
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - dd627bfa-fbc6-425a-989b-722e561324c4
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260908T125304Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?acl=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 698
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
-        headers:
-            Content-Length:
-                - "698"
-            Content-Type:
-                - text/xml; charset=utf-8
-            Date:
-                - Tue, 08 Sep 2026 12:53:04 GMT
-            X-Amz-Id-2:
-                - txgc5cbfc1dea1d42fd9968-006aa00530
-            X-Amz-Request-Id:
-                - txgc5cbfc1dea1d42fd9968-006aa00530
-        status: 200 OK
-        code: 200
-        duration: 59.55075ms
-    - id: 152
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 6851cdec-5e7c-428c-8eef-434c16cc26bd
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260908T125304Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?object-lock=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 184
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <ObjectLockConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><ObjectLockEnabled>Enabled</ObjectLockEnabled></ObjectLockConfiguration>
-        headers:
-            Content-Length:
-                - "184"
-            Content-Type:
-                - text/xml; charset=utf-8
-            Date:
-                - Tue, 08 Sep 2026 12:53:04 GMT
-            X-Amz-Id-2:
-                - txg5bbab8f541e641508ef4-006aa00530
-            X-Amz-Request-Id:
-                - txg5bbab8f541e641508ef4-006aa00530
-        status: 200 OK
-        code: 200
-        duration: 28.312333ms
-    - id: 153
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 7b592df2-e29b-42b1-aed4-40800a11c97b
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260908T125304Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 287
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
-        headers:
-            Content-Length:
-                - "287"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 08 Sep 2026 12:53:05 GMT
-            X-Amz-Id-2:
-                - txg1ef137f412de43f7af22-006aa00531
-            X-Amz-Request-Id:
-                - txg1ef137f412de43f7af22-006aa00531
-        status: 200 OK
-        code: 200
-        duration: 190.279292ms
-    - id: 154
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - bafa1ba6-dd86-48f0-808f-f64ce603464b
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260908T125305Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?tagging=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 361
-        uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgb17f52831e8e4745a64b-006aa00531</RequestId><HostId>txgb17f52831e8e4745a64b-006aa00531</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</BucketName></Error>
-        headers:
-            Content-Length:
-                - "361"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 08 Sep 2026 12:53:05 GMT
-            X-Amz-Id-2:
-                - txgb17f52831e8e4745a64b-006aa00531
-            X-Amz-Request-Id:
-                - txgb17f52831e8e4745a64b-006aa00531
-        status: 404 Not Found
-        code: 404
-        duration: 26.868709ms
-    - id: 155
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 22328f86-26a9-4012-a950-b3905ea53be0
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260908T125305Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?cors=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 298
-        uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg84411d95c237429d871b-006aa00531</RequestId><HostId>txg84411d95c237429d871b-006aa00531</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
-        headers:
-            Content-Length:
-                - "298"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 08 Sep 2026 12:53:05 GMT
-            X-Amz-Id-2:
-                - txg84411d95c237429d871b-006aa00531
-            X-Amz-Request-Id:
-                - txg84411d95c237429d871b-006aa00531
-        status: 404 Not Found
-        code: 404
-        duration: 82.432458ms
-    - id: 156
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 79d6c0d8-6dc0-48bb-9c45-6bd926494458
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260908T125305Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?versioning=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 114
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <VersioningConfiguration><Status>Enabled</Status></VersioningConfiguration>
-        headers:
-            Content-Length:
-                - "114"
-            Content-Type:
-                - text/xml; charset=utf-8
-            Date:
-                - Tue, 08 Sep 2026 12:53:05 GMT
-            X-Amz-Id-2:
-                - txg86d148ef61294cc5852c-006aa00531
-            X-Amz-Request-Id:
-                - txg86d148ef61294cc5852c-006aa00531
-        status: 200 OK
-        code: 200
-        duration: 220.649125ms
-    - id: 157
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 2c630ef9-19f9-4cd2-b694-484e36a35bc0
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260908T125305Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 505
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>2</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260908125303648800000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260908125303648800000002</ID><Status>Enabled</Status></Rule></Configuration>
-        headers:
-            Content-Length:
-                - "505"
-            Content-Type:
-                - text/xml; charset=utf-8
-            Date:
-                - Tue, 08 Sep 2026 12:53:05 GMT
-            X-Amz-Id-2:
-                - txg85b7c99b9c9448a18d7c-006aa00531
-            X-Amz-Request-Id:
-                - txg85b7c99b9c9448a18d7c-006aa00531
-        status: 200 OK
-        code: 200
-        duration: 271.759292ms
-    - id: 158
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - b7a6b071-fc56-4c69-a8c4-eae8de31d2a9
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260908T125305Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?acl=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 698
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
-        headers:
-            Content-Length:
-                - "698"
-            Content-Type:
-                - text/xml; charset=utf-8
-            Date:
-                - Tue, 08 Sep 2026 12:53:05 GMT
-            X-Amz-Id-2:
-                - txga77b3e31dc884a88b580-006aa00531
-            X-Amz-Request-Id:
-                - txga77b3e31dc884a88b580-006aa00531
-        status: 200 OK
-        code: 200
-        duration: 62.976166ms
-    - id: 159
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 38993d2b-9ee6-4874-baff-2d9dd464d92d
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260908T125305Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?object-lock=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 184
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <ObjectLockConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><ObjectLockEnabled>Enabled</ObjectLockEnabled></ObjectLockConfiguration>
-        headers:
-            Content-Length:
-                - "184"
-            Content-Type:
-                - text/xml; charset=utf-8
-            Date:
-                - Tue, 08 Sep 2026 12:53:06 GMT
-            X-Amz-Id-2:
-                - txg178342127e924ec0a143-006aa00532
-            X-Amz-Request-Id:
-                - txg178342127e924ec0a143-006aa00532
-        status: 200 OK
-        code: 200
-        duration: 24.061208ms
-    - id: 160
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 62897ec1-e93b-4348-b3f2-c4f086010b2f
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260908T125306Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 287
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
-        headers:
-            Content-Length:
-                - "287"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 08 Sep 2026 12:53:06 GMT
-            X-Amz-Id-2:
-                - txg0d75dc23a4424c87a517-006aa00532
-            X-Amz-Request-Id:
-                - txg0d75dc23a4424c87a517-006aa00532
-        status: 200 OK
-        code: 200
-        duration: 68.191667ms
-    - id: 161
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 63e31cdc-422b-46d6-b714-3ca995dafc96
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260908T125306Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?tagging=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 361
-        uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgb094286f65d14660b407-006aa00532</RequestId><HostId>txgb094286f65d14660b407-006aa00532</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</BucketName></Error>
-        headers:
-            Content-Length:
-                - "361"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 08 Sep 2026 12:53:06 GMT
-            X-Amz-Id-2:
-                - txgb094286f65d14660b407-006aa00532
-            X-Amz-Request-Id:
-                - txgb094286f65d14660b407-006aa00532
-        status: 404 Not Found
-        code: 404
-        duration: 22.462ms
-    - id: 162
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 5f770be7-039f-48bc-866b-fdf6d6441c0e
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260908T125306Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?cors=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 298
-        uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgd6be2acb3af1489fb4c1-006aa00532</RequestId><HostId>txgd6be2acb3af1489fb4c1-006aa00532</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
-        headers:
-            Content-Length:
-                - "298"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 08 Sep 2026 12:53:06 GMT
-            X-Amz-Id-2:
-                - txgd6be2acb3af1489fb4c1-006aa00532
-            X-Amz-Request-Id:
-                - txgd6be2acb3af1489fb4c1-006aa00532
-        status: 404 Not Found
-        code: 404
-        duration: 96.902208ms
-    - id: 163
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 6ef2f81e-f43f-4956-82d9-4b37e0bdf0a1
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260908T125306Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?versioning=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 114
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <VersioningConfiguration><Status>Enabled</Status></VersioningConfiguration>
-        headers:
-            Content-Length:
-                - "114"
-            Content-Type:
-                - text/xml; charset=utf-8
-            Date:
-                - Tue, 08 Sep 2026 12:53:06 GMT
-            X-Amz-Id-2:
-                - txg790d317c63864662a6fe-006aa00532
-            X-Amz-Request-Id:
-                - txg790d317c63864662a6fe-006aa00532
-        status: 200 OK
-        code: 200
-        duration: 85.6105ms
-    - id: 164
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 5f4f02da-f713-45f1-a720-81d4735abf5c
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260908T125306Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 505
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>2</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260908125303648800000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260908125303648800000002</ID><Status>Enabled</Status></Rule></Configuration>
-        headers:
-            Content-Length:
-                - "505"
-            Content-Type:
-                - text/xml; charset=utf-8
-            Date:
-                - Tue, 08 Sep 2026 12:53:06 GMT
-            X-Amz-Id-2:
-                - txgc274f50612fc4d6cb50e-006aa00532
-            X-Amz-Request-Id:
-                - txgc274f50612fc4d6cb50e-006aa00532
-        status: 200 OK
-        code: 200
-        duration: 26.147ms
-    - id: 165
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 3325f09c-6a06-4451-9738-35b7fa2cbad3
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260908T125306Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?acl=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 698
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
-        headers:
-            Content-Length:
-                - "698"
-            Content-Type:
-                - text/xml; charset=utf-8
-            Date:
-                - Tue, 08 Sep 2026 12:53:06 GMT
-            X-Amz-Id-2:
-                - txg3cb6ab3cbe7247b69346-006aa00532
-            X-Amz-Request-Id:
-                - txg3cb6ab3cbe7247b69346-006aa00532
-        status: 200 OK
-        code: 200
-        duration: 201.592792ms
-    - id: 166
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - db23f006-269c-4ee0-95e6-9232a13a66d0
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260908T125306Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?object-lock=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 184
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <ObjectLockConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><ObjectLockEnabled>Enabled</ObjectLockEnabled></ObjectLockConfiguration>
-        headers:
-            Content-Length:
-                - "184"
-            Content-Type:
-                - text/xml; charset=utf-8
-            Date:
-                - Tue, 08 Sep 2026 12:53:06 GMT
-            X-Amz-Id-2:
-                - txg56d1125eb1ce4dab80d9-006aa00532
-            X-Amz-Request-Id:
-                - txg56d1125eb1ce4dab80d9-006aa00532
-        status: 200 OK
-        code: 200
-        duration: 23.087542ms
-    - id: 167
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - ee597572-0cc4-4ba2-863a-fdb30de30cdc
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260908T125306Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 287
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
-        headers:
-            Content-Length:
-                - "287"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 08 Sep 2026 12:53:06 GMT
-            X-Amz-Id-2:
-                - txgc0bc3c79841443f79698-006aa00532
-            X-Amz-Request-Id:
-                - txgc0bc3c79841443f79698-006aa00532
-        status: 200 OK
-        code: 200
-        duration: 180.743292ms
-    - id: 168
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - a40034f6-5409-4d3e-bfb3-8f6681a44a6b
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260908T125306Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?tagging=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 361
-        uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg143669351705497d90c9-006aa00532</RequestId><HostId>txg143669351705497d90c9-006aa00532</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</BucketName></Error>
-        headers:
-            Content-Length:
-                - "361"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 08 Sep 2026 12:53:06 GMT
-            X-Amz-Id-2:
-                - txg143669351705497d90c9-006aa00532
-            X-Amz-Request-Id:
-                - txg143669351705497d90c9-006aa00532
-        status: 404 Not Found
-        code: 404
-        duration: 319.86525ms
-    - id: 169
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - bfc12923-3ff2-49e4-89c1-a772a48b134e
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260908T125306Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?cors=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 298
-        uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgb051cfc761564547b673-006aa00533</RequestId><HostId>txgb051cfc761564547b673-006aa00533</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
-        headers:
-            Content-Length:
-                - "298"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 08 Sep 2026 12:53:07 GMT
-            X-Amz-Id-2:
-                - txgb051cfc761564547b673-006aa00533
-            X-Amz-Request-Id:
-                - txgb051cfc761564547b673-006aa00533
-        status: 404 Not Found
-        code: 404
-        duration: 21.433708ms
-    - id: 170
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 6f09532b-ee89-41e6-bc8a-f86b8b8dbbdd
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260908T125307Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?versioning=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 114
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <VersioningConfiguration><Status>Enabled</Status></VersioningConfiguration>
-        headers:
-            Content-Length:
-                - "114"
-            Content-Type:
-                - text/xml; charset=utf-8
-            Date:
-                - Tue, 08 Sep 2026 12:53:07 GMT
-            X-Amz-Id-2:
-                - txg3538c14c380a49bfa732-006aa00533
-            X-Amz-Request-Id:
-                - txg3538c14c380a49bfa732-006aa00533
-        status: 200 OK
-        code: 200
-        duration: 61.897416ms
-    - id: 171
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - a8067b87-adcc-4507-9f10-c3c389847639
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260908T125307Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 505
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>2</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260908125303648800000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260908125303648800000002</ID><Status>Enabled</Status></Rule></Configuration>
-        headers:
-            Content-Length:
-                - "505"
-            Content-Type:
-                - text/xml; charset=utf-8
-            Date:
-                - Tue, 08 Sep 2026 12:53:07 GMT
-            X-Amz-Id-2:
-                - txg97c98fe0590f4a1dacb6-006aa00533
-            X-Amz-Request-Id:
-                - txg97c98fe0590f4a1dacb6-006aa00533
-        status: 200 OK
-        code: 200
-        duration: 25.593292ms
-    - id: 172
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 34f62489-8029-4985-b237-13dd958c5443
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260908T125307Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
+                - 20260908T133734Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797.s3.nl-ams.scw.cloud/
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -9011,1001 +7284,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 285
         uncompressed: false
-        body: ""
-        headers:
-            Date:
-                - Tue, 08 Sep 2026 12:53:07 GMT
-            X-Amz-Id-2:
-                - txga5081276ab9e4c91a76f-006aa00533
-            X-Amz-Request-Id:
-                - txga5081276ab9e4c91a76f-006aa00533
-        status: 204 No Content
-        code: 204
-        duration: 452.752791ms
-    - id: 173
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - ec11f832-0c22-4698-9aa0-a9b4c92b72ef
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260908T125307Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
-        method: PUT
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
+        body: <Error><Code>NoSuchBucket</Code><Message>The specified bucket does not exist</Message><RequestId>txgfb259af95caa4dc4aea2-006aa00f9e</RequestId><HostId>txgfb259af95caa4dc4aea2-006aa00f9e</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5295122287497735797</Resource></Error>
         headers:
             Content-Length:
-                - "0"
-            Date:
-                - Tue, 08 Sep 2026 12:53:07 GMT
-            Location:
-                - /tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110
-            X-Amz-Id-2:
-                - txg3b848eeae15e4c73abb8-006aa00533
-            X-Amz-Request-Id:
-                - txg3b848eeae15e4c73abb8-006aa00533
-        status: 200 OK
-        code: 200
-        duration: 4.403801334s
-    - id: 174
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - efcc1168-1430-46ff-a55c-155f23a05cbc
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,Z,e
-            X-Amz-Acl:
-                - private
-            X-Amz-Checksum-Crc32:
-                - AAAAAA==
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260908T125312Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?acl=
-        method: PUT
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
-        headers:
-            Content-Length:
-                - "0"
-            Date:
-                - Tue, 08 Sep 2026 12:53:12 GMT
-            X-Amz-Id-2:
-                - txgbc7fce4428494c4da8e5-006aa00538
-            X-Amz-Request-Id:
-                - txgbc7fce4428494c4da8e5-006aa00538
-        status: 200 OK
-        code: 200
-        duration: 2.131452375s
-    - id: 175
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 1829
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>30</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition><Transition><Days>210</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>95</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Filter><Prefix>path3/</Prefix></Filter><ID>id3</ID><Status>Enabled</Status><Transition><Days>130</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path4/</Prefix><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>155</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id6</ID><Status>Enabled</Status><Transition><Days>156</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></LifecycleConfiguration>
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 5344a251-7d61-4b32-bbc0-f046438bbde7
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            Content-Type:
-                - application/xml
-            User-Agent:
-                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,Z,e
-            X-Amz-Checksum-Crc32:
-                - K95RHg==
-            X-Amz-Content-Sha256:
-                - e8ad0a665d4b49c819e7ca5b44b920cf11ff47b2647c6df77d468c637b6b1394
-            X-Amz-Date:
-                - 20260908T125313Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
-        method: PUT
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
-        headers:
-            Content-Length:
-                - "0"
-            Date:
-                - Tue, 08 Sep 2026 12:53:14 GMT
-            X-Amz-Id-2:
-                - txgccb93a032ba74bf9a23d-006aa0053a
-            X-Amz-Request-Id:
-                - txgccb93a032ba74bf9a23d-006aa0053a
-        status: 200 OK
-        code: 200
-        duration: 2.040218083s
-    - id: 176
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 658cf47a-6b0d-40f9-a00b-3890efd694a3
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260908T125316Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?acl=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 698
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
-        headers:
-            Content-Length:
-                - "698"
-            Content-Type:
-                - text/xml; charset=utf-8
-            Date:
-                - Tue, 08 Sep 2026 12:53:16 GMT
-            X-Amz-Id-2:
-                - txg7ba04de970af43be8b45-006aa0053c
-            X-Amz-Request-Id:
-                - txg7ba04de970af43be8b45-006aa0053c
-        status: 200 OK
-        code: 200
-        duration: 514.220625ms
-    - id: 177
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - c43daed3-bf29-496a-9a86-977958922d8e
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260908T125316Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?object-lock=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 330
-        uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgb55fd921e20b49df87a7-006aa0053c</RequestId><HostId>txgb55fd921e20b49df87a7-006aa0053c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
-        headers:
-            Content-Length:
-                - "330"
+                - "285"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 08 Sep 2026 12:53:16 GMT
+                - Tue, 08 Sep 2026 13:37:34 GMT
             X-Amz-Id-2:
-                - txgb55fd921e20b49df87a7-006aa0053c
+                - txgfb259af95caa4dc4aea2-006aa00f9e
             X-Amz-Request-Id:
-                - txgb55fd921e20b49df87a7-006aa0053c
+                - txgfb259af95caa4dc4aea2-006aa00f9e
         status: 404 Not Found
         code: 404
-        duration: 1.198346167s
-    - id: 178
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 0f5f50ad-46db-4b78-8018-fbc4eaeb5cdc
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260908T125316Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 287
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
-        headers:
-            Content-Length:
-                - "287"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 08 Sep 2026 12:53:18 GMT
-            X-Amz-Id-2:
-                - txg12f84c8ca9aa434fa672-006aa0053e
-            X-Amz-Request-Id:
-                - txg12f84c8ca9aa434fa672-006aa0053e
-        status: 200 OK
-        code: 200
-        duration: 1.052834792s
-    - id: 179
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 5ab0c999-d142-4b52-bb50-406cfb99e42d
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260908T125318Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?tagging=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 361
-        uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg6b586855de3e4053967f-006aa0053f</RequestId><HostId>txg6b586855de3e4053967f-006aa0053f</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</BucketName></Error>
-        headers:
-            Content-Length:
-                - "361"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 08 Sep 2026 12:53:19 GMT
-            X-Amz-Id-2:
-                - txg6b586855de3e4053967f-006aa0053f
-            X-Amz-Request-Id:
-                - txg6b586855de3e4053967f-006aa0053f
-        status: 404 Not Found
-        code: 404
-        duration: 434.226542ms
-    - id: 180
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - a6986d1f-9f98-45b9-81d9-558086e62f5d
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260908T125319Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?cors=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 298
-        uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg17b1329aa6304602bb89-006aa0053f</RequestId><HostId>txg17b1329aa6304602bb89-006aa0053f</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
-        headers:
-            Content-Length:
-                - "298"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 08 Sep 2026 12:53:19 GMT
-            X-Amz-Id-2:
-                - txg17b1329aa6304602bb89-006aa0053f
-            X-Amz-Request-Id:
-                - txg17b1329aa6304602bb89-006aa0053f
-        status: 404 Not Found
-        code: 404
-        duration: 564.442375ms
-    - id: 181
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 747b9976-5c76-4f20-a8f5-c662f774c1f1
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260908T125319Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?versioning=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 107
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <VersioningConfiguration><Status></Status></VersioningConfiguration>
-        headers:
-            Content-Length:
-                - "107"
-            Content-Type:
-                - text/xml; charset=utf-8
-            Date:
-                - Tue, 08 Sep 2026 12:53:20 GMT
-            X-Amz-Id-2:
-                - txgf55e56afec654450b70f-006aa00540
-            X-Amz-Request-Id:
-                - txgf55e56afec654450b70f-006aa00540
-        status: 200 OK
-        code: 200
-        duration: 1.059197083s
-    - id: 182
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 8e951efd-f7da-469c-8911-2a9c2858113a
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260908T125320Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 1802
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>30</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition><Transition><Days>210</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>95</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Filter><Prefix>path3/</Prefix></Filter><ID>id3</ID><Status>Enabled</Status><Transition><Days>130</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path4/</Prefix><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>155</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id6</ID><Status>Enabled</Status><Transition><Days>156</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
-        headers:
-            Content-Length:
-                - "1802"
-            Content-Type:
-                - text/xml; charset=utf-8
-            Date:
-                - Tue, 08 Sep 2026 12:53:21 GMT
-            X-Amz-Id-2:
-                - txg53e69adc00654510ae79-006aa00541
-            X-Amz-Request-Id:
-                - txg53e69adc00654510ae79-006aa00541
-        status: 200 OK
-        code: 200
-        duration: 1.080747958s
-    - id: 183
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 6971fd34-dd8f-4de4-83e2-48e9803e0b61
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260908T125322Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
-        method: HEAD
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: false
-        body: ""
-        headers:
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 08 Sep 2026 12:53:22 GMT
-            X-Amz-Bucket-Region:
-                - nl-ams
-            X-Amz-Id-2:
-                - txg4de0bcc970574d2c96e5-006aa00542
-            X-Amz-Request-Id:
-                - txg4de0bcc970574d2c96e5-006aa00542
-        status: 200 OK
-        code: 200
-        duration: 1.20437775s
-    - id: 184
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 0e698502-29d6-4bdc-b6c6-99dfbb91aa67
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260908T125323Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?acl=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 698
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
-        headers:
-            Content-Length:
-                - "698"
-            Content-Type:
-                - text/xml; charset=utf-8
-            Date:
-                - Tue, 08 Sep 2026 12:53:23 GMT
-            X-Amz-Id-2:
-                - txg0a26e6bebe3641d8af94-006aa00543
-            X-Amz-Request-Id:
-                - txg0a26e6bebe3641d8af94-006aa00543
-        status: 200 OK
-        code: 200
-        duration: 134.985625ms
-    - id: 185
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - b6019a85-7759-463a-a541-05e60df90d50
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260908T125323Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?object-lock=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 330
-        uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg817455b9ba924c949796-006aa00544</RequestId><HostId>txg817455b9ba924c949796-006aa00544</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
-        headers:
-            Content-Length:
-                - "330"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 08 Sep 2026 12:53:24 GMT
-            X-Amz-Id-2:
-                - txg817455b9ba924c949796-006aa00544
-            X-Amz-Request-Id:
-                - txg817455b9ba924c949796-006aa00544
-        status: 404 Not Found
-        code: 404
-        duration: 1.033425416s
-    - id: 186
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 46961374-4582-4325-bd11-0cdc61e5d379
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260908T125324Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 287
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
-        headers:
-            Content-Length:
-                - "287"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 08 Sep 2026 12:53:25 GMT
-            X-Amz-Id-2:
-                - txg872753d1f594486babba-006aa00545
-            X-Amz-Request-Id:
-                - txg872753d1f594486babba-006aa00545
-        status: 200 OK
-        code: 200
-        duration: 2.072258792s
-    - id: 187
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 98bb7a4c-07a8-4626-97d7-692aa28c610b
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260908T125326Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?tagging=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 361
-        uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg47df57f1f2944ab88275-006aa00547</RequestId><HostId>txg47df57f1f2944ab88275-006aa00547</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</BucketName></Error>
-        headers:
-            Content-Length:
-                - "361"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 08 Sep 2026 12:53:27 GMT
-            X-Amz-Id-2:
-                - txg47df57f1f2944ab88275-006aa00547
-            X-Amz-Request-Id:
-                - txg47df57f1f2944ab88275-006aa00547
-        status: 404 Not Found
-        code: 404
-        duration: 2.7415095s
-    - id: 188
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 277d6d81-51e9-45f2-aec2-26ff46c4a71f
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260908T125328Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?cors=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 298
-        uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg2d2541b2855841d0b8dc-006aa00549</RequestId><HostId>txg2d2541b2855841d0b8dc-006aa00549</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110</Resource></Error>
-        headers:
-            Content-Length:
-                - "298"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 08 Sep 2026 12:53:29 GMT
-            X-Amz-Id-2:
-                - txg2d2541b2855841d0b8dc-006aa00549
-            X-Amz-Request-Id:
-                - txg2d2541b2855841d0b8dc-006aa00549
-        status: 404 Not Found
-        code: 404
-        duration: 1.02713025s
-    - id: 189
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 6f4d9bfc-f5f4-43ab-8261-e4e8e174d600
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260908T125329Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?versioning=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 107
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <VersioningConfiguration><Status></Status></VersioningConfiguration>
-        headers:
-            Content-Length:
-                - "107"
-            Content-Type:
-                - text/xml; charset=utf-8
-            Date:
-                - Tue, 08 Sep 2026 12:53:30 GMT
-            X-Amz-Id-2:
-                - txgb921777c3bf0429da7fe-006aa0054a
-            X-Amz-Request-Id:
-                - txgb921777c3bf0429da7fe-006aa0054a
-        status: 200 OK
-        code: 200
-        duration: 1.158707417s
-    - id: 190
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 9827c9e4-6fda-4c64-af09-e1ccdbb6c261
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260908T125330Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/?lifecycle=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 1802
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>30</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition><Transition><Days>210</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>95</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Filter><Prefix>path3/</Prefix></Filter><ID>id3</ID><Status>Enabled</Status><Transition><Days>130</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path4/</Prefix><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>155</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id6</ID><Status>Enabled</Status><Transition><Days>156</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
-        headers:
-            Content-Length:
-                - "1802"
-            Content-Type:
-                - text/xml; charset=utf-8
-            Date:
-                - Tue, 08 Sep 2026 12:53:32 GMT
-            X-Amz-Id-2:
-                - txg6d4868f312764b1f9d25-006aa0054c
-            X-Amz-Request-Id:
-                - txg6d4868f312764b1f9d25-006aa0054c
-        status: 200 OK
-        code: 200
-        duration: 1.041690542s
-    - id: 191
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 66100e53-7fd5-4cd3-be8e-699cf488ea0b
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.45.1 ua/2.1 os/macos lang/go#1.27.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.107.0 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260908T125333Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6504769269931519110.s3.nl-ams.scw.cloud/
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
-        headers:
-            Date:
-                - Tue, 08 Sep 2026 12:53:33 GMT
-            X-Amz-Id-2:
-                - txg417e0902991b471ab947-006aa0054d
-            X-Amz-Request-Id:
-                - txg417e0902991b471ab947-006aa0054d
-        status: 204 No Content
-        code: 204
-        duration: 1.700333958s
+        duration: 1.105843709s


### PR DESCRIPTION
The field `bucket.lifecycle_rule.expiration.expired_object_delete_marker` was automatically set to `false` in the final configuration, when empty in the user configuration. This is due to Go's default behavior to fill variables with "empty" values, which is `false` for booleans. Fixed using `GetRawConfigForKey`.

Also tackled the `bucket.lifecycle_rule.expiration` validator, which now _successfully fails_ in case of more than one field set.