### PR TITLE
fix(kafka): align version datasource tests with current API responses

### DIFF
--- a/internal/services/kafka/testdata/data-source-kafka-version-basic.cassette.yaml
+++ b/internal/services/kafka/testdata/data-source-kafka-version-basic.cassette.yaml
@@ -16,7 +16,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.3; darwin; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/kafka/v1alpha1/regions/fr-par/versions?version=4.0.0
         method: GET
       response:
@@ -25,25 +25,37 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 114
+        content_length: 117
         uncompressed: false
-        body: "{\"total_count\":1,\"versions\":[{\"version\":\"4.0.0\",\"end_of_life_at\":\"2026-03-19T00:00:00Z\",\"available_settings\":[]}]}"
+        body: '{"total_count":1,"versions":[{"available_settings":[],"end_of_life_at":"2026-03-19T00:00:00Z","version":"4.0.0"}]}'
         headers:
             Content-Length:
-                - "114"
+                - "117"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Feb 2026 10:18:37 GMT
+                - Wed, 09 Sep 2026 13:35:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Ratelimit-Limit:
+                - 50, 50;w=1
+            X-Ratelimit-Remaining:
+                - "49"
+            X-Ratelimit-Reset:
+                - "1"
             X-Request-Id:
-                - req-0-kafka-version-datasource
+                - 9e9720f1-6732-4aea-a10f-793cc0c820a9
         status: 200 OK
         code: 200
-        duration: 19.576612ms
+        duration: 207.966583ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -59,7 +71,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.3; darwin; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/kafka/v1alpha1/regions/fr-par/versions?version=4.0.0
         method: GET
       response:
@@ -68,25 +80,37 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 114
+        content_length: 117
         uncompressed: false
-        body: "{\"total_count\":1,\"versions\":[{\"version\":\"4.0.0\",\"end_of_life_at\":\"2026-03-19T00:00:00Z\",\"available_settings\":[]}]}"
+        body: '{"total_count":1,"versions":[{"available_settings":[],"end_of_life_at":"2026-03-19T00:00:00Z","version":"4.0.0"}]}'
         headers:
             Content-Length:
-                - "114"
+                - "117"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Feb 2026 10:18:37 GMT
+                - Wed, 09 Sep 2026 13:35:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Ratelimit-Limit:
+                - 50, 50;w=1
+            X-Ratelimit-Remaining:
+                - "48"
+            X-Ratelimit-Reset:
+                - "1"
             X-Request-Id:
-                - req-1-kafka-version-datasource
+                - 2a4f512a-28c9-4aca-bc8f-17e21bbf55c1
         status: 200 OK
         code: 200
-        duration: 19.576612ms
+        duration: 37.5095ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -102,7 +126,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.3; darwin; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/kafka/v1alpha1/regions/fr-par/versions?version=4.0.0
         method: GET
       response:
@@ -111,65 +135,34 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 114
+        content_length: 117
         uncompressed: false
-        body: "{\"total_count\":1,\"versions\":[{\"version\":\"4.0.0\",\"end_of_life_at\":\"2026-03-19T00:00:00Z\",\"available_settings\":[]}]}"
+        body: '{"total_count":1,"versions":[{"available_settings":[],"end_of_life_at":"2026-03-19T00:00:00Z","version":"4.0.0"}]}'
         headers:
             Content-Length:
-                - "114"
+                - "117"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Feb 2026 10:18:37 GMT
+                - Wed, 09 Sep 2026 13:35:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Ratelimit-Limit:
+                - 50, 50;w=1
+            X-Ratelimit-Remaining:
+                - "46"
+            X-Ratelimit-Reset:
+                - "1"
             X-Request-Id:
-                - req-2-kafka-version-datasource
+                - ac38d1d9-7eaf-4a53-92a2-287b64b3f09c
         status: 200 OK
         code: 200
