### PR TITLE
fix(mongodb): use future-relative expires_at in snapshot tests

### DIFF
--- a/internal/services/mongodb/snapshot_test.go
+++ b/internal/services/mongodb/snapshot_test.go
@@ -3,6 +3,7 @@ package mongodb_test
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -16,12 +17,18 @@ func TestAccMongoDBSnapshot_Basic(t *testing.T) {
 	tt := acctest.NewTestTools(t)
 	defer tt.Cleanup()
 
+	expiresAt := time.Now().AddDate(0, 6, 0).UTC().Format(time.RFC3339)
+	if !*acctest.UpdateCassettes {
+		// Hardcoded value must match expires_at in the cassette request body.
+		expiresAt = "2027-03-10T23:59:59Z"
+	}
+
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: tt.ProviderFactories,
 		CheckDestroy:             isSnapshotDestroyed(tt),
 		Steps: []resource.TestStep{
 			{
-				Config: `
+				Config: fmt.Sprintf(`
 					resource "scaleway_mongodb_instance" "main" {
 						name       = "test-mongodb-instance"
 						version    = "7.0.12"
@@ -34,9 +41,9 @@ func TestAccMongoDBSnapshot_Basic(t *testing.T) {
 					resource "scaleway_mongodb_snapshot" "main" {
 						instance_id = scaleway_mongodb_instance.main.id
 						name        = "test-snapshot"
-						expires_at  = "2026-06-30T23:59:59Z"
+						expires_at  = %q
 					}
-				`,
+				`, expiresAt),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("scaleway_mongodb_snapshot.main", "name", "test-snapshot"),
 				),
@@ -49,12 +56,18 @@ func TestAccMongoDBSnapshot_Update(t *testing.T) {
 	tt := acctest.NewTestTools(t)
 	defer tt.Cleanup()
 
+	expiresAt := time.Now().AddDate(0, 6, 0).UTC().Format(time.RFC3339)
+	if !*acctest.UpdateCassettes {
+		// Hardcoded value must match expires_at in the cassette request body.
+		expiresAt = "2027-03-10T23:59:59Z"
+	}
+
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: tt.ProviderFactories,
 		CheckDestroy:             isSnapshotDestroyed(tt),
 		Steps: []resource.TestStep{
 			{
-				Config: `
+				Config: fmt.Sprintf(`
 					resource "scaleway_mongodb_instance" "main" {
 						name       = "test-mongodb-instance"
 						version    = "7.0.12"
@@ -67,15 +80,15 @@ func TestAccMongoDBSnapshot_Update(t *testing.T) {
 					resource "scaleway_mongodb_snapshot" "main" {
 						instance_id = scaleway_mongodb_instance.main.id
 						name        = "test-snapshot"
-						expires_at  = "2026-06-30T23:59:59Z"
+						expires_at  = %q
 					}
-				`,
+				`, expiresAt),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("scaleway_mongodb_snapshot.main", "expires_at", "2026-06-30T23:59:59Z"),
+					resource.TestCheckResourceAttr("scaleway_mongodb_snapshot.main", "expires_at", expiresAt),
 				),
 			},
 			{
-				Config: `
+				Config: fmt.Sprintf(`
 					resource "scaleway_mongodb_instance" "main" {
 						name       = "test-mongodb-instance"
 						version    = "7.0.12"
@@ -88,12 +101,12 @@ func TestAccMongoDBSnapshot_Update(t *testing.T) {
 					resource "scaleway_mongodb_snapshot" "main" {
 						instance_id = scaleway_mongodb_instance.main.id
 						name        = "updated-snapshot"
-						expires_at  = "2026-06-30T23:59:59Z"
+						expires_at  = %q
 					}
-				`,
+				`, expiresAt),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("scaleway_mongodb_snapshot.main", "name", "updated-snapshot"),
-					resource.TestCheckResourceAttr("scaleway_mongodb_snapshot.main", "expires_at", "2026-06-30T23:59:59Z"),
+					resource.TestCheckResourceAttr("scaleway_mongodb_snapshot.main", "expires_at", expiresAt),
 				),
 			},
 		},

--- a/internal/services/mongodb/testdata/mongo-db-snapshot-basic.cassette.yaml
+++ b/internal/services/mongodb/testdata/mongo-db-snapshot-basic.cassette.yaml
@@ -259,7 +259,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"instance_id":"85770742-fb6c-443d-8af5-6721650ea2e2","name":"test-snapshot","expires_at":"2026-06-30T23:59:59Z"}'
+        body: '{"instance_id":"85770742-fb6c-443d-8af5-6721650ea2e2","name":"test-snapshot","expires_at":"2027-03-10T23:59:59Z"}'
         form: {}
         headers:
             Content-Type:
@@ -276,7 +276,7 @@ interactions:
         trailer: {}
         content_length: 400
         uncompressed: false
-        body: '{"created_at":"2025-10-10T05:56:30.353693Z","expires_at":"2026-06-30T23:59:59Z","id":"a0946897-3385-4f2d-b330-47d0ff7c2fae","instance_id":"85770742-fb6c-443d-8af5-6721650ea2e2","instance_name":"test-mongodb-instance","name":"test-snapshot","node_type":"mgdb-play2-nano","region":"fr-par","size_bytes":0,"status":"creating","updated_at":"2025-10-10T05:56:30.353693Z","volume_type":"sbs_5k"}'
+        body: '{"created_at":"2025-10-10T05:56:30.353693Z","expires_at":"2027-03-10T23:59:59Z","id":"a0946897-3385-4f2d-b330-47d0ff7c2fae","instance_id":"85770742-fb6c-443d-8af5-6721650ea2e2","instance_name":"test-mongodb-instance","name":"test-snapshot","node_type":"mgdb-play2-nano","region":"fr-par","size_bytes":0,"status":"creating","updated_at":"2025-10-10T05:56:30.353693Z","volume_type":"sbs_5k"}'
         headers:
             Content-Length:
                 - "400"
@@ -325,7 +325,7 @@ interactions:
         trailer: {}
         content_length: 400
         uncompressed: false
-        body: '{"created_at":"2025-10-10T05:56:30.353693Z","expires_at":"2026-06-30T23:59:59Z","id":"a0946897-3385-4f2d-b330-47d0ff7c2fae","instance_id":"85770742-fb6c-443d-8af5-6721650ea2e2","instance_name":"test-mongodb-instance","name":"test-snapshot","node_type":"mgdb-play2-nano","region":"fr-par","size_bytes":0,"status":"creating","updated_at":"2025-10-10T05:56:30.353693Z","volume_type":"sbs_5k"}'
+        body: '{"created_at":"2025-10-10T05:56:30.353693Z","expires_at":"2027-03-10T23:59:59Z","id":"a0946897-3385-4f2d-b330-47d0ff7c2fae","instance_id":"85770742-fb6c-443d-8af5-6721650ea2e2","instance_name":"test-mongodb-instance","name":"test-snapshot","node_type":"mgdb-play2-nano","region":"fr-par","size_bytes":0,"status":"creating","updated_at":"2025-10-10T05:56:30.353693Z","volume_type":"sbs_5k"}'
         headers:
             Content-Length:
                 - "400"
@@ -374,7 +374,7 @@ interactions:
         trailer: {}
         content_length: 406
         uncompressed: false
-        body: '{"created_at":"2025-10-10T05:56:30.353693Z","expires_at":"2026-06-30T23:59:59Z","id":"a0946897-3385-4f2d-b330-47d0ff7c2fae","instance_id":"85770742-fb6c-443d-8af5-6721650ea2e2","instance_name":"test-mongodb-instance","name":"test-snapshot","node_type":"mgdb-play2-nano","region":"fr-par","size_bytes":5000000000,"status":"ready","updated_at":"2025-10-10T05:56:31.134692Z","volume_type":"sbs_5k"}'
+        body: '{"created_at":"2025-10-10T05:56:30.353693Z","expires_at":"2027-03-10T23:59:59Z","id":"a0946897-3385-4f2d-b330-47d0ff7c2fae","instance_id":"85770742-fb6c-443d-8af5-6721650ea2e2","instance_name":"test-mongodb-instance","name":"test-snapshot","node_type":"mgdb-play2-nano","region":"fr-par","size_bytes":5000000000,"status":"ready","updated_at":"2025-10-10T05:56:31.134692Z","volume_type":"sbs_5k"}'
         headers:
             Content-Length:
                 - "406"
@@ -423,7 +423,7 @@ interactions:
         trailer: {}
         content_length: 406
         uncompressed: false
-        body: '{"created_at":"2025-10-10T05:56:30.353693Z","expires_at":"2026-06-30T23:59:59Z","id":"a0946897-3385-4f2d-b330-47d0ff7c2fae","instance_id":"85770742-fb6c-443d-8af5-6721650ea2e2","instance_name":"test-mongodb-instance","name":"test-snapshot","node_type":"mgdb-play2-nano","region":"fr-par","size_bytes":5000000000,"status":"ready","updated_at":"2025-10-10T05:56:31.134692Z","volume_type":"sbs_5k"}'
+        body: '{"created_at":"2025-10-10T05:56:30.353693Z","expires_at":"2027-03-10T23:59:59Z","id":"a0946897-3385-4f2d-b330-47d0ff7c2fae","instance_id":"85770742-fb6c-443d-8af5-6721650ea2e2","instance_name":"test-mongodb-instance","name":"test-snapshot","node_type":"mgdb-play2-nano","region":"fr-par","size_bytes":5000000000,"status":"ready","updated_at":"2025-10-10T05:56:31.134692Z","volume_type":"sbs_5k"}'
         headers:
             Content-Length:
                 - "406"
@@ -570,7 +570,7 @@ interactions:
         trailer: {}
         content_length: 406
         uncompressed: false
-        body: '{"created_at":"2025-10-10T05:56:30.353693Z","expires_at":"2026-06-30T23:59:59Z","id":"a0946897-3385-4f2d-b330-47d0ff7c2fae","instance_id":"85770742-fb6c-443d-8af5-6721650ea2e2","instance_name":"test-mongodb-instance","name":"test-snapshot","node_type":"mgdb-play2-nano","region":"fr-par","size_bytes":5000000000,"status":"ready","updated_at":"2025-10-10T05:56:31.134692Z","volume_type":"sbs_5k"}'
+        body: '{"created_at":"2025-10-10T05:56:30.353693Z","expires_at":"2027-03-10T23:59:59Z","id":"a0946897-3385-4f2d-b330-47d0ff7c2fae","instance_id":"85770742-fb6c-443d-8af5-6721650ea2e2","instance_name":"test-mongodb-instance","name":"test-snapshot","node_type":"mgdb-play2-nano","region":"fr-par","size_bytes":5000000000,"status":"ready","updated_at":"2025-10-10T05:56:31.134692Z","volume_type":"sbs_5k"}'
         headers:
             Content-Length:
                 - "406"
@@ -619,7 +619,7 @@ interactions:
         trailer: {}
         content_length: 409
         uncompressed: false
-        body: '{"created_at":"2025-10-10T05:56:30.353693Z","expires_at":"2026-06-30T23:59:59Z","id":"a0946897-3385-4f2d-b330-47d0ff7c2fae","instance_id":"85770742-fb6c-443d-8af5-6721650ea2e2","instance_name":"test-mongodb-instance","name":"test-snapshot","node_type":"mgdb-play2-nano","region":"fr-par","size_bytes":5000000000,"status":"deleting","updated_at":"2025-10-10T05:56:42.543434Z","volume_type":"sbs_5k"}'
+        body: '{"created_at":"2025-10-10T05:56:30.353693Z","expires_at":"2027-03-10T23:59:59Z","id":"a0946897-3385-4f2d-b330-47d0ff7c2fae","instance_id":"85770742-fb6c-443d-8af5-6721650ea2e2","instance_name":"test-mongodb-instance","name":"test-snapshot","node_type":"mgdb-play2-nano","region":"fr-par","size_bytes":5000000000,"status":"deleting","updated_at":"2025-10-10T05:56:42.543434Z","volume_type":"sbs_5k"}'
         headers:
             Content-Length:
                 - "409"

--- a/internal/services/mongodb/testdata/mongo-db-snapshot-update.cassette.yaml
+++ b/internal/services/mongodb/testdata/mongo-db-snapshot-update.cassette.yaml
@@ -259,7 +259,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"instance_id":"167444fd-9ae1-40e5-803d-2918ac01bce2","name":"test-snapshot","expires_at":"2026-06-30T23:59:59Z"}'
+        body: '{"instance_id":"167444fd-9ae1-40e5-803d-2918ac01bce2","name":"test-snapshot","expires_at":"2027-03-10T23:59:59Z"}'
         form: {}
         headers:
             Content-Type:
@@ -276,7 +276,7 @@ interactions:
         trailer: {}
         content_length: 400
         uncompressed: false
-        body: '{"created_at":"2025-10-10T05:54:18.372982Z","expires_at":"2026-06-30T23:59:59Z","id":"5a4f9ec0-6338-417f-a776-4d3ece703303","instance_id":"167444fd-9ae1-40e5-803d-2918ac01bce2","instance_name":"test-mongodb-instance","name":"test-snapshot","node_type":"mgdb-play2-nano","region":"fr-par","size_bytes":0,"status":"creating","updated_at":"2025-10-10T05:54:18.372982Z","volume_type":"sbs_5k"}'
+        body: '{"created_at":"2025-10-10T05:54:18.372982Z","expires_at":"2027-03-10T23:59:59Z","id":"5a4f9ec0-6338-417f-a776-4d3ece703303","instance_id":"167444fd-9ae1-40e5-803d-2918ac01bce2","instance_name":"test-mongodb-instance","name":"test-snapshot","node_type":"mgdb-play2-nano","region":"fr-par","size_bytes":0,"status":"creating","updated_at":"2025-10-10T05:54:18.372982Z","volume_type":"sbs_5k"}'
         headers:
             Content-Length:
                 - "400"
@@ -325,7 +325,7 @@ interactions:
         trailer: {}
         content_length: 400
         uncompressed: false
-        body: '{"created_at":"2025-10-10T05:54:18.372982Z","expires_at":"2026-06-30T23:59:59Z","id":"5a4f9ec0-6338-417f-a776-4d3ece703303","instance_id":"167444fd-9ae1-40e5-803d-2918ac01bce2","instance_name":"test-mongodb-instance","name":"test-snapshot","node_type":"mgdb-play2-nano","region":"fr-par","size_bytes":0,"status":"creating","updated_at":"2025-10-10T05:54:18.372982Z","volume_type":"sbs_5k"}'
+        body: '{"created_at":"2025-10-10T05:54:18.372982Z","expires_at":"2027-03-10T23:59:59Z","id":"5a4f9ec0-6338-417f-a776-4d3ece703303","instance_id":"167444fd-9ae1-40e5-803d-2918ac01bce2","instance_name":"test-mongodb-instance","name":"test-snapshot","node_type":"mgdb-play2-nano","region":"fr-par","size_bytes":0,"status":"creating","updated_at":"2025-10-10T05:54:18.372982Z","volume_type":"sbs_5k"}'
         headers:
             Content-Length:
                 - "400"
@@ -374,7 +374,7 @@ interactions:
         trailer: {}
         content_length: 406
         uncompressed: false
-        body: '{"created_at":"2025-10-10T05:54:18.372982Z","expires_at":"2026-06-30T23:59:59Z","id":"5a4f9ec0-6338-417f-a776-4d3ece703303","instance_id":"167444fd-9ae1-40e5-803d-2918ac01bce2","instance_name":"test-mongodb-instance","name":"test-snapshot","node_type":"mgdb-play2-nano","region":"fr-par","size_bytes":5000000000,"status":"ready","updated_at":"2025-10-10T05:54:19.461884Z","volume_type":"sbs_5k"}'
+        body: '{"created_at":"2025-10-10T05:54:18.372982Z","expires_at":"2027-03-10T23:59:59Z","id":"5a4f9ec0-6338-417f-a776-4d3ece703303","instance_id":"167444fd-9ae1-40e5-803d-2918ac01bce2","instance_name":"test-mongodb-instance","name":"test-snapshot","node_type":"mgdb-play2-nano","region":"fr-par","size_bytes":5000000000,"status":"ready","updated_at":"2025-10-10T05:54:19.461884Z","volume_type":"sbs_5k"}'
         headers:
             Content-Length:
                 - "406"
@@ -423,7 +423,7 @@ interactions:
         trailer: {}
         content_length: 406
         uncompressed: false
-        body: '{"created_at":"2025-10-10T05:54:18.372982Z","expires_at":"2026-06-30T23:59:59Z","id":"5a4f9ec0-6338-417f-a776-4d3ece703303","instance_id":"167444fd-9ae1-40e5-803d-2918ac01bce2","instance_name":"test-mongodb-instance","name":"test-snapshot","node_type":"mgdb-play2-nano","region":"fr-par","size_bytes":5000000000,"status":"ready","updated_at":"2025-10-10T05:54:19.461884Z","volume_type":"sbs_5k"}'
+        body: '{"created_at":"2025-10-10T05:54:18.372982Z","expires_at":"2027-03-10T23:59:59Z","id":"5a4f9ec0-6338-417f-a776-4d3ece703303","instance_id":"167444fd-9ae1-40e5-803d-2918ac01bce2","instance_name":"test-mongodb-instance","name":"test-snapshot","node_type":"mgdb-play2-nano","region":"fr-par","size_bytes":5000000000,"status":"ready","updated_at":"2025-10-10T05:54:19.461884Z","volume_type":"sbs_5k"}'
         headers:
             Content-Length:
                 - "406"
@@ -570,7 +570,7 @@ interactions:
         trailer: {}
         content_length: 406
         uncompressed: false
-        body: '{"created_at":"2025-10-10T05:54:18.372982Z","expires_at":"2026-06-30T23:59:59Z","id":"5a4f9ec0-6338-417f-a776-4d3ece703303","instance_id":"167444fd-9ae1-40e5-803d-2918ac01bce2","instance_name":"test-mongodb-instance","name":"test-snapshot","node_type":"mgdb-play2-nano","region":"fr-par","size_bytes":5000000000,"status":"ready","updated_at":"2025-10-10T05:54:19.461884Z","volume_type":"sbs_5k"}'
+        body: '{"created_at":"2025-10-10T05:54:18.372982Z","expires_at":"2027-03-10T23:59:59Z","id":"5a4f9ec0-6338-417f-a776-4d3ece703303","instance_id":"167444fd-9ae1-40e5-803d-2918ac01bce2","instance_name":"test-mongodb-instance","name":"test-snapshot","node_type":"mgdb-play2-nano","region":"fr-par","size_bytes":5000000000,"status":"ready","updated_at":"2025-10-10T05:54:19.461884Z","volume_type":"sbs_5k"}'
         headers:
             Content-Length:
                 - "406"
@@ -717,7 +717,7 @@ interactions:
         trailer: {}
         content_length: 406
         uncompressed: false
-        body: '{"created_at":"2025-10-10T05:54:18.372982Z","expires_at":"2026-06-30T23:59:59Z","id":"5a4f9ec0-6338-417f-a776-4d3ece703303","instance_id":"167444fd-9ae1-40e5-803d-2918ac01bce2","instance_name":"test-mongodb-instance","name":"test-snapshot","node_type":"mgdb-play2-nano","region":"fr-par","size_bytes":5000000000,"status":"ready","updated_at":"2025-10-10T05:54:19.461884Z","volume_type":"sbs_5k"}'
+        body: '{"created_at":"2025-10-10T05:54:18.372982Z","expires_at":"2027-03-10T23:59:59Z","id":"5a4f9ec0-6338-417f-a776-4d3ece703303","instance_id":"167444fd-9ae1-40e5-803d-2918ac01bce2","instance_name":"test-mongodb-instance","name":"test-snapshot","node_type":"mgdb-play2-nano","region":"fr-par","size_bytes":5000000000,"status":"ready","updated_at":"2025-10-10T05:54:19.461884Z","volume_type":"sbs_5k"}'
         headers:
             Content-Length:
                 - "406"
@@ -768,7 +768,7 @@ interactions:
         trailer: {}
         content_length: 409
         uncompressed: false
-        body: '{"created_at":"2025-10-10T05:54:18.372982Z","expires_at":"2026-06-30T23:59:59Z","id":"5a4f9ec0-6338-417f-a776-4d3ece703303","instance_id":"167444fd-9ae1-40e5-803d-2918ac01bce2","instance_name":"test-mongodb-instance","name":"updated-snapshot","node_type":"mgdb-play2-nano","region":"fr-par","size_bytes":5000000000,"status":"ready","updated_at":"2025-10-10T05:54:31.966160Z","volume_type":"sbs_5k"}'
+        body: '{"created_at":"2025-10-10T05:54:18.372982Z","expires_at":"2027-03-10T23:59:59Z","id":"5a4f9ec0-6338-417f-a776-4d3ece703303","instance_id":"167444fd-9ae1-40e5-803d-2918ac01bce2","instance_name":"test-mongodb-instance","name":"updated-snapshot","node_type":"mgdb-play2-nano","region":"fr-par","size_bytes":5000000000,"status":"ready","updated_at":"2025-10-10T05:54:31.966160Z","volume_type":"sbs_5k"}'
         headers:
             Content-Length:
                 - "409"
@@ -817,7 +817,7 @@ interactions:
         trailer: {}
         content_length: 409
         uncompressed: false
-        body: '{"created_at":"2025-10-10T05:54:18.372982Z","expires_at":"2026-06-30T23:59:59Z","id":"5a4f9ec0-6338-417f-a776-4d3ece703303","instance_id":"167444fd-9ae1-40e5-803d-2918ac01bce2","instance_name":"test-mongodb-instance","name":"updated-snapshot","node_type":"mgdb-play2-nano","region":"fr-par","size_bytes":5000000000,"status":"ready","updated_at":"2025-10-10T05:54:31.966160Z","volume_type":"sbs_5k"}'
+        body: '{"created_at":"2025-10-10T05:54:18.372982Z","expires_at":"2027-03-10T23:59:59Z","id":"5a4f9ec0-6338-417f-a776-4d3ece703303","instance_id":"167444fd-9ae1-40e5-803d-2918ac01bce2","instance_name":"test-mongodb-instance","name":"updated-snapshot","node_type":"mgdb-play2-nano","region":"fr-par","size_bytes":5000000000,"status":"ready","updated_at":"2025-10-10T05:54:31.966160Z","volume_type":"sbs_5k"}'
         headers:
             Content-Length:
                 - "409"
@@ -866,7 +866,7 @@ interactions:
         trailer: {}
         content_length: 409
         uncompressed: false
-        body: '{"created_at":"2025-10-10T05:54:18.372982Z","expires_at":"2026-06-30T23:59:59Z","id":"5a4f9ec0-6338-417f-a776-4d3ece703303","instance_id":"167444fd-9ae1-40e5-803d-2918ac01bce2","instance_name":"test-mongodb-instance","name":"updated-snapshot","node_type":"mgdb-play2-nano","region":"fr-par","size_bytes":5000000000,"status":"ready","updated_at":"2025-10-10T05:54:31.966160Z","volume_type":"sbs_5k"}'
+        body: '{"created_at":"2025-10-10T05:54:18.372982Z","expires_at":"2027-03-10T23:59:59Z","id":"5a4f9ec0-6338-417f-a776-4d3ece703303","instance_id":"167444fd-9ae1-40e5-803d-2918ac01bce2","instance_name":"test-mongodb-instance","name":"updated-snapshot","node_type":"mgdb-play2-nano","region":"fr-par","size_bytes":5000000000,"status":"ready","updated_at":"2025-10-10T05:54:31.966160Z","volume_type":"sbs_5k"}'
         headers:
             Content-Length:
                 - "409"
@@ -1013,7 +1013,7 @@ interactions:
         trailer: {}
         content_length: 409
         uncompressed: false
-        body: '{"created_at":"2025-10-10T05:54:18.372982Z","expires_at":"2026-06-30T23:59:59Z","id":"5a4f9ec0-6338-417f-a776-4d3ece703303","instance_id":"167444fd-9ae1-40e5-803d-2918ac01bce2","instance_name":"test-mongodb-instance","name":"updated-snapshot","node_type":"mgdb-play2-nano","region":"fr-par","size_bytes":5000000000,"status":"ready","updated_at":"2025-10-10T05:54:31.966160Z","volume_type":"sbs_5k"}'
+        body: '{"created_at":"2025-10-10T05:54:18.372982Z","expires_at":"2027-03-10T23:59:59Z","id":"5a4f9ec0-6338-417f-a776-4d3ece703303","instance_id":"167444fd-9ae1-40e5-803d-2918ac01bce2","instance_name":"test-mongodb-instance","name":"updated-snapshot","node_type":"mgdb-play2-nano","region":"fr-par","size_bytes":5000000000,"status":"ready","updated_at":"2025-10-10T05:54:31.966160Z","volume_type":"sbs_5k"}'
         headers:
             Content-Length:
                 - "409"
@@ -1062,7 +1062,7 @@ interactions:
         trailer: {}
         content_length: 412
         uncompressed: false
-        body: '{"created_at":"2025-10-10T05:54:18.372982Z","expires_at":"2026-06-30T23:59:59Z","id":"5a4f9ec0-6338-417f-a776-4d3ece703303","instance_id":"167444fd-9ae1-40e5-803d-2918ac01bce2","instance_name":"test-mongodb-instance","name":"updated-snapshot","node_type":"mgdb-play2-nano","region":"fr-par","size_bytes":5000000000,"status":"deleting","updated_at":"2025-10-10T05:54:33.864702Z","volume_type":"sbs_5k"}'
+        body: '{"created_at":"2025-10-10T05:54:18.372982Z","expires_at":"2027-03-10T23:59:59Z","id":"5a4f9ec0-6338-417f-a776-4d3ece703303","instance_id":"167444fd-9ae1-40e5-803d-2918ac01bce2","instance_name":"test-mongodb-instance","name":"updated-snapshot","node_type":"mgdb-play2-nano","region":"fr-par","size_bytes":5000000000,"status":"deleting","updated_at":"2025-10-10T05:54:33.864702Z","volume_type":"sbs_5k"}'
         headers:
             Content-Length:
                 - "412"


### PR DESCRIPTION
Nightly failed because `expires_at` hardcodé was in the past