-        duration: 19.576612ms
-    - id: 3
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.3; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/kafka/v1alpha1/regions/fr-par/versions?version=4.0.0
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 114
-        uncompressed: false
-        body: "{\"total_count\":1,\"versions\":[{\"version\":\"4.0.0\",\"end_of_life_at\":\"2026-03-19T00:00:00Z\",\"available_settings\":[]}]}"
-        headers:
-            Content-Length:
-                - "114"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 20 Feb 2026 10:18:37 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            X-Request-Id:
-                - req-3-kafka-version-datasource
-        status: 200 OK
-        code: 200
-        duration: 19.576612ms
+        duration: 54.001166ms

--- a/internal/services/kafka/testdata/data-source-kafka-version-basic.cassette.yaml
+++ b/internal/services/kafka/testdata/data-source-kafka-version-basic.cassette.yaml
@@ -25,12 +25,12 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 533
+        content_length: 114
         uncompressed: false
-        body: '{"total_count":1,"versions":[{"version":"4.0.0","end_of_life_at":"2026-03-19T00:00:00Z","available_settings":[{"name":"log_retention_bytes","hot_configurable":true,"description":"The maximum size of the log before it is deleted","int_property":{"min":-1,"max":2147483647,"default_value":-1,"unit":"bytes"}},{"name":"compression_type","hot_configurable":true,"description":"The compression type for a given topic","string_property":{"string_constraint":"^(uncompressed|snappy|lz4|gzip|zstd|producer)$","default_value":"producer"}}]}]}'
+        body: "{\"total_count\":1,\"versions\":[{\"version\":\"4.0.0\",\"end_of_life_at\":\"2026-03-19T00:00:00Z\",\"available_settings\":[]}]}"
         headers:
             Content-Length:
-                - "533"
+                - "114"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
@@ -68,12 +68,12 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 533
+        content_length: 114
         uncompressed: false
-        body: '{"total_count":1,"versions":[{"version":"4.0.0","end_of_life_at":"2026-03-19T00:00:00Z","available_settings":[{"name":"log_retention_bytes","hot_configurable":true,"description":"The maximum size of the log before it is deleted","int_property":{"min":-1,"max":2147483647,"default_value":-1,"unit":"bytes"}},{"name":"compression_type","hot_configurable":true,"description":"The compression type for a given topic","string_property":{"string_constraint":"^(uncompressed|snappy|lz4|gzip|zstd|producer)$","default_value":"producer"}}]}]}'
+        body: "{\"total_count\":1,\"versions\":[{\"version\":\"4.0.0\",\"end_of_life_at\":\"2026-03-19T00:00:00Z\",\"available_settings\":[]}]}"
         headers:
             Content-Length:
-                - "533"
+                - "114"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
@@ -111,12 +111,12 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 533
+        content_length: 114
         uncompressed: false
-        body: '{"total_count":1,"versions":[{"version":"4.0.0","end_of_life_at":"2026-03-19T00:00:00Z","available_settings":[{"name":"log_retention_bytes","hot_configurable":true,"description":"The maximum size of the log before it is deleted","int_property":{"min":-1,"max":2147483647,"default_value":-1,"unit":"bytes"}},{"name":"compression_type","hot_configurable":true,"description":"The compression type for a given topic","string_property":{"string_constraint":"^(uncompressed|snappy|lz4|gzip|zstd|producer)$","default_value":"producer"}}]}]}'
+        body: "{\"total_count\":1,\"versions\":[{\"version\":\"4.0.0\",\"end_of_life_at\":\"2026-03-19T00:00:00Z\",\"available_settings\":[]}]}"
         headers:
             Content-Length:
-                - "533"
+                - "114"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
@@ -154,12 +154,12 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 533
+        content_length: 114
         uncompressed: false
-        body: '{"total_count":1,"versions":[{"version":"4.0.0","end_of_life_at":"2026-03-19T00:00:00Z","available_settings":[{"name":"log_retention_bytes","hot_configurable":true,"description":"The maximum size of the log before it is deleted","int_property":{"min":-1,"max":2147483647,"default_value":-1,"unit":"bytes"}},{"name":"compression_type","hot_configurable":true,"description":"The compression type for a given topic","string_property":{"string_constraint":"^(uncompressed|snappy|lz4|gzip|zstd|producer)$","default_value":"producer"}}]}]}'
+        body: "{\"total_count\":1,\"versions\":[{\"version\":\"4.0.0\",\"end_of_life_at\":\"2026-03-19T00:00:00Z\",\"available_settings\":[]}]}"
         headers:
             Content-Length:
-                - "533"
+                - "114"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:

--- a/internal/services/kafka/testdata/data-source-kafka-version-latest.cassette.yaml
+++ b/internal/services/kafka/testdata/data-source-kafka-version-latest.cassette.yaml
@@ -16,7 +16,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.3; darwin; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/kafka/v1alpha1/regions/fr-par/versions
         method: GET
       response:
@@ -25,25 +25,37 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 366
+        content_length: 378
         uncompressed: false
-        body: "{\"total_count\":4,\"versions\":[{\"version\":\"4.1.1\",\"end_of_life_at\":\"2027-03-19T00:00:00Z\",\"available_settings\":[]},{\"version\":\"4.1.0\",\"end_of_life_at\":\"2026-11-19T00:00:00Z\",\"available_settings\":[]},{\"version\":\"4.0.1\",\"end_of_life_at\":\"2026-07-19T00:00:00Z\",\"available_settings\":[]},{\"version\":\"4.0.0\",\"end_of_life_at\":\"2026-03-19T00:00:00Z\",\"available_settings\":[]}]}"
+        body: '{"total_count":4,"versions":[{"available_settings":[],"end_of_life_at":"2027-03-19T00:00:00Z","version":"4.1.1"},{"available_settings":[],"end_of_life_at":"2026-11-19T00:00:00Z","version":"4.1.0"},{"available_settings":[],"end_of_life_at":"2026-07-19T00:00:00Z","version":"4.0.1"},{"available_settings":[],"end_of_life_at":"2026-03-19T00:00:00Z","version":"4.0.0"}]}'
         headers:
             Content-Length:
-                - "366"
+                - "378"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Feb 2026 10:18:37 GMT
+                - Wed, 09 Sep 2026 13:35:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Ratelimit-Limit:
+                - 50, 50;w=1
+            X-Ratelimit-Remaining:
+                - "49"
+            X-Ratelimit-Reset:
+                - "1"
             X-Request-Id:
-                - req-0-kafka-version-datasource
+                - 4759e676-8542-462b-a0f0-b54953adf8c7
         status: 200 OK
         code: 200
-        duration: 19.576612ms
+        duration: 208.090875ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -59,7 +71,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.3; darwin; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/kafka/v1alpha1/regions/fr-par/versions
         method: GET
       response:
@@ -68,25 +80,37 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 366
+        content_length: 378
         uncompressed: false
-        body: "{\"total_count\":4,\"versions\":[{\"version\":\"4.1.1\",\"end_of_life_at\":\"2027-03-19T00:00:00Z\",\"available_settings\":[]},{\"version\":\"4.1.0\",\"end_of_life_at\":\"2026-11-19T00:00:00Z\",\"available_settings\":[]},{\"version\":\"4.0.1\",\"end_of_life_at\":\"2026-07-19T00:00:00Z\",\"available_settings\":[]},{\"version\":\"4.0.0\",\"end_of_life_at\":\"2026-03-19T00:00:00Z\",\"available_settings\":[]}]}"
+        body: '{"total_count":4,"versions":[{"available_settings":[],"end_of_life_at":"2027-03-19T00:00:00Z","version":"4.1.1"},{"available_settings":[],"end_of_life_at":"2026-11-19T00:00:00Z","version":"4.1.0"},{"available_settings":[],"end_of_life_at":"2026-07-19T00:00:00Z","version":"4.0.1"},{"available_settings":[],"end_of_life_at":"2026-03-19T00:00:00Z","version":"4.0.0"}]}'
         headers:
             Content-Length:
-                - "366"
+                - "378"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Feb 2026 10:18:37 GMT
+                - Wed, 09 Sep 2026 13:35:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Ratelimit-Limit:
+                - 50, 50;w=1
+            X-Ratelimit-Remaining:
+                - "47"
+            X-Ratelimit-Reset:
+                - "1"
             X-Request-Id:
-                - req-1-kafka-version-datasource
+                - d37ca888-3c2a-494d-bbfe-b8740551ad09
         status: 200 OK
         code: 200
-        duration: 19.576612ms
+        duration: 40.93825ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -102,7 +126,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.3; darwin; amd64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.2; darwin; amd64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/kafka/v1alpha1/regions/fr-par/versions
         method: GET
       response:
@@ -111,65 +135,34 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 366
+        content_length: 378
         uncompressed: false
-        body: "{\"total_count\":4,\"versions\":[{\"version\":\"4.1.1\",\"end_of_life_at\":\"2027-03-19T00:00:00Z\",\"available_settings\":[]},{\"version\":\"4.1.0\",\"end_of_life_at\":\"2026-11-19T00:00:00Z\",\"available_settings\":[]},{\"version\":\"4.0.1\",\"end_of_life_at\":\"2026-07-19T00:00:00Z\",\"available_settings\":[]},{\"version\":\"4.0.0\",\"end_of_life_at\":\"2026-03-19T00:00:00Z\",\"available_settings\":[]}]}"
+        body: '{"total_count":4,"versions":[{"available_settings":[],"end_of_life_at":"2027-03-19T00:00:00Z","version":"4.1.1"},{"available_settings":[],"end_of_life_at":"2026-11-19T00:00:00Z","version":"4.1.0"},{"available_settings":[],"end_of_life_at":"2026-07-19T00:00:00Z","version":"4.0.1"},{"available_settings":[],"end_of_life_at":"2026-03-19T00:00:00Z","version":"4.0.0"}]}'
         headers:
             Content-Length:
-                - "366"
+                - "378"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Feb 2026 10:18:37 GMT
+                - Wed, 09 Sep 2026 13:35:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-1;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Ratelimit-Limit:
+                - 50, 50;w=1
+            X-Ratelimit-Remaining:
+                - "45"
+            X-Ratelimit-Reset:
+                - "1"
             X-Request-Id:
-                - req-2-kafka-version-datasource
+                - 3cd40ea4-9c85-4a4e-b3f6-ab82a5df2059
         status: 200 OK
         code: 200
-        duration: 19.576612ms
-    - id: 3
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.3; darwin; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/kafka/v1alpha1/regions/fr-par/versions
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 366
-        uncompressed: false
-        body: "{\"total_count\":4,\"versions\":[{\"version\":\"4.1.1\",\"end_of_life_at\":\"2027-03-19T00:00:00Z\",\"available_settings\":[]},{\"version\":\"4.1.0\",\"end_of_life_at\":\"2026-11-19T00:00:00Z\",\"available_settings\":[]},{\"version\":\"4.0.1\",\"end_of_life_at\":\"2026-07-19T00:00:00Z\",\"available_settings\":[]},{\"version\":\"4.0.0\",\"end_of_life_at\":\"2026-03-19T00:00:00Z\",\"available_settings\":[]}]}"
-        headers:
-            Content-Length:
-                - "366"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 20 Feb 2026 10:18:37 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            X-Request-Id:
-                - req-3-kafka-version-datasource
-        status: 200 OK
-        code: 200
-        duration: 19.576612ms
+        duration: 43.419125ms

--- a/internal/services/kafka/testdata/data-source-kafka-version-latest.cassette.yaml
+++ b/internal/services/kafka/testdata/data-source-kafka-version-latest.cassette.yaml
@@ -25,12 +25,12 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 617
+        content_length: 366
         uncompressed: false
-        body: '{"total_count":2,"versions":[{"version":"4.0.0","end_of_life_at":"2026-03-19T00:00:00Z","available_settings":[{"name":"log_retention_bytes","hot_configurable":true,"description":"The maximum size of the log before it is deleted","int_property":{"min":-1,"max":2147483647,"default_value":-1,"unit":"bytes"}},{"name":"compression_type","hot_configurable":true,"description":"The compression type for a given topic","string_property":{"string_constraint":"^(uncompressed|snappy|lz4|gzip|zstd|producer)$","default_value":"producer"}}]},{"version":"3.7.0","end_of_life_at":"2025-12-31T00:00:00Z","available_settings":[]}]}'
+        body: "{\"total_count\":4,\"versions\":[{\"version\":\"4.1.1\",\"end_of_life_at\":\"2027-03-19T00:00:00Z\",\"available_settings\":[]},{\"version\":\"4.1.0\",\"end_of_life_at\":\"2026-11-19T00:00:00Z\",\"available_settings\":[]},{\"version\":\"4.0.1\",\"end_of_life_at\":\"2026-07-19T00:00:00Z\",\"available_settings\":[]},{\"version\":\"4.0.0\",\"end_of_life_at\":\"2026-03-19T00:00:00Z\",\"available_settings\":[]}]}"
         headers:
             Content-Length:
-                - "617"
+                - "366"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
@@ -68,12 +68,12 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 617
+        content_length: 366
         uncompressed: false
-        body: '{"total_count":2,"versions":[{"version":"4.0.0","end_of_life_at":"2026-03-19T00:00:00Z","available_settings":[{"name":"log_retention_bytes","hot_configurable":true,"description":"The maximum size of the log before it is deleted","int_property":{"min":-1,"max":2147483647,"default_value":-1,"unit":"bytes"}},{"name":"compression_type","hot_configurable":true,"description":"The compression type for a given topic","string_property":{"string_constraint":"^(uncompressed|snappy|lz4|gzip|zstd|producer)$","default_value":"producer"}}]},{"version":"3.7.0","end_of_life_at":"2025-12-31T00:00:00Z","available_settings":[]}]}'
+        body: "{\"total_count\":4,\"versions\":[{\"version\":\"4.1.1\",\"end_of_life_at\":\"2027-03-19T00:00:00Z\",\"available_settings\":[]},{\"version\":\"4.1.0\",\"end_of_life_at\":\"2026-11-19T00:00:00Z\",\"available_settings\":[]},{\"version\":\"4.0.1\",\"end_of_life_at\":\"2026-07-19T00:00:00Z\",\"available_settings\":[]},{\"version\":\"4.0.0\",\"end_of_life_at\":\"2026-03-19T00:00:00Z\",\"available_settings\":[]}]}"
         headers:
             Content-Length:
-                - "617"
+                - "366"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
@@ -111,12 +111,12 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 617
+        content_length: 366
         uncompressed: false
-        body: '{"total_count":2,"versions":[{"version":"4.0.0","end_of_life_at":"2026-03-19T00:00:00Z","available_settings":[{"name":"log_retention_bytes","hot_configurable":true,"description":"The maximum size of the log before it is deleted","int_property":{"min":-1,"max":2147483647,"default_value":-1,"unit":"bytes"}},{"name":"compression_type","hot_configurable":true,"description":"The compression type for a given topic","string_property":{"string_constraint":"^(uncompressed|snappy|lz4|gzip|zstd|producer)$","default_value":"producer"}}]},{"version":"3.7.0","end_of_life_at":"2025-12-31T00:00:00Z","available_settings":[]}]}'
+        body: "{\"total_count\":4,\"versions\":[{\"version\":\"4.1.1\",\"end_of_life_at\":\"2027-03-19T00:00:00Z\",\"available_settings\":[]},{\"version\":\"4.1.0\",\"end_of_life_at\":\"2026-11-19T00:00:00Z\",\"available_settings\":[]},{\"version\":\"4.0.1\",\"end_of_life_at\":\"2026-07-19T00:00:00Z\",\"available_settings\":[]},{\"version\":\"4.0.0\",\"end_of_life_at\":\"2026-03-19T00:00:00Z\",\"available_settings\":[]}]}"
         headers:
             Content-Length:
-                - "617"
+                - "366"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
@@ -154,12 +154,12 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 617
+        content_length: 366
         uncompressed: false
-        body: '{"total_count":2,"versions":[{"version":"4.0.0","end_of_life_at":"2026-03-19T00:00:00Z","available_settings":[{"name":"log_retention_bytes","hot_configurable":true,"description":"The maximum size of the log before it is deleted","int_property":{"min":-1,"max":2147483647,"default_value":-1,"unit":"bytes"}},{"name":"compression_type","hot_configurable":true,"description":"The compression type for a given topic","string_property":{"string_constraint":"^(uncompressed|snappy|lz4|gzip|zstd|producer)$","default_value":"producer"}}]},{"version":"3.7.0","end_of_life_at":"2025-12-31T00:00:00Z","available_settings":[]}]}'
+        body: "{\"total_count\":4,\"versions\":[{\"version\":\"4.1.1\",\"end_of_life_at\":\"2027-03-19T00:00:00Z\",\"available_settings\":[]},{\"version\":\"4.1.0\",\"end_of_life_at\":\"2026-11-19T00:00:00Z\",\"available_settings\":[]},{\"version\":\"4.0.1\",\"end_of_life_at\":\"2026-07-19T00:00:00Z\",\"available_settings\":[]},{\"version\":\"4.0.0\",\"end_of_life_at\":\"2026-03-19T00:00:00Z\",\"available_settings\":[]}]}"
         headers:
             Content-Length:
-                - "617"
+                - "366"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:

--- a/internal/services/kafka/version_data_source_test.go
+++ b/internal/services/kafka/version_data_source_test.go
@@ -26,15 +26,8 @@ func TestAccDataSourceKafkaVersion_Basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.scaleway_kafka_version.by_name", "name", version),
 					resource.TestCheckResourceAttrSet("data.scaleway_kafka_version.by_name", "id"),
-					resource.TestCheckResourceAttr("data.scaleway_kafka_version.by_name", "end_of_life_at", "2026-03-19T00:00:00Z"),
-					resource.TestCheckResourceAttr("data.scaleway_kafka_version.by_name", "available_settings.#", "2"),
-					resource.TestCheckResourceAttr("data.scaleway_kafka_version.by_name", "available_settings.0.name", "log_retention_bytes"),
-					resource.TestCheckResourceAttr("data.scaleway_kafka_version.by_name", "available_settings.0.hot_configurable", "true"),
-					resource.TestCheckResourceAttr("data.scaleway_kafka_version.by_name", "available_settings.0.int_property.min", "-1"),
-					resource.TestCheckResourceAttr("data.scaleway_kafka_version.by_name", "available_settings.0.int_property.default_value", "-1"),
-					resource.TestCheckResourceAttr("data.scaleway_kafka_version.by_name", "available_settings.0.int_property.unit", "bytes"),
-					resource.TestCheckResourceAttr("data.scaleway_kafka_version.by_name", "available_settings.1.name", "compression_type"),
-					resource.TestCheckResourceAttr("data.scaleway_kafka_version.by_name", "available_settings.1.string_property.default_value", "producer"),
+					resource.TestCheckResourceAttrSet("data.scaleway_kafka_version.by_name", "end_of_life_at"),
+					resource.TestCheckResourceAttr("data.scaleway_kafka_version.by_name", "available_settings.#", "0"),
 				),
 			},
 		},
@@ -55,7 +48,7 @@ func TestAccDataSourceKafkaVersion_Latest(t *testing.T) {
 					}
 				`,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.scaleway_kafka_version.latest", "name", "4.0.0"),
+					resource.TestCheckResourceAttrSet("data.scaleway_kafka_version.latest", "name"),
 					resource.TestCheckResourceAttrSet("data.scaleway_kafka_version.latest", "id"),
 					resource.TestCheckResourceAttrSet("data.scaleway_kafka_version.latest", "end_of_life_at"),
 				),


### PR DESCRIPTION
## Summary
- Update `scaleway_kafka_version` acceptance checks after the Kafka API drift seen in nightly (`latest` is now `4.1.1`, `available_settings` is empty).
- Refresh the related VCR cassettes with a live re-record (`TF_UPDATE_CASSETTES=true`).

## Context
Empty `available_settings` on all Kafka versions is **expected** for now (confirmed with Kafka team): the settings concept was imported from Mongo but no options have been added yet.